### PR TITLE
fix: sendCalls triggered more than once for same route

### DIFF
--- a/src/providers/ZapInitProvider/ZapInitProvider.tsx
+++ b/src/providers/ZapInitProvider/ZapInitProvider.tsx
@@ -107,6 +107,7 @@ export const ZapInitProvider: FC<ZapInitProviderProps> = ({
     removePendingOperation,
     getPendingOperationsForFromValues,
     getPromiseResolversForOperation,
+    setProcessingPendingOperation,
   } = useZapPendingOperationsStore();
 
   const pendingOperationsLength = useZapPendingOperationsStore(
@@ -278,6 +279,10 @@ export const ZapInitProvider: FC<ZapInitProviderProps> = ({
         actualCurrentRoute?.fromChainId,
       );
 
+      if (filteredPendingOps.length === 0) {
+        return;
+      }
+
       console.warn(
         `Preparing to execute ${filteredPendingOps.length}/${pendingOperationsLength} pending operations`,
       );
@@ -325,6 +330,8 @@ export const ZapInitProvider: FC<ZapInitProviderProps> = ({
             continue;
           }
 
+          setProcessingPendingOperation(pendingOp.id);
+
           const result = await operation(
             pendingOp.args as any,
             biconomyClients?.meeClient,
@@ -368,6 +375,7 @@ export const ZapInitProvider: FC<ZapInitProviderProps> = ({
     initializeClients,
     getPromiseResolversForOperation,
     removePendingOperation,
+    setProcessingPendingOperation,
   ]);
 
   // Enhanced initialization with retry logic and better error handling


### PR DESCRIPTION
Issue: https://lifi.atlassian.net/browse/LF-15116

The issue occurred when clients were not initialized and sendCalls was queued. During execution, if the transaction wasn’t signed—because other dependencies caused the useEffect to run again—it would attempt to re-execute the operation. The fix was to introduce a flag indicating that the operation is already in progress but has not yet produced a result.

## Testing steps
1. Go to `/zap/morpho-katana-usdc`
2. Select a chain different that the current wallet
3. Select any token and insert an amount
4. Click on `Deposit`, but **do not sign the transaction**
5. You should see in the logs `Preparing to execute {x}/{y} pending operation` - if not just refresh the page and try again steps 2-4
6. Wait for ~2-3minutes and check there is no extra approval txs triggered