### PR TITLE
feat: add vaults override with Gauntlet

### DIFF
--- a/src/components/Widgets/variants/widgetConfig/hooks.ts
+++ b/src/components/Widgets/variants/widgetConfig/hooks.ts
@@ -1,31 +1,31 @@
-import { useMemo } from 'react';
 import { WidgetConfig } from '@lifi/widget';
 import merge from 'lodash/merge';
-
-import { ConfigContext } from './types';
+import { useMemo } from 'react';
+import { useBaseWidget } from './base/useBaseWidget';
+import { useFormOverride } from './overrides/formOverride';
+import { useLanguageOverride } from './overrides/languageOverride';
+import { useRPCOverride } from './overrides/rpcOverride';
+import { useSubvariantOverride } from './overrides/subvariantOverride';
+import { useVaultOverride } from './overrides/vaultOverride';
+import { useZapOverride } from './overrides/zapOverride';
 import {
   getRegisteredOverrideHooks,
   registerOverrideHook,
 } from './overridesRegistry';
-
-import { useBaseWidget } from './base/useBaseWidget';
-
-import { useLanguageOverride } from './overrides/languageOverride';
-import { useSubvariantOverride } from './overrides/subvariantOverride';
-import { useFormOverride } from './overrides/formOverride';
-import { useZapOverride } from './overrides/zapOverride';
-import { useRPCOverride } from './overrides/rpcOverride';
+import { ConfigContext } from './types';
 
 registerOverrideHook('languageResources', useLanguageOverride);
 registerOverrideHook('subvariant', useSubvariantOverride);
 registerOverrideHook('form', useFormOverride);
 registerOverrideHook('rpc', useRPCOverride);
 registerOverrideHook('zap', useZapOverride);
+registerOverrideHook('vauts', useVaultOverride);
 
 function getOverrideNamesForContext(ctx: ConfigContext): string[] {
   const names = ['languageResources', 'subvariant', 'form'];
   if (ctx.includeZap) {
     names.push('zap');
+    names.push('vauts');
   } else {
     names.push('rpc');
   }

--- a/src/components/Widgets/variants/widgetConfig/overrides/vaultOverride.ts
+++ b/src/components/Widgets/variants/widgetConfig/overrides/vaultOverride.ts
@@ -1,0 +1,21 @@
+import { Token } from '@lifi/widget';
+import { ConfigOverrideHook } from '../types';
+
+// https://app.morpho.org/katana/vault/0xE4248e2105508FcBad3fe95691551d1AF14015f7/gauntlet-usdc
+const LP_TOKEN_GAUNTLET_USDC: Token = {
+  address: '0xE4248e2105508FcBad3fe95691551d1AF14015f7',
+  symbol: 'gtUSDC',
+  name: 'ERC-20: Gauntlet USDC',
+  decimals: 18,
+  priceUSD: '1',
+  chainId: 747474,
+  logoURI: 'https://cdn.morpho.org/v2/assets/images/gauntlet.svg',
+};
+
+export const useVaultOverride: ConfigOverrideHook = (ctx) => {
+  return {
+    tokens: {
+      include: [LP_TOKEN_GAUNTLET_USDC],
+    },
+  };
+};


### PR DESCRIPTION
Fixes https://lifi.atlassian.net/browse/LF-15086

Adds Katana's target token:
<img width="150" src="https://github.com/user-attachments/assets/09313022-c13d-46e6-bc4f-37ebf28c603d" />

💣  Do not merge:

**Problem 1: The token will show up in other parts of the UI, like at as a source, we don't want that**
<img width="150" src="https://github.com/user-attachments/assets/c5277b8c-e8b6-4dcf-9e3d-414fbe00ccfc" />

**Problem 2: We need to decide if we want to hardcode these now and release, or implement it "correctly"**

The "right" way would pull to the data from Strapi or the Backend, maybe through the `get-zaps-data` endpoint,
and update the Widget Config dynamically.

https://github.com/jumperexchange/jumper-backend/blob/15d6bf30784dfd0659c034e98f2aa634ddac964f/src/common/contracts/contracts.json#L208-L212