### PR TITLE
fix: differentiate between campaign carousel and hero stats cards color modes

### DIFF
--- a/src/app/ui/missions/BannerCampaign/BannerCampaign.stories.tsx
+++ b/src/app/ui/missions/BannerCampaign/BannerCampaign.stories.tsx
@@ -27,7 +27,7 @@ const defaultCampaigns = [
     missionsCount: 5,
     rewardChainIds: ['1', '10'],
     slug: 'campaign-a',
-    statsCardVariant: MissionHeroStatsCardVariant.Default,
+    heroStatsCardVariant: MissionHeroStatsCardVariant.Default,
   },
   {
     bannerImage:
@@ -37,7 +37,7 @@ const defaultCampaigns = [
     benefitLabel: 'Bonus Pool',
     benefitValue: '$200K',
     missionsCount: 8,
-    statsCardVariant: MissionHeroStatsCardVariant.Inverted,
+    heroStatsCardVariant: MissionHeroStatsCardVariant.Inverted,
     rewardChainIds: ['42161'],
     slug: 'campaign-b',
   },
@@ -49,7 +49,7 @@ const defaultCampaigns = [
     missionsCount: 3,
     rewardChainIds: ['10', '137', '8453'],
     slug: 'campaign-c',
-    statsCardVariant: MissionHeroStatsCardVariant.Default,
+    heroStatsCardVariant: MissionHeroStatsCardVariant.Default,
   },
 ];
 
@@ -84,21 +84,21 @@ const Template: StoryFn<typeof CarouselShell> = (_props, { args }) => {
             <MissionHeroStatsCard
               title={campaign.benefitLabel}
               description={campaign.benefitValue}
-              variant={campaign.statsCardVariant}
+              variant={campaign.heroStatsCardVariant}
             />
           )}
           {!!campaign.missionsCount && (
             <MissionHeroStatsCard
               title="Missions"
               description={campaign.missionsCount.toString()}
-              variant={campaign.statsCardVariant}
+              variant={campaign.heroStatsCardVariant}
             />
           )}
           {!!campaign.rewardChainIds?.length && (
             <MissionHeroStatsCard
               title="Rewards"
               description={<ChainStack chainIds={campaign.rewardChainIds} />}
-              variant={campaign.statsCardVariant}
+              variant={campaign.heroStatsCardVariant}
             />
           )}
         </BannerCampaignContent>
@@ -132,7 +132,7 @@ export const CustomCampaigns: Story = {
         missionsCount: 2,
         rewardChainIds: ['56'],
         slug: 'custom-campaign',
-        statsCardVariant: MissionHeroStatsCardVariant.Default,
+        heroStatsCardVariant: MissionHeroStatsCardVariant.Default,
       },
     ],
   },

--- a/src/app/ui/missions/BannerCampaign/BannerCampaignSlide.tsx
+++ b/src/app/ui/missions/BannerCampaign/BannerCampaignSlide.tsx
@@ -26,7 +26,7 @@ export const BannerCampaignSlide: FC<BannerCampaignSlideProps> = ({
     rewardChainIds,
     missionsCount,
     link,
-    statsCardVariant,
+    bannerStatsCardVariant,
   } = useCampaignDisplayData(campaign);
 
   const { t } = useTranslation();
@@ -45,21 +45,21 @@ export const BannerCampaignSlide: FC<BannerCampaignSlideProps> = ({
         <MissionHeroStatsCard
           title={benefitLabel ?? t('campaign.stats.totalRewards')}
           description={benefitValue}
-          variant={statsCardVariant}
+          variant={bannerStatsCardVariant}
         />
       )}
       {!!missionsCount && (
         <MissionHeroStatsCard
           title={t('campaign.stats.missions')}
           description={missionsCount.toString()}
-          variant={statsCardVariant}
+          variant={bannerStatsCardVariant}
         />
       )}
       {!!rewardChainIds?.length && (
         <MissionHeroStatsCard
           title={t('campaign.stats.rewards')}
           description={<ChainStack chainIds={rewardChainIds} />}
-          variant={statsCardVariant}
+          variant={bannerStatsCardVariant}
         />
       )}
     </BannerCampaignContent>

--- a/src/components/Campaign/CampaignHero/CampaignHero.tsx
+++ b/src/components/Campaign/CampaignHero/CampaignHero.tsx
@@ -36,7 +36,7 @@ export const CampaignHero: FC<CampaignHeroProps> = ({ campaign }) => {
     benefitValue,
     rewardChainIds,
     missionsCount,
-    statsCardVariant,
+    heroStatsCardVariant,
   } = useCampaignDisplayData(campaign);
 
   const handleGoBack = () => {
@@ -76,21 +76,21 @@ export const CampaignHero: FC<CampaignHeroProps> = ({ campaign }) => {
               <MissionHeroStatsCard
                 title={benefitLabel ?? t('campaign.stats.totalRewards')}
                 description={benefitValue}
-                variant={statsCardVariant}
+                variant={heroStatsCardVariant}
               />
             )}
             {!!missionsCount && (
               <MissionHeroStatsCard
                 title={t('campaign.stats.missions')}
                 description={missionsCount.toString()}
-                variant={statsCardVariant}
+                variant={heroStatsCardVariant}
               />
             )}
             {!!rewardChainIds?.length && (
               <MissionHeroStatsCard
                 title={t('campaign.stats.rewards')}
                 description={<ChainStack chainIds={rewardChainIds} />}
-                variant={statsCardVariant}
+                variant={heroStatsCardVariant}
               />
             )}
           </CampaignHeroStatsWrapper>

--- a/src/components/Campaign/CampaignHero/CampaignHeroCard.stories.tsx
+++ b/src/components/Campaign/CampaignHero/CampaignHeroCard.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryFn, StoryObj } from '@storybook/nextjs-vite';
+import { ComponentProps } from 'react';
 
 import { CampaignHeroCard } from './CampaignHeroCard';
 import { CampaignHeroCardSkeleton } from './CampaignHeroCardSkeletion';
@@ -10,10 +11,20 @@ import {
   CampaignHeroStatsWrapper,
 } from './CampaignHero.style';
 
+type CampaignHeroCardStoryProps = ComponentProps<typeof CampaignHeroCard> & {
+  heroStatsCardVariant?: MissionHeroStatsCardVariant;
+};
+
 const meta = {
   component: CampaignHeroCard,
   title: 'Campaigns/Hero Card',
-} satisfies Meta<typeof CampaignHeroCard>;
+  argTypes: {
+    heroStatsCardVariant: {
+      control: { type: 'select' },
+      options: Object.values(MissionHeroStatsCardVariant),
+    },
+  },
+} satisfies Meta<CampaignHeroCardStoryProps>;
 
 export default meta;
 type CustomStoryArgs = {
@@ -23,15 +34,16 @@ type CustomStoryArgs = {
   benefitValue?: string;
   missionsCount?: number;
   rewardChainIds?: string[];
+  heroStatsCardVariant?: MissionHeroStatsCardVariant;
 };
 
-type Story = StoryObj<typeof CampaignHeroCard> & {
+type Story = StoryObj<CampaignHeroCardStoryProps> & {
   args?: CustomStoryArgs;
 };
 
 // For presentation purposes only — this custom template allows us to display components without relying on hooks for data manipulation
 // Renders the campaign card with optional prop overrides
-const Template: StoryFn<typeof CampaignHeroCard> = (_props, { args }) => {
+const Template: StoryFn<CampaignHeroCardStoryProps> = (_props, { args }) => {
   const {
     isLoading,
     icon,
@@ -39,6 +51,7 @@ const Template: StoryFn<typeof CampaignHeroCard> = (_props, { args }) => {
     benefitValue,
     missionsCount,
     rewardChainIds,
+    heroStatsCardVariant,
   } = args as CustomStoryArgs;
 
   if (isLoading) {
@@ -62,21 +75,21 @@ const Template: StoryFn<typeof CampaignHeroCard> = (_props, { args }) => {
           <MissionHeroStatsCard
             title={benefitLabel}
             description={benefitValue}
-            variant={MissionHeroStatsCardVariant.Default}
+            variant={heroStatsCardVariant}
           />
         )}
         {!!missionsCount && (
           <MissionHeroStatsCard
             title="Missions"
             description={missionsCount}
-            variant={MissionHeroStatsCardVariant.Default}
+            variant={heroStatsCardVariant}
           />
         )}
         {!!rewardChainIds?.length && (
           <MissionHeroStatsCard
             title="Rewards"
             description={<ChainStack chainIds={rewardChainIds} />}
-            variant={MissionHeroStatsCardVariant.Default}
+            variant={heroStatsCardVariant}
           />
         )}
       </CampaignHeroStatsWrapper>
@@ -98,5 +111,6 @@ export const Default: Story = {
     benefitValue: '$100K',
     missionsCount: 5,
     rewardChainIds: ['1', '10'],
+    heroStatsCardVariant: MissionHeroStatsCardVariant.Default,
   },
 };

--- a/src/hooks/campaigns/useCampaignDisplayData.ts
+++ b/src/hooks/campaigns/useCampaignDisplayData.ts
@@ -7,6 +7,12 @@ import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
 export const useCampaignDisplayData = (campaign: CampaignData) => {
   return useMemo(() => {
     const apiBaseUrl = getStrapiBaseUrl();
+
+    const getStatsCardVariant = (colorMode?: BenefitCardColorMode) =>
+      colorMode === BenefitCardColorMode.Dark
+        ? MissionHeroStatsCardVariant.Inverted
+        : MissionHeroStatsCardVariant.Default;
+
     return {
       missionsCount: campaign.MissionCount || campaign.quests?.length || 0,
       slug: campaign.Slug || '',
@@ -26,10 +32,12 @@ export const useCampaignDisplayData = (campaign: CampaignData) => {
         campaign.ProfileBannerCTA ||
         `${AppPaths.Campaign}/${campaign.Slug}` ||
         '',
-      statsCardVariant:
-        campaign.BenefitCardColorMode === BenefitCardColorMode.Dark
-          ? MissionHeroStatsCardVariant.Inverted
-          : MissionHeroStatsCardVariant.Default,
+      bannerStatsCardVariant: getStatsCardVariant(
+        campaign.CarouselBenefitCardColorMode,
+      ),
+      heroStatsCardVariant: getStatsCardVariant(
+        campaign.HeroBenefitCardColorMode,
+      ),
     };
   }, [campaign]);
 };

--- a/src/types/strapi.ts
+++ b/src/types/strapi.ts
@@ -377,7 +377,8 @@ export interface CampaignAttributes {
   updatedAt: string;
   publishedAt?: string;
   MissionCount?: number;
-  BenefitCardColorMode?: BenefitCardColorMode;
+  HeroBenefitCardColorMode?: BenefitCardColorMode;
+  CarouselBenefitCardColorMode?: BenefitCardColorMode;
 }
 
 /* MerklRewards */

--- a/src/utils/strapi/StrapiApi.ts
+++ b/src/utils/strapi/StrapiApi.ts
@@ -238,7 +238,8 @@ type CampaignField =
   | 'ProfileBannerDescription'
   | 'ProfileBannerBadge'
   | 'ProfileBannerCTA'
-  | 'BenefitCardColorMode'
+  | 'CarouselBenefitCardColorMode'
+  | 'HeroBenefitCardColorMode'
   | 'ShowProfileBanner'
   | 'MissionCount'
   | 'StartDate'
@@ -257,7 +258,7 @@ class CampaignParams {
     'StartDate',
     'EndDate',
     'ShowProfileBanner',
-    'BenefitCardColorMode',
+    'HeroBenefitCardColorMode',
     'createdAt',
     'updatedAt',
     'BenefitLabel',
@@ -274,6 +275,7 @@ class CampaignParams {
   ];
 
   private static profileBannerFields: CampaignField[] = [
+    'CarouselBenefitCardColorMode',
     'ProfileBannerTitle',
     'ProfileBannerDescription',
     'ProfileBannerBadge',


### PR DESCRIPTION
Fixes feedback from https://www.figma.com/design/MmAjz3cDZU2BbPDFeisAdi/Missions?node-id=1104-120430&m=dev
Needs this PR merged and released https://github.com/jumperexchange/strapi-cms/pull/67