### PR TITLE
feat: connect perks to the profile page

### DIFF
--- a/src/app/lib/getPerks.ts
+++ b/src/app/lib/getPerks.ts
@@ -1,4 +1,4 @@
-import type { PerksData, StrapiResponse } from '@/types/strapi';
+import type { PerksDataAttributes, StrapiResponse } from '@/types/strapi';
 import { PaginationProps, PerkStrapiApi } from '@/utils/strapi/StrapiApi';
 import { getStrapiApiAccessToken } from 'src/utils/strapi/strapiHelper';
 
@@ -33,7 +33,7 @@ export async function getPerks(
     throw new Error('Failed to fetch perks data');
   }
 
-  const data: StrapiResponse<PerksData> = await res.json();
+  const data: StrapiResponse<PerksDataAttributes> = await res.json();
 
   return { data };
 }

--- a/src/components/Cards/PerksCard/PerksCard.tsx
+++ b/src/components/Cards/PerksCard/PerksCard.tsx
@@ -10,6 +10,7 @@ import {
   PerksCardImage,
 } from './PerksCard.style';
 import { PerksCardSkeleton } from './PerksCardSkeleton';
+import { PERK_CARD_SIZES } from './constants';
 interface PerksCardProps {
   title: string;
   description: string;
@@ -38,11 +39,15 @@ export const PerksCard = ({
           <PerksCardImage
             src={imageUrl}
             alt={`achievement-card-${title}`}
-            width={296}
-            height={192}
+            width={PERK_CARD_SIZES.CARD_WIDTH}
+            height={PERK_CARD_SIZES.IMAGE_HEIGHT}
           />
         ) : (
-          <BaseSkeleton variant="rectangular" width={'100%'} height={320} />
+          <BaseSkeleton
+            variant="rectangular"
+            width={'100%'}
+            height={PERK_CARD_SIZES.IMAGE_HEIGHT}
+          />
         )}
         <PerksCardContent>
           <Typography variant="bodyLargeStrong" sx={getTextEllipsisStyles(1)}>

--- a/src/components/Cards/PerksCard/PerksCardSkeleton.tsx
+++ b/src/components/Cards/PerksCard/PerksCardSkeleton.tsx
@@ -1,3 +1,4 @@
+import { PERK_CARD_SIZES } from './constants';
 import {
   BaseSkeleton,
   BaseStyledSkeleton,
@@ -11,7 +12,11 @@ export const PerksCardSkeleton = () => {
   return (
     <PerksCardContainer>
       <PerksCardActionArea focusRipple={false} disabled>
-        <BaseSkeleton variant="rectangular" width={'100%'} height={320} />
+        <BaseSkeleton
+          variant="rectangular"
+          width={'100%'}
+          height={PERK_CARD_SIZES.IMAGE_HEIGHT}
+        />
         <PerksCardContent>
           <BaseStyledSkeleton
             variant="text"
@@ -21,7 +26,7 @@ export const PerksCardSkeleton = () => {
           />
           <BaseStyledSkeleton
             variant="text"
-            width={192}
+            width={PERK_CARD_SIZES.CARD_WIDTH}
             height={20}
             animation="wave"
           />

--- a/src/components/Cards/PerksCard/constants.ts
+++ b/src/components/Cards/PerksCard/constants.ts
@@ -1,0 +1,4 @@
+export const PERK_CARD_SIZES = {
+  CARD_WIDTH: 296,
+  IMAGE_HEIGHT: 192,
+} as const;

--- a/src/components/Containers/GridContainer.tsx
+++ b/src/components/Containers/GridContainer.tsx
@@ -1,12 +1,19 @@
 import { FC, PropsWithChildren } from 'react';
 import Box from '@mui/material/Box';
 
-export const GridContainer: FC<PropsWithChildren> = ({ children }) => {
+interface GridContainerProps extends PropsWithChildren {
+  gridTemplateColumns?: string;
+}
+
+export const GridContainer: FC<GridContainerProps> = ({
+  children,
+  gridTemplateColumns = 'repeat(auto-fit, minmax(296px, 1fr))',
+}) => {
   return (
     <Box
       sx={{
         display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fit, minmax(296px, 1fr))',
+        gridTemplateColumns,
         gap: 4,
       }}
     >

--- a/src/components/ProfilePage/ProfilePage.tsx
+++ b/src/components/ProfilePage/ProfilePage.tsx
@@ -1,26 +1,28 @@
 'use client';
+
 import { useAccount } from '@lifi/wallet-management';
 import { ProfileProvider } from 'src/providers/ProfileProvider';
-import { QuestDataExtended } from 'src/types/merkl';
-import { CampaignData } from 'src/types/strapi';
+import { PerksData, StrapiResponseData } from 'src/types/strapi';
 import { PageContainer } from '../Containers/PageContainer';
 import { IntroSection } from './sections/IntroSection';
 import { RewardsSection } from './sections/RewardsSection';
 import { TabsSection } from './TabsSection/TabsSection';
 import { AvailableTabs } from './TabsSection/constants';
+import { PerksList } from './components/PerksList/PerksList';
+import { GridContainer } from '../Containers/GridContainer';
 
 interface ProfilePageProps {
   walletAddress?: string;
   isPublic?: boolean;
-  campaigns?: CampaignData[];
-  quests?: QuestDataExtended[];
+  perks: StrapiResponseData<PerksData>;
+  hasMorePerks: boolean;
 }
 
 export const ProfilePage = ({
   walletAddress,
   isPublic,
-  campaigns,
-  quests,
+  perks,
+  hasMorePerks,
 }: ProfilePageProps) => {
   const { account } = useAccount();
 
@@ -33,7 +35,10 @@ export const ProfilePage = ({
     >
       <PageContainer>
         <IntroSection />
-        <RewardsSection />
+        {isPublic && <RewardsSection />}
+        <GridContainer gridTemplateColumns="repeat(auto-fill, minmax(296px, max-content))">
+          <PerksList initialPerks={perks} shouldLoadMore={hasMorePerks} />
+        </GridContainer>
         <TabsSection>
           {(activeTab: string) => {
             if (activeTab === AvailableTabs.Achievements) {

--- a/src/components/ProfilePage/ProfilePage.tsx
+++ b/src/components/ProfilePage/ProfilePage.tsx
@@ -2,7 +2,7 @@
 
 import { useAccount } from '@lifi/wallet-management';
 import { ProfileProvider } from 'src/providers/ProfileProvider';
-import { PerksData, StrapiResponseData } from 'src/types/strapi';
+import { PerksDataAttributes, StrapiResponseData } from 'src/types/strapi';
 import { PageContainer } from '../Containers/PageContainer';
 import { IntroSection } from './sections/IntroSection';
 import { RewardsSection } from './sections/RewardsSection';
@@ -14,7 +14,7 @@ import { GridContainer } from '../Containers/GridContainer';
 interface ProfilePageProps {
   walletAddress?: string;
   isPublic?: boolean;
-  perks: StrapiResponseData<PerksData>;
+  perks: StrapiResponseData<PerksDataAttributes>;
   hasMorePerks: boolean;
 }
 

--- a/src/components/ProfilePage/ProfilePage.tsx
+++ b/src/components/ProfilePage/ProfilePage.tsx
@@ -36,15 +36,19 @@ export const ProfilePage = ({
       <PageContainer>
         <IntroSection />
         {isPublic && <RewardsSection />}
-        <GridContainer gridTemplateColumns="repeat(auto-fill, minmax(296px, max-content))">
-          <PerksList initialPerks={perks} shouldLoadMore={hasMorePerks} />
-        </GridContainer>
         <TabsSection>
           {(activeTab: string) => {
             if (activeTab === AvailableTabs.Achievements) {
               return <p>Achievements</p>;
             } else if (activeTab === AvailableTabs.Perks) {
-              return <p>Perks</p>;
+              return (
+                <GridContainer gridTemplateColumns="repeat(auto-fill, minmax(296px, max-content))">
+                  <PerksList
+                    initialPerks={perks}
+                    shouldLoadMore={hasMorePerks}
+                  />
+                </GridContainer>
+              );
             }
           }}
         </TabsSection>

--- a/src/components/ProfilePage/ProfilePageSkeleton.tsx
+++ b/src/components/ProfilePage/ProfilePageSkeleton.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { GridContainer } from '../Containers/GridContainer';
 import { PageContainer } from '../Containers/PageContainer';
+import { PerksListSkeleton } from './components/PerksList/PerksListSkeleton';
 import { IntroSectionSkeleton } from './sections/IntroSectionSkeleton';
 import { AvailableTabs } from './TabsSection/constants';
 import { TabsSection } from './TabsSection/TabsSection';
@@ -14,7 +16,11 @@ export const ProfilePageSkeleton = () => {
           if (activeTab === AvailableTabs.Achievements) {
             return <p>Achievements Skeleton</p>;
           } else if (activeTab === AvailableTabs.Perks) {
-            return <p>Perks Skeleton</p>;
+            return (
+              <GridContainer>
+                <PerksListSkeleton />
+              </GridContainer>
+            );
           }
         }}
       </TabsSection>

--- a/src/components/ProfilePage/components/PerksList/PerksCard.tsx
+++ b/src/components/ProfilePage/components/PerksList/PerksCard.tsx
@@ -1,0 +1,83 @@
+import { FC, useMemo } from 'react';
+import LockIcon from '@mui/icons-material/Lock';
+import LockOpenIcon from '@mui/icons-material/LockOpen';
+
+import { Badge } from 'src/components/Badge/Badge';
+import { BadgeSize, BadgeVariant } from 'src/components/Badge/Badge.styles';
+import { PerksCard as PerksCardComponent } from 'src/components/Cards/PerksCard/PerksCard';
+import { Link } from 'src/components/Link';
+import { useFormatDisplayPerkData } from 'src/hooks/perks/useFormatDisplayPerkData';
+import { PerksDataAttributes } from 'src/types/strapi';
+import { useActiveAccountByChainType } from 'src/hooks/useActiveAccountByChainType';
+import { useLoyaltyPass } from 'src/hooks/useLoyaltyPass';
+import { useTranslation } from 'react-i18next';
+import Typography from '@mui/material/Typography';
+
+interface PerksCardProps {
+  perk: PerksDataAttributes;
+}
+
+export const PerksCard: FC<PerksCardProps> = ({ perk }) => {
+  const { title, description, imageUrl, href, unlockLevel, perkItems } =
+    useFormatDisplayPerkData(perk);
+  const activeAccount = useActiveAccountByChainType();
+  const { t } = useTranslation();
+  const { level, isLoading } = useLoyaltyPass(activeAccount?.address);
+
+  // @TODO show loading badge if isLoading is true
+  const levelBadge = useMemo(() => {
+    const currentLevel = Number(level ?? 0);
+    if (unlockLevel > currentLevel) {
+      return (
+        <Badge
+          startIcon={<LockIcon />}
+          label={t('profile_page.levelWithValue', { level: unlockLevel })}
+          variant={BadgeVariant.Alpha}
+          size={BadgeSize.LG}
+        />
+      );
+    }
+
+    return (
+      <Badge
+        startIcon={<LockOpenIcon />}
+        label={t('profile_page.unlocked')}
+        variant={BadgeVariant.Success}
+        size={BadgeSize.LG}
+      />
+    );
+  }, [unlockLevel, level, t]);
+
+  const perksBadge = useMemo(() => {
+    return perkItems.map((perkItem) => (
+      <Badge
+        label={
+          <Typography component="span" variant="bodySmallStrong">
+            {perkItem}
+          </Typography>
+        }
+        variant={BadgeVariant.Alpha}
+        size={BadgeSize.LG}
+      />
+    ));
+  }, [perkItems]);
+
+  return (
+    <Link
+      href={href}
+      target="_blank"
+      sx={{
+        textDecoration: 'none',
+        width: 'auto',
+      }}
+    >
+      <PerksCardComponent
+        title={title}
+        description={description}
+        imageUrl={imageUrl}
+        levelBadge={levelBadge}
+        perksBadge={perksBadge}
+      />
+    </Link>
+  );
+};

--- a/src/components/ProfilePage/components/PerksList/PerksCard.tsx
+++ b/src/components/ProfilePage/components/PerksList/PerksCard.tsx
@@ -49,8 +49,9 @@ export const PerksCard: FC<PerksCardProps> = ({ perk }) => {
   }, [unlockLevel, level, t]);
 
   const perksBadge = useMemo(() => {
-    return perkItems.map((perkItem) => (
+    return perkItems.map((perkItem, index) => (
       <Badge
+        key={`${perkItem}-${index}`}
         label={
           <Typography component="span" variant="bodySmallStrong">
             {perkItem}
@@ -62,7 +63,17 @@ export const PerksCard: FC<PerksCardProps> = ({ perk }) => {
     ));
   }, [perkItems]);
 
-  return (
+  const perkCard = (
+    <PerksCardComponent
+      title={title}
+      description={description}
+      imageUrl={imageUrl}
+      levelBadge={levelBadge}
+      perksBadge={perksBadge}
+    />
+  );
+
+  return href ? (
     <Link
       href={href}
       target="_blank"
@@ -71,13 +82,9 @@ export const PerksCard: FC<PerksCardProps> = ({ perk }) => {
         width: 'auto',
       }}
     >
-      <PerksCardComponent
-        title={title}
-        description={description}
-        imageUrl={imageUrl}
-        levelBadge={levelBadge}
-        perksBadge={perksBadge}
-      />
+      {perkCard}
     </Link>
+  ) : (
+    perkCard
   );
 };

--- a/src/components/ProfilePage/components/PerksList/PerksList.tsx
+++ b/src/components/ProfilePage/components/PerksList/PerksList.tsx
@@ -1,0 +1,31 @@
+import { InfiniteScroll } from 'src/components/InfiniteScroll/InfiniteScroll';
+import { usePerksInfinite } from 'src/hooks/perks/usePerksInfinite';
+import { PerksData } from 'src/types/strapi';
+import { PerksListSkeleton } from './PerksListSkeleton';
+import { PerksCard } from './PerksCard';
+
+interface PerksListProps {
+  initialPerks: PerksData[];
+  shouldLoadMore: boolean;
+}
+
+export const PerksList = ({ initialPerks }: PerksListProps) => {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    usePerksInfinite(initialPerks);
+
+  const perks = data?.pages.flatMap((page) => page.data) || initialPerks;
+
+  return (
+    <InfiniteScroll
+      isLoading={isFetchingNextPage}
+      hasMore={hasNextPage}
+      loadMore={fetchNextPage}
+      loader={<PerksListSkeleton count={2} />}
+      triggerMargin={400}
+    >
+      {perks.map((perk: any) => (
+        <PerksCard key={perk.id} perk={perk} />
+      ))}
+    </InfiniteScroll>
+  );
+};

--- a/src/components/ProfilePage/components/PerksList/PerksList.tsx
+++ b/src/components/ProfilePage/components/PerksList/PerksList.tsx
@@ -1,11 +1,11 @@
 import { InfiniteScroll } from 'src/components/InfiniteScroll/InfiniteScroll';
 import { usePerksInfinite } from 'src/hooks/perks/usePerksInfinite';
-import { PerksData } from 'src/types/strapi';
+import { PerksDataAttributes } from 'src/types/strapi';
 import { PerksListSkeleton } from './PerksListSkeleton';
 import { PerksCard } from './PerksCard';
 
 interface PerksListProps {
-  initialPerks: PerksData[];
+  initialPerks: PerksDataAttributes[];
   shouldLoadMore: boolean;
 }
 

--- a/src/components/ProfilePage/components/PerksList/PerksListSkeleton.tsx
+++ b/src/components/ProfilePage/components/PerksList/PerksListSkeleton.tsx
@@ -1,0 +1,14 @@
+import { FC } from 'react';
+import { PerksCardSkeleton } from 'src/components/Cards/PerksCard/PerksCardSkeleton';
+
+interface PerksListSkeletonProps {
+  count?: number;
+}
+
+export const PerksListSkeleton: FC<PerksListSkeletonProps> = ({
+  count = 2,
+}) => {
+  return Array.from({ length: count }, (_, index) => (
+    <PerksCardSkeleton key={index} />
+  ));
+};

--- a/src/hooks/perks/useFormatDisplayPerkData.ts
+++ b/src/hooks/perks/useFormatDisplayPerkData.ts
@@ -19,6 +19,16 @@ export const useFormatDisplayPerkData = (perk: PerksDataAttributes) => {
       Slug,
     } = perk;
 
+    let bannerImageUrl = '';
+    if (BannerImage?.url) {
+      bannerImageUrl = `${baseStrapiUrl}${BannerImage?.url}`;
+    }
+
+    let imageUrl = '';
+    if (Image?.url) {
+      imageUrl = `${baseStrapiUrl}${Image?.url}`;
+    }
+
     return {
       id,
       title: Title,
@@ -29,8 +39,8 @@ export const useFormatDisplayPerkData = (perk: PerksDataAttributes) => {
       perkItems: PerkItems.map((perkItem) => perkItem.Label),
       unlockLevel: UnlockLevel,
       slug: Slug,
-      bannerImageUrl: `${baseStrapiUrl}${BannerImage?.url}`,
-      imageUrl: `${baseStrapiUrl}${Image?.url}`,
+      bannerImageUrl,
+      imageUrl,
     };
   }, [perk]);
 };

--- a/src/hooks/perks/useFormatDisplayPerkData.ts
+++ b/src/hooks/perks/useFormatDisplayPerkData.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { PerksData, PerksDataAttributes } from 'src/types/strapi';
+import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
+
+export const useFormatDisplayPerkData = (perk: PerksDataAttributes) => {
+  return useMemo(() => {
+    const baseStrapiUrl = getStrapiBaseUrl();
+    const {
+      id,
+      Title,
+      Description,
+      BannerImage,
+      Image,
+      Link,
+      StartDate,
+      EndDate,
+      PerkItems,
+      UnlockLevel,
+      Slug,
+    } = perk;
+
+    return {
+      id,
+      title: Title,
+      description: Description,
+      href: Link,
+      startDate: StartDate,
+      endDate: EndDate,
+      perkItems: PerkItems.map((perkItem) => perkItem.Label),
+      unlockLevel: UnlockLevel,
+      slug: Slug,
+      bannerImageUrl: `${baseStrapiUrl}${BannerImage?.url}`,
+      imageUrl: `${baseStrapiUrl}${Image?.url}`,
+    };
+  }, [perk]);
+};

--- a/src/hooks/perks/useFormatDisplayPerkData.ts
+++ b/src/hooks/perks/useFormatDisplayPerkData.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { PerksData, PerksDataAttributes } from 'src/types/strapi';
+import { PerksDataAttributes } from 'src/types/strapi';
 import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
 
 export const useFormatDisplayPerkData = (perk: PerksDataAttributes) => {

--- a/src/hooks/perks/usePerksInfinite.ts
+++ b/src/hooks/perks/usePerksInfinite.ts
@@ -1,4 +1,4 @@
-import { PerksData, QuestData, StrapiResponseData } from 'src/types/strapi';
+import { PerksDataAttributes, StrapiResponseData } from 'src/types/strapi';
 import { usePaginatedData } from '../usePaginatedData';
 import { PAGE_SIZE } from 'src/const/quests';
 import { getPerks } from 'src/app/lib/getPerks';
@@ -14,7 +14,7 @@ export async function fetchPerksData(page: number, pageSize: number = 12) {
 }
 
 export const usePerksInfinite = (
-  initialData?: StrapiResponseData<PerksData>,
+  initialData?: StrapiResponseData<PerksDataAttributes>,
   pageSize: number = PAGE_SIZE,
 ) => {
   return usePaginatedData({

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -202,6 +202,8 @@ interface Resources {
       availableRewards: 'Available Rewards';
       perks: 'Perks';
       achievements: 'Achievements';
+      unlocked: 'Unlocked';
+      levelWithValue: 'Level {{level}}';
     };
     campaign: {
       missions: {

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -194,7 +194,9 @@
     "rewards": "Rewards Earned",
     "availableRewards": "Available Rewards",
     "perks": "Perks",
-    "achievements": "Achievements"
+    "achievements": "Achievements",
+    "unlocked": "Unlocked",
+    "levelWithValue": "Level {{level}}"
   },
   "campaign": {
     "missions": {

--- a/src/utils/strapi/StrapiApi.ts
+++ b/src/utils/strapi/StrapiApi.ts
@@ -362,6 +362,8 @@ class PerkParams {
     'Slug',
     'StartDate',
     'EndDate',
+    'Link',
+    'UnlockLevel',
     'createdAt',
     'updatedAt',
   ];


### PR DESCRIPTION
Issue: https://lifi.atlassian.net/browse/LF-14684

<img width="1107" height="729" alt="Screenshot 2025-07-25 at 15 50 43" src="https://github.com/user-attachments/assets/72d8a07f-4bc4-47a0-b07b-4611014a9244" />

> [!NOTE]
> The feature flag value might still be cached with a falsy value, so if you test this endpoint
`https://api-develop.jumper.exchange/v1/posthog/feature-flag?key=profile_page&distinctId={random value here}`
you should get `"data": true` while if you call 
`https://api-develop.jumper.exchange/v1/posthog/feature-flag?key=profile_page&distinctId=distinct-id` 
the data field might not be available
>
> If you don't see yet the new profile page with just the intro section, please run the app locally and set a different value at `line 34` in `src/app/[lng]/(infos)/profile/page.tsx`
> <img width="554" height="115" alt="Screenshot 2025-07-25 at 14 45 42" src="https://github.com/user-attachments/assets/0c838db6-9ffc-4b96-a886-3223d629f267" />