### PR TITLE
fix: zap improvements

### DIFF
--- a/src/components/Widgets/variants/base/ZapWidget/ZapDepositWidget.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapDepositWidget.tsx
@@ -67,6 +67,7 @@ export const ZapDepositWidget: FC<ZapDepositWidgetProps> = ({
       hiddenUI: [
         HiddenUI.LowAddressActivityConfirmation,
         HiddenUI.GasRefuelMessage,
+        HiddenUI.IntegratorStepDetails,
       ],
     };
 

--- a/src/components/Widgets/variants/widgetConfig/base/useZapRPC.tsx
+++ b/src/components/Widgets/variants/widgetConfig/base/useZapRPC.tsx
@@ -38,7 +38,7 @@ export const useZapRPC = () => {
           ...publicRPCList,
         },
         routeOptions: {
-          allowSwitchChain: true,
+          allowSwitchChain: false,
         },
       },
       useRecommendedRoute: true,

--- a/src/components/Widgets/variants/widgetConfig/hooks.ts
+++ b/src/components/Widgets/variants/widgetConfig/hooks.ts
@@ -41,6 +41,11 @@ export function useLiFiWidgetConfig(ctx: ConfigContext = {}): WidgetConfig {
   const overrides = overrideHooks.map((hook) => hook(ctx));
 
   return useMemo(() => {
-    return merge({}, base, ...overrides, ctx.baseOverrides);
+    return merge({}, base, ...overrides, ctx.baseOverrides, {
+      hiddenUI: [
+        ...(base.hiddenUI ?? []),
+        ...(ctx.baseOverrides?.hiddenUI ?? []),
+      ],
+    });
   }, [base, overrides, ctx.baseOverrides]);
 }

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -265,8 +265,8 @@
       "token": "Asset"
     },
     "zap": {
-      "sendToAddressName": "Send to {{name}}",
-      "sentToAddressName": "Sent to {{name}}"
+      "sendToAddressName": "Deposit into {{name}}",
+      "sentToAddressName": "Deposited into {{name}}"
     }
   }
 }


### PR DESCRIPTION
Fixes:
- allowSwitchChain set to `false`: Specifies whether to return routes that require chain switches (2-step routes) as in [docs](https://docs.li.fi/sdk/request-routes#route-options)
- fix issue with hidden ui options being overriden
- hide the integrator step for the moment until we ensure we properly compute the fee
- update translation for `toAddress` in the widget