### PR TITLE
feat: update lifi widget config

### DIFF
--- a/src/components/Widgets/variants/base/ZapWidget/ZapDepositWidget.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapDepositWidget.tsx
@@ -57,6 +57,7 @@ export const ZapDepositWidget: FC<ZapDepositWidgetProps> = ({
       includeZap: true,
       zapProviders: providers,
       zapToAddress: toAddress,
+      zapPoolName: poolName,
       baseOverrides,
     };
   }, [

--- a/src/components/Widgets/variants/base/ZapWidget/ZapDepositWidget.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapDepositWidget.tsx
@@ -42,9 +42,14 @@ export const ZapDepositWidget: FC<ZapDepositWidgetProps> = ({
     return zapData?.market?.depositToken.chainId;
   }, [JSON.stringify(zapData ?? {})]);
 
+  const minFromAmountUSD = useMemo(() => {
+    return Number(projectData?.minFromAmountUSD ?? '0');
+  }, [projectData?.minFromAmountUSD]);
+
   const enhancedCtx = useMemo(() => {
     const baseOverrides: ConfigContext['baseOverrides'] = {
       integrator: projectData.integrator,
+      minFromAmountUSD,
     };
 
     return {
@@ -60,6 +65,7 @@ export const ZapDepositWidget: FC<ZapDepositWidgetProps> = ({
     providers,
     toAddress,
     projectData.integrator,
+    minFromAmountUSD,
   ]);
 
   const widgetConfig = useLiFiWidgetConfig(enhancedCtx);

--- a/src/components/Widgets/variants/widgetConfig/base/useBaseWidget.ts
+++ b/src/components/Widgets/variants/widgetConfig/base/useBaseWidget.ts
@@ -28,6 +28,7 @@ export const useBaseWidget = () => {
         HiddenUI.ReverseTokensButton,
         HiddenUI.History,
       ],
+      defaultUI: { navigationHeaderTitleNoWrap: false },
       requiredUI: [RequiredUI.ToAddress],
       walletConfig: {
         onConnect() {

--- a/src/components/Widgets/variants/widgetConfig/base/useLanguageResources.ts
+++ b/src/components/Widgets/variants/widgetConfig/base/useLanguageResources.ts
@@ -5,8 +5,12 @@ import { ConfigContext } from '../types';
 import { useTranslation } from 'react-i18next';
 import { LanguageKey } from 'src/types/i18n';
 
+type EnglishLanguageResource = NonNullable<
+  WidgetConfig['languageResources']
+>['en'];
+
 export const useLanguageResources = (ctx: ConfigContext) => {
-  const { i18n } = useTranslation();
+  const { i18n, t } = useTranslation();
   const {
     currentActiveTaskType,
     destinationChain,
@@ -14,6 +18,7 @@ export const useLanguageResources = (ctx: ConfigContext) => {
     sourceChain,
     sourceToken,
     overrideHeader,
+    zapPoolName,
   } = ctx;
 
   const config: Partial<WidgetConfig> = useMemo(() => {
@@ -39,28 +44,44 @@ export const useLanguageResources = (ctx: ConfigContext) => {
       overrideHeader ??
       `${currentActiveTaskType ?? TaskType.Deposit} ${sourceDestinationTemplate}`;
 
+    const languageResourcesEN: EnglishLanguageResource = {
+      header: {
+        checkout: translationTemplate,
+        exchange: translationTemplate,
+        deposit: translationTemplate,
+        swap: translationTemplate,
+      },
+    };
+
+    if (zapPoolName) {
+      languageResourcesEN.main = {
+        sentToAddress: t('widget.zap.sentToAddressName', {
+          name: zapPoolName,
+        }),
+        sendToAddress: t('widget.zap.sendToAddressName', {
+          name: zapPoolName,
+        }),
+      };
+    }
+
     return {
       languages: {
         default: i18n.language as LanguageKey,
         allow: i18n.languages as LanguageKey[],
       },
       languageResources: {
-        en: {
-          header: {
-            checkout: translationTemplate,
-            exchange: translationTemplate,
-            deposit: translationTemplate,
-            swap: translationTemplate,
-          },
-        },
+        en: languageResourcesEN,
       },
     };
   }, [
+    i18n,
+    t,
     currentActiveTaskType,
     destinationChain?.chainKey,
     sourceChain?.chainKey,
     destinationToken?.tokenSymbol,
     sourceToken?.tokenSymbol,
+    zapPoolName,
   ]);
 
   return config;

--- a/src/components/Widgets/variants/widgetConfig/types.ts
+++ b/src/components/Widgets/variants/widgetConfig/types.ts
@@ -13,6 +13,7 @@ export type ConfigContext = {
   includeZap?: boolean;
   zapToAddress?: `0x${string}`;
   zapProviders?: EVMProvider[];
+  zapPoolName?: string;
 
   taskType?: TaskType;
 


### PR DESCRIPTION
- One of the issues: https://lifi.atlassian.net/browse/LF-14093
- Using the ` defaultUI: { navigationHeaderTitleNoWrap: false }` widget config for covering the case where the header expands on multiple lines
- Linked the zap `projectData` `minFromAmountUSD` to the widget config
Thanks to @chybisov for the changes 🦾 

**Testing steps**

**For: Linked the zap `projectData` `minFromAmountUSD` to the widget config**
- Try depositing into `/zap/test-zap-morpho-base-usdc`
- Enter an amount `< 6` (if you want, you can update the `CustomInformation.projectData.minFromAmountUSD` in the strapi quest and refresh the page)
- You should get a warning
<img width="432" height="596" alt="Screenshot 2025-07-29 at 19 38 51" src="https://github.com/user-attachments/assets/1963193a-b9bb-49f9-9d26-4cb5fec47847" />

- On the widget deposit screen the CTA should be disabled
<img width="435" height="587" alt="Screenshot 2025-07-29 at 19 38 56" src="https://github.com/user-attachments/assets/46abc783-170a-4665-8e7d-81ceccb7f0a1" />

**For: https://lifi.atlassian.net/browse/LF-14093**
- On the widget deposit screen, the `Send to` should include the current pool name
<img width="409" height="96" alt="Screenshot 2025-07-29 at 19 39 36" src="https://github.com/user-attachments/assets/630b71ef-7d56-4df0-ad38-c1dfb645a8a2" />

- On successful deposit, the `Sent to` should include the current pool name

**For the header**
- Simplest way would be to modify `line 43` in `src/components/Widgets/variants/widgetConfig/base/useLanguageResources.ts`
<img width="704" height="95" alt="Screenshot 2025-07-29 at 19 42 22" src="https://github.com/user-attachments/assets/33395873-273e-47b2-b62d-2e69c2102f22" />

- Then the widget title should expand on multiple lines
<img width="461" height="144" alt="Screenshot 2025-07-29 at 19 42 57" src="https://github.com/user-attachments/assets/98692e04-cf62-40d1-9939-2f8fa670e25e" />
