### PR TITLE
fix: disable redirect for locked perks

### DIFF
--- a/src/components/Cards/PerksCard/PerksCard.tsx
+++ b/src/components/Cards/PerksCard/PerksCard.tsx
@@ -18,6 +18,7 @@ interface PerksCardProps {
   levelBadge: ReactNode;
   perksBadge?: ReactNode;
   isLoading?: boolean;
+  isDisabled?: boolean;
   fullWidth?: boolean;
 }
 
@@ -28,6 +29,7 @@ export const PerksCard = ({
   levelBadge,
   perksBadge,
   isLoading,
+  isDisabled = false,
   fullWidth,
 }: PerksCardProps) => {
   if (isLoading) {
@@ -42,7 +44,7 @@ export const PerksCard = ({
         maxWidth: fullWidth ? '100%' : PERK_CARD_SIZES.CARD_WIDTH,
       }}
     >
-      <PerksCardActionArea disableRipple>
+      <PerksCardActionArea disableRipple disabled={isDisabled}>
         {imageUrl ? (
           <PerksCardImage
             src={imageUrl}

--- a/src/components/ProfilePage/components/PerksList/PerksCard.tsx
+++ b/src/components/ProfilePage/components/PerksList/PerksCard.tsx
@@ -24,10 +24,14 @@ export const PerksCard: FC<PerksCardProps> = ({ perk }) => {
   const { t } = useTranslation();
   const { level, isLoading } = useLoyaltyPass(activeAccount?.address);
 
+  const isLocked = useMemo(() => {
+    const currentLevel = Number(level ?? 0);
+    return unlockLevel > currentLevel;
+  }, [unlockLevel, level]);
+
   // @TODO show loading badge if isLoading is true
   const levelBadge = useMemo(() => {
-    const currentLevel = Number(level ?? 0);
-    if (unlockLevel > currentLevel) {
+    if (isLocked) {
       return (
         <Badge
           startIcon={<LockIcon />}
@@ -46,7 +50,7 @@ export const PerksCard: FC<PerksCardProps> = ({ perk }) => {
         size={BadgeSize.LG}
       />
     );
-  }, [unlockLevel, level, t]);
+  }, [unlockLevel, isLocked, t]);
 
   const perksBadge = useMemo(() => {
     return perkItems.map((perkItem, index) => (
@@ -71,10 +75,11 @@ export const PerksCard: FC<PerksCardProps> = ({ perk }) => {
       levelBadge={levelBadge}
       perksBadge={perksBadge}
       fullWidth
+      isDisabled={isLocked}
     />
   );
 
-  return href ? (
+  return href && !isLocked ? (
     <Link
       href={href}
       target="_blank"


### PR DESCRIPTION
This PR handles enabling the redirect for unlocked perks and disabling card interactivity for locked ones.

**Testing steps**
1. Use a fresh wallet to and navigate to the perks page 
2. The current perks should be locked and not clickable
3. Either switch to a wallet having a high enough level (min. 12) or create a perk inside strapi with a small unlock level (as a DRAFT)
4. Check perks with a level < current level are unlocked and clickable