### PR TITLE
fix: add fallbacks for widget title and cta for non-lifi-widget tasks

### DIFF
--- a/src/app/ui/mission/MissionWidget/MissionForm.tsx
+++ b/src/app/ui/mission/MissionWidget/MissionForm.tsx
@@ -9,6 +9,7 @@ import { useMissionStore } from 'src/stores/mission';
 import { TaskWidgetInformationInputData } from 'src/types/strapi';
 import { MissionInstructionFormContainer } from './MissionWidget.styles';
 import { useVerifyTaskWithSharedState } from 'src/hooks/tasksVerification/useVerifyTaskWithSharedState';
+import { useTranslation } from 'react-i18next';
 
 const buildDynamicSchema = (taskInputs: TaskWidgetInformationInputData[]) => {
   const shape = taskInputs.reduce(
@@ -30,6 +31,10 @@ export const MissionForm = () => {
     currentActiveTaskName,
     missionId,
   } = useMissionStore();
+  const { t } = useTranslation();
+  const taskCTATextWithFallback =
+    taskCTAText ?? t('missions.tasks.action.verify');
+
   const [formValues, setFormValues] = useState<Record<string, string>>({});
 
   const { handleVerifyTask, isPending } = useVerifyTaskWithSharedState(
@@ -99,7 +104,7 @@ export const MissionForm = () => {
         variant={isFormValid && !isPending ? 'primary' : 'transparent'}
         type="submit"
       >
-        {taskCTAText}
+        {taskCTATextWithFallback}
       </Button>
     </MissionInstructionFormContainer>
   );

--- a/src/app/ui/mission/MissionWidget/MissionFormWidget.tsx
+++ b/src/app/ui/mission/MissionWidget/MissionFormWidget.tsx
@@ -15,14 +15,26 @@ import { useUserTracking } from 'src/hooks/userTracking';
 import { openInNewTab } from 'src/utils/openInNewTab';
 import { MissionForm } from './MissionForm';
 import { SectionCardContainer } from 'src/components/Cards/SectionCard/SectionCard.style';
+import { useTranslation } from 'react-i18next';
 
 export const MissionFormWidget = () => {
-  const { taskTitle, taskDescription, taskCTALink, taskCTAText, taskInputs } =
-    useMissionStore();
+  const { t } = useTranslation();
+  const {
+    taskTitle,
+    taskDescription,
+    taskCTALink,
+    taskCTAText,
+    taskInputs,
+    currentActiveTaskType,
+  } = useMissionStore();
+
+  const taskTitleWithFallback =
+    taskTitle ?? t('missions.tasks.type', { type: currentActiveTaskType });
+  const taskCTATextWithFallback = taskCTAText ?? t('missions.tasks.action.go');
 
   const { trackEvent } = useUserTracking();
 
-  const hasForm = !taskCTALink || !!taskInputs;
+  const hasForm = !taskCTALink || !!(taskInputs && taskInputs.length);
 
   const handleClick = () => {
     trackEvent({
@@ -45,7 +57,7 @@ export const MissionFormWidget = () => {
       <MissionWidgetContainer>
         <MissionWidgetContentContainer>
           <MissionWidgetTitle variant="titleSmall">
-            {taskTitle}
+            {taskTitleWithFallback}
           </MissionWidgetTitle>
           <MissionWidgetDescription variant="bodyMedium">
             {taskDescription}
@@ -54,7 +66,7 @@ export const MissionFormWidget = () => {
         {hasForm ? (
           <MissionForm />
         ) : (
-          <Button onClick={handleClick}>{taskCTAText}</Button>
+          <Button onClick={handleClick}>{taskCTATextWithFallback}</Button>
         )}
       </MissionWidgetContainer>
     </SectionCardContainer>

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -179,6 +179,10 @@ interface Resources {
           verify: 'Verify';
           verified: 'Verified';
         };
+        action: {
+          verify: 'Verify';
+          go: 'Go';
+        };
       };
     };
     profile_page: {
@@ -235,7 +239,7 @@ interface Resources {
     tooltips: {
       tvl: 'Total value of crypto assets deposited in this market.';
       apy: 'Expected yearly return rate of the tokens invested.';
-      deposit: 'The displayed token is the token on which the market is defined and yield accrues on.';
+      deposit: 'The token on which the market is defined and yield accrues on.';
       deposited: 'The token you have deposited into this market.';
       boostedApy: '{{baseApy}}% is the expected yearly return rate of the underlying tokens invested. There is an additional {{boostedApy}}% in extra rewards paid in other tokens, check the protocol website for more information.';
     };

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -171,6 +171,10 @@
       "status": {
         "verify": "Verify",
         "verified": "Verified"
+      },
+      "action": {
+        "verify": "Verify",
+        "go": "Go"
       }
     }
   },


### PR DESCRIPTION
**Now**

<img width="1149" height="768" alt="Screenshot 2025-07-16 at 18 46 44" src="https://github.com/user-attachments/assets/0b8458ce-1776-47c7-8f2d-02dd89fce35f" />
<img width="1181" height="620" alt="Screenshot 2025-07-16 at 18 46 50" src="https://github.com/user-attachments/assets/31da3f4f-b8d1-46df-bbd9-b76ffbfd4437" />

**Before**

<img width="1176" height="626" alt="Screenshot 2025-07-16 at 18 49 22" src="https://github.com/user-attachments/assets/ebd1910a-bf0f-4a9f-8a17-1a663fe1de75" />
<img width="1156" height="760" alt="Screenshot 2025-07-16 at 18 49 28" src="https://github.com/user-attachments/assets/6f8c3629-b5b6-4622-b6e2-34cade943be0" />
