### PR TITLE
fix: broken widget theme due to surface2 change

### DIFF
--- a/src/components/Badge/Badge.styles.ts
+++ b/src/components/Badge/Badge.styles.ts
@@ -36,7 +36,7 @@ export const StyledBadge = styled(Box, {
 }) => {
   const variantStyles: Record<BadgeVariant, CSSObject> = {
     default: {
-      backgroundColor: (theme.vars || theme).palette.surface2.main,
+      backgroundColor: (theme.vars || theme).palette.surface1.main,
       color: (theme.vars || theme).palette.alphaLight900.main,
       ...theme.applyStyles('light', {
         color: (theme.vars || theme).palette.alphaDark900.main,

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1120,9 +1120,9 @@ export const themeCustomized: Omit<Theme, 'applyStyles'> & CssVarsTheme =
             dark: '#faf5ff',
           },
           surface2: {
-            light: '#F9F5FF',
-            main: '#F9F5FF',
-            dark: '#F9F5FF',
+            light: '#FFFFFF',
+            main: '#FFFFFF',
+            dark: '#FFFFFF',
           },
           surface3: {
             light: '#E5E1EB',


### PR DESCRIPTION
Wrong

<img width="1142" height="1104" alt="image (1)" src="https://github.com/user-attachments/assets/0313b653-0238-4f7b-be92-5199c4513533" />

Correct

<img width="578" height="556" alt="Screenshot 2025-07-10 at 16 05 25" src="https://github.com/user-attachments/assets/239f78b5-c86b-430d-a080-cc01369da5bf" />
