### PR TITLE
fix: add taskId and taskName to dependency list

### DIFF
--- a/src/hooks/tasksVerification/useVerifyTaskWithSharedState.ts
+++ b/src/hooks/tasksVerification/useVerifyTaskWithSharedState.ts
@@ -36,6 +36,7 @@ export const useVerifyTaskWithSharedState = (
 
   const handleVerifyTask = useCallback(
     (extraParams?: { [key: string]: string }) => {
+      console.log(missionId, taskId, taskName);
       trackEvent({
         category: TrackingCategory.Quests,
         action: TrackingAction.ClickMissionCtaSteps,
@@ -52,7 +53,7 @@ export const useVerifyTaskWithSharedState = (
         additionalFields: extraParams || {},
       });
     },
-    [missionId, accountAddress],
+    [missionId, taskId, taskName, accountAddress],
   );
 
   const handleReset = useCallback(() => {

--- a/src/hooks/tasksVerification/useVerifyTaskWithSharedState.ts
+++ b/src/hooks/tasksVerification/useVerifyTaskWithSharedState.ts
@@ -36,7 +36,6 @@ export const useVerifyTaskWithSharedState = (
 
   const handleVerifyTask = useCallback(
     (extraParams?: { [key: string]: string }) => {
-      console.log(missionId, taskId, taskName);
       trackEvent({
         category: TrackingCategory.Quests,
         action: TrackingAction.ClickMissionCtaSteps,


### PR DESCRIPTION
Due to not having the dep list updated, the request was made w/ the wrong task id

<img width="384" height="215" alt="Screenshot 2025-07-21 at 15 00 20" src="https://github.com/user-attachments/assets/ce9bd2f4-a65f-4e08-935b-2a09e13ecaaa" />
<img width="388" height="135" alt="Screenshot 2025-07-21 at 15 00 51" src="https://github.com/user-attachments/assets/f2909902-c979-41cd-88ff-bafe0d4ee9f1" />

Contributes to https://lifi.atlassian.net/browse/LF-14608