### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/build-and-push-multitag.yaml
+++ b/.github/workflows/build-and-push-multitag.yaml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Init GCP
         id: build-init
@@ -114,7 +114,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Init GCP
         id: build-init
         uses: ./.github/actions/init-gcp
@@ -190,7 +190,7 @@ jobs:
 
       # Step 2: Checkout the repository for the build context
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       # Step 3: Initialize Docker build
       - name: Init GCP secrets
@@ -265,7 +265,7 @@ jobs:
         shell: bash
         run: echo "UNIQ_ID=$(date +'%y%m%d')-${GITHUB_SHA:0:7}" >> $GITHUB_ENV
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Init GCP
         id: build-init

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -78,7 +78,7 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
     - uses: actions/setup-node@v4
       with:
@@ -127,7 +127,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0