### PR TITLE
fix: wallet connection error for biconomy clients due to wrong transport

### DIFF
--- a/src/providers/ZapInitProvider/WalletClient/hooks.ts
+++ b/src/providers/ZapInitProvider/WalletClient/hooks.ts
@@ -2,7 +2,8 @@ import { useCallback } from 'react';
 import { EVMAddress } from 'src/types/internal';
 import { useConfig, useWalletClient } from 'wagmi';
 import { useBiconomyClientsStore } from 'src/stores/biconomyClients/BiconomyClientsStore';
-import { useAccount } from '@lifi/wallet-management';
+import { Account, useAccount } from '@lifi/wallet-management';
+import { ChainType } from '@lifi/sdk';
 
 interface WalletClientParams {
   address?: EVMAddress;
@@ -10,6 +11,17 @@ interface WalletClientParams {
   projectAddress: EVMAddress;
   projectChainId: number;
 }
+
+const getEVMProvider = async (connector: any) => {
+  if (connector && 'getProvider' in connector) {
+    return await connector.getProvider();
+  }
+  return window.ethereum;
+};
+
+const validateAccountChainType = (account: Account) => {
+  return !account.chainType || account.chainType === ChainType.EVM;
+};
 
 export const useWalletClientInitialization = () => {
   const wagmiConfig = useConfig();
@@ -32,10 +44,20 @@ export const useWalletClientInitialization = () => {
       projectChainId,
     }: WalletClientParams) => {
       try {
+        if (!validateAccountChainType(account)) {
+          throw new Error('Account is not an EVM account');
+        }
+
         console.warn(
           'initializeClients based on these wallet client values',
+          'walletClient chain:',
           walletClient?.chain?.id,
+          'walletClient address:',
           walletClient?.account.address,
+          'priority address:',
+          address,
+          'priority chainId:',
+          chainId,
         );
 
         if (
@@ -49,11 +71,14 @@ export const useWalletClientInitialization = () => {
           );
         }
 
+        const provider = await getEVMProvider(account.connector);
+
         // Note: getClients would need to be passed as parameter or imported
         const biconomyClients = await getClients(
           projectAddress,
           projectChainId,
           walletClient,
+          provider,
           chainId,
         );
 
@@ -63,7 +88,12 @@ export const useWalletClientInitialization = () => {
         return { walletClient: null, biconomyClients: null };
       }
     },
-    [wagmiConfig, walletClient?.account.address, walletClient?.chain?.id],
+    [
+      wagmiConfig,
+      walletClient?.account.address,
+      walletClient?.chain?.id,
+      account,
+    ],
   );
 
   return { initializeClients };

--- a/src/providers/ZapInitProvider/WalletClient/hooks.ts
+++ b/src/providers/ZapInitProvider/WalletClient/hooks.ts
@@ -3,7 +3,7 @@ import { EVMAddress } from 'src/types/internal';
 import { useConfig, useWalletClient } from 'wagmi';
 import { useBiconomyClientsStore } from 'src/stores/biconomyClients/BiconomyClientsStore';
 import { Account, useAccount } from '@lifi/wallet-management';
-import { ChainType } from '@lifi/sdk';
+import { ChainId, ChainType } from '@lifi/sdk';
 
 interface WalletClientParams {
   address?: EVMAddress;
@@ -23,7 +23,7 @@ const validateAccountChainType = (account: Account) => {
   return !account.chainType || account.chainType === ChainType.EVM;
 };
 
-export const useWalletClientInitialization = () => {
+export const useWalletClientInitialization = (allowedChains: ChainId[]) => {
   const wagmiConfig = useConfig();
   const { getClients } = useBiconomyClientsStore();
   const { account } = useAccount();
@@ -46,6 +46,10 @@ export const useWalletClientInitialization = () => {
       try {
         if (!validateAccountChainType(account)) {
           throw new Error('Account is not an EVM account');
+        }
+
+        if (chainId && !allowedChains.includes(chainId)) {
+          throw new Error('Chain is not allowed');
         }
 
         console.warn(
@@ -93,6 +97,7 @@ export const useWalletClientInitialization = () => {
       walletClient?.account.address,
       walletClient?.chain?.id,
       account,
+      allowedChains,
     ],
   );
 

--- a/src/stores/biconomyClients/BiconomyClientsStore.ts
+++ b/src/stores/biconomyClients/BiconomyClientsStore.ts
@@ -5,7 +5,7 @@ import {
   MultichainSmartAccount,
   toMultichainNexusAccount,
 } from '@biconomy/abstractjs';
-import { createWalletClient, custom, http } from 'viem';
+import { createWalletClient, custom, http, publicActions } from 'viem';
 import { chains } from '../../const/chains/chains';
 import { createWithEqualityFn } from 'zustand/traditional';
 import { retryWithBackoff } from 'src/utils/retryWithBackoff';
@@ -270,11 +270,16 @@ export const useBiconomyClientsStore =
                 transport: custom(provider, { key: 'jumper-custom-zap' }),
               }),
               chains: [currentChain, depositChain],
-              transports: [
-                custom(provider, { key: 'jumper-custom-zap' }),
-                custom(provider, { key: 'jumper-custom-zap' }),
-              ],
+              transports: [http(), http()],
               ...BICONOMY_CONFIG,
+            });
+
+            oNexusInit.deployments.forEach((deployment) => {
+              deployment.walletClient = createWalletClient({
+                account: deployment.walletClient.account.address as EVMAddress,
+                chain: deployment.walletClient.chain,
+                transport: custom(provider, { key: 'jumper-custom-zap' }),
+              }).extend(publicActions);
             });
 
             const meeClientInit = await createMeeClient({

--- a/src/stores/biconomyClients/BiconomyClientsStore.ts
+++ b/src/stores/biconomyClients/BiconomyClientsStore.ts
@@ -5,7 +5,7 @@ import {
   MultichainSmartAccount,
   toMultichainNexusAccount,
 } from '@biconomy/abstractjs';
-import { http } from 'viem';
+import { createWalletClient, custom, http } from 'viem';
 import { chains } from '../../const/chains/chains';
 import { createWithEqualityFn } from 'zustand/traditional';
 import { retryWithBackoff } from 'src/utils/retryWithBackoff';
@@ -51,6 +51,7 @@ interface BiconomyClientsState {
     projectAddress?: EVMAddress,
     destinationChainId?: number,
     walletClient?: UseWalletClientReturnType['data'],
+    provider?: any,
     currentChainId?: number,
   ) => Promise<BiconomyClients | null>;
   getToAddress: (
@@ -207,6 +208,7 @@ export const useBiconomyClientsStore =
         projectAddress,
         projectChainId,
         walletClient,
+        provider,
         currentChainId,
       ) => {
         if (!walletClient) {
@@ -262,9 +264,16 @@ export const useBiconomyClientsStore =
         try {
           const { oNexus, meeClient } = await retryWithBackoff(async () => {
             const oNexusInit = await toMultichainNexusAccount({
-              signer: walletClient,
+              signer: createWalletClient({
+                account: walletClient.account.address as EVMAddress,
+                chain: walletClient.chain,
+                transport: custom(provider, { key: 'jumper-custom-zap' }),
+              }),
               chains: [currentChain, depositChain],
-              transports: [http(), http()],
+              transports: [
+                custom(provider, { key: 'jumper-custom-zap' }),
+                custom(provider, { key: 'jumper-custom-zap' }),
+              ],
               ...BICONOMY_CONFIG,
             });
 


### PR DESCRIPTION
Contributes to https://lifi.atlassian.net/browse/LF-15080

## Testing steps
1. Make sure you have at least 2 wallet extensions enabled in incognito
2. Open incognito and ensure both extensions are logged in
3. Connect the app to one of them
4. Go to `/zap/morpho-katana-usdc` or `/zap/morpho-katana-usdc-ioana`
5. Try depositing and make sure the correct wallet extension opens up
6. Ensure you don't get any of these errors
<img width="1020" height="885" alt="Screenshot 2025-08-13 at 21 43 23" src="https://github.com/user-attachments/assets/3990e829-ba06-411d-9b7d-37c6f5b2395b" />

This might still appear, though my assumption is it was showing up due to the wrong wallet extension popping up
<img width="936" height="1534" alt="image (5) (1)" src="https://github.com/user-attachments/assets/fe84e4ec-45f2-4901-88d5-d19c37ccab03" />
