### PR TITLE
fix: active nav item on language switch

### DIFF
--- a/src/components/Navbar/components/Buttons/LevelButton.tsx
+++ b/src/components/Navbar/components/Buttons/LevelButton.tsx
@@ -1,18 +1,15 @@
 import { useTranslation } from 'react-i18next';
-import { usePathname } from 'next/navigation';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import Skeleton from '@mui/material/Skeleton';
-import { Link } from 'src/components/Link';
-import { NavbarButton, NavbarButtonLabel } from './Buttons.style';
 import { AppPaths } from 'src/const/urls';
 import AvatarBadge from 'src/components/AvatarBadge/AvatarBadge';
 import { useLevelDisplayData } from '../../hooks';
 import { LabelButton } from './LabelButton';
+import { usePathnameWithoutLocale } from 'src/hooks/routing/usePathnameWithoutLocale';
 
 export const LevelButton = () => {
   const { t } = useTranslation();
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'));
-  const pathname = usePathname();
+  const pathname = usePathnameWithoutLocale();
   const {
     imageAlt: levelImageAlt,
     imageUrl: levelImageUrl,

--- a/src/components/Navbar/hooks.ts
+++ b/src/components/Navbar/hooks.ts
@@ -14,7 +14,7 @@ import type { Address } from 'viem';
 import { walletDigest } from 'src/utils/walletDigest';
 import { AppPaths } from 'src/const/urls';
 import { useTranslation } from 'react-i18next';
-import { usePathname } from 'next/navigation';
+import { usePathnameWithoutLocale } from 'src/hooks/routing/usePathnameWithoutLocale';
 
 export const useLevelDisplayData = () => {
   const activeAccount = useActiveAccountByChainType();
@@ -71,7 +71,7 @@ export const useIsDisconnected = () => {
 
 export const useMainLinks = () => {
   const { t } = useTranslation();
-  const pathname = usePathname();
+  const pathname = usePathnameWithoutLocale();
 
   const links = useMemo(() => {
     return [

--- a/src/hooks/routing/usePathnameWithoutLocale.ts
+++ b/src/hooks/routing/usePathnameWithoutLocale.ts
@@ -1,0 +1,13 @@
+import { usePathname } from 'next/navigation';
+import { locales } from 'src/i18n/i18next-locales';
+
+export const usePathnameWithoutLocale = () => {
+  const pathname = usePathname();
+
+  const segments = pathname.split('/');
+  if (segments.length > 1 && locales.includes(segments[1])) {
+    return '/' + segments.slice(2).join('/') || '/';
+  }
+
+  return pathname;
+};


### PR DESCRIPTION
Fixes an issue discovered during testing that on language switch, the navigation items loose the active state

<img width="1389" height="940" alt="Screenshot 2025-08-18 at 16 44 20" src="https://github.com/user-attachments/assets/fe814902-1984-489b-a477-da08fb3e45cf" />
<img width="1389" height="940" alt="Screenshot 2025-08-18 at 16 44 32" src="https://github.com/user-attachments/assets/9de32321-173e-4372-b427-a9a980d82ea9" />

https://lifi.atlassian.net/browse/LF-15199

## Testing steps
1. Go to `/`
2. Check the `Exchange` item in the navigation has the active state
3. Now from the `•••` menu, change the language
4. Observe the `Exchange` item in the navigation keeps the active state
5. Select the `Gas` option in the main widget
6. Observe `Exchange` still keeps the active state
7. Now repeat for the mission and profile pages