### PR TITLE
feat(ci): tweak playwright + output on PR

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,9 +31,12 @@ jobs:
         run: sudo apt-get install xvfb
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
-      - name: Run Playwright tests
+      - name: Setup Playwright Cache
         run: |
           pnpm build:cache:ci
+      - name: Run Playwright tests
+        if: ${{ !cancelled()}} # Always attempt to run the tests even if cache setup failed
+        run: |
           pnpm run test:ci:e2e \
             --shard ${{ matrix.shard }}/${{ strategy.job-total }}
       - name: Upload blob report to Github Actions Artifacts

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -33,9 +33,9 @@ jobs:
         run: npx playwright install --with-deps chromium
       - name: Run Playwright tests
         run: |
-          pnpm build:cache:ci &
-           pnpm run test:ci:e2e \
-             --shard ${{ matrix.shard }}/${{ strategy.job-total }}
+          pnpm build:cache:ci
+          pnpm run test:ci:e2e \
+            --shard ${{ matrix.shard }}/${{ strategy.job-total }}
       - name: Upload blob report to Github Actions Artifacts
         if: ${{ !cancelled()}}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,29 +14,29 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        shard: [ 1, 2, 3, 4 , 5 , 6 ]
+        shard: [1, 2, 3, 4, 5, 6]
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 18
-    - name: Install pnpm
-      run: npm install -g pnpm
-    - name: Install dependencies
-      run: pnpm install
-    - name: Install xvfb server
-      run: sudo apt-get install xvfb
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps chromium
-    - name: Run Playwright tests
-      run: |
-       pnpm build:cache:ci &
-        pnpm run test:ci:e2e \
-          --shard ${{ matrix.shard }}/${{ strategy.job-total }}
-    - name: Upload blob report to Github Actions Artifacts
-      if: ${{ !cancelled()}}
-      uses: actions/upload-artifact@v4
-      with:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Install pnpm
+        run: npm install -g pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Install xvfb server
+        run: sudo apt-get install xvfb
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps chromium
+      - name: Run Playwright tests
+        run: |
+          pnpm build:cache:ci &
+           pnpm run test:ci:e2e \
+             --shard ${{ matrix.shard }}/${{ strategy.job-total }}
+      - name: Upload blob report to Github Actions Artifacts
+        if: ${{ !cancelled()}}
+        uses: actions/upload-artifact@v4
+        with:
           name: blob-report-${{ matrix.shard }}
           path: blob-report
           retention-days: 1
@@ -55,17 +55,17 @@ jobs:
         run: npm install -g pnpm
       - name: Install dependencies
         run: pnpm install
-      
+
       - name: Download blob reports from GitHub Actions Articfacts
         uses: actions/download-artifact@v4
         with:
           path: all-blob-reports
           pattern: blob-report-*
           merge-multiple: true
-          
+
       - name: Merge into HTML Report
         run: npx playwright merge-reports --reporter html ./all-blob-reports
-        
+
       - name: Upload HTML report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -67,10 +67,10 @@ jobs:
           path: all-blob-reports
           pattern: blob-report-*
           merge-multiple: true
-      - name: Merge into HTML Report
-        run: npx playwright merge-reports --reporter html ./all-blob-reports
-      - name: Merge into JSON Report
-        run: npx playwright merge-reports --reporter json ./all-blob-reports 1>report.json
+      - name: Merge into HTML and JSON Reports
+        run: npx playwright merge-reports --reporter=html,json ./all-blob-reports
+        env:
+          PLAYWRIGHT_JSON_OUTPUT_NAME: report.json
       - uses: daun/playwright-report-summary@be9e270edd5ad86038604d3caa84a819a6ff6fed # v3.10.0
         id: summary
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,11 +17,11 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-      - name: Install pnpm
-        run: npm install -g pnpm
+          cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
       - name: Install xvfb server
@@ -48,24 +48,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-      - name: Install pnpm
-        run: npm install -g pnpm
+          cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
-
       - name: Download blob reports from GitHub Actions Articfacts
         uses: actions/download-artifact@v4
         with:
           path: all-blob-reports
           pattern: blob-report-*
           merge-multiple: true
-
       - name: Merge into HTML Report
         run: npx playwright merge-reports --reporter html ./all-blob-reports
-
       - name: Upload HTML report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -66,6 +66,12 @@ jobs:
           merge-multiple: true
       - name: Merge into HTML Report
         run: npx playwright merge-reports --reporter html ./all-blob-reports
+      - name: Merge into JSON Report
+        run: npx playwright merge-reports --reporter json ./all-blob-reports 1>report.json
+      - uses: daun/playwright-report-summary@be9e270edd5ad86038604d3caa84a819a6ff6fed # v3.10.0
+        id: summary
+        with:
+          report-file: ./report.json
       - name: Upload HTML report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,12 +12,13 @@ concurrency:
 jobs:
   test:
     name: Test (${{ matrix.shard }} / ${{ strategy.job-total}})
-    continue-on-error: true
+    continue-on-error: false # Instead we use fail-fast to forward the failure state to subsequent jobs
     timeout-minutes: 20
     runs-on: ubuntu-latest
     strategy:
       matrix:
         shard: [1, 2, 3, 4, 5, 6]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,6 +6,9 @@ permissions:
   checks: write
   pull-requests: write
   contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     name: Test (${{ matrix.shard }} / ${{ strategy.job-total}})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 3 : 3,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 4 : undefined,
+  workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI ? 'blob' : [['html']],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
Main changes:

- [x] fix playwright setup, it was using a background job - might help with flakiness
- [x] fix `Opt out of parallel tests on CI` config
- [x] playwright outputs on the PR
- [x] split the cache & test execution
- [x] forward failure state to avoid a green CI when playwright is broken

Also:

- [x] format yaml
- [x] setup concurrency (avoid running multiple playwright on push)
- [x] Use pnpm action to set it up
- [x] Setup node action to cache 'pnpm'


Issue seen in CI:

https://github.com/jumperexchange/jumper-exchange/actions/runs/16595870147/job/46942228872?pr=2108
> Triggering cache creation for: 532f685e346606c2a803 (basic.setup.{ts,js,mjs})
> Aborting...
> Error: [WaitForExtensionOnLoadPage] Extension did not load in time!

Which seems to come from: https://github.com/Synthetixio/synpress/blob/2563f907bc86ac400edd59678dc9e57085d1191d/wallets/metamask/test/playwright/e2e/importWallet.spec.ts#L32

