### PR TITLE
chore: remove hideConnectButton from navbar

### DIFF
--- a/src/components/Navbar/ClientNavbar.tsx
+++ b/src/components/Navbar/ClientNavbar.tsx
@@ -46,7 +46,7 @@ export const ClientNavbar = () => {
           variant={isScanPage ? 'scan' : isLearnPage ? 'learn' : 'default'}
         />
       </LogoLinkWrapper>
-      <Layout hideConnectButton={isLearnPage} />
+      <Layout />
     </NavbarContainer>
   );
 };

--- a/src/components/Navbar/ServerNavbar.tsx
+++ b/src/components/Navbar/ServerNavbar.tsx
@@ -1,25 +1,19 @@
 import RouterLink from 'next/link';
-import { cookies } from 'next/headers';
 
 import { Logo } from './components/Logo/Logo';
 import { NavbarContainer } from './Navbar.style';
 import { Layout } from './layout/Layout';
 import { Link } from '../Link';
 
-import { checkIsLearnPage } from './utils';
 import { AppPaths } from 'src/const/urls';
 
 export const ServerNavbar = async () => {
-  const cookieStore = await cookies();
-  const pathname = cookieStore.get('pathname')?.value || '';
-  const isLearnPage = checkIsLearnPage(pathname);
-
   return (
     <NavbarContainer enableColorOnDark>
       <Link component={RouterLink} href={AppPaths.Main}>
         <Logo variant="default" />
       </Link>
-      <Layout hideConnectButton={isLearnPage} />
+      <Layout />
     </NavbarContainer>
   );
 };

--- a/src/components/Navbar/layout/Layout.tsx
+++ b/src/components/Navbar/layout/Layout.tsx
@@ -11,16 +11,12 @@ import { MobileLayout } from './MobileLayout';
 import { WalletMenu } from 'src/components/Menus/WalletMenu';
 import { WalletButtons } from '../components/Buttons/WalletButtons';
 
-interface LayoutProps {
-  hideConnectButton: boolean;
-}
-
-export const Layout = ({ hideConnectButton }: LayoutProps) => {
+export const Layout = () => {
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'));
 
-  const secondaryButtons = !hideConnectButton && (
+  const secondaryButtons = (
     <Box display="flex" flexDirection="row" gap={1}>
-      {!hideConnectButton && <WalletButtons />}
+      <WalletButtons />
     </Box>
   );
 


### PR DESCRIPTION
Remove hideConnectButton flag in order to always display the wallet buttons - level and wallet address buttons