### PR TITLE
feat: add widget variants for missions and zaps

### DIFF
--- a/.storybook/withProviders.tsx
+++ b/.storybook/withProviders.tsx
@@ -5,6 +5,7 @@ import {
   MUIThemeProvider,
 } from '../src/providers/ThemeProvider';
 import TranslationsProvider from '../src/providers/TranslationProvider';
+import { WalletProvider } from '../src/providers/WalletProvider/WalletProvider';
 import { SettingsStoreProvider } from '../src/stores/settings';
 import initTranslations from '../src/app/i18n';
 import { defaultNS, fallbackLng, namespaces } from '../src/i18n';
@@ -50,13 +51,15 @@ export const withProviders = (Story: () => ReactNode, context) => {
         resources={resources}
       >
         <DefaultThemeProvider themes={mockThemes} activeTheme={activeTheme}>
-          <MUIThemeProvider>
-            <SettingsStoreProvider>
-              <ThemeBridge theme={activeTheme}>
-                <Story {...context} />
-              </ThemeBridge>
-            </SettingsStoreProvider>
-          </MUIThemeProvider>
+          <WalletProvider>
+            <MUIThemeProvider>
+              <SettingsStoreProvider>
+                <ThemeBridge theme={activeTheme}>
+                  <Story {...context} />
+                </ThemeBridge>
+              </SettingsStoreProvider>
+            </MUIThemeProvider>
+          </WalletProvider>
         </DefaultThemeProvider>
       </TranslationsProvider>
     </ReactQueryProvider>

--- a/src/components/Widgets/variants/base/Widget.stories.tsx
+++ b/src/components/Widgets/variants/base/Widget.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Widget } from './Widget';
+import { TaskType } from 'src/types/loyaltyPass';
+import { ChainId, ChainKey } from '@lifi/sdk';
+
+const meta = {
+  component: Widget,
+  title: 'Components/Side Widget/Base',
+} satisfies Meta<typeof Widget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Base: Story = {
+  args: {
+    ctx: {
+      taskType: TaskType.Bridge,
+      destinationChain: {
+        chainId: ChainId.ARB.toString(),
+        chainKey: ChainKey.ARB.toUpperCase(),
+      },
+      destinationToken: {
+        tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+        tokenSymbol: 'USDC',
+      },
+      sourceChain: {
+        chainId: ChainId.ARB.toString(),
+        chainKey: ChainKey.ARB.toUpperCase(),
+      },
+      sourceToken: {
+        tokenAddress: '0x0000000000000000000000000000000000000000',
+        tokenSymbol: 'ETH',
+      },
+      fromAmount: '100',
+      //   toAddress: "",
+    },
+  },
+};

--- a/src/components/Widgets/variants/base/Widget.tsx
+++ b/src/components/Widgets/variants/base/Widget.tsx
@@ -1,0 +1,12 @@
+import { FC } from 'react';
+import { useLiFiWidgetConfig } from '../widgetConfig/hooks';
+import { LiFiWidget } from '@lifi/widget';
+import { WidgetProps } from './Widget.types';
+
+export const Widget: FC<WidgetProps> = ({ ctx }) => {
+  const widgetConfig = useLiFiWidgetConfig(ctx);
+
+  return (
+    <LiFiWidget config={widgetConfig} integrator={widgetConfig.integrator} />
+  );
+};

--- a/src/components/Widgets/variants/base/Widget.types.ts
+++ b/src/components/Widgets/variants/base/Widget.types.ts
@@ -1,0 +1,10 @@
+import { CustomInformation } from 'src/types/loyaltyPass';
+import { ConfigContext } from '../widgetConfig/types';
+
+export interface EntityWidgetProps {
+  customInformation?: Partial<CustomInformation>;
+}
+
+export interface WidgetProps extends EntityWidgetProps {
+  ctx: ConfigContext;
+}

--- a/src/components/Widgets/variants/base/WidgetSkeleton.tsx
+++ b/src/components/Widgets/variants/base/WidgetSkeleton.tsx
@@ -1,0 +1,26 @@
+import { WidgetSkeleton as LiFiWidgetSkeleton } from '@lifi/widget/skeleton';
+import { useThemeStore } from 'src/stores/theme/ThemeStore';
+
+export const WidgetSkeleton = () => {
+  const [widgetTheme] = useThemeStore((state) => [
+    state.widgetTheme,
+    state.configTheme,
+  ]);
+
+  return (
+    <LiFiWidgetSkeleton
+      config={{
+        variant: 'compact',
+        appearance: widgetTheme.config.appearance,
+        theme: {
+          ...widgetTheme.config.theme,
+          container: {
+            maxHeight: 820,
+            maxWidth: 'unset',
+            borderRadius: 24,
+          },
+        },
+      }}
+    />
+  );
+};

--- a/src/components/Widgets/variants/base/ZapWidget/ZapDepositWidget.stories.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapDepositWidget.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { ZapDepositWidget } from './ZapDepositWidget';
+import { TaskType } from 'src/types/loyaltyPass';
+import { ConnectButton } from 'src/components/ConnectButton';
+
+const meta = {
+  component: ZapDepositWidget,
+  title: 'Components/Side Widget/Zap Deposit',
+  render: (args) => (
+    <div>
+      <ConnectButton />
+      <div style={{ marginTop: '1rem' }}>
+        <ZapDepositWidget {...args} />
+      </div>
+    </div>
+  ),
+} satisfies Meta<typeof ZapDepositWidget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ZapDeposit: Story = {
+  args: {
+    ctx: {
+      taskType: TaskType.Zap,
+    },
+    customInformation: {
+      projectData: {
+        chain: 'base',
+        address: '0xa900a17a49bc4d442ba7f72c39fa2108865671f0',
+        chainId: 8453,
+        project: 'ionic',
+        integrator: 'zap.ionic',
+      },
+      claimingIds: [],
+    },
+  },
+};

--- a/src/components/Widgets/variants/base/ZapWidget/ZapDepositWidget.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapDepositWidget.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { FC, useEffect, useMemo } from 'react';
+import { LiFiWidget, Route, useWidgetEvents, WidgetEvent } from '@lifi/widget';
+import { useInitializeZapConfig } from './useInitializeZapConfig';
+import { formatUnits } from 'viem/utils';
+import { DepositCard } from 'src/components/ZapWidget/Deposit/DepositCard';
+import { WidgetSkeleton } from '../WidgetSkeleton';
+import { useLiFiWidgetConfig } from '../../widgetConfig/hooks';
+import { WidgetProps } from '../Widget.types';
+
+interface ZapDepositWidgetProps extends WidgetProps {}
+
+export const ZapDepositWidget: FC<ZapDepositWidgetProps> = ({
+  customInformation,
+  ctx,
+}) => {
+  const projectData = useMemo(() => {
+    return customInformation?.projectData;
+  }, [customInformation?.projectData]);
+
+  const claimingIds = useMemo(() => {
+    return customInformation?.claimingIds;
+  }, [customInformation?.claimingIds]);
+
+  console.log(customInformation);
+
+  const {
+    isInitialized,
+    providers,
+    toAddress,
+    zapData,
+    isZapDataSuccess,
+    depositTokenData,
+    depositTokenDecimals,
+    refetchDepositToken,
+    setCurrentRoute,
+  } = useInitializeZapConfig(projectData);
+
+  const poolName = useMemo(() => {
+    return `${zapData?.meta.name} ${zapData?.market?.depositToken?.symbol.toUpperCase()} Pool`;
+  }, [JSON.stringify(zapData)]);
+
+  const enhancedCtx = useMemo(() => {
+    return {
+      ...ctx,
+      overrideHeader: `Deposit to ${zapData?.meta.name} pool`,
+      includeZap: true,
+      zapProviders: providers,
+      zapToAddress: toAddress,
+      baseOverrides: {
+        integrator: projectData.integrator,
+      },
+    };
+  }, [
+    JSON.stringify(ctx),
+    poolName,
+    providers,
+    toAddress,
+    projectData.integrator,
+  ]);
+
+  const widgetConfig = useLiFiWidgetConfig(enhancedCtx);
+
+  const widgetEvents = useWidgetEvents();
+  // Custom effect to refetch the balance
+  useEffect(() => {
+    function onRouteExecutionCompleted() {
+      refetchDepositToken();
+    }
+
+    function onRouteExecutionStarted(route: Route) {
+      setCurrentRoute(route);
+    }
+
+    widgetEvents.on(WidgetEvent.RouteExecutionStarted, onRouteExecutionStarted);
+
+    widgetEvents.on(
+      WidgetEvent.RouteExecutionCompleted,
+      onRouteExecutionCompleted,
+    );
+
+    return () => {
+      widgetEvents.off(
+        WidgetEvent.RouteExecutionStarted,
+        onRouteExecutionStarted,
+      );
+      widgetEvents.off(
+        WidgetEvent.RouteExecutionCompleted,
+        onRouteExecutionCompleted,
+      );
+    };
+  }, [widgetEvents, refetchDepositToken, setCurrentRoute]);
+
+  const token = useMemo(
+    () =>
+      isZapDataSuccess && zapData
+        ? {
+            chainId: zapData.market?.depositToken.chainId,
+            address: zapData.market?.depositToken.address as `0x${string}`,
+            symbol: zapData.market?.depositToken.symbol,
+            name: zapData.market?.depositToken.name,
+            decimals: zapData.market?.depositToken.decimals,
+            priceUSD: '0',
+            coinKey:
+              zapData.market?.depositToken.symbol ||
+              zapData.market?.depositToken.name ||
+              '',
+            logoURI: zapData.market?.depositToken.logoURI,
+            amount: BigInt(0),
+          }
+        : null,
+    [isZapDataSuccess, zapData],
+  );
+
+  const lpTokenDecimals = Number(depositTokenDecimals ?? 18);
+
+  const analytics = useMemo(
+    () => ({
+      ...(zapData?.analytics || {}), // Provide default empty object
+      position: depositTokenData
+        ? formatUnits(depositTokenData as bigint, lpTokenDecimals)
+        : 0,
+    }),
+    [zapData, lpTokenDecimals],
+  );
+
+  return token && isInitialized ? (
+    <LiFiWidget
+      key={poolName}
+      contractComponent={
+        <DepositCard
+          poolName={poolName}
+          underlyingToken={zapData?.market?.depositToken}
+          token={token}
+          chainId={zapData?.market?.depositToken.chainId}
+          contractTool={zapData?.meta}
+          analytics={analytics}
+          contractCalls={[]}
+          claimingIds={claimingIds}
+        />
+      }
+      config={widgetConfig}
+      integrator={widgetConfig.integrator}
+    />
+  ) : (
+    <WidgetSkeleton />
+  );
+};

--- a/src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget.stories.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { ZapWithdrawWidget } from './ZapWithdrawWidget';
+import { TaskType } from 'src/types/loyaltyPass';
+
+const meta = {
+  component: ZapWithdrawWidget,
+  title: 'Components/Side Widget/Zap Withdraw',
+} satisfies Meta<typeof ZapWithdrawWidget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ZapWithdraw: Story = {
+  args: {
+    ctx: {
+      taskType: TaskType.Zap,
+    },
+    customInformation: {
+      projectData: {
+        chain: 'base',
+        address: '0xa900a17a49bc4d442ba7f72c39fa2108865671f0',
+        chainId: 8453,
+        project: 'ionic',
+        integrator: 'zap.ionic',
+      },
+      claimingIds: [],
+    },
+  },
+};

--- a/src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget.tsx
@@ -1,0 +1,66 @@
+import { FC, useMemo } from 'react';
+import { WidgetProps } from '../Widget.types';
+import { useInitializeZapConfig } from './useInitializeZapConfig';
+import { WithdrawWidget } from 'src/components/ZapWidget/Withdraw/WithdrawWidget';
+import { WidgetSkeleton } from '../WidgetSkeleton';
+
+interface ZapWithdrawWidgetProps extends WidgetProps {}
+
+export const ZapWithdrawWidget: FC<ZapWithdrawWidgetProps> = ({
+  customInformation,
+  ctx,
+}) => {
+  const projectData = useMemo(() => {
+    return customInformation?.projectData;
+  }, [customInformation?.projectData]);
+
+  const {
+    zapData,
+    isZapDataSuccess,
+    isLoadingDepositTokenData,
+    depositTokenData,
+    depositTokenDecimals,
+    refetchDepositToken,
+  } = useInitializeZapConfig(projectData);
+
+  const poolName = useMemo(() => {
+    return `${zapData?.meta.name} ${zapData?.market?.depositToken?.symbol.toUpperCase()} Pool`;
+  }, [JSON.stringify(zapData)]);
+
+  const token = useMemo(
+    () =>
+      isZapDataSuccess && zapData
+        ? {
+            chainId: zapData.market?.depositToken.chainId,
+            address: zapData.market?.depositToken.address as `0x${string}`,
+            symbol: zapData.market?.depositToken.symbol,
+            name: zapData.market?.depositToken.name,
+            decimals: zapData.market?.depositToken.decimals,
+            priceUSD: '0',
+            coinKey:
+              zapData.market?.depositToken.symbol ||
+              zapData.market?.depositToken.name ||
+              '',
+            logoURI: zapData.market?.depositToken.logoURI,
+            amount: BigInt(0),
+          }
+        : null,
+    [isZapDataSuccess, zapData],
+  );
+
+  const lpTokenDecimals = Number(depositTokenDecimals ?? 18);
+
+  return !isLoadingDepositTokenData && token ? (
+    <WithdrawWidget
+      poolName={poolName}
+      refetchPosition={refetchDepositToken}
+      token={token}
+      lpTokenDecimals={lpTokenDecimals}
+      projectData={projectData}
+      depositTokenData={depositTokenData}
+      withdrawAbi={zapData?.abi?.withdraw}
+    />
+  ) : (
+    <WidgetSkeleton />
+  );
+};

--- a/src/components/Widgets/variants/base/ZapWidget/types.ts
+++ b/src/components/Widgets/variants/base/ZapWidget/types.ts
@@ -1,0 +1,65 @@
+import { AbiFunction } from 'viem';
+
+// Type definitions for better type safety
+export interface AbiInput {
+  name: string;
+  type: string;
+  indexed?: boolean;
+}
+
+export interface WalletCall {
+  to: `0x${string}`;
+  data: `0x${string}`;
+  value?: string;
+}
+
+export interface WalletMethodArgs {
+  method: string;
+  params?: unknown[];
+}
+
+export interface WalletSendCallsArgs extends WalletMethodArgs {
+  method: 'wallet_sendCalls';
+  account: {
+    address: string;
+    type: string;
+  };
+  calls: WalletCall[];
+}
+
+export interface WalletGetCallsStatusArgs extends WalletMethodArgs {
+  method: 'wallet_getCallsStatus';
+  params: [string]; // hash
+}
+
+export interface WalletCapabilitiesArgs extends WalletMethodArgs {
+  method: 'wallet_getCapabilities';
+  params?: never;
+}
+
+export interface WalletWaitForCallsStatusArgs extends WalletMethodArgs {
+  method: 'wallet_waitForCallsStatus';
+  id: string;
+  timeout?: number;
+}
+
+export interface ContractComposableConfig {
+  address: string;
+  chainId: number;
+  abi: AbiFunction;
+  functionName: string;
+  args: unknown[];
+  gasLimit?: bigint;
+}
+
+export interface CallsStatusResponse {
+  atomic: boolean;
+  chainId?: string;
+  id: string;
+  status: string; // 'success' | 'failed' - string status as expected by LiFi SDK
+  statusCode: number; // 200 | 400 - numeric status code
+  receipts: Array<{
+    transactionHash: `0x${string}`;
+    status: 'success' | 'reverted';
+  }>;
+}

--- a/src/components/Widgets/variants/base/ZapWidget/useInitializeZapConfig.ts
+++ b/src/components/Widgets/variants/base/ZapWidget/useInitializeZapConfig.ts
@@ -1,0 +1,487 @@
+import {
+  MultichainSmartAccount,
+  MeeClient,
+  toMultichainNexusAccount,
+  createMeeClient,
+  WaitForSupertransactionReceiptPayload,
+  greaterThanOrEqualTo,
+  runtimeERC20BalanceOf,
+} from '@biconomy/abstractjs';
+import { useState, useMemo, useCallback, useEffect } from 'react';
+import { buildContractComposable } from './utils';
+import { useZaps } from 'src/hooks/useZaps';
+import { createCustomEVMProvider } from 'src/providers/WalletProvider/createCustomEVMProvider';
+import { createWalletClient, custom, http, parseUnits } from 'viem';
+import { mainnet, optimism, base } from 'viem/chains';
+import { useAccount, useReadContracts, useConfig } from 'wagmi';
+import {
+  WalletCapabilitiesArgs,
+  WalletGetCallsStatusArgs,
+  WalletWaitForCallsStatusArgs,
+  WalletSendCallsArgs,
+  WalletCall,
+  AbiInput,
+} from './types';
+import { Route } from '@lifi/sdk';
+import { ProjectData } from 'src/types/questDetails';
+
+export const useInitializeZapConfig = (projectData: ProjectData) => {
+  const [oNexus, setONexus] = useState<MultichainSmartAccount | null>(null);
+  const [meeClient, setMeeClient] = useState<MeeClient | null>(null);
+  const [currentRoute, setCurrentRoute] = useState<Route | null>(null);
+  const [areClientInitializing, setAreClientInitializing] = useState(false);
+
+  const account = useAccount();
+  const { address, chain } = account;
+  const { data, isSuccess } = useZaps(projectData);
+  const zapData = data?.data;
+
+  const contractsConfig = useMemo(() => {
+    return [
+      {
+        address: projectData.address as `0x${string}`,
+        abi: [
+          {
+            inputs: [{ name: 'owner', type: 'address' }],
+            name: 'balanceOf',
+            outputs: [{ name: '', type: 'uint256' }],
+            stateMutability: 'view',
+            type: 'function',
+          },
+        ] as const,
+        functionName: 'balanceOf',
+        args: [account.address as `0x${string}`],
+      },
+      {
+        abi: [
+          {
+            inputs: [],
+            name: 'decimals',
+            outputs: [{ name: '', type: 'uint8' }],
+            stateMutability: 'view',
+            type: 'function',
+          },
+        ] as const,
+        address: (projectData.tokenAddress ||
+          projectData.address) as `0x${string}`,
+        chainId: projectData.chainId,
+        functionName: 'decimals',
+      },
+    ];
+  }, [
+    projectData.address,
+    projectData.tokenAddress,
+    projectData.chainId,
+    account.address,
+  ]);
+
+  const {
+    data: [
+      { result: depositTokenData } = {},
+      { result: depositTokenDecimals } = {},
+    ] = [],
+    isLoading: isLoadingDepositTokenData,
+    refetch,
+  } = useReadContracts({
+    contracts: contractsConfig,
+    query: {
+      enabled: !!account.address,
+    },
+  });
+
+  // Enhanced initialization with retry logic and better error handling
+  useEffect(() => {
+    const initMeeClient = async () => {
+      if (!chain) {
+        console.warn('Chain is undefined, skipping MEE client initialization.');
+        return;
+      }
+
+      if (areClientInitializing) {
+        console.warn('Init MEE client.');
+        return;
+      }
+
+      if (!areClientInitializing && (!oNexus || !meeClient)) {
+        setAreClientInitializing(true);
+      }
+
+      // create multichain nexus account
+      // Creates the Biconomy "Multichain Nexus Account", a smart contract account
+      // that orchestrates actions across multiple chains.
+      // See: https://docs.biconomy.io/multichain-orchestration/comprehensive#multichain-nexus-account
+      const oNexusInit = await toMultichainNexusAccount({
+        signer: createWalletClient({
+          chain,
+          transport: custom(global?.window?.ethereum ?? ''),
+        }),
+        chains: [mainnet, optimism, base],
+        transports: [http(), http(), http()],
+      });
+
+      // create mee client
+      // Initializes the Biconomy "MEE (Modular Execution Environment) Client".
+      // This client interacts with Biconomy's backend to manage the orchestration.
+      // See: https://docs.biconomy.io/multichain-orchestration/comprehensive#modular-execution-environment-mee
+      const meeClientInit = await createMeeClient({
+        account: oNexusInit,
+      });
+
+      console.log('MEE client initialized successfully', meeClientInit);
+
+      setONexus(oNexusInit);
+      setMeeClient(meeClientInit);
+      setAreClientInitializing(false);
+    };
+    initMeeClient();
+  }, [chain]);
+
+  const wagmiConfig = useConfig();
+
+  const handleGetCapabilities = useCallback(
+    async (
+      args: WalletCapabilitiesArgs,
+    ): Promise<{
+      atomic: { status: 'supported' | 'ready' | 'unsupported' };
+    }> => {
+      return Promise.resolve({
+        atomic: { status: 'supported' },
+      });
+    },
+    // @TODO do we need this?
+    // [baseWidgetConfig],
+    [],
+  );
+
+  // Helper function to handle 'wallet_getCallsStatus'
+  const handleWalletGetCallsStatus = useCallback(
+    async (args: WalletGetCallsStatusArgs) => {
+      if (!meeClient) {
+        // oNexus is not directly used here but its initialization is tied to meeClient
+        throw new Error('MEE client not initialized');
+      }
+      if (!args.params || !Array.isArray(args.params)) {
+        throw new Error(
+          'Invalid args.params structure for wallet_getCallsStatus',
+        );
+      }
+      const hash = args.params[0];
+      if (typeof hash !== 'string' || !hash) {
+        throw new Error('Missing or invalid hash in params object');
+      }
+
+      const receipt = (await meeClient.waitForSupertransactionReceipt({
+        hash: hash as `0x${string}`,
+      })) as WaitForSupertransactionReceiptPayload;
+
+      const originalReceipts = receipt?.receipts || [];
+      // Ensure the last receipt has the correct transactionHash format
+      if (originalReceipts.length > 0) {
+        originalReceipts[originalReceipts.length - 1].transactionHash =
+          `biconomy:${hash}` as `0x${string}`;
+      }
+
+      const chainIdAsNumber = receipt?.paymentInfo?.chainId;
+      const hexChainId = chainIdAsNumber
+        ? `0x${Number(chainIdAsNumber).toString(16)}`
+        : undefined;
+
+      const isSuccess = receipt?.transactionStatus
+        ?.toLowerCase()
+        .includes('success');
+      const statusCode = isSuccess ? 200 : 400;
+
+      return {
+        atomic: true,
+        chainId: hexChainId,
+        id: hash,
+        status: isSuccess ? 'success' : 'failed', // String status as expected by LiFi SDK
+        statusCode, // Numeric status code
+        receipts: originalReceipts.map((receipt) => ({
+          transactionHash: receipt.transactionHash,
+          status: receipt.status || (isSuccess ? 'success' : 'reverted'),
+        })),
+      };
+    },
+    [meeClient],
+  );
+
+  // Helper function to handle 'wallet_waitForCallsStatus'
+  const handleWalletWaitForCallsStatus = useCallback(
+    async (args: WalletWaitForCallsStatusArgs) => {
+      if (!meeClient) {
+        throw new Error('MEE client not initialized');
+      }
+      if (!args.id) {
+        throw new Error(
+          'Invalid args structure for wallet_waitForCallsStatus: missing id',
+        );
+      }
+
+      const { id, timeout = 60000 } = args;
+
+      // waitForSupertransactionReceipt already waits for completion, so we don't need to poll
+      // We'll use the timeout to set a maximum wait time
+      const receipt = (await Promise.race([
+        meeClient!.waitForSupertransactionReceipt({
+          hash: id as `0x${string}`,
+        }),
+        new Promise((_, reject) =>
+          setTimeout(
+            () =>
+              reject(
+                new Error(
+                  `Timed out while waiting for call bundle with id "${id}" to be confirmed.`,
+                ),
+              ),
+            timeout,
+          ),
+        ),
+      ])) as WaitForSupertransactionReceiptPayload;
+
+      // Now get the status using the same logic as handleWalletGetCallsStatus
+      const originalReceipts = receipt?.receipts || [];
+      if (originalReceipts.length > 0) {
+        originalReceipts[originalReceipts.length - 1].transactionHash =
+          `biconomy:${id}` as `0x${string}`;
+      }
+
+      const chainIdAsNumber = receipt?.paymentInfo?.chainId;
+      const hexChainId = chainIdAsNumber
+        ? `0x${Number(chainIdAsNumber).toString(16)}`
+        : undefined;
+
+      const isSuccess = receipt?.transactionStatus
+        ?.toLowerCase()
+        .includes('success');
+      const statusCode = isSuccess ? 200 : 400;
+
+      return {
+        atomic: true,
+        chainId: hexChainId,
+        id: id,
+        status: isSuccess ? 'success' : 'failed',
+        statusCode,
+        receipts: originalReceipts.map((receipt) => ({
+          transactionHash: receipt.transactionHash,
+          status: receipt.status || (isSuccess ? 'success' : 'reverted'),
+        })),
+      };
+    },
+    [meeClient],
+  );
+
+  // Helper function to handle 'wallet_sendCalls'
+  const handleWalletSendCalls = useCallback(
+    async (args: WalletSendCallsArgs) => {
+      if (!meeClient || !oNexus) {
+        throw new Error('MEE client or oNexus not initialized');
+      }
+
+      // Handle the new args structure with account and calls directly
+      if (!args.account || !args.calls) {
+        throw new Error('Invalid args structure: Missing account or calls');
+      }
+
+      const { calls } = args;
+      if (calls.length === 0) {
+        throw new Error("'calls' array is empty");
+      }
+
+      if (!chain) {
+        throw new Error('Cannot determine current chain ID from wallet.');
+      }
+      const currentChainId = chain.id;
+
+      if (!currentRoute) {
+        throw new Error('Cannot process transaction: Route is undefined.');
+      }
+      if (!zapData) {
+        throw new Error('Integration data is not available.');
+      }
+
+      const integrationData = zapData;
+      const depositAddress = integrationData.market?.address as `0x${string}`;
+      const depositToken = integrationData.market?.depositToken?.address;
+      const depositChainId = projectData.chainId;
+
+      if (!depositAddress || !depositToken) {
+        throw new Error('Deposit address or token is undefined.');
+      }
+
+      // raw calldata from the widget
+      const instructions = await Promise.all(
+        calls.map(async (call: WalletCall) => {
+          if (!call.to || !call.data) {
+            throw new Error('Invalid call structure: Missing to or data field');
+          }
+          return oNexus.buildComposable({
+            type: 'rawCalldata',
+            data: {
+              to: call.to,
+              calldata: call.data,
+              chainId: currentChainId,
+            },
+          });
+        }),
+      );
+
+      // constraints
+      const depositTokenDecimals = zapData.market?.depositToken.decimals;
+      const constraints = [
+        greaterThanOrEqualTo(parseUnits('0.1', depositTokenDecimals)), // TODO: Remove hardcoded value
+      ];
+
+      // token approval
+      const approveInstruction = await buildContractComposable(oNexus, {
+        address: depositToken,
+        chainId: depositChainId,
+        abi: integrationData.abi.approve,
+        functionName: integrationData.abi.approve.name,
+        gasLimit: 100000n,
+        args: [
+          depositAddress,
+          runtimeERC20BalanceOf({
+            targetAddress: oNexus.addressOn(
+              depositChainId,
+              true,
+            ) as `0x${string}`,
+            tokenAddress: depositToken,
+            constraints,
+          }),
+        ],
+      });
+      instructions.push(approveInstruction);
+
+      // Deposit instruction (dynamic ABI-driven args)
+      const depositInputs = integrationData.abi.deposit.inputs;
+      const depositArgs = depositInputs.map((input: AbiInput) => {
+        if (input.type === 'uint256') {
+          return runtimeERC20BalanceOf({
+            targetAddress: oNexus.addressOn(
+              depositChainId,
+              true,
+            ) as `0x${string}`,
+            tokenAddress: depositToken,
+            constraints,
+          });
+        } else if (input.type === 'address') {
+          // Use the user's EOA address or another relevant address
+          return address;
+        }
+        throw new Error(`Unsupported deposit input type: ${input.type}`);
+      });
+      const depositInstruction = await buildContractComposable(oNexus, {
+        address: depositAddress,
+        chainId: depositChainId,
+        abi: integrationData.abi.deposit,
+        functionName: integrationData.abi.deposit.name,
+        gasLimit: 1000000n,
+        args: depositArgs,
+      });
+      instructions.push(depositInstruction);
+
+      // Only add transferLpInstruction if deposit ABI does NOT have an address input
+      const depositHasAddressArg = depositInputs.some(
+        (input: AbiInput) => input.type === 'address',
+      );
+
+      if (!depositHasAddressArg) {
+        if (!address) {
+          throw new Error('User address (EOA) is not available.');
+        }
+        const transferLpInstruction = await buildContractComposable(oNexus, {
+          address: depositAddress,
+          chainId: depositChainId,
+          abi: integrationData.abi.transfer,
+          functionName: integrationData.abi.transfer.name,
+          gasLimit: 200000n,
+          args: [
+            address,
+            runtimeERC20BalanceOf({
+              targetAddress: oNexus.addressOn(
+                depositChainId,
+                true,
+              ) as `0x${string}`,
+              tokenAddress: depositAddress,
+              constraints,
+            }),
+          ],
+        });
+        instructions.push(transferLpInstruction);
+      }
+
+      const quote = await meeClient.getFusionQuote({
+        trigger: {
+          tokenAddress: currentRoute.fromToken.address as `0x${string}`,
+          amount: BigInt(currentRoute.fromAmount),
+          chainId: currentChainId,
+        },
+        cleanUps: [
+          {
+            tokenAddress: depositToken,
+            chainId: depositChainId,
+            recipientAddress: account.address as `0x${string}`,
+          },
+        ],
+        feeToken: {
+          address: currentRoute.fromToken.address as `0x${string}`,
+          chainId: currentChainId,
+        },
+        instructions,
+      });
+
+      console.log('quote', quote);
+
+      const { hash } = await meeClient.executeFusionQuote({
+        fusionQuote: quote,
+      });
+
+      return { id: hash };
+    },
+    [meeClient, oNexus, chain, currentRoute, zapData, projectData, address],
+  );
+
+  const providers = useMemo(() => {
+    return [
+      createCustomEVMProvider({
+        wagmiConfig,
+        getCapabilities: async (_, args) => handleGetCapabilities(args),
+        getCallsStatus: async (_, args) => handleWalletGetCallsStatus(args),
+        sendCalls: async (_, args) => handleWalletSendCalls(args),
+        waitForCallsStatus: async (_, args) =>
+          handleWalletWaitForCallsStatus(args),
+      }),
+    ];
+  }, [
+    wagmiConfig,
+    handleGetCapabilities,
+    handleWalletGetCallsStatus,
+    handleWalletSendCalls,
+    handleWalletWaitForCallsStatus,
+  ]);
+
+  const toAddress = useMemo(
+    () =>
+      oNexus
+        ? (oNexus.addressOn(projectData.chainId, true) as `0x${string}`)
+        : (address as `0x${string}`) || '0x',
+    [oNexus, address, projectData.chainId],
+  );
+
+  // Check if oNexus and meeClient are initialized before rendering
+  const isInitialized = oNexus && meeClient;
+
+  return {
+    isInitialized,
+    providers,
+    toAddress,
+    zapData,
+    isZapDataSuccess: isSuccess,
+    setCurrentRoute,
+    depositTokenData,
+    depositTokenDecimals,
+    isLoadingDepositTokenData,
+    refetchDepositToken: refetch,
+  };
+};

--- a/src/components/Widgets/variants/base/ZapWidget/utils.ts
+++ b/src/components/Widgets/variants/base/ZapWidget/utils.ts
@@ -1,0 +1,19 @@
+import { MultichainSmartAccount } from '@biconomy/abstractjs';
+import { ContractComposableConfig } from './types';
+
+export const buildContractComposable = async (
+  oNexus: MultichainSmartAccount,
+  contractConfig: ContractComposableConfig,
+) => {
+  return oNexus.buildComposable({
+    type: 'default',
+    data: {
+      abi: [contractConfig.abi],
+      to: contractConfig.address as `0x${string}`,
+      chainId: contractConfig.chainId,
+      functionName: contractConfig.functionName,
+      gasLimit: contractConfig.gasLimit,
+      args: contractConfig.args,
+    },
+  });
+};

--- a/src/components/Widgets/variants/mission/MissionBaseWidget.tsx
+++ b/src/components/Widgets/variants/mission/MissionBaseWidget.tsx
@@ -1,0 +1,42 @@
+import { useMissionStore } from 'src/stores/mission/MissionStore';
+import { EntityWidgetProps } from '../base/Widget.types';
+import { FC, useMemo } from 'react';
+import { Widget } from '../base/Widget';
+import { ConfigContext } from '../widgetConfig/types';
+
+interface MissionBaseWidgetProps extends EntityWidgetProps {}
+
+export const MissionBaseWidget: FC<MissionBaseWidgetProps> = () => {
+  const {
+    destinationChain,
+    destinationToken,
+    sourceChain,
+    sourceToken,
+    fromAmount,
+    toAddress,
+    currentActiveTaskType,
+    // missionChainIds,
+  } = useMissionStore();
+
+  const ctx: ConfigContext = useMemo(() => {
+    return {
+      destinationChain,
+      destinationToken,
+      sourceChain,
+      sourceToken,
+      fromAmount,
+      toAddress,
+      taskType: currentActiveTaskType,
+    };
+  }, [
+    destinationChain,
+    destinationToken,
+    sourceChain,
+    sourceToken,
+    fromAmount,
+    toAddress,
+    currentActiveTaskType,
+  ]);
+
+  return <Widget ctx={ctx} />;
+};

--- a/src/components/Widgets/variants/mission/MissionZapDepositWidget.tsx
+++ b/src/components/Widgets/variants/mission/MissionZapDepositWidget.tsx
@@ -1,0 +1,44 @@
+import { useMissionStore } from 'src/stores/mission/MissionStore';
+import { EntityWidgetProps } from '../base/Widget.types';
+import { FC, useMemo } from 'react';
+import { ZapDepositWidget } from '../base/ZapWidget/ZapDepositWidget';
+import { ConfigContext } from '../widgetConfig/types';
+
+interface MissionZapDepositWidgetProps extends EntityWidgetProps {}
+
+export const MissionZapDepositWidget: FC<MissionZapDepositWidgetProps> = ({
+  customInformation,
+}) => {
+  const {
+    // destinationChain,
+    // destinationToken,
+    // sourceChain,
+    // sourceToken,
+    // fromAmount,
+    toAddress,
+    currentActiveTaskType,
+    // missionChainIds,
+  } = useMissionStore();
+
+  const ctx: ConfigContext = useMemo(() => {
+    return {
+      // destinationChain,
+      // destinationToken,
+      // sourceChain,
+      // sourceToken,
+      // fromAmount,
+      toAddress,
+      taskType: currentActiveTaskType,
+    };
+  }, [
+    // destinationChain,
+    // destinationToken,
+    // sourceChain,
+    // sourceToken,
+    // fromAmount,
+    toAddress,
+    currentActiveTaskType,
+  ]);
+
+  return <ZapDepositWidget ctx={ctx} customInformation={customInformation} />;
+};

--- a/src/components/Widgets/variants/mission/MissionZapWithdrawWidget.tsx
+++ b/src/components/Widgets/variants/mission/MissionZapWithdrawWidget.tsx
@@ -1,0 +1,44 @@
+import { useMissionStore } from 'src/stores/mission/MissionStore';
+import { EntityWidgetProps } from '../base/Widget.types';
+import { FC, useMemo } from 'react';
+import { ZapWithdrawWidget } from '../base/ZapWidget/ZapWithdrawWidget';
+import { ConfigContext } from '../widgetConfig/types';
+
+interface MissionZapWithdrawWidgetProps extends EntityWidgetProps {}
+
+export const MissionZapWithdrawWidget: FC<MissionZapWithdrawWidgetProps> = ({
+  customInformation,
+}) => {
+  const {
+    // destinationChain,
+    // destinationToken,
+    // sourceChain,
+    // sourceToken,
+    // fromAmount,
+    toAddress,
+    currentActiveTaskType,
+    // missionChainIds,
+  } = useMissionStore();
+
+  const ctx: ConfigContext = useMemo(() => {
+    return {
+      // destinationChain,
+      // destinationToken,
+      // sourceChain,
+      // sourceToken,
+      // fromAmount,
+      toAddress,
+      taskType: currentActiveTaskType,
+    };
+  }, [
+    // destinationChain,
+    // destinationToken,
+    // sourceChain,
+    // sourceToken,
+    // fromAmount,
+    toAddress,
+    currentActiveTaskType,
+  ]);
+
+  return <ZapWithdrawWidget ctx={ctx} customInformation={customInformation} />;
+};

--- a/src/components/Widgets/variants/widgetConfig/base/useBaseForm.ts
+++ b/src/components/Widgets/variants/widgetConfig/base/useBaseForm.ts
@@ -1,0 +1,54 @@
+import { ChainType } from '@lifi/sdk';
+import { WidgetConfig } from '@lifi/widget';
+import { useMemo } from 'react';
+import { ConfigContext } from '../types';
+
+export const useBaseForm = (ctx: ConfigContext) => {
+  const {
+    destinationChain,
+    destinationToken,
+    sourceChain,
+    sourceToken,
+    fromAmount,
+    toAddress,
+    // missionChainIds,
+  } = ctx;
+
+  const config: Partial<WidgetConfig> = useMemo(() => {
+    return {
+      fromChain: sourceChain?.chainId
+        ? Number(sourceChain?.chainId)
+        : undefined,
+      fromToken: sourceToken?.tokenAddress,
+      toChain: destinationChain?.chainId
+        ? Number(destinationChain?.chainId)
+        : undefined,
+      toToken: destinationToken?.tokenAddress,
+      toAddress: toAddress
+        ? {
+            address: toAddress.walletAddress,
+            chainType: (toAddress.chainType as ChainType) ?? ChainType.EVM,
+          }
+        : undefined,
+      fromAmount,
+      // chains: {
+      //   from: {
+      //     allow: missionChainIds,
+      //   },
+      //   to: {
+      //     allow: missionChainIds,
+      //   },
+      // },
+    };
+  }, [
+    destinationChain?.chainId,
+    destinationToken?.tokenAddress,
+    sourceChain?.chainId,
+    sourceToken?.tokenAddress,
+    fromAmount,
+    toAddress?.walletAddress,
+    // missionChainIds,
+  ]);
+
+  return config;
+};

--- a/src/components/Widgets/variants/widgetConfig/base/useBaseRPC.ts
+++ b/src/components/Widgets/variants/widgetConfig/base/useBaseRPC.ts
@@ -1,0 +1,24 @@
+import { WidgetConfig } from '@lifi/widget';
+import { useMemo } from 'react';
+import { publicRPCList } from 'src/const/rpcList';
+import getApiUrl from 'src/utils/getApiUrl';
+
+export const useBaseRPC = () => {
+  const config: Partial<WidgetConfig> = useMemo(() => {
+    return {
+      sdkConfig: {
+        apiUrl: getApiUrl(),
+        useRelayerRoutes: true,
+        rpcUrls: {
+          ...JSON.parse(process.env.NEXT_PUBLIC_CUSTOM_RPCS),
+          ...publicRPCList,
+        },
+        routeOptions: {
+          maxPriceImpact: 0.4,
+        },
+      },
+    };
+  }, []);
+
+  return config;
+};

--- a/src/components/Widgets/variants/widgetConfig/base/useBaseWidget.ts
+++ b/src/components/Widgets/variants/widgetConfig/base/useBaseWidget.ts
@@ -1,0 +1,52 @@
+import { useWalletMenu } from '@lifi/wallet-management';
+import { HiddenUI, RequiredUI, WidgetConfig } from '@lifi/widget';
+import { useMemo } from 'react';
+import { useThemeStore } from 'src/stores/theme/ThemeStore';
+
+export const useBaseWidget = () => {
+  const [widgetTheme] = useThemeStore((state) => [
+    state.widgetTheme,
+    state.configTheme,
+  ]);
+
+  const { openWalletMenu } = useWalletMenu();
+
+  const baseConfig = useMemo(() => {
+    return {
+      integrator: process.env.NEXT_PUBLIC_WIDGET_INTEGRATOR,
+      appearance: widgetTheme.config.appearance,
+      keyPrefix: 'jumper-custom',
+      apiKey: process.env.NEXT_PUBLIC_LIFI_API_KEY,
+      variant: 'compact',
+      hiddenUI: [
+        HiddenUI.Appearance,
+        HiddenUI.Language,
+        HiddenUI.PoweredBy,
+        HiddenUI.WalletMenu,
+        HiddenUI.ToAddress, // @Note this should be dependant on the task type?
+        HiddenUI.ReverseTokensButton,
+        HiddenUI.History,
+      ],
+      requiredUI: [RequiredUI.ToAddress],
+      walletConfig: {
+        onConnect() {
+          openWalletMenu();
+        },
+      },
+      theme: {
+        ...widgetTheme.config.theme,
+        container: {
+          maxHeight: 820,
+          maxWidth: 'unset',
+          borderRadius: 24,
+        },
+        header: {
+          // @Note this needs a workaround to be able to show title on multiple lines
+          whiteSpace: 'break-spaces !important',
+        },
+      },
+    } as WidgetConfig;
+  }, [widgetTheme.config, openWalletMenu]);
+
+  return baseConfig;
+};

--- a/src/components/Widgets/variants/widgetConfig/base/useLanguageResources.ts
+++ b/src/components/Widgets/variants/widgetConfig/base/useLanguageResources.ts
@@ -1,0 +1,60 @@
+import { WidgetConfig } from '@lifi/widget';
+import { useMemo } from 'react';
+import { TaskType } from 'src/types/loyaltyPass';
+import { ConfigContext } from '../types';
+
+export const useLanguageResources = (ctx: ConfigContext) => {
+  const {
+    currentActiveTaskType,
+    destinationChain,
+    destinationToken,
+    sourceChain,
+    sourceToken,
+    overrideHeader,
+  } = ctx;
+
+  const config: Partial<WidgetConfig> = useMemo(() => {
+    let sourceDestinationTemplate = '';
+
+    if (destinationToken?.tokenSymbol && destinationChain?.chainKey) {
+      sourceDestinationTemplate = `to ${destinationToken?.tokenSymbol} on ${destinationChain?.chainKey}`;
+    } else if (sourceToken?.tokenSymbol && sourceChain?.chainKey) {
+      sourceDestinationTemplate = `from ${sourceToken?.tokenSymbol} on ${sourceChain?.chainKey}`;
+    } else if (sourceToken?.tokenSymbol && destinationToken?.tokenSymbol) {
+      sourceDestinationTemplate = `from ${sourceToken?.tokenSymbol} to ${destinationToken?.tokenSymbol}`;
+    } else if (sourceToken?.tokenSymbol) {
+      sourceDestinationTemplate = `from ${sourceToken?.tokenSymbol}`;
+    } else if (destinationToken?.tokenSymbol) {
+      sourceDestinationTemplate = `to ${destinationToken?.tokenSymbol}`;
+    } else if (sourceChain?.chainKey) {
+      sourceDestinationTemplate = `from ${sourceChain?.chainKey} chain`;
+    } else if (destinationChain?.chainKey) {
+      sourceDestinationTemplate = `to ${destinationChain?.chainKey} chain`;
+    }
+
+    const translationTemplate =
+      overrideHeader ??
+      `${currentActiveTaskType ?? 'Deposit'} ${sourceDestinationTemplate}`;
+
+    return {
+      languageResources: {
+        en: {
+          header: {
+            checkout: translationTemplate,
+            exchange: translationTemplate,
+            deposit: translationTemplate,
+            swap: translationTemplate,
+          },
+        },
+      },
+    };
+  }, [
+    currentActiveTaskType,
+    destinationChain?.chainKey,
+    sourceChain?.chainKey,
+    destinationToken?.tokenSymbol,
+    sourceToken?.tokenSymbol,
+  ]);
+
+  return config;
+};

--- a/src/components/Widgets/variants/widgetConfig/base/useZapRPC.tsx
+++ b/src/components/Widgets/variants/widgetConfig/base/useZapRPC.tsx
@@ -1,0 +1,59 @@
+import { EVMProvider, ChainType } from '@lifi/sdk';
+import { WidgetConfig } from '@lifi/widget';
+import { useMemo } from 'react';
+
+export const useZapRPC = (
+  providers: EVMProvider[],
+  toAddress: `0x${string}`,
+  enabled?: boolean,
+) => {
+  if (!enabled) {
+    return {};
+  }
+  const config: Partial<WidgetConfig> = useMemo(() => {
+    const explorerConfig = [
+      {
+        url: 'https://meescan.biconomy.io',
+        txPath: 'details',
+        addressPath: 'address',
+      },
+    ];
+    const explorerChainIds = [
+      56, 1399811149, 1, 8453, 42161, 130, 101, 43114, 137, 728126428, 999, 146,
+      10, 49705, 5000, 80094, 531, 369, 2741, 59144, 42220, 100, 81457, 2020,
+      57420037, 480, 25, 57073, 534352, 324, 98866, 1116, 1088, 1284, 169, 747,
+      250, 34443, 1514, 13371, 204, 288, 1285, 50104, 48900, 1923, 153153, 4689,
+      7700, 1480, 88888, 1101, 55244, 33139, 888, 1313161554, 592, 53935, 2001,
+      428962, 122, 2000, 109, 106, 7777777, 42262, 660279, 10000, 54176, 321,
+      20, 246, 666666666, 1996, 24, 4321, 9001, 5112, 57, 10143, 50312,
+      11155111, 84532,
+    ];
+    const explorerUrls = explorerChainIds.reduce(
+      (acc, id) => {
+        acc[String(id)] = explorerConfig;
+        return acc;
+      },
+      {} as Record<string, typeof explorerConfig>,
+    );
+
+    return {
+      toAddress: {
+        name: 'Smart Account',
+        address: toAddress,
+        chainType: ChainType.EVM,
+      },
+      explorerUrls,
+      bridges: {
+        allow: ['across', 'relay'],
+      },
+      sdkConfig: {
+        apiUrl: process.env.NEXT_PUBLIC_LIFI_API_URL,
+        providers,
+      },
+      useRecommendedRoute: true,
+      contractCompactComponent: <></>,
+    };
+  }, [providers, toAddress]);
+
+  return config;
+};

--- a/src/components/Widgets/variants/widgetConfig/hooks.ts
+++ b/src/components/Widgets/variants/widgetConfig/hooks.ts
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import { WidgetConfig } from '@lifi/widget';
+
+import { ConfigContext } from './types';
+import {
+  getRegisteredOverrideHooks,
+  registerOverrideHook,
+} from './overridesRegistry';
+
+import { useBaseWidget } from './base/useBaseWidget';
+
+import { useLanguageOverride } from './overrides/languageOverride';
+import { useSubvariantOverride } from './overrides/subvariantOverride';
+import { useFormOverride } from './overrides/formOverride';
+import { useZapOverride } from './overrides/zapOverride';
+import { useRPCOverride } from './overrides/rpcOverride';
+
+registerOverrideHook('languageResources', useLanguageOverride);
+registerOverrideHook('subvariant', useSubvariantOverride);
+registerOverrideHook('form', useFormOverride);
+registerOverrideHook('rpc', useRPCOverride);
+registerOverrideHook('zap', useZapOverride);
+
+function getOverrideNamesForContext(ctx: ConfigContext): string[] {
+  const names = ['languageResources', 'subvariant', 'form', 'rpc'];
+  if (ctx.includeZap && ctx.zapToAddress && ctx.zapProviders) {
+    names.push('zap');
+  }
+  return names;
+}
+
+export function useLiFiWidgetConfig(ctx: ConfigContext = {}): WidgetConfig {
+  const base = useBaseWidget();
+  const overrideHooks = getRegisteredOverrideHooks(
+    getOverrideNamesForContext(ctx),
+  );
+
+  const overrides = overrideHooks.map((hook) => hook(ctx));
+
+  return useMemo(() => {
+    return {
+      ...base,
+      ...Object.assign({}, ...overrides),
+      ...ctx.baseOverrides,
+    };
+  }, [base, overrides, ctx.baseOverrides]);
+}

--- a/src/components/Widgets/variants/widgetConfig/overrides/formOverride.ts
+++ b/src/components/Widgets/variants/widgetConfig/overrides/formOverride.ts
@@ -1,0 +1,4 @@
+import { useBaseForm } from '../base/useBaseForm';
+import { ConfigOverrideHook } from '../types';
+
+export const useFormOverride: ConfigOverrideHook = (ctx) => useBaseForm(ctx);

--- a/src/components/Widgets/variants/widgetConfig/overrides/languageOverride.ts
+++ b/src/components/Widgets/variants/widgetConfig/overrides/languageOverride.ts
@@ -1,0 +1,5 @@
+import { useLanguageResources } from '../base/useLanguageResources';
+import { ConfigOverrideHook } from '../types';
+
+export const useLanguageOverride: ConfigOverrideHook = (ctx) =>
+  useLanguageResources(ctx);

--- a/src/components/Widgets/variants/widgetConfig/overrides/rpcOverride.ts
+++ b/src/components/Widgets/variants/widgetConfig/overrides/rpcOverride.ts
@@ -1,0 +1,4 @@
+import { useBaseRPC } from '../base/useBaseRPC';
+import { ConfigOverrideHook } from '../types';
+
+export const useRPCOverride: ConfigOverrideHook = () => useBaseRPC();

--- a/src/components/Widgets/variants/widgetConfig/overrides/subvariantOverride.ts
+++ b/src/components/Widgets/variants/widgetConfig/overrides/subvariantOverride.ts
@@ -1,0 +1,21 @@
+import { TaskType } from 'src/types/loyaltyPass';
+import { ConfigOverrideHook } from '../types';
+import { useMemo } from 'react';
+
+export const useSubvariantOverride: ConfigOverrideHook = (ctx) => {
+  return useMemo(() => {
+    if (ctx.taskType === TaskType.Zap || ctx.taskType === TaskType.Deposit) {
+      return {
+        subvariant: 'custom',
+        subvariantOptions: {
+          custom: 'deposit',
+        },
+      };
+    }
+
+    return {
+      subvariant: 'default',
+      subvariantOptions: undefined,
+    };
+  }, [ctx.taskType]);
+};

--- a/src/components/Widgets/variants/widgetConfig/overrides/zapOverride.ts
+++ b/src/components/Widgets/variants/widgetConfig/overrides/zapOverride.ts
@@ -1,0 +1,7 @@
+import { ConfigOverrideHook } from '../types';
+import { useZapRPC } from '../base/useZapRPC';
+
+export const useZapOverride: ConfigOverrideHook = (ctx) => {
+  const enabled = ctx.includeZap && !!ctx.zapToAddress && !!ctx.zapProviders;
+  return useZapRPC(ctx.zapProviders ?? [], ctx.zapToAddress ?? '0x', enabled);
+};

--- a/src/components/Widgets/variants/widgetConfig/overridesRegistry.ts
+++ b/src/components/Widgets/variants/widgetConfig/overridesRegistry.ts
@@ -1,0 +1,20 @@
+import { ConfigOverrideHook } from './types';
+
+const overrideHookRegistry = new Map<string, ConfigOverrideHook>();
+
+export function registerOverrideHook(name: string, hook: ConfigOverrideHook) {
+  overrideHookRegistry.set(name, hook);
+}
+
+export function getRegisteredOverrideHooks(
+  names: string[],
+): ConfigOverrideHook[] {
+  return names.map((name) => {
+    const hook = overrideHookRegistry.get(name);
+    if (!hook) {
+      console.warn(`Override hook "${name}" not registered`);
+      return () => ({});
+    }
+    return hook;
+  });
+}

--- a/src/components/Widgets/variants/widgetConfig/types.ts
+++ b/src/components/Widgets/variants/widgetConfig/types.ts
@@ -1,0 +1,30 @@
+import { EVMProvider, WidgetConfig } from '@lifi/widget';
+import {
+  TaskType,
+  TaskWidgetInformationChainData,
+  TaskWidgetInformationTokenData,
+  TaskWidgetInformationWalletData,
+} from 'src/types/loyaltyPass';
+
+export type ConfigContext = {
+  overrideHeader?: string;
+  baseOverrides?: Partial<WidgetConfig>;
+  baseVariant?: string;
+  includeZap?: boolean;
+  zapToAddress?: `0x${string}`;
+  zapProviders?: EVMProvider[];
+
+  taskType?: TaskType;
+
+  // Need to make these more generic
+  destinationChain?: TaskWidgetInformationChainData;
+  destinationToken?: TaskWidgetInformationTokenData;
+  sourceChain?: TaskWidgetInformationChainData;
+  sourceToken?: TaskWidgetInformationTokenData;
+  fromAmount?: string;
+  toAddress?: TaskWidgetInformationWalletData;
+
+  [key: string]: any;
+};
+
+export type ConfigOverrideHook = (ctx: ConfigContext) => Partial<WidgetConfig>;

--- a/src/components/ZapWidget/Withdraw/WithdrawWidget.tsx
+++ b/src/components/ZapWidget/Withdraw/WithdrawWidget.tsx
@@ -3,11 +3,12 @@ import { type ContractCall, type TokenAmount } from '@lifi/widget';
 import { useTheme } from '@mui/material';
 import { formatUnits } from 'viem';
 import WidgetLikeField from '../WidgetLikeField/WidgetLikeField';
-import type { ProjectData } from '../ZapWidget';
 import { WithdrawWidgetBox } from './WithdrawWidget.style';
 import type { AbiFunction } from 'viem';
+import { ProjectData } from 'src/types/questDetails';
 
 export interface WithdrawWidgetProps {
+  poolName?: string;
   token: TokenAmount;
   contractCalls?: ContractCall[];
   lpTokenDecimals: number;
@@ -18,6 +19,7 @@ export interface WithdrawWidgetProps {
 }
 
 export const WithdrawWidget: React.FC<WithdrawWidgetProps> = ({
+  poolName,
   token,
   lpTokenDecimals,
   projectData,
@@ -42,7 +44,7 @@ export const WithdrawWidget: React.FC<WithdrawWidgetProps> = ({
           },
         ]}
         refetch={refetchPosition}
-        label={`Redeem from Pool`}
+        label={`Redeem from ${poolName || 'Pool'}`}
         token={token}
         image={
           token?.logoURI && (

--- a/src/stores/mission/MissionStore.tsx
+++ b/src/stores/mission/MissionStore.tsx
@@ -1,0 +1,90 @@
+'use client';
+import {
+  TaskWidgetInformationChainData,
+  TaskWidgetInformationWalletData,
+  TaskWidgetInformationTokenData,
+  TaskType,
+} from 'src/types/loyaltyPass';
+import { createWithEqualityFn } from 'zustand/traditional';
+
+interface MissionState {
+  currentActiveTaskId?: string;
+  currentActiveTaskType?: TaskType;
+
+  destinationChain?: TaskWidgetInformationChainData;
+  destinationToken?: TaskWidgetInformationTokenData;
+
+  sourceChain?: TaskWidgetInformationChainData;
+  sourceToken?: TaskWidgetInformationTokenData;
+
+  fromAmount?: string;
+
+  toAddress?: TaskWidgetInformationWalletData;
+
+  missionChainIds?: number[];
+  missionType?: string;
+
+  setCurrentTaskWidgetFormParams: ({
+    destinationChain,
+    destinationToken,
+    sourceChain,
+    sourceToken,
+    fromAmount,
+    toAddress,
+  }: {
+    destinationChain?: TaskWidgetInformationChainData;
+    destinationToken?: TaskWidgetInformationTokenData;
+    sourceChain?: TaskWidgetInformationChainData;
+    sourceToken?: TaskWidgetInformationTokenData;
+    fromAmount?: string;
+    toAddress?: TaskWidgetInformationWalletData;
+  }) => void;
+
+  setCurrentActiveTask: (taskId: string, taskType: TaskType) => void;
+
+  setMissionDefaults: (chainIds?: number[], missionType?: string) => void;
+
+  isMissionCompleted: boolean;
+  setIsMissionCompleted: (isCompleted: boolean) => void;
+}
+
+export const useMissionStore = createWithEqualityFn<MissionState>(
+  (set) => ({
+    currentActiveTaskId: undefined,
+    currentActiveTaskType: undefined,
+
+    destinationChain: undefined,
+    destinationToken: undefined,
+
+    sourceChain: undefined,
+    sourceToken: undefined,
+
+    fromAmount: undefined,
+
+    toAddress: undefined,
+
+    missionChainIds: [],
+    missionType: undefined,
+
+    setCurrentActiveTask: (currentActiveTaskId, currentActiveTaskType) =>
+      set({
+        currentActiveTaskId,
+        currentActiveTaskType,
+      }),
+
+    setCurrentTaskWidgetFormParams: (params) =>
+      set({
+        ...params,
+      }),
+
+    setMissionDefaults: (missionChainIds, missionType) =>
+      set({
+        missionChainIds,
+        missionType,
+      }),
+
+    isMissionCompleted: false,
+    setIsMissionCompleted: (isMissionCompleted) => set({ isMissionCompleted }),
+  }),
+  Object.is,
+);

--- a/src/stores/mission/index.ts
+++ b/src/stores/mission/index.ts
@@ -1,0 +1,1 @@
+export * from './MissionStore';

--- a/src/types/loyaltyPass.ts
+++ b/src/types/loyaltyPass.ts
@@ -104,6 +104,51 @@ export type QuestAttributes = {
   tasks_verification: TaskVerification[];
 };
 
+export interface RewardGroup {
+  value: string | number;
+  label: string;
+  avatarUrl?: string;
+}
+
+export interface ParticipantChain {
+  avatarUrl: string;
+  label: string;
+  id: number;
+}
+
+export enum TaskType {
+  Bridge = 'Bridge',
+  Swap = 'Swap',
+  Deposit = 'Deposit',
+  OnChain = 'On-chain',
+  OffChain = 'Off-chain',
+  Zap = 'Zap',
+}
+
+export interface TaskWidgetInformationChainData {
+  chainId: string;
+  chainKey: string;
+}
+
+export interface TaskWidgetInformationTokenData {
+  tokenAddress: string;
+  tokenSymbol: string;
+}
+
+export interface TaskWidgetInformationWalletData {
+  walletAddress: string;
+  chainType: string;
+}
+
+export interface TaskWidgetInformationData {
+  sourceChain?: TaskWidgetInformationChainData;
+  sourceToken?: TaskWidgetInformationTokenData;
+  destinationChain?: TaskWidgetInformationChainData;
+  destinationToken?: TaskWidgetInformationTokenData;
+  toAddress?: TaskWidgetInformationWalletData;
+  fromAmount?: string;
+}
+
 export interface TaskVerification {
   id: number;
   name: string;

--- a/src/types/questDetails.ts
+++ b/src/types/questDetails.ts
@@ -15,6 +15,17 @@ export interface Chain {
   name: string;
   chainId: number;
 }
+
+export interface ProjectData {
+  chain: string;
+  chainId: number;
+  project: string;
+  integrator: string;
+  address: string;
+  withdrawAddress?: string;
+  tokenAddress?: string;
+}
+
 export interface QuestDetails {
   type: string;
   socials: QuestSocials;
@@ -30,6 +41,7 @@ export interface QuestDetails {
   CTA: MerklOpportunity[];
   partner: { logo: string; name: string }[];
   marketIds?: string[];
+  projectData: ProjectData;
 }
 
 export interface ExtendedQuest extends Quest {


### PR DESCRIPTION
Contributes to https://lifi.atlassian.net/browse/LF-14112

This PR sets up the base configuration for a widget that we might use on various pages like mission, zap, and others. The configuration is organized across multiple hooks to keep things focused and make it easier to manage specific changes.

Depending on the context, we can apply overrides by enabling the relevant hooks. For example, the zap page requires some additional props, so its hook can include those extras. In addition to the hook-based setup, the widget is also configurable through the baseOverrides provided by context. This allows us to tweak specific props without needing to alter the entire configuration.

In the `missions` folder the widget component depends on the mission store, which further configures the widget context based on that data.

At this stage, only the Storybook stories have been added for the `base` widgets ✨ so go ahead and run `pnpm build-storybook` and then `pnpm storybook`
