### PR TITLE
feat(tooling): Update local lint setup & add lint staged in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,24 +40,24 @@ jobs:
             git diff --stat --staged | head -n -1 >> DIFF.txt
             echo '```' >> DIFF.txt
             echo "" >> DIFF.txt
-            echo "To fix this issue, use \`pnpm lint-staged --diff=\"${SOURCE_NAME:-develop}...${BRANCH_NAME}\"\` to lint changed files." >> DIFF.txt
+            echo "To fix this issue, use \`pnpm lint-staged --diff=\"${SOURCE_NAME}...${BRANCH_NAME}\"\` to lint changed files." >> DIFF.txt
             echo "" >> DIFF.txt
             echo "🚧 Your commit hooks might be missing 🚧" >> DIFF.txt
             exit 1
           fi
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-          SOURCE_NAME: ${{ github.base_ref }}
+          SOURCE_NAME: ${{ github.base_ref || 'base-branch' }}
       - name: Comment on PR in case of failure
         if: failure()
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
-          header: "Lint-staged"
+          header: 'Lint-staged'
           path: DIFF.txt
       - name: Hide the Comment in case of success
         if: success()
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
-          header: "Lint-staged"
+          header: 'Lint-staged'
           hide: true
-          hide_classify: "OUTDATED"
+          hide_classify: 'RESOLVED'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,63 @@
+name: PR Checks
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions:
+  pull-requests: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  lint-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure git
+        run: |
+          git config --global user.name github-actions[bot]
+          git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Lint Staged
+        run: |
+          pnpm lint-staged --diff="${PR_TARGET_SHA}...${PR_SOURCE_SHA}"
+        env:
+          PR_TARGET_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
+      - name: Check for uncommitted changes after lint-staged
+        run: |
+          if ! git diff --staged --quiet --exit-code; then
+            echo "## 🎨 The following files missed linting:" > DIFF.txt
+            echo "" >> DIFF.txt
+            echo '```' >> DIFF.txt
+            git diff --stat --staged | head -n -1 >> DIFF.txt
+            echo '```' >> DIFF.txt
+            echo "" >> DIFF.txt
+            echo "To fix this issue, use \`pnpm lint-staged --diff=\"${SOURCE_NAME:-develop}...${BRANCH_NAME}\"\` to lint changed files." >> DIFF.txt
+            echo "" >> DIFF.txt
+            echo "🚧 Your commit hooks might be missing 🚧" >> DIFF.txt
+            exit 1
+          fi
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          SOURCE_NAME: ${{ github.base_ref }}
+      - name: Comment on PR in case of failure
+        if: failure()
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: "Lint-staged"
+          path: DIFF.txt
+      - name: Hide the Comment in case of success
+        if: success()
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: "Lint-staged"
+          hide: true
+          hide_classify: "OUTDATED"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,2 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 echo "Executing pre-commit scripts"
-
 pnpm pre-commit

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,2 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 echo "Executing pre-push scripts"
-pnpm pre-push
+# no-op for now

--- a/README.md
+++ b/README.md
@@ -34,21 +34,11 @@ Please refer to the following descriptions of the dev serve scripts:
     dev:staging - starts the app using the backend staging stage
     dev:production - starts the app using the backend production stage
 
-### Husky Scripts
+## Lint and checks
 
-In addition to these commands you should also run
+We use [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/lint-staged/lint-staged) to run checks and linting on your code before you commit.
 
-```
-yarn add husky
-```
-
-if you plan to commit to this repository please use all necessary husky hooks. If you have trouble running a script try modifying the permissions for the scripts with
-
-```
-chmod ug+x .husky/
-```
-
-to mark them as executables.
+Husky should be installed automatically when you run `pnpm install`.
 
 ### lint-staged
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,5 @@
 // For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
-import storybook from "eslint-plugin-storybook";
+import storybook from 'eslint-plugin-storybook';
 
 import { defineConfig, globalIgnores } from 'eslint/config';
 import { FlatCompat } from '@eslint/eslintrc';
@@ -8,31 +8,26 @@ const compat = new FlatCompat({
   baseDirectory: import.meta.dirname,
 });
 
-
 const eslintConfig = defineConfig([
-  globalIgnores(["**/node_modules/**/*", "**/dist/**/*", "**/build/**/*", "**/*.d.ts"]),
+  globalIgnores([
+    '**/node_modules/**/*',
+    '**/dist/**/*',
+    '**/build/**/*',
+    '**/*.d.ts',
+  ]),
   ...compat.config({
-    'extends': [
-      'plugin:prettier/recommended',
-      'plugin:@next/next/recommended',
-    ],
-    'rules': {
+    extends: ['plugin:prettier/recommended', 'plugin:@next/next/recommended'],
+    rules: {
       'class-methods-use-this': 'off',
-      'comma-dangle': [
-        'error',
-        'always-multiline',
-      ],
-      'curly': 1,
+      'comma-dangle': ['error', 'always-multiline'],
+      curly: 1,
       'import/extensions': 'off',
       // "import/no-default-export": "error",
       'import/no-extraneous-dependencies': 'off',
       'import/no-unresolved': 0,
       'import/prefer-default-export': 'off',
-      'indent': 'off',
-      'jsx-quotes': [
-        'error',
-        'prefer-double',
-      ],
+      indent: 'off',
+      'jsx-quotes': ['error', 'prefer-double'],
       'linebreak-style': 'off',
       'max-len': 'off',
       'newline-per-chained-call': 'off',
@@ -40,11 +35,7 @@ const eslintConfig = defineConfig([
       'no-console': [
         'error',
         {
-          'allow': [
-            'error',
-            'warn',
-            'debug',
-          ],
+          allow: ['error', 'warn', 'debug'],
         },
       ],
       'no-continue': 'off',
@@ -59,12 +50,12 @@ const eslintConfig = defineConfig([
       'no-var': 'warn',
       'object-curly-newline': 'off',
       'prettier/prettier': 'error',
-      'quotes': [
+      quotes: [
         'error',
         'single',
         {
-          'avoidEscape': true,
-          'allowTemplateLiterals': true,
+          avoidEscape: true,
+          allowTemplateLiterals: true,
         },
       ],
     },

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "debug": "NODE_OPTIONS='--inspect' next dev"
   },
   "lint-staged": {
-    "**/*.(ts|tsx|js)": [
+    "**/*.(ts|tsx|js|mjs)": [
       "bash -c tsc --noEmit",
       "pnpm eslint --fix",
       "pnpm prettier --write"

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "xvfb": "^0.4.0"
   },
   "scripts": {
+    "prepare": "husky",
     "analyze:bundle": "ANALYZE=true pnpm build",
     "dev": "next dev --turbopack",
     "dev:local": "dotenv -e .env.localhost next dev",
@@ -157,7 +158,6 @@
     "fix:staged-files": "lint-staged --allow-empty",
     "fix:all-files": "eslint . --ext .ts,.tsx,.js,.jsx --fix",
     "pre-commit": "lint-staged",
-    "pre-push": "pnpm install && pnpm build",
     "i18next-resources-for-ts": "i18next-resources-for-ts interface -i ./src/i18n/translations/en -o ./src/i18n/resources.d.ts",
     "test": "pnpm exec playwright test",
     "test:install": "pnpm exec playwright install",


### PR DESCRIPTION
- [x] make sure husky is enabled on setup
- [x] fix the commit hooks scripts
- [x] disable pre-push (it was building the whole app 🐌 )
- [x] enable pre-commit (it should be linting the app)
- [x] add a lint CI job to catch missing lint (see example below)

`pnpm prettier --write ./` gives:

- in july: 68 files changed, 9539 insertions(+), 3465 deletions(-)
- 2025-11-12: 66 files changed, 11054 insertions(+), 4251 deletions(-)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated PR checks that validate code changes on pull requests

* **Chores**
  * Disabled local pre-commit and pre-push hooks
  * Updated linting configuration to include additional file types in the scanning pipeline
  * Added automatic Husky initialization during dependency installation

* **Documentation**
  * Updated setup guide for the new linting and checks workflow

* **Style**
  * Reformatted ESLint configuration for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->