### PR TITLE
fix: Discord link (prod)

### DIFF
--- a/src/components/JoinDiscordBanner/JoinDiscordBanner.tsx
+++ b/src/components/JoinDiscordBanner/JoinDiscordBanner.tsx
@@ -27,7 +27,7 @@ export const JoinDiscordBanner = () => {
 
   return (
     <DiscordBannerLink
-      href={'https://discord.com/invite/lifi'}
+      href={'https://discord.com/invite/jumperexchange'}
       onClick={(e) => handleClick(e)}
       isArticlePage={isArticle}
     >

--- a/src/const/urls.ts
+++ b/src/const/urls.ts
@@ -3,7 +3,7 @@ import type { SitemapPage } from '@/types/sitemap';
 export const JUMPER_URL = 'https://jumper.exchange';
 export const LIFI_URL = 'https://li.fi';
 export const EXPLORER_URL = 'https://explorer.li.fi';
-export const DISCORD_URL = 'https://discord.gg/lifi';
+export const DISCORD_URL = 'https://discord.gg/jumperexchange';
 export const X_URL = 'https://x.com/JumperExchange';
 export const GITHUB_URL = 'https://github.com/jumperexchange';
 export const DOCS_URL = 'https://docs.li.fi/';

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -107,7 +107,7 @@ test.describe('Jumper full e2e flow', () => {
     expect(newPage.url()).toBe(xUrl);
   });
   test('should be able to navigate to Discord', async ({ page, context }) => {
-    let discordUrl = 'https://discord.com/invite/lifi';
+    let discordUrl = 'https://discord.com/invite/jumperexchange';
     // await closeWelcomeScreen(page);
     await page.locator('#main-burger-menu-button').click();
     await expect(page.getByRole('menu')).toBeVisible();


### PR DESCRIPTION
```
Hi, we need to urgently replace the Discord link on our Jumper UI burger menu to the new discord invite link: https://discord.gg/jumperexchange. 

It was changed from our previous ‘ /LIFI’ and that currently redirects to another server which is not ours.
```

https://discord.com/channels/849912621360218112/1267141147248169013