### PR TITLE
chore: use the title field in the widget section to overwrite widget title on the task page

### DIFF
--- a/src/components/Widgets/variants/mission/MissionBaseWidget.tsx
+++ b/src/components/Widgets/variants/mission/MissionBaseWidget.tsx
@@ -15,6 +15,7 @@ export const MissionBaseWidget: FC<MissionBaseWidgetProps> = () => {
     fromAmount,
     toAddress,
     currentActiveTaskType,
+    taskTitle,
     // missionChainIds,
   } = useMissionStore();
 
@@ -27,6 +28,7 @@ export const MissionBaseWidget: FC<MissionBaseWidgetProps> = () => {
       fromAmount,
       toAddress,
       taskType: currentActiveTaskType,
+      overrideHeader: taskTitle,
     };
   }, [
     destinationChain,
@@ -36,6 +38,7 @@ export const MissionBaseWidget: FC<MissionBaseWidgetProps> = () => {
     fromAmount,
     toAddress,
     currentActiveTaskType,
+    taskTitle,
   ]);
 
   return <Widget ctx={ctx} />;

--- a/src/components/Widgets/variants/widgetConfig/base/useLanguageResources.ts
+++ b/src/components/Widgets/variants/widgetConfig/base/useLanguageResources.ts
@@ -12,7 +12,7 @@ type EnglishLanguageResource = NonNullable<
 export const useLanguageResources = (ctx: ConfigContext) => {
   const { i18n, t } = useTranslation();
   const {
-    currentActiveTaskType,
+    taskType,
     destinationChain,
     destinationToken,
     sourceChain,
@@ -42,7 +42,7 @@ export const useLanguageResources = (ctx: ConfigContext) => {
 
     const translationTemplate =
       overrideHeader ??
-      `${currentActiveTaskType ?? TaskType.Deposit} ${sourceDestinationTemplate}`;
+      `${taskType ?? TaskType.Deposit} ${sourceDestinationTemplate}`;
 
     const languageResourcesEN: EnglishLanguageResource = {
       header: {
@@ -76,7 +76,7 @@ export const useLanguageResources = (ctx: ConfigContext) => {
   }, [
     i18n,
     t,
-    currentActiveTaskType,
+    taskType,
     destinationChain?.chainKey,
     sourceChain?.chainKey,
     destinationToken?.tokenSymbol,


### PR DESCRIPTION
Issue: https://lifi.atlassian.net/browse/LF-15271

## Description
This PR adds the option to override the widget title for `Deposit/Swap/Bridge` tasks.
Also fixed a bug where the task type was not correctly displayed due to using the wrong prop.

## Testing steps

1. Go to `/missions/test123`
2. Select the first task
3. Ensure the title is overridden with the `TaskWidgetInformation.title` from Strapi
<img width="1134" height="228" alt="Screenshot 2025-08-25 at 18 40 55" src="https://github.com/user-attachments/assets/e2512f35-f7c8-4bce-bd9d-14d9a97e39d5" />

4. Now select the swap task
5. This task should have the title `Swap to ETH on LSK`
<img width="1109" height="353" alt="Screenshot 2025-08-25 at 18 41 00" src="https://github.com/user-attachments/assets/05ba0521-91c6-4e7e-bf11-dba9f2b8b21b" />
