### PR TITLE
fix: zap dynamic min constraint

### DIFF
--- a/src/providers/ZapInitProvider/ModularZaps/DefaultZap.ts
+++ b/src/providers/ZapInitProvider/ModularZaps/DefaultZap.ts
@@ -20,7 +20,7 @@ export const approve: ZapInstruction = async (
   const depositChainId = projectData.chainId;
 
   const constraints = [
-    greaterThanOrEqualTo(parseUnits('0.1', depositTokenDecimals)),
+    greaterThanOrEqualTo(context.getMinConstraintValue(depositTokenDecimals)),
   ];
 
   return buildContractComposable(oNexus, {
@@ -52,7 +52,7 @@ export const deposit: ZapInstruction = async (
   const depositChainId = projectData.chainId;
 
   const constraints = [
-    greaterThanOrEqualTo(parseUnits('0.1', depositTokenDecimals)),
+    greaterThanOrEqualTo(context.getMinConstraintValue(depositTokenDecimals)),
   ];
 
   const depositInputs = integrationData.abi.deposit.inputs;
@@ -91,7 +91,7 @@ export const transfer: ZapInstruction = async (
   const depositChainId = projectData.chainId;
 
   const constraints = [
-    greaterThanOrEqualTo(parseUnits('0.1', depositTokenDecimals)),
+    greaterThanOrEqualTo(context.getMinConstraintValue(depositTokenDecimals)),
   ];
 
   const depositInputs = integrationData.abi.deposit.inputs;

--- a/src/providers/ZapInitProvider/ModularZaps/DefaultZap.ts
+++ b/src/providers/ZapInitProvider/ModularZaps/DefaultZap.ts
@@ -4,7 +4,7 @@ import {
   runtimeERC20BalanceOf,
 } from '@biconomy/abstractjs';
 import { EVMAddress } from 'src/types/internal';
-import { AbiParameter, parseUnits } from 'viem';
+import { AbiParameter } from 'viem';
 import { buildContractComposable } from '../utils';
 import { ZapExecutionContext, ZapDefinition, ZapInstruction } from './base';
 

--- a/src/providers/ZapInitProvider/ModularZaps/HyperwaveZap.ts
+++ b/src/providers/ZapInitProvider/ModularZaps/HyperwaveZap.ts
@@ -78,7 +78,7 @@ export const hyperwaveDeposit: ZapInstruction = async (
   const depositChainId = projectData.chainId;
 
   const constraints = [
-    greaterThanOrEqualTo(parseUnits('0.1', depositTokenDecimals)),
+    greaterThanOrEqualTo(context.getMinConstraintValue(depositTokenDecimals)),
   ];
 
   const minimumMint: bigint = withSlippage(

--- a/src/providers/ZapInitProvider/ModularZaps/HyperwaveZap.ts
+++ b/src/providers/ZapInitProvider/ModularZaps/HyperwaveZap.ts
@@ -4,14 +4,7 @@ import {
   runtimeERC20BalanceOf,
 } from '@biconomy/abstractjs';
 import { EVMAddress } from 'src/types/internal';
-import {
-  Abi,
-  AbiParameter,
-  createPublicClient,
-  getContract,
-  http,
-  parseUnits,
-} from 'viem';
+import { Abi, AbiParameter, createPublicClient, getContract, http } from 'viem';
 import { hyperevm } from 'src/const/chains/hyperwave';
 import { buildContractComposable } from '../utils';
 import { approve, transfer } from './DefaultZap';

--- a/src/providers/ZapInitProvider/ModularZaps/base.ts
+++ b/src/providers/ZapInitProvider/ModularZaps/base.ts
@@ -80,7 +80,8 @@ export const makeZapExecutionContext = (
   const getMinConstraintValue = (decimals: number) => {
     if (
       !params.projectData.minFromAmountUSD ||
-      !params.currentRoute.toToken.priceUSD
+      !params.currentRoute.toToken.priceUSD ||
+      isNaN(Number(params.currentRoute.toToken.priceUSD))
     ) {
       return parseUnits('0.001', decimals);
     }

--- a/src/providers/ZapInitProvider/ModularZaps/base.ts
+++ b/src/providers/ZapInitProvider/ModularZaps/base.ts
@@ -80,20 +80,21 @@ export const makeZapExecutionContext = (
   const getMinConstraintValue = (decimals: number) => {
     if (
       !params.projectData.minFromAmountUSD ||
-      !params.currentRoute.toAmountUSD ||
-      !params.currentRoute.toAmount
+      !params.currentRoute.toToken.priceUSD
     ) {
       return parseUnits('0.001', decimals);
     }
 
-    const tokenRateUSD =
-      Number(params.currentRoute.toAmountUSD) /
-      Number(params.currentRoute.toAmount);
-
+    // @Note: Alternatively we could use the toAmountUSD and toAmount to calculate the token rate.
+    // (Number(params.currentRoute.toAmountUSD) / Number(params.currentRoute.toAmount)) * 10**decimals
+    const tokenRateUSD = Number(params.currentRoute.toToken.priceUSD);
     const minTokenAmount =
       Number(params.projectData.minFromAmountUSD) / tokenRateUSD;
+
+    // @Note: We divide by 2 as the final amount might get some loss due to gas payments.
     const halfMinTokenAmount = minTokenAmount / 2;
-    return BigInt(Math.floor(halfMinTokenAmount));
+
+    return parseUnits(halfMinTokenAmount.toString(), decimals);
   };
 
   return {

--- a/src/providers/ZapInitProvider/ModularZaps/base.ts
+++ b/src/providers/ZapInitProvider/ModularZaps/base.ts
@@ -3,6 +3,7 @@ import { Route } from '@lifi/sdk';
 import { EVMAddress } from 'src/types/internal';
 import { ProjectData } from 'src/types/questDetails';
 import { AbiEntry, ZapDataResponse } from './zap.jumper-backend';
+import { parseUnits } from 'viem';
 
 export interface SendCallsExtraParams {
   currentRoute: Route | null;
@@ -33,6 +34,7 @@ export interface ValidatedSendCallsExtraParams extends SendCallsExtraParams {
 export interface ZapExecutionContext extends ValidatedSendCallsExtraParams {
   getAbiAddress: (fct: AbiEntry) => EVMAddress;
   getDepositAddress: () => EVMAddress;
+  getMinConstraintValue: (decimals: number) => bigint;
 }
 
 export interface ZapDefinition {
@@ -75,10 +77,30 @@ export const makeZapExecutionContext = (
     return getAbiAddress(params.zapData.abi.deposit);
   };
 
+  const getMinConstraintValue = (decimals: number) => {
+    if (
+      !params.projectData.minFromAmountUSD ||
+      !params.currentRoute.toAmountUSD ||
+      !params.currentRoute.toAmount
+    ) {
+      return parseUnits('0.001', decimals);
+    }
+
+    const tokenRateUSD =
+      Number(params.currentRoute.toAmountUSD) /
+      Number(params.currentRoute.toAmount);
+
+    const minTokenAmount =
+      Number(params.projectData.minFromAmountUSD) / tokenRateUSD;
+    const halfMinTokenAmount = minTokenAmount / 2;
+    return BigInt(Math.floor(halfMinTokenAmount));
+  };
+
   return {
     ...params,
     getAbiAddress,
     getDepositAddress,
+    getMinConstraintValue,
   };
 };
 

--- a/src/types/questDetails.ts
+++ b/src/types/questDetails.ts
@@ -31,6 +31,7 @@ export interface ProjectData {
   address: string;
   withdrawAddress?: string;
   tokenAddress?: string;
+  minFromAmountUSD?: number | string;
 }
 
 export interface QuestDetails {


### PR DESCRIPTION
Should fix the issue experienced during same-token deposit of wETH

<img width="1346" height="1584" alt="Screenshot 2025-08-26 at 21 04 12" src="https://github.com/user-attachments/assets/ad09cd4f-f6d1-49df-ade2-2b8b773877e5" />

## Testing steps
1. Go to `zap/morpho-katana-gauntlet-weth-ioana`
2. Select `wETH` on `Katana`
3. Enter an amount and deposit (on this zap the minimum is `0.5$`)
4. Check the deposit is successful
