### PR TITLE
chore: hide low activity address confirmation for zap

### DIFF
--- a/src/components/Widgets/variants/base/ZapWidget/ZapDepositWidget.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapDepositWidget.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import { FC, useEffect, useMemo } from 'react';
-import { LiFiWidget, Route, useWidgetEvents, WidgetEvent } from '@lifi/widget';
+import {
+  HiddenUI,
+  LiFiWidget,
+  Route,
+  useWidgetEvents,
+  WidgetEvent,
+} from '@lifi/widget';
 import { WidgetSkeleton } from '../WidgetSkeleton';
 import { useLiFiWidgetConfig } from '../../widgetConfig/hooks';
 import { WidgetProps } from '../Widget.types';
@@ -50,6 +56,7 @@ export const ZapDepositWidget: FC<ZapDepositWidgetProps> = ({
     const baseOverrides: ConfigContext['baseOverrides'] = {
       integrator: projectData.integrator,
       minFromAmountUSD,
+      hiddenUI: [HiddenUI.LowAddressActivityConfirmation],
     };
 
     return {


### PR DESCRIPTION
This PR **hides** the `Low activity` warning for zaps

<img width="428" height="523" alt="Screenshot 2025-08-06 at 16 43 14" src="https://github.com/user-attachments/assets/171fda0a-de5c-466b-bc5c-a455c5ccef00" />
