### PR TITLE
fix: zap remove gas refuel widget UI

### DIFF
--- a/src/components/Widgets/variants/base/ZapWidget/ZapDepositWidget.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapDepositWidget.tsx
@@ -64,7 +64,10 @@ export const ZapDepositWidget: FC<ZapDepositWidgetProps> = ({
     const baseOverrides: ConfigContext['baseOverrides'] = {
       integrator: projectData.integrator,
       minFromAmountUSD,
-      hiddenUI: [HiddenUI.LowAddressActivityConfirmation],
+      hiddenUI: [
+        HiddenUI.LowAddressActivityConfirmation,
+        HiddenUI.GasRefuelMessage,
+      ],
     };
 
     return {

--- a/src/components/ZapWidget/DepositPoolCard/DepositPoolCard.tsx
+++ b/src/components/ZapWidget/DepositPoolCard/DepositPoolCard.tsx
@@ -123,6 +123,7 @@ export const DepositPoolCard: FC<DepositPoolCardProps> = ({
           <BadgeWithChain
             logoURI={zapData?.meta?.logoURI}
             chainId={token?.chainId}
+            badgeSize={15}
             alt={`${zapData?.meta?.name} protocol`}
           />
           <Typography
@@ -170,7 +171,7 @@ export const DepositPoolCard: FC<DepositPoolCardProps> = ({
                   chainId={token.chainId}
                   alt={`${zapData?.meta?.name} protocol`}
                   logoSize={24}
-                  badgeSize={8}
+                  badgeSize={9}
                 />
               }
               contentStyles={{ alignItems: 'center' }}


### PR DESCRIPTION
Removes this option in the UI

![photo_2025-08-11 11 02 01 (1)](https://github.com/user-attachments/assets/17e1557c-82c5-4ed9-966b-b049a496ad19)

And treats the chain sizes for the Deposit Pool card (see [comment 1](https://lifi.atlassian.net/browse/LF-15002) and [Figma](https://www.figma.com/design/MmAjz3cDZU2BbPDFeisAdi/Missions?node-id=704-132085&m=dev))