### PR TITLE
chore: add cleanup operation for source token if different then deposit token

### DIFF
--- a/src/providers/ZapInitProvider/WalletClient/methods.ts
+++ b/src/providers/ZapInitProvider/WalletClient/methods.ts
@@ -232,19 +232,29 @@ export const sendCalls = async (
   const userBalance = BigInt(currentTokenBalance?.amount ?? 0);
   const requestedAmount = BigInt(currentRouteFromAmount);
 
+  const cleanUps = [
+    {
+      tokenAddress: depositToken,
+      chainId: depositChainId,
+      recipientAddress: currentAddress as EVMAddress,
+    },
+  ];
+
+  if (!isSameTokenDeposit) {
+    cleanUps.unshift({
+      tokenAddress: currentRouteFromToken.address as EVMAddress,
+      chainId: currentChainId,
+      recipientAddress: currentAddress as EVMAddress,
+    });
+  }
+
   const fusionQuoteParams: GetFusionQuoteParams = {
     trigger: {
       tokenAddress: currentRouteFromToken.address as EVMAddress,
       amount: requestedAmount,
       chainId: currentChainId,
     },
-    cleanUps: [
-      {
-        tokenAddress: depositToken,
-        chainId: depositChainId,
-        recipientAddress: currentAddress as EVMAddress,
-      },
-    ],
+    cleanUps,
     feeToken: {
       address: currentRouteFromToken.address as EVMAddress,
       chainId: currentChainId,


### PR DESCRIPTION
Issue: https://lifi.atlassian.net/browse/LF-15110

## Testing steps

1. Try depositing any token beside `USDC` on `Katana` **no need to sign the tx**
<img width="446" height="541" alt="Screenshot 2025-08-15 at 18 06 32" src="https://github.com/user-attachments/assets/0cd4820b-e965-42b9-8838-2a5baae61c3c" />

3. Open the network tab and filter by `quote-permit`
4. In the response you should see in the `userOps` 2 operations having `isCleanUpUserOp` set to `true`

<img width="683" height="682" alt="Screenshot 2025-08-15 at 18 08 30" src="https://github.com/user-attachments/assets/2eb92f28-ae7a-4439-8c82-747aaf167447" />

6. Now select the `USDC` on `Katana`
7. Click deposit
8. Filter for `quote-permit` and the response should contain in `userOps` a single operation having `isCleanUpUserOp` set to true

<img width="667" height="352" alt="Screenshot 2025-08-15 at 18 09 57" src="https://github.com/user-attachments/assets/0d8b5101-32e9-4d99-9610-d1c54dd24f9c" />
