### PR TITLE
style: lower size of promo-label

### DIFF
--- a/src/components/PromoLabel.style.ts
+++ b/src/components/PromoLabel.style.ts
@@ -18,8 +18,8 @@ export const PromoLabel = styled(Typography, {
     ':before': {
       content: `"${label || t('promo.new')}"`,
       height: 24,
-      textTransform: 'uppercase',
-      padding: theme.spacing(0.75, 1.5),
+      textTransform: 'lowercase',
+      padding: theme.spacing(0.5, 1),
       whiteSpace: 'nowrap',
       color: theme.palette.common.white,
       backgroundColor: theme.palette.primary.main,


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/e292aea9-8c3d-4bf9-861b-6380cc100c8f)


After:
![image](https://github.com/user-attachments/assets/9a604c9a-0903-42b7-8375-de71213e5213)

✅  lowercase
✅  saving 2px vertically
✅  saving 4px horizontally