### PR TITLE
LF-13741 merge playwright reports from different shards

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,17 +29,46 @@ jobs:
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps chromium
     - name: Run Playwright tests
-      env:
-        PLAYWRIGHT_HTML_OUTPUT_NAME: report-${{ matrix.shard }}.html
       run: |
        pnpm build:cache:ci &
         pnpm run test:ci:e2e \
-          --shard ${{ matrix.shard }}/${{ strategy.job-total }} \
-          --reporter=html
-    - name: Upload Playwright Report
-      if: always()
+          --shard ${{ matrix.shard }}/${{ strategy.job-total }}
+    - name: Upload blob report to Github Actions Artifacts
+      if: ${{ !cancelled()}}
       uses: actions/upload-artifact@v4
       with:
-          name: playwright-report-${{ matrix.shard }}
-          path: playwright-report/
+          name: blob-report-${{ matrix.shard }}
+          path: blob-report
+          retention-days: 1
+
+  merge-reports:
+    if: ${{ !cancelled() }}
+    needs: [test]
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Install pnpm
+        run: npm install -g pnpm
+      - name: Install dependencies
+        run: pnpm install
+      
+      - name: Download blob reports from GitHub Actions Articfacts
+        uses: actions/download-artifact@v4
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+          
+      - name: Merge into HTML Report
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+        
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-report--attempt-${{ github.run_attempt }}
+          path: playwright-report
           retention-days: 2

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 4 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [['html']],
+  reporter: process.env.CI ? 'blob' : [['html']],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
## 📋 Description
previously playwright reports were distributed between different shards, but this resulted in different reports for each shard. In this PR the reports will be merged into one.


### Related issue(s)
[LF-13741](https://lifi.atlassian.net/browse/LF-13741)

---

## ✅ Checklist

- [x] My code follows the project's coding style
- [x] I have self-reviewed my code
- [x] I have added or updated tests where necessary
- [ ] I have added necessary documentation (if appropriate)

---

## 📸 Screenshots / Logs (optional)

<img width="1129" alt="github actions summary" src="https://github.com/user-attachments/assets/5103b102-6297-464b-a971-2adacae6e92a" />

## Exported HTML Report
[html-report--attempt-1.zip](https://github.com/user-attachments/files/20288629/html-report--attempt-1.zip)
