### PR TITLE
fix: keep missions tab active

### DIFF
--- a/src/components/Navbar/hooks.ts
+++ b/src/components/Navbar/hooks.ts
@@ -84,7 +84,7 @@ export const useMainLinks = () => {
       {
         value: AppPaths.Missions,
         label: t('navbar.links.missions'),
-        subLinks: [AppPaths.Campaign],
+        subLinks: [AppPaths.Missions, AppPaths.Campaign],
         testId: 'navbar-missions-button',
       },
     ];

--- a/src/components/Navbar/hooks.ts
+++ b/src/components/Navbar/hooks.ts
@@ -84,7 +84,7 @@ export const useMainLinks = () => {
       {
         value: AppPaths.Missions,
         label: t('navbar.links.missions'),
-        subLinks: [AppPaths.Missions, AppPaths.Campaign],
+        subLinks: [AppPaths.Missions, AppPaths.Campaign, AppPaths.Zap],
         testId: 'navbar-missions-button',
       },
     ];


### PR DESCRIPTION
## Testing steps
1. Go to `/missions` page and check the `Missions` is active
2. Click on a mission that performs a redirect to a current sub-path
3. Check the `Missions` is active
4. Go to `/zap/morpho-katana-usdc` and check the `Missions` is still active
5. Go to main page and check that `Missions` is no longer active
6. Repeat for mobile

<img width="1209" height="462" alt="Screenshot 2025-08-15 at 17 04 39" src="https://github.com/user-attachments/assets/0deb651d-8306-4cb4-89f0-05de5eac6ef9" />
