### PR TITLE
fix: mismatch between page sizes for perks prevents 2nd page fetching

### DIFF
--- a/src/app/[lng]/(infos)/profile/[walletAddress]/page.tsx
+++ b/src/app/[lng]/(infos)/profile/[walletAddress]/page.tsx
@@ -6,6 +6,7 @@ import { Suspense } from 'react';
 import { getPerks } from 'src/app/lib/getPerks';
 import { ProfilePage } from 'src/components/ProfilePage/ProfilePage';
 import { ProfilePageSkeleton } from 'src/components/ProfilePage/ProfilePageSkeleton';
+import { PAGE_SIZE } from 'src/const/perks';
 
 type Params = Promise<{ walletAddress: string }>;
 
@@ -62,7 +63,11 @@ export default async function Page({ params }: { params: Params }) {
   }
 
   const sanitizedAddress = result.data;
-  const { data: perksResponse } = await getPerks();
+  const { data: perksResponse } = await getPerks({
+    page: 1,
+    pageSize: PAGE_SIZE,
+    withCount: true,
+  });
 
   const perks = perksResponse.data;
   const totalPerks = perksResponse.meta.pagination?.total || 0;

--- a/src/app/[lng]/(infos)/profile/page.tsx
+++ b/src/app/[lng]/(infos)/profile/page.tsx
@@ -4,6 +4,7 @@ import { Suspense } from 'react';
 import { getPerks } from 'src/app/lib/getPerks';
 import { ProfilePage } from 'src/components/ProfilePage/ProfilePage';
 import { ProfilePageSkeleton } from 'src/components/ProfilePage/ProfilePageSkeleton';
+import { PAGE_SIZE } from 'src/const/perks';
 
 export const metadata: Metadata = {
   title: 'Jumper Loyalty Pass',
@@ -15,7 +16,11 @@ export const metadata: Metadata = {
 };
 
 export default async function Page() {
-  const { data: perksResponse } = await getPerks();
+  const { data: perksResponse } = await getPerks({
+    page: 1,
+    pageSize: PAGE_SIZE,
+    withCount: true,
+  });
 
   const perks = perksResponse.data;
   const totalPerks = perksResponse.meta.pagination?.total || 0;

--- a/src/const/perks.ts
+++ b/src/const/perks.ts
@@ -1,0 +1,1 @@
+export const PAGE_SIZE = 10;

--- a/src/hooks/perks/usePerksInfinite.ts
+++ b/src/hooks/perks/usePerksInfinite.ts
@@ -1,7 +1,7 @@
 import { PerksDataAttributes, StrapiResponseData } from 'src/types/strapi';
 import { usePaginatedData } from '../usePaginatedData';
-import { PAGE_SIZE } from 'src/const/quests';
 import { getPerks } from 'src/app/lib/getPerks';
+import { PAGE_SIZE } from 'src/const/perks';
 
 export async function fetchPerksData(page: number, pageSize: number = 12) {
   const { data: perksResponse } = await getPerks({


### PR DESCRIPTION
This fixes issue of having the page size mismatch for the perks on the profile page.

On staging you can see the 2nd page of perks are not fetched, but on this PR all pages should be fetched.