### PR TITLE
LF-81: fix rounding bug in balances

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,7 +76,7 @@ function App() {
                     {/* <Menu.Item>
                       <a href="https://docs.li.finance/for-users/user-faq" target="_blank" rel="noreferrer">FAQ</a>
                     </Menu.Item> */}
-                    <Menu.Item>
+                    <Menu.Item key="dev-list">
                       <a href="https://docs.google.com/forms/d/e/1FAIpQLSe4vZSN02dmN4W0V_-sB1Aw4erZh577L2h0aDbnzfoRhurPQQ/viewform?usp=send_form" target="_blank" rel="nofollow noreferrer">Developer Waitinglist</a>
                     </Menu.Item>
                     {false && <Menu.Item key="wallets" style={{ float: "right" }}>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,22 +1,23 @@
-import { CheckCircleTwoTone, CloseCircleTwoTone, DeleteOutlined, SyncOutlined, WalletOutlined } from '@ant-design/icons';
-import { useWeb3React } from "@web3-react/core";
-import { Avatar, Badge, Button, Col, Input, Modal, Row, Skeleton, Table, Tooltip } from 'antd';
-import { Content } from 'antd/lib/layout/layout';
-import { ethers } from "ethers";
-import React, { useEffect, useState } from 'react';
-import { getBalancesForWallet } from '../services/balanceService';
-import { readWallets, storeWallets } from '../services/localStorage';
-import { Amounts, ChainKey, chainKeysToObject, ChainPortfolio, Coin, CoinKey, ColomnType, DataType, defaultCoins, getChainByKey, SummaryAmounts, supportedChains, Token, Wallet, WalletSummary } from '../types';
-import './Dashboard.css';
-import ConnectButton from "./web3/ConnectButton";
+import { CheckCircleTwoTone, CloseCircleTwoTone, DeleteOutlined, SyncOutlined, WalletOutlined } from '@ant-design/icons'
+import { useWeb3React } from '@web3-react/core'
+import { Avatar, Badge, Button, Col, Input, Modal, Row, Skeleton, Table, Tooltip } from 'antd'
+import { Content } from 'antd/lib/layout/layout'
+import BigNumber from 'bignumber.js'
+import { ethers } from 'ethers'
+import React, { useEffect, useState } from 'react'
+import { getBalancesForWallet } from '../services/balanceService'
+import { readWallets, storeWallets } from '../services/localStorage'
+import { Amounts, ChainKey, chainKeysToObject, ChainPortfolio, Coin, CoinKey, ColomnType, DataType, defaultCoins, getChainByKey, SummaryAmounts, supportedChains, Token, Wallet, WalletSummary } from '../types'
+import './Dashboard.css'
+import ConnectButton from './web3/ConnectButton'
 
-const emptySummaryAmounts = {
-  amount_usd: 0,
-  percentage_of_portfolio: 0,
+const emptySummaryAmounts: SummaryAmounts = {
+  amount_usd: new BigNumber(0),
+  percentage_of_portfolio: new BigNumber(0),
 }
 
 const emptyWallet = {
-  address: "0x..",
+  address: '0x..',
   loading: true,
   portfolio: chainKeysToObject([]),
 }
@@ -24,8 +25,8 @@ const emptyWallet = {
 let coins = defaultCoins.filter(coin => coin.key !== CoinKey.TEST)
 
 // individual render functions
-function renderAmounts(amounts: Amounts = { amount_coin: -1, amount_usd: -1 }) {
-  if (amounts.amount_coin === -1) {
+function renderAmounts(amounts: Amounts = { amount_coin: new BigNumber(-1), amount_usd: new BigNumber(-1) }) {
+  if (amounts.amount_coin.eq(-1)) {
     // loading
     return (
       <div className="amounts">
@@ -37,7 +38,7 @@ function renderAmounts(amounts: Amounts = { amount_coin: -1, amount_usd: -1 }) {
         </div>
       </div>
     )
-  } else if (amounts.amount_coin === 0) {
+  } else if (amounts.amount_coin.isZero()) {
     // empty
     return (
       <div className="amounts amounts-empty">
@@ -48,9 +49,9 @@ function renderAmounts(amounts: Amounts = { amount_coin: -1, amount_usd: -1 }) {
   } else {
     // default
     return (
-      <div className={'amounts' + (amounts.amount_coin === 0 ? ' amounts-empty' : '')}>
-        <div className="amount_coin">{amounts.amount_coin.toLocaleString(undefined, { minimumFractionDigits: 4, maximumFractionDigits: 4 })}</div>
-        <div className="amount_usd">{amounts.amount_usd.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} USD</div>
+      <div className={'amounts' + (amounts.amount_coin.isZero() ? ' amounts-empty' : '')}>
+        <div className="amount_coin">{amounts.amount_coin.toFixed(4)}</div>
+        <div className="amount_usd">{amounts.amount_usd.toFixed(2)} USD</div>
       </div>
     )
   }
@@ -73,10 +74,11 @@ function renderCoin(coin: Coin) {
 }
 
 function renderSummary(summary: SummaryAmounts) {
+  summary.amount_usd = new BigNumber(summary.amount_usd) // Ugly fix
   return (
     <div className="amounts">
-      <div className="amount_coin">{summary.amount_usd.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} USD</div>
-      <div className="amount_usd">{(summary.percentage_of_portfolio * 100.0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} % of portfolio</div>
+      <div className="amount_coin">{summary.amount_usd.toFixed(2)} USD</div>
+      <div className="amount_usd">{summary.percentage_of_portfolio.shiftedBy(2).toFixed(2)} % of portfolio</div>
     </div>
   )
 }
@@ -95,7 +97,7 @@ const showGasModal = (gas: ChainKey) => {
           </div>
         )
       })
-      break;
+      break
     case ChainKey.POL:
       Modal.info({
         title: 'Gas Info for Polygon/Matic chain',
@@ -109,7 +111,7 @@ const showGasModal = (gas: ChainKey) => {
           </div>
         )
       })
-      break;
+      break
     case ChainKey.BSC:
       Modal.info({
         title: 'Gas Info for Binance Smart Chain',
@@ -120,7 +122,7 @@ const showGasModal = (gas: ChainKey) => {
           </div>
         )
       })
-      break;
+      break
     case ChainKey.DAI:
       Modal.info({
         title: 'Gas Info for xDAI chain',
@@ -135,7 +137,7 @@ const showGasModal = (gas: ChainKey) => {
           </div>
         )
       })
-      break;
+      break
     case ChainKey.FTM:
       Modal.info({
         title: 'Gas Info for FTM chain',
@@ -148,7 +150,7 @@ const showGasModal = (gas: ChainKey) => {
           </div>
         )
       })
-      break;
+      break
     case ChainKey.OKT:
       Modal.info({
         title: 'Gas Info for OKExChain chain',
@@ -161,7 +163,7 @@ const showGasModal = (gas: ChainKey) => {
           </div>
         )
       })
-      break;
+      break
     case ChainKey.AVA:
       Modal.info({
         title: 'Gas Info for Avalanche chain',
@@ -174,7 +176,7 @@ const showGasModal = (gas: ChainKey) => {
           </div>
         )
       })
-      break;
+      break
     case ChainKey.RIN:
       Modal.info({
         title: 'Gas Info for Rinkeby Testnet',
@@ -187,7 +189,7 @@ const showGasModal = (gas: ChainKey) => {
           </div>
         )
       })
-      break;
+      break
     case ChainKey.GOR:
       Modal.info({
         title: 'Gas Info for Goerli Testnet',
@@ -200,7 +202,7 @@ const showGasModal = (gas: ChainKey) => {
           </div>
         )
       })
-      break;
+      break
   }
 }
 
@@ -220,19 +222,19 @@ for (const k in ChainKey) {
 function renderGas(wallet: Wallet, chain: ChainKey, coinName: CoinKey) {
   const coin = coins.find(coin => coin.key === coinName)
   const isChainUsed = wallet.portfolio[chain]?.length > 0
-  const inPortfolio = wallet.portfolio[chain]?.find(e => e.id === '0x0000000000000000000000000000000000000000' || e.id ===  coin?.chains[chain]?.id)
-  const amounts: Amounts = inPortfolio ? parsePortfolioToAmount(inPortfolio) : { amount_coin: 0, amount_usd: 0 }
+  const inPortfolio = wallet.portfolio[chain]?.find(e => e.id === '0x0000000000000000000000000000000000000000' || e.id === coin?.chains[chain]?.id)
+  const amounts: Amounts = inPortfolio ? parsePortfolioToAmount(inPortfolio) : { amount_coin: new BigNumber(0), amount_usd: new BigNumber(0) }
 
-  const tooltipEmpty = tooltipsEmpty[chain];
-  const tooltip = tooltips[chain];
+  const tooltipEmpty = tooltipsEmpty[chain]
+  const tooltip = tooltips[chain]
   return (
     <div className="gas">
       <div className="amount_coin">
-        {amounts.amount_coin === -1 ? (
+        {amounts.amount_coin.eq(-1) ? (
           <Tooltip title={tooltip}>
             {coinName}: <Skeleton.Button style={{ width: 60 }} active={true} size={'small'} shape={'round'} />
           </Tooltip>
-        ) : amounts.amount_coin === 0 ? (
+        ) : amounts.amount_coin.isZero() ? (
           <Tooltip color={isChainUsed ? 'red' : 'gray'} title={tooltipEmpty}>
             {coinName}: -
             <Badge
@@ -244,7 +246,7 @@ function renderGas(wallet: Wallet, chain: ChainKey, coinName: CoinKey) {
           </Tooltip>
         ) : (
           <Tooltip title={tooltip}>
-            {coinName}: {amounts.amount_coin.toLocaleString(undefined, { minimumFractionDigits: 4, maximumFractionDigits: 4 })}
+            {coinName}: {amounts.amount_coin.toFixed(4)}
           </Tooltip>
         )}
       </div>
@@ -270,12 +272,12 @@ const renderWalletColumnTitle = (address: string, syncHandler: Function, deleteH
 const parsePortfolioToAmount = (inPortfolio: any) => {
   const subAmounts: Amounts = {
     amount_coin: inPortfolio.amount,
-    amount_usd: inPortfolio.amount * inPortfolio.pricePerCoin,
+    amount_usd: inPortfolio.amount.times(inPortfolio.pricePerCoin),
   }
 
   return subAmounts
 }
-const baseWidth = 150;
+const baseWidth = 150
 const buildColumnForWallet = (wallet: Wallet, syncHandler: Function, deleteHandler: Function) => {
   const walletColumn: ColomnType = {
     title: renderWalletColumnTitle(wallet.address, syncHandler, deleteHandler),
@@ -328,24 +330,25 @@ const initialRows: Array<DataType> = coins.map(coin => {
   return {
     key: coin.key,
     coin: coin as Coin,
-    portfolio: { amount_coin: -1, amount_usd: -1 },
-    ...chainKeysToObject({ amount_coin: -1, amount_usd: -1 }),
+    portfolio: { amount_coin: new BigNumber(-1), amount_usd: new BigNumber(-1) },
+    ...chainKeysToObject({ amount_coin: new BigNumber(-1), amount_usd: new BigNumber(-1) }),
   }
 })
 
-const calculateWalletSummary = (wallet: Wallet, totalSumUsd: number) => {
+const calculateWalletSummary = (wallet: Wallet, totalSumUsd: BigNumber) => {
   var summary: WalletSummary = Object.assign(
     {
       wallet: wallet.address,
     },
-    chainKeysToObject({ amount_usd: 0.0, percentage_of_portfolio: 0.0 }),
+    chainKeysToObject({ amount_usd: new BigNumber(0), percentage_of_portfolio: new BigNumber(0) }),
   ) as WalletSummary
 
   Object.values(ChainKey).forEach(chain => {
     wallet.portfolio[chain]?.forEach(portfolio => {
-      summary[chain].amount_usd += portfolio.amount * portfolio.pricePerCoin;
+      summary[chain].amount_usd = new BigNumber(summary[chain].amount_usd) // chainKeysToObject retruns string
+      summary[chain].amount_usd = summary[chain].amount_usd.plus(portfolio.amount.times(portfolio.pricePerCoin))
     })
-    summary[chain].percentage_of_portfolio = wallet.portfolio[chain]?.reduce((sum, current) => sum + current.amount * current.pricePerCoin, 0) / totalSumUsd
+    summary[chain].percentage_of_portfolio = wallet.portfolio[chain]?.reduce((sum, current) => sum.plus(current.amount.times(current.pricePerCoin)), new BigNumber(0)).div(totalSumUsd)
   })
   return summary
 }
@@ -356,13 +359,13 @@ const Dashboard = () => {
   const [registeredWallets, setRegisteredWallets] = useState<Array<Wallet>>(() => { return readWallets() })
   const web3 = useWeb3React()
   const [columns, setColumns] = useState<Array<ColomnType>>(initialColumns)
-  const [walletModalVisible, setWalletModalVisible] = useState(false);
-  const [walletModalAddress, setWalletModalAddress] = useState('');
+  const [walletModalVisible, setWalletModalVisible] = useState(false)
+  const [walletModalAddress, setWalletModalAddress] = useState('')
   const [walletModalLoading, setWalletModalLoading] = useState<boolean>(false)
-  const [data, setData] = useState<Array<DataType>>(initialRows);
+  const [data, setData] = useState<Array<DataType>>(initialRows)
   // fixes react warning
   // https://stackoverflow.com/a/63144665
-  const [isSubscribed, setIsSubscribed] = useState<boolean>(true);
+  const [isSubscribed, setIsSubscribed] = useState<boolean>(true)
 
 
   const deleteWallet = (wallet: Wallet) => {
@@ -375,7 +378,7 @@ const Dashboard = () => {
       const col = buildColumnForWallet(wallet, () => updateWalletPortfolio(wallet), () => deleteWallet(wallet))
       walletColumns.push(col)
     })
-    return walletColumns;
+    return walletColumns
   }
 
   const buildColumns = (initialBuild: boolean = false) => {
@@ -397,7 +400,7 @@ const Dashboard = () => {
       dataIndex: '',
       width: 100,
     })
-    return columns;
+    return columns
   }
 
   //builders
@@ -409,32 +412,32 @@ const Dashboard = () => {
         key: coin.key,
         coin: coin as Coin,
         portfolio: {
-          amount_coin: 0.0,
-          amount_usd: 0.0,
+          amount_coin: new BigNumber(0),
+          amount_usd: new BigNumber(0),
         },
       }
       registeredWallets.forEach(wallet => {
         Object.values(ChainKey).forEach(chain => {
           const emptyAmounts: Amounts = {
-            amount_coin: wallet.loading ? -1 : 0.0,
-            amount_usd: wallet.loading ? -1 : 0.0,
+            amount_coin: wallet.loading ? new BigNumber(-1) : new BigNumber(0),
+            amount_usd: wallet.loading ? new BigNumber(-1) : new BigNumber(0),
           }
           const inPortfolio = wallet.portfolio[chain].find(e => e.id === coin.chains[chain]?.id)
           const cellContent: Amounts = inPortfolio ? parsePortfolioToAmount(inPortfolio) : emptyAmounts
           coinRow[`${wallet.address}_${chain}`] = cellContent
 
-          if (cellContent.amount_coin > 0) {
-            coinRow.portfolio.amount_coin += cellContent.amount_coin
-            coinRow.portfolio.amount_usd += cellContent.amount_usd
+          if (cellContent.amount_coin.gt(0)) {
+            coinRow.portfolio.amount_coin = coinRow.portfolio.amount_coin.plus(cellContent.amount_coin)
+            coinRow.portfolio.amount_usd = coinRow.portfolio.amount_usd.plus(cellContent.amount_usd)
           }
-        }); // for each chain
-      }); // for each wallet
+        }) // for each chain
+      }) // for each wallet
       generatedRows.push(coinRow)
     }) // for each coin
 
     // sort
-    generatedRows.sort((a, b) => b.portfolio.amount_coin - a.portfolio.amount_coin) // DESC token
-    generatedRows.sort((a, b) => b.portfolio.amount_usd - a.portfolio.amount_usd) // DESC usd
+    generatedRows.sort((a, b) => b.portfolio.amount_coin.minus(a.portfolio.amount_coin).toNumber()) // DESC token
+    generatedRows.sort((a, b) => b.portfolio.amount_usd.minus(a.portfolio.amount_usd).toNumber()) // DESC usd
 
     return generatedRows
   }
@@ -502,7 +505,7 @@ const Dashboard = () => {
 
   const updateEntirePortfolio = () => {
     registeredWallets.forEach(async wallet => {
-      await updateWalletPortfolio(wallet);
+      await updateWalletPortfolio(wallet)
     })
   }
 
@@ -516,11 +519,11 @@ const Dashboard = () => {
   useEffect(() => {
     if (!registeredWallets.length) {
       setWalletModalVisible(true)
-      setColumns(initialColumns);
+      setColumns(initialColumns)
       setData(initialRows)
     } else {
       updateEntirePortfolio()
-      setColumns(buildColumns());
+      setColumns(buildColumns())
       setData(buildRows)
     }
     // eslint-disable-next-line
@@ -547,8 +550,8 @@ const Dashboard = () => {
   }
 
   const handleWalletModalAdd = async () => {
-    setWalletModalLoading(true);
-    let address = getModalAddressSuggestion();
+    setWalletModalLoading(true)
+    let address = getModalAddressSuggestion()
 
     if (address.endsWith('.eth')) {
       address = await resolveEnsName(address) || ''
@@ -559,8 +562,8 @@ const Dashboard = () => {
       setWalletModalAddress(' ')
       addWallet(address)
     }
-    setWalletModalLoading(false);
-  };
+    setWalletModalLoading(false)
+  }
 
   const handleWalletModalClose = () => {
     if (!registeredWallets.length) {
@@ -573,7 +576,7 @@ const Dashboard = () => {
   const getModalAddressSuggestion = () => {
     const addedWallets = registeredWallets.map(wallet => wallet.address)
     const web3Account = (web3.account && addedWallets.indexOf(web3.account) === -1) ? web3.account : ''
-    return walletModalAddress || web3Account;
+    return walletModalAddress || web3Account
   }
 
   let summaryIndex = 0
@@ -592,17 +595,24 @@ const Dashboard = () => {
             <Table.Summary fixed>
               <Table.Summary.Row>
                 <Table.Summary.Cell index={summaryIndex} className="sum">SUM</Table.Summary.Cell>
-                <Table.Summary.Cell index={summaryIndex++}>{renderSummary(!registeredWallets.length ? emptySummaryAmounts : { amount_usd: data.reduce((sum, curr) => sum + curr.portfolio.amount_usd, 0), percentage_of_portfolio: 1 } as SummaryAmounts)}</Table.Summary.Cell>
+                <Table.Summary.Cell index={summaryIndex++}>
+                  {
+                    renderSummary(!registeredWallets.length ? emptySummaryAmounts : {
+                      amount_usd: data.reduce((sum, curr) => sum.plus(curr.portfolio.amount_usd), new BigNumber(0)),
+                      percentage_of_portfolio: new BigNumber(1)
+                    } as SummaryAmounts)
+                  }
+                </Table.Summary.Cell>
                 {
                   registeredWallets.map((wallet: Wallet) => {
-                    const total = data.reduce((sum, curr) => sum + curr.portfolio.amount_usd, 0)
+                    const total = data.reduce((sum, curr) => sum.plus(curr.portfolio.amount_usd), new BigNumber(0))
                     const summary = calculateWalletSummary(wallet, total)
 
                     return supportedChains
                       .filter(chain => chain.visible)
                       .map(chain => {
                         return (
-                          <Table.Summary.Cell index={summaryIndex++} key={`${wallet.address}_${chain.key}`}>{wallet.loading ? renderSummary({ amount_usd: 0, percentage_of_portfolio: 0 }) : renderSummary(summary[chain.key])}</Table.Summary.Cell>
+                          <Table.Summary.Cell index={summaryIndex++} key={`${wallet.address}_${chain.key}`}>{wallet.loading ? renderSummary({ amount_usd: new BigNumber(0), percentage_of_portfolio: new BigNumber(0) }) : renderSummary(summary[chain.key])}</Table.Summary.Cell>
                         )
                       })
                   })

--- a/src/components/Swap.tsx
+++ b/src/components/Swap.tsx
@@ -1,29 +1,29 @@
 // LIBS
-import { LoginOutlined, SwapOutlined, SyncOutlined } from '@ant-design/icons';
-import { Web3Provider } from '@ethersproject/providers';
-import { useWeb3React } from '@web3-react/core';
-import { Button, Col, Collapse, Form, Image, InputNumber, Modal, Row, Typography } from 'antd';
-import { Content } from 'antd/lib/layout/layout';
-import Title from 'antd/lib/typography/Title';
-import axios, { CancelTokenSource } from 'axios';
-import BigNumber from 'bignumber.js';
-import { animate, stagger } from "motion";
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import heroImage from '../assets/info_header.jpg';
-import { loadTokenListAsTokens } from '../services/tokenListService';
-import { formatTokenAmountOnly } from '../services/utils';
-import { Chain, ChainKey, ChainPortfolio, defaultTokens, DepositAction, getChainByKey, Token, TransferStep, WithdrawAction } from '../types';
-import LoadingIndicator from './LoadingIndicator';
-import Route from './Route';
-import './Swap.css';
-import SwapForm from './SwapForm';
-import Swapping from './Swapping';
-import { injected } from './web3/connectors';
+import { LoginOutlined, SwapOutlined, SyncOutlined } from '@ant-design/icons'
+import { Web3Provider } from '@ethersproject/providers'
+import { useWeb3React } from '@web3-react/core'
+import { Button, Col, Collapse, Form, Image, InputNumber, Modal, Row, Typography } from 'antd'
+import { Content } from 'antd/lib/layout/layout'
+import Title from 'antd/lib/typography/Title'
+import axios, { CancelTokenSource } from 'axios'
+import BigNumber from 'bignumber.js'
+import { animate, stagger } from "motion"
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import heroImage from '../assets/info_header.jpg'
+import { loadTokenListAsTokens } from '../services/tokenListService'
+import { formatTokenAmountOnly } from '../services/utils'
+import { Chain, ChainKey, ChainPortfolio, defaultTokens, DepositAction, getChainByKey, Token, TransferStep, WithdrawAction } from '../types'
+import LoadingIndicator from './LoadingIndicator'
+import Route from './Route'
+import './Swap.css'
+import SwapForm from './SwapForm'
+import Swapping from './Swapping'
+import { injected } from './web3/connectors'
 
-const { Panel } = Collapse;
+const { Panel } = Collapse
 
 interface TokenWithAmounts extends Token {
-  amount?: number
+  amount?: BigNumber
   amountRendered?: string
 }
 let source: CancelTokenSource | undefined = undefined
@@ -54,10 +54,10 @@ const Swap = ({
 
   // From
   const [depositChain, setDepositChain] = useState<ChainKey>(transferChains[0].key)
-  const [depositAmount, setDepositAmount] = useState<number>(1)
+  const [depositAmount, setDepositAmount] = useState<BigNumber>(new BigNumber(1))
   const [depositToken, setDepositToken] = useState<string | undefined>() // tokenId
   const [withdrawChain, setWithdrawChain] = useState<ChainKey>(transferChains[1].key)
-  const [withdrawAmount, setWithdrawAmount] = useState<number>(Infinity)
+  const [withdrawAmount, setWithdrawAmount] = useState<BigNumber>(new BigNumber(Infinity))
   const [withdrawToken, setWithdrawToken] = useState<string | undefined>() // tokenId
   const [tokens, setTokens] = useState<{ [ChainKey: string]: Array<TokenWithAmounts> }>(defaultTokens)
   const [refreshTokens, setRefreshTokens] = useState<boolean>(true)
@@ -126,11 +126,11 @@ const Swap = ({
 
   const getBalance = (currentBalances: { [ChainKey: string]: Array<ChainPortfolio> } | undefined, chainKey: ChainKey, tokenId: string) => {
     if (!currentBalances) {
-      return 0
+      return new BigNumber(0)
     }
 
     const tokenBalance = currentBalances[chainKey].find(portfolio => portfolio.id === tokenId)
-    return tokenBalance?.amount || 0
+    return tokenBalance?.amount || new BigNumber(0)
   }
 
   useEffect(() => {
@@ -138,7 +138,7 @@ const Swap = ({
     if (!balances) {
       for (const chain of transferChains) {
         for (const token of tokens[chain.key]) {
-          token.amount = -1
+          token.amount = new BigNumber(-1)
           token.amountRendered = ''
         }
       }
@@ -176,7 +176,7 @@ const Swap = ({
       setHighlightedIndex(-1)
       setNoRoutesAvailable(false)
 
-      if ((isFinite(depositAmount) && depositAmount > 0) && depositChain && depositToken && withdrawChain && withdrawToken) {
+      if (depositAmount.gt(0) && depositChain && depositToken && withdrawChain && withdrawToken) {
         setRoutesLoading(true)
         const dToken = findToken(depositChain, depositToken)
         const deposit: DepositAction = {

--- a/src/components/SwapForm.tsx
+++ b/src/components/SwapForm.tsx
@@ -1,27 +1,28 @@
-import { SwapOutlined } from '@ant-design/icons';
-import { SubgraphSyncRecord } from '@connext/nxtp-sdk';
-import { useWeb3React } from '@web3-react/core';
-import { Button, Col, Input, Row } from 'antd';
-import { RefSelectProps } from 'antd/lib/select';
-import React, { useRef } from 'react';
-import { Chain, ChainKey, ChainPortfolio, TokenWithAmounts } from '../types';
-import ChainSelect from './ChainSelect';
-import TokenSelect from './TokenSelect';
-import { injected } from './web3/connectors';
+import { SwapOutlined } from '@ant-design/icons'
+import { SubgraphSyncRecord } from '@connext/nxtp-sdk'
+import { useWeb3React } from '@web3-react/core'
+import { Button, Col, Input, Row } from 'antd'
+import { RefSelectProps } from 'antd/lib/select'
+import BigNumber from 'bignumber.js'
+import React, { useRef } from 'react'
+import { Chain, ChainKey, ChainPortfolio, TokenWithAmounts } from '../types'
+import ChainSelect from './ChainSelect'
+import TokenSelect from './TokenSelect'
+import { injected } from './web3/connectors'
 
 interface SwapFormProps {
   depositChain: ChainKey,
   setDepositChain: Function,
   depositToken?: string,
   setDepositToken: Function,
-  depositAmount: number,
+  depositAmount: BigNumber,
   setDepositAmount: Function,
 
   withdrawChain: ChainKey,
   setWithdrawChain: Function,
   withdrawToken?: string,
   setWithdrawToken: Function,
-  withdrawAmount: number,
+  withdrawAmount: BigNumber,
   setWithdrawAmount: Function,
   estimatedWithdrawAmount: string,
 
@@ -95,12 +96,12 @@ const SwapForm = ({
 
   const getBalance = (chainKey: ChainKey, tokenId: string) => {
     if (!balances) {
-      return 0
+      return new BigNumber(0)
     }
 
     const tokenBalance = balances[chainKey].find(portfolio => portfolio.id === tokenId)
 
-    return tokenBalance?.amount || 0
+    return tokenBalance?.amount || new BigNumber(0)
   }
 
   const onChangeDepositToken = (tokenId: string) => {
@@ -116,8 +117,8 @@ const SwapForm = ({
     // set token
     setDepositToken(tokenId)
     const balance = getBalance(depositChain, tokenId)
-    if (balance < depositAmount && balance > 0) {
-      setDepositAmount(Math.floor(balance * 10000) / 10000)
+    if (balance < depositAmount && balance.gt(0)) {
+      setDepositAmount(balance)
     }
 
     // set withdraw token?
@@ -149,16 +150,16 @@ const SwapForm = ({
     }
   }
 
-  const onChangeDepositAmount = (amount: number) => {
+  const onChangeDepositAmount = (amount: BigNumber) => {
     setDepositAmount(amount)
-    setWithdrawAmount(Infinity)
+    setWithdrawAmount(new BigNumber(Infinity))
   }
-  const onChangeWithdrawAmount = (amount: number) => {
-    setDepositAmount(Infinity)
+  const onChangeWithdrawAmount = (amount: BigNumber) => {
+    setDepositAmount(new BigNumber(Infinity))
     setWithdrawAmount(amount)
   }
   const formatAmountInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    return parseFloat(e.currentTarget.value)
+    return new BigNumber(e.currentTarget.value)
   }
 
   const setMaxDeposit = () => {
@@ -206,7 +207,7 @@ const SwapForm = ({
               defaultValue={0.0}
               min={0}
               step={0.000000000000000001}
-              value={isFinite(depositAmount) && depositAmount >= 0 ? depositAmount : ''}
+              value={depositAmount.gte(0) ? depositAmount.toString() : ''}
               onChange={((event) => onChangeDepositAmount(formatAmountInput(event)))}
               placeholder="0.0"
               bordered={false}

--- a/src/components/TokenSelect.tsx
+++ b/src/components/TokenSelect.tsx
@@ -1,9 +1,9 @@
-import { Web3Provider } from '@ethersproject/providers';
-import { useWeb3React } from '@web3-react/core';
-import { Avatar, Select } from 'antd';
-import { RefSelectProps } from 'antd/lib/select';
-import React from 'react';
-import { ChainKey, ChainPortfolio, TokenWithAmounts } from '../types';
+import { Web3Provider } from '@ethersproject/providers'
+import { useWeb3React } from '@web3-react/core'
+import { Avatar, Select } from 'antd'
+import { RefSelectProps } from 'antd/lib/select'
+import React from 'react'
+import { ChainKey, ChainPortfolio, TokenWithAmounts } from '../types'
 
 interface TokenSelectProps {
   tokens: { [ChainKey: string]: Array<TokenWithAmounts> }
@@ -111,7 +111,7 @@ const TokenSelect = ({
               label={token.symbol + ' - ' + token.name}
               data-label={token.symbol + (balances ? (' (' + token.amountRendered + ')') : '')}
             >
-              <div className={'option-item ' + (grayed && token.amount === 0 ? 'disabled' : '')}>
+              <div className={'option-item ' + (grayed && token.amount?.eq(0) ? 'disabled' : '')}>
                 <span role="img" aria-label={token.symbol}>
                   <Avatar
                     size="small"

--- a/src/components/nxtp/SwapXpollinate.tsx
+++ b/src/components/nxtp/SwapXpollinate.tsx
@@ -1,37 +1,37 @@
-import { CheckOutlined, DownOutlined, ExportOutlined, InfoCircleOutlined, LinkOutlined, LoginOutlined, SwapOutlined, SyncOutlined } from '@ant-design/icons';
-import { HistoricalTransaction, NxtpSdk, NxtpSdkEvent, NxtpSdkEvents, SubgraphSyncRecord } from '@connext/nxtp-sdk';
-import { AuctionResponse, getDeployedSubgraphUri, TransactionPreparedEvent } from '@connext/nxtp-utils';
-import { Web3Provider } from '@ethersproject/providers';
-import { useWeb3React } from '@web3-react/core';
-import { Alert, Badge, Button, Checkbox, Col, Collapse, Dropdown, Form, Input, Menu, Modal, Row, Tooltip } from 'antd';
-import { Content } from 'antd/lib/layout/layout';
-import Title from 'antd/lib/typography/Title';
-import BigNumber from 'bignumber.js';
-import { providers, utils } from 'ethers';
-import { gql, request } from 'graphql-request';
-import { createBrowserHistory } from 'history';
-import QueryString from 'qs';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import onehiveWordmark from '../../assets/1hive_wordmark.svg';
-import connextWordmark from '../../assets/connext_wordmark.png';
-import lifiWordmark from '../../assets/lifi_wordmark.svg';
-import xpollinateWordmark from '../../assets/xpollinate_wordmark.svg';
-import { getBalancesForWalletFromChain } from '../../services/balanceService';
-import { clearLocalStorage, readHideAbout, storeHideAbout } from '../../services/localStorage';
-import { switchChain } from '../../services/metamask';
-import { chainConfigOverwrites, finishTransfer, getTransferQuote, setup, triggerTransfer } from '../../services/nxtp';
-import { deepClone, formatTokenAmountOnly } from '../../services/utils';
-import { Chain, ChainKey, ChainPortfolio, CoinKey, CrossAction, CrossEstimate, CrossStep, defaultCoins, Execution, findDefaultCoinOnChain, getChainById, getChainByKey, Token, TokenWithAmounts, TransferStep } from '../../types';
-import '../Swap.css';
-import SwapForm from '../SwapForm';
-import { getRpcProviders, injected } from '../web3/connectors';
-import HistoricTransactionsTableNxtp from './HistoricTransactionsTableNxtp';
-import LiquidityTableNxtp from './LiquidityTableNxtp';
-import SwappingNxtp from './SwappingNxtp';
-import './SwapXpollinate.css';
-import TestBalanceOverview from './TestBalanceOverview';
-import TransactionsTableNxtp from './TransactionsTableNxtp';
-import { ActiveTransaction, CrosschainTransaction } from './typesNxtp';
+import { CheckOutlined, DownOutlined, ExportOutlined, InfoCircleOutlined, LinkOutlined, LoginOutlined, SwapOutlined, SyncOutlined } from '@ant-design/icons'
+import { HistoricalTransaction, NxtpSdk, NxtpSdkEvent, NxtpSdkEvents, SubgraphSyncRecord } from '@connext/nxtp-sdk'
+import { AuctionResponse, getDeployedSubgraphUri, TransactionPreparedEvent } from '@connext/nxtp-utils'
+import { Web3Provider } from '@ethersproject/providers'
+import { useWeb3React } from '@web3-react/core'
+import { Alert, Badge, Button, Checkbox, Col, Collapse, Dropdown, Form, Input, Menu, Modal, Row, Tooltip } from 'antd'
+import { Content } from 'antd/lib/layout/layout'
+import Title from 'antd/lib/typography/Title'
+import BigNumber from 'bignumber.js'
+import { providers, utils } from 'ethers'
+import { gql, request } from 'graphql-request'
+import { createBrowserHistory } from 'history'
+import QueryString from 'qs'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import onehiveWordmark from '../../assets/1hive_wordmark.svg'
+import connextWordmark from '../../assets/connext_wordmark.png'
+import lifiWordmark from '../../assets/lifi_wordmark.svg'
+import xpollinateWordmark from '../../assets/xpollinate_wordmark.svg'
+import { getBalancesForWalletFromChain } from '../../services/balanceService'
+import { clearLocalStorage, readHideAbout, storeHideAbout } from '../../services/localStorage'
+import { switchChain } from '../../services/metamask'
+import { chainConfigOverwrites, finishTransfer, getTransferQuote, setup, triggerTransfer } from '../../services/nxtp'
+import { deepClone, formatTokenAmountOnly } from '../../services/utils'
+import { Chain, ChainKey, ChainPortfolio, CoinKey, CrossAction, CrossEstimate, CrossStep, defaultCoins, Execution, findDefaultCoinOnChain, getChainById, getChainByKey, Token, TokenWithAmounts, TransferStep } from '../../types'
+import '../Swap.css'
+import SwapForm from '../SwapForm'
+import { getRpcProviders, injected } from '../web3/connectors'
+import HistoricTransactionsTableNxtp from './HistoricTransactionsTableNxtp'
+import LiquidityTableNxtp from './LiquidityTableNxtp'
+import SwappingNxtp from './SwappingNxtp'
+import './SwapXpollinate.css'
+import TestBalanceOverview from './TestBalanceOverview'
+import TransactionsTableNxtp from './TransactionsTableNxtp'
+import { ActiveTransaction, CrosschainTransaction } from './typesNxtp'
 
 const history = createBrowserHistory()
 
@@ -45,7 +45,7 @@ const getDefaultParams = (search: string, transferChains: Chain[], transferToken
   const defaultParams = {
     depositChain: transferChains[0].key,
     depositToken: transferTokens[transferChains[0].key][0].id,
-    depositAmount: -1,
+    depositAmount: new BigNumber(-1),
     withdrawChain: transferChains[1].key,
     withdrawToken: transferTokens[transferChains[1].key][0].id,
   }
@@ -87,7 +87,7 @@ const getDefaultParams = (search: string, transferChains: Chain[], transferToken
     try {
       const newAmount = parseFloat(params.fromAmount)
       if (newAmount > 0) {
-        defaultParams.depositAmount = parseFloat(params.fromAmount)
+        defaultParams.depositAmount = new BigNumber(params.fromAmount)
       }
     } catch (e) { console.error(e) }
   }
@@ -142,11 +142,11 @@ function debounce(func: Function, timeout: number = 300) {
 let chainProviders: Record<number, providers.FallbackProvider>
 
 let startParams: {
-  depositChain: ChainKey;
-  depositToken: string;
-  depositAmount: number;
-  withdrawChain: ChainKey;
-  withdrawToken: string;
+  depositChain: ChainKey
+  depositToken: string
+  depositAmount: BigNumber
+  withdrawChain: ChainKey
+  withdrawToken: string
 }
 
 interface SwapXpollinateProps {
@@ -173,10 +173,10 @@ const SwapXpollinate = ({
 
   // Form
   const [depositChain, setDepositChain] = useState<ChainKey>(startParams.depositChain)
-  const [depositAmount, setDepositAmount] = useState<number>(startParams.depositAmount)
+  const [depositAmount, setDepositAmount] = useState<BigNumber>(startParams.depositAmount)
   const [depositToken, setDepositToken] = useState<string>(startParams.depositToken)
   const [withdrawChain, setWithdrawChain] = useState<ChainKey>(startParams.withdrawChain)
-  const [withdrawAmount, setWithdrawAmount] = useState<number>(Infinity)
+  const [withdrawAmount, setWithdrawAmount] = useState<BigNumber>(new BigNumber(Infinity))
   const [withdrawToken, setWithdrawToken] = useState<string>(startParams.withdrawToken)
   const [tokens, setTokens] = useState<{ [ChainKey: string]: Array<TokenWithAmounts> }>(transferTokens)
   const [refreshBalances, setRefreshBalances] = useState<number>(1)
@@ -226,12 +226,12 @@ const SwapXpollinate = ({
       fromToken: depositToken,
       toChain: getChainByKey(withdrawChain).id,
       toToken: withdrawToken,
-      fromAmount: depositAmount > 0 ? depositAmount : undefined,
+      fromAmount: depositAmount.gt(0) ? depositAmount.toString() : undefined,
     }
     const search = QueryString.stringify(params)
     history.push({
       search,
-    });
+    })
   }, [depositChain, withdrawChain, depositToken, withdrawToken, depositAmount])
 
   // hide about
@@ -550,12 +550,12 @@ const SwapXpollinate = ({
 
   const getBalance = (chainKey: ChainKey, tokenId: string) => {
     if (!balances) {
-      return 0
+      return new BigNumber(0)
     }
 
     const tokenBalance = balances[chainKey].find(portfolio => portfolio.id === tokenId)
 
-    return tokenBalance?.amount || 0
+    return tokenBalance?.amount || new BigNumber(0)
   }
 
   useEffect(() => {
@@ -563,7 +563,7 @@ const SwapXpollinate = ({
     if (!balances) {
       for (const chain of transferChains) {
         for (const token of tokens[chain.key]) {
-          token.amount = -1
+          token.amount = new BigNumber(-1)
           token.amountRendered = ''
         }
       }
@@ -571,7 +571,7 @@ const SwapXpollinate = ({
       for (const chain of transferChains) {
         for (const token of tokens[chain.key]) {
           token.amount = getBalance(chain.key, token.id)
-          token.amountRendered = token.amount >= 0.0001 ? token.amount.toFixed(4) : token.amount.toFixed()
+          token.amountRendered = token.amount.gte(0.0001) ? token.amount.toFixed(4) : token.amount.toFixed()
         }
       }
     }
@@ -646,7 +646,7 @@ const SwapXpollinate = ({
       return
     }
 
-    if ((isFinite(depositAmount) && depositAmount > 0) && depositChain && depositToken && withdrawChain && withdrawToken) {
+    if (depositAmount.gt(0) && depositChain && depositToken && withdrawChain && withdrawToken) {
       const receiving = optionReceivingAddress !== '' ? optionReceivingAddress : web3.account
       const callTo = optionContractAddress !== '' ? optionContractAddress : undefined
       const callData = optionCallData !== '' ? optionCallData : undefined
@@ -739,14 +739,14 @@ const SwapXpollinate = ({
     const wToken = findToken(routeRequest.withdrawChain, routeRequest.withdrawToken)
 
     const crossAction: CrossAction = {
-        type: 'cross',
-        tool: 'nxtp',
-        chainId: getChainByKey(routeRequest.depositChain).id,
-        toChainId: getChainByKey(routeRequest.withdrawChain).id,
-        token: dToken,
-        toToken: wToken,
-        amount: dAmount,
-        toAddress: '',
+      type: 'cross',
+      tool: 'nxtp',
+      chainId: getChainByKey(routeRequest.depositChain).id,
+      toChainId: getChainByKey(routeRequest.withdrawChain).id,
+      token: dToken,
+      toToken: wToken,
+      amount: dAmount,
+      toAddress: '',
     }
     // TODO: calculate real fee
     const crossEstimate: CrossEstimate = {
@@ -795,7 +795,7 @@ const SwapXpollinate = ({
     setExecutionRoutes(routes => [...routes, route])
 
     // get new route to avoid triggering the same quote twice
-    setDepositAmount(-1)
+    setDepositAmount(new BigNumber(-1))
     setRouteRequest(undefined)
     setRouteQuote(undefined)
 
@@ -978,29 +978,29 @@ const SwapXpollinate = ({
     }
 
     return (
-    <div>
-      <Tooltip color={'gray'} placement="topRight" title={(
-        <table>
-          <tbody>
-          <tr>
-              <td>Included Fees:</td>
-              <td style={{textAlign: 'right'}}></td>
-            </tr>
-            <tr>
-              <td>Base Fee</td>
-              <td style={{textAlign: 'right'}}>{routerFee.toFixed(decimals, 1)} {token?.symbol}</td>
-            </tr>
-            <tr>
-              <td style={{paddingRight: 10}}>Router Gas Fee</td>
-              <td style={{textAlign: 'right'}}>{gasFee.toFixed(decimals, 1)} {token?.symbol}</td>
-            </tr>
-          </tbody>
-        </table>
-      )}>
-        Fee Impact: {impact.toFixed(2)}%
+      <div>
+        <Tooltip color={'gray'} placement="topRight" title={(
+          <table>
+            <tbody>
+              <tr>
+                <td>Included Fees:</td>
+                <td style={{ textAlign: 'right' }}></td>
+              </tr>
+              <tr>
+                <td>Base Fee</td>
+                <td style={{ textAlign: 'right' }}>{routerFee.toFixed(decimals, 1)} {token?.symbol}</td>
+              </tr>
+              <tr>
+                <td style={{ paddingRight: 10 }}>Router Gas Fee</td>
+                <td style={{ textAlign: 'right' }}>{gasFee.toFixed(decimals, 1)} {token?.symbol}</td>
+              </tr>
+            </tbody>
+          </table>
+        )}>
+          Fee Impact: {impact.toFixed(2)}%
 
-        <Badge count={<InfoCircleOutlined  style={{ color: 'gray' }} />} offset={[4,-1]} />
-      </Tooltip>
+          <Badge count={<InfoCircleOutlined style={{ color: 'gray' }} />} offset={[4, -1]} />
+        </Tooltip>
       </div>
     )
   }
@@ -1179,7 +1179,7 @@ const SwapXpollinate = ({
                   syncStatus={syncStatus}
                 />
 
-                <Row justify={"end"} style={{ marginRight: 20, marginTop: 4}}>
+                <Row justify={"end"} style={{ marginRight: 20, marginTop: 4 }}>
                   {priceImpact()}
                 </Row>
 

--- a/src/services/balanceService.ts
+++ b/src/services/balanceService.ts
@@ -1,11 +1,11 @@
-import ERC20 from "@connext/nxtp-contracts/artifacts/contracts/interfaces/IERC20Minimal.sol/IERC20Minimal.json";
-import axios from 'axios';
-import { BigNumber as BigNumberJs } from 'bignumber.js';
-import { BigNumber, constants, Contract, ethers } from 'ethers';
-import { getRpcProvider } from '../components/web3/connectors';
-import { ChainId, ChainKey, chainKeysToObject, ChainPortfolio, getChainById, Token } from '../types';
-import { getDefaultTokenBalancesForWallet } from './testToken';
-import { deepClone } from './utils';
+import ERC20 from "@connext/nxtp-contracts/artifacts/contracts/interfaces/IERC20Minimal.sol/IERC20Minimal.json"
+import axios from 'axios'
+import { BigNumber } from 'bignumber.js'
+import { BigNumber as BN, constants, Contract, ethers } from 'ethers'
+import { getRpcProvider } from '../components/web3/connectors'
+import { ChainId, ChainKey, chainKeysToObject, ChainPortfolio, getChainById, Token } from '../types'
+import { getDefaultTokenBalancesForWallet } from './testToken'
+import { deepClone } from './utils'
 
 type tokenListDebankT = {
   id: string,
@@ -96,8 +96,8 @@ export async function covalentGetCoinsOnChain(walletAdress: string, chainId: num
         name: token.contract_name,
         symbol: token.contract_ticker_symbol,
         img_url: token.logo_url,
-        amount: parseInt(token.balance) / (10 ** token.contract_decimals),
-        pricePerCoin: token.quote_rate || 0,
+        amount: new BigNumber(token.balance).shiftedBy(-token.contract_decimals),
+        pricePerCoin: new BigNumber(token.quote_rate || 0),
         verified: false,
       })
     }
@@ -142,17 +142,17 @@ async function getCoinsOnChain(walletAdress: string, chainKey: ChainKey) {
 
   var result
   try {
-    result = await axios.get<any>(tokenListUrl);
+    result = await axios.get<any>(tokenListUrl)
   } catch (e) {
     console.warn(`Debank api call for token list on chain ${chainKey} failed with status ` + e)
     console.warn(e)
     return []
   }
 
-  var tokenList: Array<tokenListDebankT>;
+  var tokenList: Array<tokenListDebankT>
   // response body is empty?
   if (Object.keys(result.data).length === 0) {
-    return [];
+    return []
   } else {
     tokenList = result.data
   }
@@ -165,8 +165,8 @@ async function getCoinsOnChain(walletAdress: string, chainKey: ChainKey) {
       name: token.name,
       symbol: token.optimized_symbol,
       img_url: token.logo_url,
-      amount: token.amount as number,
-      pricePerCoin: token.price as number,
+      amount: new BigNumber(token.amount),
+      pricePerCoin: new BigNumber(token.price),
       verified: token.is_verified,
     })
   }
@@ -197,7 +197,7 @@ const getBlancesFromDebank = async (walletAdress: string) => {
 
   var result
   try {
-    result = await axios.get<any>(tokenListUrl);
+    result = await axios.get<any>(tokenListUrl)
   } catch (e) {
     console.warn(`Debank api call for token list failed with status ` + e)
     throw e
@@ -214,8 +214,8 @@ const getBlancesFromDebank = async (walletAdress: string) => {
       name: token.name,
       symbol: token.optimized_symbol,
       img_url: token.logo_url,
-      amount: token.amount,
-      pricePerCoin: token.price,
+      amount: new BigNumber(token.amount),
+      pricePerCoin: new BigNumber(token.price),
       verified: token.is_verified,
     })
   }
@@ -256,7 +256,7 @@ export const getBalanceFromProvider = async (
   address: string,
   assetId: string,
   chainId: number,
-): Promise<BigNumber> => {
+): Promise<BN> => {
   const provider = getRpcProvider(chainId)
   if (assetId === constants.AddressZero) {
     return provider.getBalance(address)
@@ -275,7 +275,7 @@ export const getBalancesForWalletFromChain = async (address: string, tokens: { [
       const promise = getBalanceFromProvider(address, token.id, token.chainId)
         .catch((e) => {
           console.warn(address, token.id, token.chainId, e)
-          return BigNumber.from(0)
+          return BN.from(0)
         })
       promises.push(promise)
       const amount = await promise
@@ -285,8 +285,8 @@ export const getBalancesForWalletFromChain = async (address: string, tokens: { [
         name: token.name,
         symbol: token.key,
         img_url: '',
-        amount: new BigNumberJs(amount.toString()).shiftedBy(-token.decimals).toNumber(),
-        pricePerCoin: 0,
+        amount: new BigNumber(amount.toString()).shiftedBy(-token.decimals),
+        pricePerCoin: new BigNumber(0),
         verified: false,
       })
     })
@@ -296,5 +296,5 @@ export const getBalancesForWalletFromChain = async (address: string, tokens: { [
   return portfolio
 }
 
-export { getCoinsOnChain, getBalancesForWallet };
+export { getCoinsOnChain, getBalancesForWallet }
 

--- a/src/services/testToken.ts
+++ b/src/services/testToken.ts
@@ -1,5 +1,7 @@
 import { FallbackProvider, JsonRpcSigner } from '@ethersproject/providers'
-import { BigNumber, constants, Contract, providers, utils } from "ethers"
+import BigNumber from 'bignumber.js'
+import { BigNumber as BN, constants, Contract, providers, utils } from 'ethers'
+
 import { getRpcProviders } from '../components/web3/connectors'
 import { ChainId, chainKeysToObject, ChainPortfolio, CoinKey, defaultTokens, getChainById, TokenWithAmounts } from '../types'
 
@@ -91,8 +93,8 @@ export const getBalancesForWallet = async (address: string) => {
   const promises: Array<Promise<any>> = []
 
   Object.entries(testToken).forEach(async ([chainKey, token]) => {
-    const ethAmount = getBalance(address, constants.AddressZero, chainProviders[token[0].chainId]).catch((e) => { console.warn(e); return BigNumber.from(0) })
-    const testAmount = getBalance(address, token[0].id, chainProviders[token[0].chainId]).catch((e) => { console.warn(e); return BigNumber.from(0) })
+    const ethAmount = getBalance(address, constants.AddressZero, chainProviders[token[0].chainId]).catch((e) => { console.warn(e); return BN.from(0) })
+    const testAmount = getBalance(address, token[0].id, chainProviders[token[0].chainId]).catch((e) => { console.warn(e); return BN.from(0) })
     promises.push(ethAmount)
     promises.push(testAmount)
 
@@ -103,8 +105,8 @@ export const getBalancesForWallet = async (address: string) => {
         name: 'ETH',
         symbol: 'ETH',
         img_url: '',
-        amount: (await ethAmount).div(BigNumber.from(10).pow(14)).toNumber() / 10000,
-        pricePerCoin: 0,
+        amount: new BigNumber(ethAmount.toString()).shiftedBy(-18),
+        pricePerCoin: new BigNumber(0),
         verified: false,
       },
       // test token
@@ -113,8 +115,8 @@ export const getBalancesForWallet = async (address: string) => {
         name: token[0].name,
         symbol: token[0].symbol,
         img_url: '',
-        amount: (await testAmount).div(BigNumber.from(10).pow(14)).toNumber() / 10000,
-        pricePerCoin: 0,
+        amount: new BigNumber(testAmount.toString()).shiftedBy(-18),
+        pricePerCoin: new BigNumber(0),
         verified: false,
       },
     ]
@@ -135,15 +137,15 @@ export const getDefaultTokenBalancesForWallet = async (address: string, onChains
     }
 
     tokens.forEach(async (token) => {
-      const amount = getBalance(address, token.id, chainProviders[token.chainId]).catch((e) => { console.warn(e); return BigNumber.from(0) })
+      const amount = getBalance(address, token.id, chainProviders[token.chainId]).catch((e) => { console.warn(e); return BN.from(0) })
       promises.push(amount)
       portfolio[chainKey].push({
         id: token.id,
         name: token.name,
         symbol: token.key,
         img_url: '',
-        amount: (await amount).div(BigNumber.from(10).pow(14)).toNumber() / 10000,
-        pricePerCoin: 0,
+        amount: new BigNumber((await amount).toString()).shiftedBy(-token.decimals),
+        pricePerCoin: new BigNumber(0),
         verified: false,
       })
     })

--- a/src/types/internal.types.ts
+++ b/src/types/internal.types.ts
@@ -1,29 +1,30 @@
 
-import { TableColumnType } from 'antd';
-import { Action, ChainKey, Coin, Estimate, Execution, Token } from '.';
-import bsc from '../assets/icons/bsc.png';
-import eth from '../assets/icons/ethereum.png';
-import pancake from '../assets/icons/pancake.png';
-import pol from '../assets/icons/polygon.png';
-import quick from '../assets/icons/quick.png';
-import honey from '../assets/icons/honey.png';
-import dai from '../assets/icons/xdai.png';
-import uniswap from '../assets/icons/uniswap.png';
-import spooky from '../assets/icons/spooky.png';
-import viper from '../assets/icons/viper.png';
-import sushi from '../assets/icons/sushi.png';
-import ftm from '../assets/icons/fantom.png';
-import ava from '../assets/icons/avalanche.png';
-import arb from '../assets/icons/arbitrum.svg';
-import opt from '../assets/icons/optimism.png';
-import one from '../assets/icons/harmony.png';
-import rop from '../assets/icons/ethereum_ropsten.png';
-import rin from '../assets/icons/ethereum_rinkeby.png';
-import gor from '../assets/icons/ethereum_goerli.png';
-import mum from '../assets/icons/polygon_test.png';
-import bsct from '../assets/icons/bsc_test.png';
-import arbt from '../assets/icons/arbitrum_test.png';
-import onet from '../assets/icons/harmony_test.png';
+import { TableColumnType } from 'antd'
+import { Action, ChainKey, Coin, Estimate, Execution, Token } from '.'
+import bsc from '../assets/icons/bsc.png'
+import eth from '../assets/icons/ethereum.png'
+import pancake from '../assets/icons/pancake.png'
+import pol from '../assets/icons/polygon.png'
+import quick from '../assets/icons/quick.png'
+import honey from '../assets/icons/honey.png'
+import dai from '../assets/icons/xdai.png'
+import uniswap from '../assets/icons/uniswap.png'
+import spooky from '../assets/icons/spooky.png'
+import viper from '../assets/icons/viper.png'
+import sushi from '../assets/icons/sushi.png'
+import ftm from '../assets/icons/fantom.png'
+import ava from '../assets/icons/avalanche.png'
+import arb from '../assets/icons/arbitrum.svg'
+import opt from '../assets/icons/optimism.png'
+import one from '../assets/icons/harmony.png'
+import rop from '../assets/icons/ethereum_ropsten.png'
+import rin from '../assets/icons/ethereum_rinkeby.png'
+import gor from '../assets/icons/ethereum_goerli.png'
+import mum from '../assets/icons/polygon_test.png'
+import bsct from '../assets/icons/bsc_test.png'
+import arbt from '../assets/icons/arbitrum_test.png'
+import onet from '../assets/icons/harmony_test.png'
+import BigNumber from 'bignumber.js'
 
 export const icons: { [key: string]: string } = {
   // Mainnets
@@ -69,20 +70,20 @@ export const getIcon = (name: string | undefined) => {
 }
 
 export interface Amounts {
-  amount_coin: number;
-  amount_usd: number;
+  amount_coin: BigNumber
+  amount_usd: BigNumber
 }
 
 export interface TokenWithAmounts extends Token {
-  amount?: number
+  amount?: BigNumber
   amountRendered?: string
 }
 
 export interface DataType {
-  [key: string]: string | number | Amounts | Coin; // kind of deactivating typing for DataType; last resort?
-  key: React.Key;
-  coin: Coin;
-  portfolio: Amounts;
+  [key: string]: string | number | Amounts | Coin // kind of deactivating typing for DataType; last resort?
+  key: React.Key
+  coin: Coin
+  portfolio: Amounts
 }
 
 export function chainKeysToObject(val: any) {
@@ -94,7 +95,7 @@ export function chainKeysToObject(val: any) {
 }
 
 export interface ColomnType extends TableColumnType<DataType> {
-  children?: Array<ColomnType>;
+  children?: Array<ColomnType>
 }
 
 export interface ChainPortfolio {
@@ -102,14 +103,14 @@ export interface ChainPortfolio {
   name: string,
   symbol: string,
   img_url: string,
-  pricePerCoin: number,
-  amount: number,
+  pricePerCoin: BigNumber,
+  amount: BigNumber,
   verified: boolean,
 }
 
 export interface Wallet {
-  address: string;
-  loading: boolean;
+  address: string
+  loading: boolean
   portfolio: { [ChainKey: string]: Array<ChainPortfolio> } // ChainKeys -> [ChainPortfolio]
 }
 
@@ -119,34 +120,34 @@ export enum Currencies {
 }
 
 export interface SummaryAmounts {
-  amount_usd: number;
-  percentage_of_portfolio: number;
+  amount_usd: BigNumber
+  percentage_of_portfolio: BigNumber
 }
 
 export interface WalletSummary {
   wallet: string
-  [ChainKey.ETH]: SummaryAmounts;
-  [ChainKey.POL]: SummaryAmounts;
-  [ChainKey.BSC]: SummaryAmounts;
-  [ChainKey.DAI]: SummaryAmounts;
-  [ChainKey.OKT]: SummaryAmounts;
-  [ChainKey.FTM]: SummaryAmounts;
-  [ChainKey.AVA]: SummaryAmounts;
-  [ChainKey.HEC]: SummaryAmounts;
-  [ChainKey.OPT]: SummaryAmounts;
-  [ChainKey.ARB]: SummaryAmounts;
-  [ChainKey.ONE]: SummaryAmounts;
+  [ChainKey.ETH]: SummaryAmounts
+  [ChainKey.POL]: SummaryAmounts
+  [ChainKey.BSC]: SummaryAmounts
+  [ChainKey.DAI]: SummaryAmounts
+  [ChainKey.OKT]: SummaryAmounts
+  [ChainKey.FTM]: SummaryAmounts
+  [ChainKey.AVA]: SummaryAmounts
+  [ChainKey.HEC]: SummaryAmounts
+  [ChainKey.OPT]: SummaryAmounts
+  [ChainKey.ARB]: SummaryAmounts
+  [ChainKey.ONE]: SummaryAmounts
 
-  [ChainKey.ROP]: SummaryAmounts;
-  [ChainKey.RIN]: SummaryAmounts;
-  [ChainKey.GOR]: SummaryAmounts;
-  [ChainKey.KOV]: SummaryAmounts;
-  [ChainKey.MUM]: SummaryAmounts;
-  [ChainKey.ARBT]: SummaryAmounts;
-  [ChainKey.OPTT]: SummaryAmounts;
-  [ChainKey.BSCT]: SummaryAmounts;
-  [ChainKey.HECT]: SummaryAmounts;
-  [ChainKey.ONET]: SummaryAmounts;
+  [ChainKey.ROP]: SummaryAmounts
+  [ChainKey.RIN]: SummaryAmounts
+  [ChainKey.GOR]: SummaryAmounts
+  [ChainKey.KOV]: SummaryAmounts
+  [ChainKey.MUM]: SummaryAmounts
+  [ChainKey.ARBT]: SummaryAmounts
+  [ChainKey.OPTT]: SummaryAmounts
+  [ChainKey.BSCT]: SummaryAmounts
+  [ChainKey.HECT]: SummaryAmounts
+  [ChainKey.ONET]: SummaryAmounts
 }
 
 export interface ProgressStep {


### PR DESCRIPTION
Users sometimes experience issues when using the "MAX" button, because the automatically entered value is higher than the balance they actually own. The data returned from the DeBank API is sometimes rounded which is a source of this issues but it also happened when getting he balances directly from the chain (xpollinate implementation).

The issue was that we parse the balances to javascript numbers which do not allow that many decimals. Eg. when testing with USDC on BSC the balance was rounded. Replacing all numbers with BigNumbers.js resolved the issue.