### PR TITLE
fix: navbar colors for new tabbed navigation

### DIFF
--- a/src/components/Navbar/NavbarButtons/NavbarButtons.style.ts
+++ b/src/components/Navbar/NavbarButtons/NavbarButtons.style.ts
@@ -61,10 +61,14 @@ export const FloatingLinksContainer = styled(Stack)(({ theme }) => ({
   margin: theme.spacing(0, 2),
   padding: theme.spacing(1.25, 1.5),
   justifyContent: 'space-between',
+  alignItems: 'center',
   gap: theme.spacing(1),
-  backgroundColor: (theme.vars || theme).palette.surface3.main,
+  backgroundColor: (theme.vars || theme).palette.background.default,
   boxShadow: '0px 4px 24px 0px rgba(0, 0, 0, 0.08)',
   borderRadius: 64,
+  ...theme.applyStyles('light', {
+    backgroundColor: (theme.vars || theme).palette.lavenderLight[200],
+  }),
 }));
 
 export const LinksContainer = styled('div')(({ theme }) => ({

--- a/src/components/Navbar/NavbarButtons/NavbarButtons.tsx
+++ b/src/components/Navbar/NavbarButtons/NavbarButtons.tsx
@@ -125,6 +125,7 @@ export const NavbarButtons = () => {
         {!isDesktop && (
           <FloatingLinksContainer direction="row">
             <Links />
+            // @Note: Remove left padding once this is enabled
             <MenuToggle
               ref={mainMenuAnchor}
               id="main-burger-menu-button"

--- a/src/components/Tabs/Tabs.style.ts
+++ b/src/components/Tabs/Tabs.style.ts
@@ -78,7 +78,7 @@ export const HorizontalTabsContainer = styled(Tabs)(({ theme }) => ({
     width: '100%',
     borderRadius: 24,
     transform: 'translateX(0) scaleX(0.98)',
-    backgroundColor: (theme.vars || theme).palette.alphaLight300.main,
+    backgroundColor: (theme.vars || theme).palette.alphaLight500.main,
     zIndex: -1,
     ...theme.applyStyles('light', {
       backgroundColor: (theme.vars || theme).palette.white.main,
@@ -111,11 +111,8 @@ export const HorizontalTab = styled(Tab)(({ theme }) => ({
   },
   '&.Mui-selected': {
     boxShadow: theme.shadows[2],
-    backgroundColor: (theme.vars || theme).palette.alphaLight500.main,
     pointerEvents: 'none',
-    ...theme.applyStyles('light', {
-      backgroundColor: (theme.vars || theme).palette.white.main,
-    }),
+    backgroundColor: 'transparent',
   },
   flex: 1,
   [theme.breakpoints.up('md')]: {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -80,6 +80,8 @@ declare module '@mui/material/styles' {
     azure: Pick<Color, 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900>;
     scarlet: Pick<Color, 100 | 500>;
     orchid: Pick<Color, 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900>;
+    lavenderLight: Pick<Color, 100 | 200 | 300 | 400>;
+    lavenderDark: Pick<Color, 100 | 200 | 300 | 400>;
   }
 
   interface PaletteOptions {
@@ -122,6 +124,8 @@ declare module '@mui/material/styles' {
     azure?: Pick<Color, 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900>;
     scarlet?: Pick<Color, 100 | 500>;
     orchid?: Pick<Color, 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900>;
+    lavenderLight?: Pick<Color, 100 | 200 | 300 | 400>;
+    lavenderDark?: Pick<Color, 100 | 200 | 300 | 400>;
   }
   interface ButtonPropsColorOverrides {
     tertiary: true;
@@ -162,6 +166,8 @@ declare module '@mui/material/styles' {
     azure: true;
     scarlet: true;
     orchid: true;
+    lavenderLight: true;
+    lavenderDark: true;
   }
 
   interface TypographyVariants {
@@ -600,6 +606,20 @@ const palette = {
     700: '#AA51B8',
     800: '#702C7A',
     900: '#37113D',
+  },
+  lavenderLight: {
+    0: '#FCFAFF',
+    100: '#F9F5FF',
+    200: '#F6F0FF',
+    300: '#F3EBFF',
+    400: '#F0E5FF',
+  },
+  lavenderDark: {
+    0: '#30007A',
+    100: '#200052',
+    200: '#18003D',
+    300: '#100029',
+    400: '#0C001F',
   },
 };
 


### PR DESCRIPTION
Currently the floating navbar is disabled, but there were some colours that weren't matching [Figma](https://www.figma.com/design/t3KUDuncWV6TypGGrkf2TE/Navigation--Website-?node-id=1133-59491&m=dev)

If you want to check it, please uncomment all pieces of code in `components/Navbar/NavbarButtons/NavbarButtons.tsx`