### PR TITLE
style: provide fallback aspect-ratio for blog article card images

### DIFF
--- a/src/components/Blog/BlogArticleCard/BlogArticleCard.style.ts
+++ b/src/components/Blog/BlogArticleCard/BlogArticleCard.style.ts
@@ -72,7 +72,9 @@ export const BlogArticleCardImage = styled('img')(({ theme }) => ({
   width: '100%',
   height: 'auto',
   borderRadius: '16px',
-  objectFit: 'contain',
+  objectFit: 'cover',
+  aspectRatio: 1.6,
+  objectPosition: 'left',
 }));
 
 export const BlogArticleCardImageSkeleton = styled(Skeleton)(({ theme }) => ({


### PR DESCRIPTION
Ticket: https://lifi.atlassian.net/browse/LF-9572

Fixes thumbnail images with wrong aspect-ratio to "cover" the area.
![Uploading image.png…]()
