### PR TITLE
fix: error shown due to rpc rate limiting

### DIFF
--- a/src/const/rpcList.ts
+++ b/src/const/rpcList.ts
@@ -30,3 +30,8 @@ export const publicRPCList = {
   '42161': shuffleArray(arbRPCList),
   '8453': shuffleArray(basRPCList),
 };
+
+export const mergedRPCList = {
+  ...JSON.parse(config.NEXT_PUBLIC_CUSTOM_RPCS ?? {}),
+  ...publicRPCList,
+};

--- a/src/const/rpcList.ts
+++ b/src/const/rpcList.ts
@@ -18,11 +18,13 @@ const arbRPCList = [
 ];
 
 const basRPCList = [
+  'https://base.llamarpc.com',
   'https://mainnet.base.org/',
-  'https://base.meowrpc.com',
+  // 'https://base.meowrpc.com',
   // 'https://base.drpc.org',
   `https://lb.drpc.org/ogrpc?network=base&dkey=${config.NEXT_PUBLIC_DKEY}`,
   'https://base-pokt.nodies.app',
+  'https://base-rpc.publicnode.com',
 ];
 
 export const publicRPCList = {

--- a/src/stores/biconomyClients/BiconomyClientsStore.ts
+++ b/src/stores/biconomyClients/BiconomyClientsStore.ts
@@ -11,7 +11,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { retryWithBackoff } from 'src/utils/retryWithBackoff';
 import { UseWalletClientReturnType } from 'wagmi';
 import { EVMAddress } from 'src/types/internal';
-import { mergedRPCList } from 'src/const/rpcList';
+import { getShuffledRPCForChain } from 'src/utils/rpc/getShuffledRPCForChain';
 
 export type BiconomyClients = {
   meeClient: MeeClient;
@@ -267,15 +267,16 @@ export const useBiconomyClientsStore =
         // Initialize new clients
         try {
           const usedChains = [currentChain, depositChain];
-
-          const chainsConfig = {
-            chains: usedChains,
-            transports: usedChains.map((chain) =>
-              http(mergedRPCList[chain.id]?.[0]),
-            ),
-          };
-
           const { oNexus, meeClient } = await retryWithBackoff(async () => {
+            const chainsConfig = {
+              chains: usedChains,
+              transports: usedChains.map((chain) => {
+                const rpcUrl = getShuffledRPCForChain(chain.id);
+                console.warn(`Using RPC ${rpcUrl} for chain ${chain.id}`);
+                return http(rpcUrl || undefined);
+              }),
+            };
+
             const oNexusInit = await toMultichainNexusAccount({
               signer: createWalletClient({
                 account: walletClient.account.address as EVMAddress,

--- a/src/stores/biconomyClients/BiconomyClientsStore.ts
+++ b/src/stores/biconomyClients/BiconomyClientsStore.ts
@@ -11,6 +11,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 import { retryWithBackoff } from 'src/utils/retryWithBackoff';
 import { UseWalletClientReturnType } from 'wagmi';
 import { EVMAddress } from 'src/types/internal';
+import { mergedRPCList } from 'src/const/rpcList';
 
 export type BiconomyClients = {
   meeClient: MeeClient;
@@ -265,6 +266,15 @@ export const useBiconomyClientsStore =
 
         // Initialize new clients
         try {
+          const usedChains = [currentChain, depositChain];
+
+          const chainsConfig = {
+            chains: usedChains,
+            transports: usedChains.map((chain) =>
+              http(mergedRPCList[chain.id]?.[0]),
+            ),
+          };
+
           const { oNexus, meeClient } = await retryWithBackoff(async () => {
             const oNexusInit = await toMultichainNexusAccount({
               signer: createWalletClient({
@@ -272,8 +282,7 @@ export const useBiconomyClientsStore =
                 chain: walletClient.chain,
                 transport: custom(provider, { key: 'jumper-custom-zap' }),
               }),
-              chains: [currentChain, depositChain],
-              transports: [http(), http()],
+              ...chainsConfig,
               ...BICONOMY_CONFIG,
             });
 

--- a/src/utils/rpc/getShuffledRPCForChain.ts
+++ b/src/utils/rpc/getShuffledRPCForChain.ts
@@ -1,0 +1,11 @@
+import { shuffle } from 'lodash';
+import { mergedRPCList } from 'src/const/rpcList';
+
+export const getShuffledRPCForChain = (chainId: string | number) => {
+  const rpcUrls = mergedRPCList[chainId];
+  if (!rpcUrls?.length) {
+    return;
+  }
+
+  return shuffle([...rpcUrls])[0];
+};


### PR DESCRIPTION
Issue: https://lifi.atlassian.net/browse/LF-15140

## Testing steps
1. Go to `/zap/morpho-katana-usdc`
2. Select `Base` as the source chain
3. Select any token and insert an amount > 5$
4. Deposit
5. Sign the tx
6. Ensure you don't get this error message

![2370405a-1881-45d9-8718-d49a079017df](https://github.com/user-attachments/assets/9aee8b4f-ba05-4f68-b5fb-3b36c0abe4bb)

> [!IMPORTANT]
> Bonus testing points:
> Repeatedly refresh the page while your wallet is connected to Base.
> If an RPC URL causes an error during the Biconomy initialization, the next initialization attempt should automatically switch to a different RPC URL, since we shuffle them on each retry.
