### PR TITLE
fix: filter out nullable pda or pda rewards

### DIFF
--- a/src/components/ProfilePage/components/AchievementsList/AchievementsList.tsx
+++ b/src/components/ProfilePage/components/AchievementsList/AchievementsList.tsx
@@ -6,6 +6,12 @@ import { AchievementsCard } from './AchievementsCard';
 import { useAchievementsInfinite } from 'src/hooks/achievements/useAchievementsInfinite';
 import { NoDataPlaceholder } from '../NoDataPlaceholder/NoDataPlaceholder';
 import { useTranslation } from 'react-i18next';
+import { PDA } from 'src/types/loyaltyPass';
+
+const hasValidReward = (
+  pda: any,
+): pda is PDA & { reward: NonNullable<PDA['reward']> } =>
+  pda != null && pda.reward != null;
 
 export const AchievementsList = () => {
   const { walletAddress, isLoading: isWalletLoading } =
@@ -16,7 +22,8 @@ export const AchievementsList = () => {
 
   const { t } = useTranslation();
 
-  const pdas = data?.pages.flatMap((page) => page.data) || [];
+  const pdas =
+    data?.pages.flatMap((page) => page.data).filter(hasValidReward) || [];
 
   if (!pdas.length) {
     const entityTranslation = t(


### PR DESCRIPTION
Fixes error encountered on `Profile page - Achievements section`

<img width="2660" height="1418" alt="image (4)" src="https://github.com/user-attachments/assets/02b64524-5cd5-44e3-930a-1d47013627e9" />
