### PR TITLE
feat: add achievement cards list to profile

### DIFF
--- a/src/components/Cards/AchievementCard/AchievementCard.style.ts
+++ b/src/components/Cards/AchievementCard/AchievementCard.style.ts
@@ -13,7 +13,10 @@ import { getTextEllipsisStyles } from 'src/utils/styles/getTextEllipsisStyles';
 
 export const AchievementCardContainer = styled(Card)(({ theme, onClick }) => ({
   borderRadius: theme.shape.cardBorderRadius,
-  backgroundColor: (theme.vars || theme).palette.lavenderLight[0],
+  backgroundColor: (theme.vars || theme).palette.surface2.main,
+  ...theme.applyStyles('light', {
+    backgroundColor: (theme.vars || theme).palette.lavenderLight[0],
+  }),
   boxShadow: theme.shadows[2],
   width: 296,
   height: 420,
@@ -32,7 +35,7 @@ export const AchievementCardContent = styled(CardContent)(({ theme }) => ({
   gap: theme.spacing(1),
   backgroundColor: (theme.vars || theme).palette.surface2.main,
   ...theme.applyStyles('light', {
-    backgroundColor: (theme.vars || theme).palette.white.main,
+    backgroundColor: (theme.vars || theme).palette.lavenderLight[0],
   }),
   '.badge-container': {
     flexShrink: 0,

--- a/src/components/Cards/SectionCard/SectionCard.tsx
+++ b/src/components/Cards/SectionCard/SectionCard.tsx
@@ -1,8 +1,11 @@
 import { FC, PropsWithChildren } from 'react';
 import { SectionCardContainer } from './SectionCard.style';
+import { SxProps, Theme } from '@mui/material/styles';
 
-interface SectionCardProp extends PropsWithChildren {}
+interface SectionCardProp extends PropsWithChildren {
+  sx?: SxProps<Theme>;
+}
 
-export const SectionCard: FC<SectionCardProp> = ({ children }) => {
-  return <SectionCardContainer>{children}</SectionCardContainer>;
+export const SectionCard: FC<SectionCardProp> = ({ children, sx }) => {
+  return <SectionCardContainer sx={sx}>{children}</SectionCardContainer>;
 };

--- a/src/components/ProfilePage/ProfilePage.tsx
+++ b/src/components/ProfilePage/ProfilePage.tsx
@@ -10,6 +10,7 @@ import { TabsSection } from './TabsSection/TabsSection';
 import { AvailableTabs } from './TabsSection/constants';
 import { PerksList } from './components/PerksList/PerksList';
 import { GridContainer } from '../Containers/GridContainer';
+import { AchievementsList } from './components/AchievementsList/AchievementsList';
 
 interface ProfilePageProps {
   walletAddress?: string;
@@ -39,7 +40,11 @@ export const ProfilePage = ({
         <TabsSection>
           {(activeTab: string) => {
             if (activeTab === AvailableTabs.Achievements) {
-              return <p>Achievements</p>;
+              return (
+                <GridContainer gridTemplateColumns="repeat(auto-fill, minmax(296px, max-content))">
+                  <AchievementsList />
+                </GridContainer>
+              );
             } else if (activeTab === AvailableTabs.Perks) {
               return (
                 <GridContainer gridTemplateColumns="repeat(auto-fill, minmax(296px, max-content))">

--- a/src/components/ProfilePage/ProfilePageSkeleton.tsx
+++ b/src/components/ProfilePage/ProfilePageSkeleton.tsx
@@ -2,6 +2,7 @@
 
 import { GridContainer } from '../Containers/GridContainer';
 import { PageContainer } from '../Containers/PageContainer';
+import { AchievementsListSkeleton } from './components/AchievementsList/AchievementsListSkeleton';
 import { PerksListSkeleton } from './components/PerksList/PerksListSkeleton';
 import { IntroSectionSkeleton } from './sections/IntroSectionSkeleton';
 import { AvailableTabs } from './TabsSection/constants';
@@ -14,7 +15,11 @@ export const ProfilePageSkeleton = () => {
       <TabsSection>
         {(activeTab: string) => {
           if (activeTab === AvailableTabs.Achievements) {
-            return <p>Achievements Skeleton</p>;
+            return (
+              <GridContainer>
+                <AchievementsListSkeleton />
+              </GridContainer>
+            );
           } else if (activeTab === AvailableTabs.Perks) {
             return (
               <GridContainer>

--- a/src/components/ProfilePage/TabsSection/TabsSection.tsx
+++ b/src/components/ProfilePage/TabsSection/TabsSection.tsx
@@ -28,7 +28,7 @@ export const TabsSection: FC<TabsSectionProps> = ({ children }) => {
   );
 
   return (
-    <SectionCard>
+    <SectionCard sx={{ minHeight: '540px' }}>
       <Box
         sx={(theme) => ({
           display: 'flex',

--- a/src/components/ProfilePage/components/AchievementsList/AchievementsCard.tsx
+++ b/src/components/ProfilePage/components/AchievementsList/AchievementsCard.tsx
@@ -1,0 +1,36 @@
+import { format } from 'date-fns';
+import { FC, useMemo } from 'react';
+import { Badge } from 'src/components/Badge/Badge';
+import { BadgeVariant, BadgeSize } from 'src/components/Badge/Badge.styles';
+import { AchievementCard } from 'src/components/Cards/AchievementCard/AchievementCard';
+import { PDA } from 'src/types/loyaltyPass';
+
+interface AchievementsCardProps {
+  pda: PDA;
+}
+
+export const AchievementsCard: FC<AchievementsCardProps> = ({ pda }) => {
+  const { title, description, imageUrl, points } = useMemo(() => {
+    return {
+      title: pda.reward.name,
+      description: format(pda.timestamp, `LLLL yyyy`),
+      imageUrl: pda.reward.image,
+      points: pda.points,
+    };
+  }, [JSON.stringify(pda)]);
+
+  return (
+    <AchievementCard
+      title={title}
+      description={description}
+      imageUrl={imageUrl}
+      badge={
+        <Badge
+          label={`${points} XP`}
+          variant={BadgeVariant.Alpha}
+          size={BadgeSize.MD}
+        />
+      }
+    />
+  );
+};

--- a/src/components/ProfilePage/components/AchievementsList/AchievementsList.tsx
+++ b/src/components/ProfilePage/components/AchievementsList/AchievementsList.tsx
@@ -1,0 +1,70 @@
+import { useContext, useMemo, useEffect, useCallback, useState } from 'react';
+import { InfiniteScroll } from 'src/components/InfiniteScroll/InfiniteScroll';
+import { useLoyaltyPass } from 'src/hooks/useLoyaltyPass';
+import { ProfileContext } from 'src/providers/ProfileProvider';
+import { AchievementsListSkeleton } from './AchievementsListSkeleton';
+import { AchievementsCard } from './AchievementsCard';
+import { PDA } from 'src/types/loyaltyPass';
+
+export const AchievementsList = () => {
+  const { walletAddress, isLoading: isWalletLoading } =
+    useContext(ProfileContext);
+  // @TODO: does the backend support pagination? If not, we should implement it
+  const { pdas, isLoading } = useLoyaltyPass(walletAddress);
+
+  // Simulate pagination by truncating the existing data
+  // @TODO: remove this once we have a proper pagination solution
+  const [displayedPdas, setDisplayedPdas] = useState<PDA[]>([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [isFetchingNextPage, setIsFetchingNextPage] = useState(
+    isWalletLoading || isLoading,
+  );
+  const pageSize = 10;
+
+  const totalPages = useMemo(() => {
+    if (!pdas) return 0;
+    return Math.ceil(pdas.length / pageSize);
+  }, [pdas]);
+
+  const hasNextPage = currentPage < totalPages;
+
+  useEffect(() => {
+    setIsFetchingNextPage(isWalletLoading || isLoading);
+  }, [isWalletLoading, isLoading]);
+
+  useEffect(() => {
+    if (pdas && pdas.length > 0) {
+      const initialPdas = pdas.slice(0, pageSize);
+      setDisplayedPdas(initialPdas);
+      setCurrentPage(1);
+    }
+  }, [pdas]);
+
+  const fetchNextPage = useCallback(() => {
+    if (pdas && hasNextPage) {
+      setIsFetchingNextPage(true);
+      const timeout = setTimeout(() => {
+        const nextPdas = pdas.slice(0, (currentPage + 1) * pageSize);
+        setDisplayedPdas(nextPdas);
+        setCurrentPage((prev) => prev + 1);
+        setIsFetchingNextPage(false);
+      }, 250);
+
+      return () => clearTimeout(timeout);
+    }
+  }, [pdas, currentPage, hasNextPage]);
+
+  return (
+    <InfiniteScroll
+      isLoading={isFetchingNextPage}
+      hasMore={hasNextPage}
+      loadMore={fetchNextPage}
+      loader={<AchievementsListSkeleton count={2} />}
+      triggerMargin={400}
+    >
+      {displayedPdas.map((pda) => (
+        <AchievementsCard key={pda.id} pda={pda} />
+      ))}
+    </InfiniteScroll>
+  );
+};

--- a/src/components/ProfilePage/components/AchievementsList/AchievementsList.tsx
+++ b/src/components/ProfilePage/components/AchievementsList/AchievementsList.tsx
@@ -1,68 +1,28 @@
-import { useContext, useMemo, useEffect, useCallback, useState } from 'react';
+import { useContext } from 'react';
 import { InfiniteScroll } from 'src/components/InfiniteScroll/InfiniteScroll';
-import { useLoyaltyPass } from 'src/hooks/useLoyaltyPass';
 import { ProfileContext } from 'src/providers/ProfileProvider';
 import { AchievementsListSkeleton } from './AchievementsListSkeleton';
 import { AchievementsCard } from './AchievementsCard';
-import { PDA } from 'src/types/loyaltyPass';
+import { useAchievementsInfinite } from 'src/hooks/achievements/useAchievementsInfinite';
 
 export const AchievementsList = () => {
   const { walletAddress, isLoading: isWalletLoading } =
     useContext(ProfileContext);
-  // @TODO: does the backend support pagination? If not, we should implement it
-  const { pdas, isLoading } = useLoyaltyPass(walletAddress);
 
-  // Simulate pagination by truncating the existing data
-  // @TODO: remove this once we have a proper pagination solution
-  const [displayedPdas, setDisplayedPdas] = useState<PDA[]>([]);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [isFetchingNextPage, setIsFetchingNextPage] = useState(
-    isWalletLoading || isLoading,
-  );
-  const pageSize = 10;
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useAchievementsInfinite(walletAddress);
 
-  const totalPages = useMemo(() => {
-    if (!pdas) return 0;
-    return Math.ceil(pdas.length / pageSize);
-  }, [pdas]);
-
-  const hasNextPage = currentPage < totalPages;
-
-  useEffect(() => {
-    setIsFetchingNextPage(isWalletLoading || isLoading);
-  }, [isWalletLoading, isLoading]);
-
-  useEffect(() => {
-    if (pdas && pdas.length > 0) {
-      const initialPdas = pdas.slice(0, pageSize);
-      setDisplayedPdas(initialPdas);
-      setCurrentPage(1);
-    }
-  }, [pdas]);
-
-  const fetchNextPage = useCallback(() => {
-    if (pdas && hasNextPage) {
-      setIsFetchingNextPage(true);
-      const timeout = setTimeout(() => {
-        const nextPdas = pdas.slice(0, (currentPage + 1) * pageSize);
-        setDisplayedPdas(nextPdas);
-        setCurrentPage((prev) => prev + 1);
-        setIsFetchingNextPage(false);
-      }, 250);
-
-      return () => clearTimeout(timeout);
-    }
-  }, [pdas, currentPage, hasNextPage]);
+  const pdas = data?.pages.flatMap((page) => page.data) || [];
 
   return (
     <InfiniteScroll
-      isLoading={isFetchingNextPage}
+      isLoading={isFetchingNextPage || isWalletLoading}
       hasMore={hasNextPage}
       loadMore={fetchNextPage}
       loader={<AchievementsListSkeleton count={2} />}
       triggerMargin={400}
     >
-      {displayedPdas.map((pda) => (
+      {pdas.map((pda) => (
         <AchievementsCard key={pda.id} pda={pda} />
       ))}
     </InfiniteScroll>

--- a/src/components/ProfilePage/components/AchievementsList/AchievementsListSkeleton.tsx
+++ b/src/components/ProfilePage/components/AchievementsList/AchievementsListSkeleton.tsx
@@ -1,0 +1,14 @@
+import { FC } from 'react';
+import { AchievementCardSkeleton } from 'src/components/Cards/AchievementCard/AchievementCardSkeleton';
+
+interface AchievementsListSkeletonProps {
+  count?: number;
+}
+
+export const AchievementsListSkeleton: FC<AchievementsListSkeletonProps> = ({
+  count = 2,
+}) => {
+  return Array.from({ length: count }).map((_, index) => (
+    <AchievementCardSkeleton key={index} />
+  ));
+};

--- a/src/hooks/achievements/useAchievementsInfinite.ts
+++ b/src/hooks/achievements/useAchievementsInfinite.ts
@@ -1,0 +1,31 @@
+import { useLoyaltyPass } from 'src/hooks/useLoyaltyPass';
+import { usePaginatedData } from 'src/hooks/usePaginatedData';
+import { PAGE_SIZE } from 'src/const/quests';
+import { PDA } from 'src/types/loyaltyPass';
+
+export const useAchievementsInfinite = (
+  walletAddress?: string,
+  initialData?: PDA[],
+  pageSize: number = PAGE_SIZE,
+) => {
+  // @Note For now, simulate pagination with existing data
+  // When backend supports pagination, this can be replaced with proper API calls
+  const { pdas, isLoading } = useLoyaltyPass(walletAddress);
+
+  return usePaginatedData({
+    queryKey: ['achievements', walletAddress, pageSize],
+    queryFn: async (page: number, pageSize: number) => {
+      // Simulate API delay
+      await new Promise((resolve) => setTimeout(resolve, 250));
+
+      if (!pdas) return [];
+
+      const startIndex = (page - 1) * pageSize;
+      const endIndex = startIndex + pageSize;
+      return pdas.slice(startIndex, endIndex);
+    },
+    initialData: initialData || pdas?.slice(0, pageSize),
+    pageSize,
+    enabled: !!walletAddress && !isLoading,
+  });
+};

--- a/src/hooks/usePaginatedData.ts
+++ b/src/hooks/usePaginatedData.ts
@@ -13,6 +13,7 @@ type UsePaginatedDataParams<T> = {
   queryFn: (page: number, pageSize: number) => Promise<T[]>;
   initialData?: T[];
   pageSize?: number;
+  enabled?: boolean;
   staleTime?: number;
   gcTime?: number;
 };
@@ -22,6 +23,7 @@ export function usePaginatedData<T>({
   queryFn,
   initialData,
   pageSize = 12,
+  enabled = true,
   staleTime = FIVE_MINUTES_MS,
   gcTime = TEN_MINUTES_MS,
 }: UsePaginatedDataParams<T>) {
@@ -58,6 +60,7 @@ export function usePaginatedData<T>({
           pageParams: [1],
         }
       : undefined,
+    enabled,
     staleTime,
     gcTime,
   });

--- a/src/providers/ProfileProvider.tsx
+++ b/src/providers/ProfileProvider.tsx
@@ -1,28 +1,32 @@
 'use client';
 import { createContext, useMemo, type PropsWithChildren } from 'react';
 
-export const ProfileContext = createContext<ProfileProps>({
+interface ProfileContextValue {
+  walletAddress: string;
+  isPublic: boolean;
+  isLoading: boolean;
+}
+
+export const ProfileContext = createContext<ProfileContextValue>({
   walletAddress: '',
   isPublic: false,
   isLoading: true,
 });
 
-interface ProfileProps {
-  walletAddress: string;
-  isPublic?: boolean;
-  isLoading?: boolean;
-}
+type ProfileProps = Pick<ProfileContextValue, 'walletAddress'> &
+  Partial<Pick<ProfileContextValue, 'isPublic' | 'isLoading'>>;
 
-export const ProfileProvider: React.FC<
-  PropsWithChildren<
-    Pick<ProfileProps, 'walletAddress' | 'isPublic' | 'isLoading'>
-  >
-> = ({ children, walletAddress, isPublic, isLoading }) => {
+export const ProfileProvider: React.FC<PropsWithChildren<ProfileProps>> = ({
+  children,
+  walletAddress,
+  isPublic,
+  isLoading,
+}) => {
   const value = useMemo(
     () => ({
       walletAddress,
       isPublic: isPublic ?? false,
-      isLoading,
+      isLoading: isLoading ?? false,
     }),
     [walletAddress, isPublic, isLoading],
   );


### PR DESCRIPTION
Issue: https://lifi.atlassian.net/browse/LF-14683

> [!IMPORTANT]
> Ping me for a wallet address having achievements

> [!NOTE]
> The feature flag value might still be cached with a falsy value, so if you test this endpoint
`https://api-develop.jumper.exchange/v1/posthog/feature-flag?key=profile_page&distinctId={random value here}`
you should get `"data": true` while if you call 
`https://api-develop.jumper.exchange/v1/posthog/feature-flag?key=profile_page&distinctId=distinct-id` 
the data field might not be available
>
> If you don't see yet the new profile page with just the intro section, please run the app locally and set a different value at `line 34` in `src/app/[lng]/(infos)/profile/page.tsx`
> <img width="554" height="115" alt="Screenshot 2025-07-25 at 14 45 42" src="https://github.com/user-attachments/assets/0c838db6-9ffc-4b96-a886-3223d629f267" />