### PR TITLE
feat: add description link text and cta

### DIFF
--- a/src/app/ui/mission/MissionWidget/MissionFormWidget.tsx
+++ b/src/app/ui/mission/MissionWidget/MissionFormWidget.tsx
@@ -1,9 +1,11 @@
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import { useMissionStore } from 'src/stores/mission';
 import {
   MissionWidgetContainer,
   MissionWidgetContentContainer,
   MissionWidgetTitle,
   MissionWidgetDescription,
+  MissionDescriptionLink,
 } from './MissionWidget.styles';
 import { Button } from 'src/components/Button';
 import {
@@ -22,6 +24,8 @@ export const MissionFormWidget = () => {
   const {
     taskTitle,
     taskDescription,
+    taskDescriptionCTALink,
+    taskDescriptionCTAText,
     taskCTALink,
     taskCTAText,
     taskInputs,
@@ -63,6 +67,12 @@ export const MissionFormWidget = () => {
             {taskDescription}
           </MissionWidgetDescription>
         </MissionWidgetContentContainer>
+        {!!taskDescriptionCTALink && !!taskDescriptionCTAText && (
+          <MissionDescriptionLink target="_blank" href={taskDescriptionCTALink}>
+            {taskDescriptionCTAText}
+            <ArrowForwardIcon />
+          </MissionDescriptionLink>
+        )}
         {hasForm ? (
           <MissionForm />
         ) : (

--- a/src/app/ui/mission/MissionWidget/MissionWidget.styles.tsx
+++ b/src/app/ui/mission/MissionWidget/MissionWidget.styles.tsx
@@ -3,6 +3,7 @@ import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 
 import CheckIcon from '@mui/icons-material/Check';
+import { Link } from 'src/components/Link';
 
 export const MissionWidgetContainer = styled(Box)(({ theme }) => ({
   display: 'flex',
@@ -46,4 +47,22 @@ export const MissionInstructionFormContainer = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   gap: theme.spacing(3),
+}));
+
+export const MissionDescriptionLink = styled(Link)(({ theme }) => ({
+  color: (theme.vars || theme).palette.text.primary,
+  ...theme.typography.bodyMediumStrong,
+  textDecoration: 'none',
+  display: 'inline-flex',
+  width: 'fit-content',
+  alignItems: 'center',
+  gap: theme.spacing(0.75),
+  transition: 'color 0.3s ease',
+  '&:hover': {
+    color: (theme.vars || theme).palette.primary.main,
+  },
+  '& svg': {
+    width: 20,
+    height: 20,
+  },
 }));

--- a/src/components/Cards/EntityCard/EntityCard.styles.tsx
+++ b/src/components/Cards/EntityCard/EntityCard.styles.tsx
@@ -103,6 +103,10 @@ export const StyledEntityCardLink = styled(Link)(({ theme }) => ({
   '&:hover': {
     color: (theme.vars || theme).palette.primary.main,
   },
+  '& svg': {
+    width: 20,
+    height: 20,
+  },
 }));
 
 // Avatars

--- a/src/hooks/tasksVerification/useEnhancedTasks.ts
+++ b/src/hooks/tasksVerification/useEnhancedTasks.ts
@@ -69,6 +69,8 @@ export const useEnhancedTasks = (
       setCurrentTaskInstructionParams({
         taskTitle: widgetParams.title ?? undefined,
         taskDescription: widgetParams.description ?? undefined,
+        taskDescriptionCTALink: widgetParams.descriptionCTALink ?? undefined,
+        taskDescriptionCTAText: widgetParams.descriptionCTAText ?? undefined,
         taskCTAText: widgetParams.CTAText ?? undefined,
         taskCTALink: widgetParams.CTALink ?? undefined,
         taskInputs: widgetParams.inputs ?? undefined,

--- a/src/stores/mission/MissionStore.tsx
+++ b/src/stores/mission/MissionStore.tsx
@@ -18,6 +18,8 @@ interface MissionState {
 
   taskTitle?: string;
   taskDescription?: string;
+  taskDescriptionCTAText?: string;
+  taskDescriptionCTALink?: string;
   taskCTAText?: string;
   taskCTALink?: string;
   taskInputs?: TaskWidgetInformationInputData[];
@@ -55,12 +57,16 @@ interface MissionState {
   setCurrentTaskInstructionParams: ({
     taskTitle,
     taskDescription,
+    taskDescriptionCTALink,
+    taskDescriptionCTAText,
     taskCTALink,
     taskCTAText,
     taskInputs,
   }: {
     taskTitle?: string;
     taskDescription?: string;
+    taskDescriptionCTALink?: string;
+    taskDescriptionCTAText?: string;
     taskCTAText?: string;
     taskCTALink?: string;
     taskInputs?: TaskWidgetInformationInputData[];

--- a/src/types/strapi.ts
+++ b/src/types/strapi.ts
@@ -428,6 +428,8 @@ export interface TaskWidgetInformationData {
   description?: string | null;
   CTALink?: string | null;
   CTAText?: string | null;
+  descriptionCTALink?: string;
+  descriptionCTAText?: string;
   inputs?: TaskWidgetInformationInputData[] | null;
 }
 


### PR DESCRIPTION
In order to allow linking to an external url while also have the task verification form in place, the `descriptionCTALink` and `descriptionCTAText` have been added

Figma: https://www.figma.com/design/MmAjz3cDZU2BbPDFeisAdi/Missions?node-id=281-21782&m=dev

Dependent on https://github.com/jumperexchange/strapi-cms/pull/68