### PR TITLE
feat: add modular rich blocks component and use it for missions

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "framer-motion": "^11.18.2",
     "graphql": "^16.11.0",
     "graphql-request": "^7.2.0",
+    "html-react-parser": "^5.2.6",
     "i18next": "^25.3.4",
     "i18next-resources-for-ts": "^1.6.0",
     "i18next-resources-to-backend": "^1.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,13 +16,13 @@ importers:
         version: 1.9.0(abitype@1.0.9(typescript@5.9.2)(zod@3.25.76))(typescript@5.9.2)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@abstract-foundation/agw-react':
         specifier: ^1.8.8
-        version: 1.9.0(900b6c4b605cbc63a33b27f6d0d41013)
+        version: 1.9.0(b2bb8a28b6f1532b169cc7aa0a3cfc80)
       '@biconomy/abstractjs':
         specifier: 1.1.2
         version: 1.1.2(@metamask/delegation-toolkit@0.11.0(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)))(@rhinestone/module-sdk@0.2.7(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)))(typescript@5.9.2)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@bigmi/react':
         specifier: ^0.5.2
-        version: 0.5.2(@tanstack/query-core@5.85.5)(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))
+        version: 0.5.2(@tanstack/query-core@5.85.6)(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))
       '@emotion/cache':
         specifier: ^11.14.0
         version: 11.14.0
@@ -40,19 +40,19 @@ importers:
         version: 2.2.7(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@lifi/explorer':
         specifier: ^0.4.0
-        version: 0.4.0(1d1d2f31a47dbc4ef181ea6e976dc515)
+        version: 0.4.0(443d4a98bc398b101fbf2c3a6df4868c)
       '@lifi/sdk':
         specifier: ^3.11.3
         version: 3.11.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       '@lifi/wallet-management':
         specifier: ^3.15.1
-        version: 3.15.1(2253da81c6352ac10ab8fdaad0f0396a)
+        version: 3.15.1(6563757cbdaa3e0d35dfbfaa24256b29)
       '@lifi/widget':
         specifier: ^3.29.1
-        version: 3.29.1(534c746f8745bae7d18f451c050fda9d)
+        version: 3.29.1(ad9c7bb7a0bd60375e43334dfe0a508f)
       '@merkl/api':
         specifier: 1.1.2
-        version: 1.1.2(exact-mirror@0.2.0(@sinclair/typebox@0.34.40))(file-type@21.0.0)(typescript@5.9.2)
+        version: 1.1.2(exact-mirror@0.2.0(@sinclair/typebox@0.34.41))(file-type@21.0.0)(typescript@5.9.2)
       '@metaplex-foundation/mpl-core':
         specifier: ^1.1.1
         version: 1.6.0(@metaplex-foundation/umi@0.9.2)(@noble/hashes@1.8.0)
@@ -82,7 +82,7 @@ importers:
         version: 7.3.1(@types/react@19.1.12)(react@19.1.1)
       '@mysten/dapp-kit':
         specifier: ^0.17.6
-        version: 0.17.6(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(babel-plugin-macros@3.1.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
+        version: 0.17.6(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(babel-plugin-macros@3.1.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
       '@mysten/sui':
         specifier: ^1.37.5
         version: 1.37.5(typescript@5.9.2)
@@ -121,7 +121,7 @@ importers:
         version: 1.0.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tanstack/react-query':
         specifier: ^5.85.0
-        version: 5.85.5(react@19.1.1)
+        version: 5.85.6(react@19.1.1)
       '@turtledev/api':
         specifier: 1.4.5
         version: 1.4.5(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)
@@ -130,7 +130,7 @@ importers:
         version: 5.0.2(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1))
       '@wagmi/core':
         specifier: ^2.20.1
-        version: 2.20.1(@tanstack/query-core@5.85.5)(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
+        version: 2.20.3(@tanstack/query-core@5.85.6)(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@walletconnect/solana-adapter':
         specifier: ^0.0.8
         version: 0.0.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -161,6 +161,9 @@ importers:
       graphql-request:
         specifier: ^7.2.0
         version: 7.2.0(graphql@16.11.0)
+      html-react-parser:
+        specifier: ^5.2.6
+        version: 5.2.6(@types/react@19.1.12)(react@19.1.1)
       i18next:
         specifier: ^25.3.4
         version: 25.4.2(typescript@5.9.2)
@@ -223,7 +226,7 @@ importers:
         version: 2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       wagmi:
         specifier: ^2.16.8
-        version: 2.16.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.5)(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+        version: 2.16.9(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.6)(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       zod:
         specifier: ^3.25.73
         version: 3.25.76
@@ -257,7 +260,7 @@ importers:
         version: 1.54.0
       '@rainbow-me/rainbowkit':
         specifier: ^2.2.6
-        version: 2.2.8(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react@19.1.12)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.16.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.5)(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
+        version: 2.2.8(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.16.9(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.6)(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
       '@storybook/addon-a11y':
         specifier: ^9.1.2
         version: 9.1.3(storybook@9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1)))
@@ -272,7 +275,7 @@ importers:
         version: 9.1.3(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1)))(vitest@3.2.4)
       '@storybook/nextjs-vite':
         specifier: 9.1.2
-        version: 9.1.2(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(next@15.5.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.49.0)(storybook@9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1))
+        version: 9.1.2(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(next@15.5.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.50.0)(storybook@9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1))
       '@synthetixio/synpress':
         specifier: 4.1.0
         version: 4.1.0(@depay/solana-web3.js@1.98.3)(@depay/web3-blockchains@9.8.6)(@playwright/test@1.54.0)(bufferutil@4.0.9)(ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(playwright-core@1.54.0)(postcss@8.5.6)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -359,7 +362,7 @@ importers:
         version: 3.6.2
       rollup-plugin-polyfill-node:
         specifier: ^0.13.0
-        version: 0.13.0(rollup@4.49.0)
+        version: 0.13.0(rollup@4.50.0)
       storybook:
         specifier: ^9.1.2
         version: 9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1))
@@ -2245,8 +2248,8 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@mdx-js/react@3.1.0':
-    resolution: {integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==}
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
@@ -2999,8 +3002,8 @@ packages:
     peerDependencies:
       viem: ^2.21.36
 
-  '@privy-io/js-sdk-core@0.54.0':
-    resolution: {integrity: sha512-BJ6RGtO9mRrJrbF4PGO03+ruZX+zuA11JQ/RBIeFR/aGtc2gYLGY7VwFFyiQzIvohU31Z10PBVavRN0fTl93ug==}
+  '@privy-io/js-sdk-core@0.54.2':
+    resolution: {integrity: sha512-EDg10NFnbRd+pUbKbg7Cbg9qUq31hKg4trEq4CDhFbixfno0uOO924Dj1vbFzdVBOkFudHsoAmmgfSZ8shXGyQ==}
     peerDependencies:
       permissionless: ^0.2.47
       viem: ^2.30.6
@@ -3010,13 +3013,14 @@ packages:
       viem:
         optional: true
 
-  '@privy-io/public-api@2.44.0':
-    resolution: {integrity: sha512-89+jDodeOTCGrs+uazwcnj7b+gdW935yvBBzfuQF7WY3iuZPlT5/FgrvS/91e8NWGTh4tuFEa189q5V+9SdjCw==}
+  '@privy-io/public-api@2.44.2':
+    resolution: {integrity: sha512-w+IpGmHIbCHyPka4fmcsIOO8IOaWRV8la/LRAZ1pDhkeKxMNR8zVVJu8jlLFbxu45tAhREvChpz0OGyDu40hmA==}
 
-  '@privy-io/react-auth@2.22.0':
-    resolution: {integrity: sha512-MkWEMKpWiaON41UjBVcjAyugOITMT2kpDvvztQ849VsH7YyUOOlTBC8sGNsdzGsr7d4nqGE8yc2qWwbLUKHa0g==}
+  '@privy-io/react-auth@2.24.0':
+    resolution: {integrity: sha512-ujG/4LZEBSXLZPzlcsiRx+mq3l6fUAGccHWtNbFMJK072uys2tQDrwDO2RPwlgWPMnQmu8XH7uaW80MG2TxivQ==}
     peerDependencies:
       '@abstract-foundation/agw-client': ^1.0.0
+      '@solana/kit': ^2.3.0
       '@solana/spl-token': ^0.4.9
       '@solana/web3.js': ^1.95.8
       permissionless: ^0.2.47
@@ -3024,6 +3028,8 @@ packages:
       react-dom: ^18 || ^19
     peerDependenciesMeta:
       '@abstract-foundation/agw-client':
+        optional: true
+      '@solana/kit':
         optional: true
       '@solana/spl-token':
         optional: true
@@ -3546,103 +3552,108 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.49.0':
-    resolution: {integrity: sha512-rlKIeL854Ed0e09QGYFlmDNbka6I3EQFw7iZuugQjMb11KMpJCLPFL4ZPbMfaEhLADEL1yx0oujGkBQ7+qW3eA==}
+  '@rollup/rollup-android-arm-eabi@4.50.0':
+    resolution: {integrity: sha512-lVgpeQyy4fWN5QYebtW4buT/4kn4p4IJ+kDNB4uYNT5b8c8DLJDg6titg20NIg7E8RWwdWZORW6vUFfrLyG3KQ==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.49.0':
-    resolution: {integrity: sha512-cqPpZdKUSQYRtLLr6R4X3sD4jCBO1zUmeo3qrWBCqYIeH8Q3KRL4F3V7XJ2Rm8/RJOQBZuqzQGWPjjvFUcYa/w==}
+  '@rollup/rollup-android-arm64@4.50.0':
+    resolution: {integrity: sha512-2O73dR4Dc9bp+wSYhviP6sDziurB5/HCym7xILKifWdE9UsOe2FtNcM+I4xZjKrfLJnq5UR8k9riB87gauiQtw==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.49.0':
-    resolution: {integrity: sha512-99kMMSMQT7got6iYX3yyIiJfFndpojBmkHfTc1rIje8VbjhmqBXE+nb7ZZP3A5skLyujvT0eIUCUsxAe6NjWbw==}
+  '@rollup/rollup-darwin-arm64@4.50.0':
+    resolution: {integrity: sha512-vwSXQN8T4sKf1RHr1F0s98Pf8UPz7pS6P3LG9NSmuw0TVh7EmaE+5Ny7hJOZ0M2yuTctEsHHRTMi2wuHkdS6Hg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.49.0':
-    resolution: {integrity: sha512-y8cXoD3wdWUDpjOLMKLx6l+NFz3NlkWKcBCBfttUn+VGSfgsQ5o/yDUGtzE9HvsodkP0+16N0P4Ty1VuhtRUGg==}
+  '@rollup/rollup-darwin-x64@4.50.0':
+    resolution: {integrity: sha512-cQp/WG8HE7BCGyFVuzUg0FNmupxC+EPZEwWu2FCGGw5WDT1o2/YlENbm5e9SMvfDFR6FRhVCBePLqj0o8MN7Vw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.49.0':
-    resolution: {integrity: sha512-3mY5Pr7qv4GS4ZvWoSP8zha8YoiqrU+e0ViPvB549jvliBbdNLrg2ywPGkgLC3cmvN8ya3za+Q2xVyT6z+vZqA==}
+  '@rollup/rollup-freebsd-arm64@4.50.0':
+    resolution: {integrity: sha512-UR1uTJFU/p801DvvBbtDD7z9mQL8J80xB0bR7DqW7UGQHRm/OaKzp4is7sQSdbt2pjjSS72eAtRh43hNduTnnQ==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.49.0':
-    resolution: {integrity: sha512-C9KzzOAQU5gU4kG8DTk+tjdKjpWhVWd5uVkinCwwFub2m7cDYLOdtXoMrExfeBmeRy9kBQMkiyJ+HULyF1yj9w==}
+  '@rollup/rollup-freebsd-x64@4.50.0':
+    resolution: {integrity: sha512-G/DKyS6PK0dD0+VEzH/6n/hWDNPDZSMBmqsElWnCRGrYOb2jC0VSupp7UAHHQ4+QILwkxSMaYIbQ72dktp8pKA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.49.0':
-    resolution: {integrity: sha512-OVSQgEZDVLnTbMq5NBs6xkmz3AADByCWI4RdKSFNlDsYXdFtlxS59J+w+LippJe8KcmeSSM3ba+GlsM9+WwC1w==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.50.0':
+    resolution: {integrity: sha512-u72Mzc6jyJwKjJbZZcIYmd9bumJu7KNmHYdue43vT1rXPm2rITwmPWF0mmPzLm9/vJWxIRbao/jrQmxTO0Sm9w==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.49.0':
-    resolution: {integrity: sha512-ZnfSFA7fDUHNa4P3VwAcfaBLakCbYaxCk0jUnS3dTou9P95kwoOLAMlT3WmEJDBCSrOEFFV0Y1HXiwfLYJuLlA==}
+  '@rollup/rollup-linux-arm-musleabihf@4.50.0':
+    resolution: {integrity: sha512-S4UefYdV0tnynDJV1mdkNawp0E5Qm2MtSs330IyHgaccOFrwqsvgigUD29uT+B/70PDY1eQ3t40+xf6wIvXJyg==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.49.0':
-    resolution: {integrity: sha512-Z81u+gfrobVK2iV7GqZCBfEB1y6+I61AH466lNK+xy1jfqFLiQ9Qv716WUM5fxFrYxwC7ziVdZRU9qvGHkYIJg==}
+  '@rollup/rollup-linux-arm64-gnu@4.50.0':
+    resolution: {integrity: sha512-1EhkSvUQXJsIhk4msxP5nNAUWoB4MFDHhtc4gAYvnqoHlaL9V3F37pNHabndawsfy/Tp7BPiy/aSa6XBYbaD1g==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.49.0':
-    resolution: {integrity: sha512-zoAwS0KCXSnTp9NH/h9aamBAIve0DXeYpll85shf9NJ0URjSTzzS+Z9evmolN+ICfD3v8skKUPyk2PO0uGdFqg==}
+  '@rollup/rollup-linux-arm64-musl@4.50.0':
+    resolution: {integrity: sha512-EtBDIZuDtVg75xIPIK1l5vCXNNCIRM0OBPUG+tbApDuJAy9mKago6QxX+tfMzbCI6tXEhMuZuN1+CU8iDW+0UQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.49.0':
-    resolution: {integrity: sha512-2QyUyQQ1ZtwZGiq0nvODL+vLJBtciItC3/5cYN8ncDQcv5avrt2MbKt1XU/vFAJlLta5KujqyHdYtdag4YEjYQ==}
+  '@rollup/rollup-linux-loongarch64-gnu@4.50.0':
+    resolution: {integrity: sha512-BGYSwJdMP0hT5CCmljuSNx7+k+0upweM2M4YGfFBjnFSZMHOLYR0gEEj/dxyYJ6Zc6AiSeaBY8dWOa11GF/ppQ==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.49.0':
-    resolution: {integrity: sha512-k9aEmOWt+mrMuD3skjVJSSxHckJp+SiFzFG+v8JLXbc/xi9hv2icSkR3U7uQzqy+/QbbYY7iNB9eDTwrELo14g==}
+  '@rollup/rollup-linux-ppc64-gnu@4.50.0':
+    resolution: {integrity: sha512-I1gSMzkVe1KzAxKAroCJL30hA4DqSi+wGc5gviD0y3IL/VkvcnAqwBf4RHXHyvH66YVHxpKO8ojrgc4SrWAnLg==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.49.0':
-    resolution: {integrity: sha512-rDKRFFIWJ/zJn6uk2IdYLc09Z7zkE5IFIOWqpuU0o6ZpHcdniAyWkwSUWE/Z25N/wNDmFHHMzin84qW7Wzkjsw==}
+  '@rollup/rollup-linux-riscv64-gnu@4.50.0':
+    resolution: {integrity: sha512-bSbWlY3jZo7molh4tc5dKfeSxkqnf48UsLqYbUhnkdnfgZjgufLS/NTA8PcP/dnvct5CCdNkABJ56CbclMRYCA==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.49.0':
-    resolution: {integrity: sha512-FkkhIY/hYFVnOzz1WeV3S9Bd1h0hda/gRqvZCMpHWDHdiIHn6pqsY3b5eSbvGccWHMQ1uUzgZTKS4oGpykf8Tw==}
+  '@rollup/rollup-linux-riscv64-musl@4.50.0':
+    resolution: {integrity: sha512-LSXSGumSURzEQLT2e4sFqFOv3LWZsEF8FK7AAv9zHZNDdMnUPYH3t8ZlaeYYZyTXnsob3htwTKeWtBIkPV27iQ==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.49.0':
-    resolution: {integrity: sha512-gRf5c+A7QiOG3UwLyOOtyJMD31JJhMjBvpfhAitPAoqZFcOeK3Kc1Veg1z/trmt+2P6F/biT02fU19GGTS529A==}
+  '@rollup/rollup-linux-s390x-gnu@4.50.0':
+    resolution: {integrity: sha512-CxRKyakfDrsLXiCyucVfVWVoaPA4oFSpPpDwlMcDFQvrv3XY6KEzMtMZrA+e/goC8xxp2WSOxHQubP8fPmmjOQ==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.49.0':
-    resolution: {integrity: sha512-BR7+blScdLW1h/2hB/2oXM+dhTmpW3rQt1DeSiCP9mc2NMMkqVgjIN3DDsNpKmezffGC9R8XKVOLmBkRUcK/sA==}
+  '@rollup/rollup-linux-x64-gnu@4.50.0':
+    resolution: {integrity: sha512-8PrJJA7/VU8ToHVEPu14FzuSAqVKyo5gg/J8xUerMbyNkWkO9j2ExBho/68RnJsMGNJq4zH114iAttgm7BZVkA==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.49.0':
-    resolution: {integrity: sha512-hDMOAe+6nX3V5ei1I7Au3wcr9h3ktKzDvF2ne5ovX8RZiAHEtX1A5SNNk4zt1Qt77CmnbqT+upb/umzoPMWiPg==}
+  '@rollup/rollup-linux-x64-musl@4.50.0':
+    resolution: {integrity: sha512-SkE6YQp+CzpyOrbw7Oc4MgXFvTw2UIBElvAvLCo230pyxOLmYwRPwZ/L5lBe/VW/qT1ZgND9wJfOsdy0XptRvw==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.49.0':
-    resolution: {integrity: sha512-wkNRzfiIGaElC9kXUT+HLx17z7D0jl+9tGYRKwd8r7cUqTL7GYAvgUY++U2hK6Ar7z5Z6IRRoWC8kQxpmM7TDA==}
+  '@rollup/rollup-openharmony-arm64@4.50.0':
+    resolution: {integrity: sha512-PZkNLPfvXeIOgJWA804zjSFH7fARBBCpCXxgkGDRjjAhRLOR8o0IGS01ykh5GYfod4c2yiiREuDM8iZ+pVsT+Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.50.0':
+    resolution: {integrity: sha512-q7cIIdFvWQoaCbLDUyUc8YfR3Jh2xx3unO8Dn6/TTogKjfwrax9SyfmGGK6cQhKtjePI7jRfd7iRYcxYs93esg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.49.0':
-    resolution: {integrity: sha512-gq5aW/SyNpjp71AAzroH37DtINDcX1Qw2iv9Chyz49ZgdOP3NV8QCyKZUrGsYX9Yyggj5soFiRCgsL3HwD8TdA==}
+  '@rollup/rollup-win32-ia32-msvc@4.50.0':
+    resolution: {integrity: sha512-XzNOVg/YnDOmFdDKcxxK410PrcbcqZkBmz+0FicpW5jtjKQxcW1BZJEQOF0NJa6JO7CZhett8GEtRN/wYLYJuw==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.49.0':
-    resolution: {integrity: sha512-gEtqFbzmZLFk2xKh7g0Rlo8xzho8KrEFEkzvHbfUGkrgXOpZ4XagQ6n+wIZFNh1nTb8UD16J4nFSFKXYgnbdBg==}
+  '@rollup/rollup-win32-x64-msvc@4.50.0':
+    resolution: {integrity: sha512-xMmiWRR8sp72Zqwjgtf3QbZfF1wdh8X2ABu3EaozvZcyHJeU0r+XAnXdKgs4cCAp6ORoYoCygipYP1mjmbjrsg==}
     cpu: [x64]
     os: [win32]
 
@@ -3834,8 +3845,8 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
-  '@sinclair/typebox@0.34.40':
-    resolution: {integrity: sha512-gwBNIP8ZAYev/ORDWW0QvxdwPXwxBtLsdsJgSc7eDIRt8ubP+rxUBzPsrwnu16fgEF8Bx4lh/+mvQvJzcTM6Kw==}
+  '@sinclair/typebox@0.34.41':
+    resolution: {integrity: sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==}
 
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
@@ -4121,16 +4132,16 @@ packages:
     resolution: {integrity: sha512-cs1WKawpXIe+vSTeiZUuSBy8JFjEuDgdMKZFRLKwQysKo8y2q6Q1HvS74Yw+m5IhOW1nTZooa6rlgdfXcgFAaw==}
     engines: {node: '>=12'}
 
-  '@tanstack/query-core@5.85.5':
-    resolution: {integrity: sha512-KO0WTob4JEApv69iYp1eGvfMSUkgw//IpMnq+//cORBzXf0smyRwPLrUvEe5qtAEGjwZTXrjxg+oJNP/C00t6w==}
+  '@tanstack/query-core@5.85.6':
+    resolution: {integrity: sha512-hCj0TktzdCv2bCepIdfwqVwUVWb+GSHm1Jnn8w+40lfhQ3m7lCO7ADRUJy+2unxQ/nzjh2ipC6ye69NDW3l73g==}
 
-  '@tanstack/react-query@5.85.5':
-    resolution: {integrity: sha512-/X4EFNcnPiSs8wM2v+b6DqS5mmGeuJQvxBglmDxl6ZQb5V26ouD2SJYAcC3VjbNwqhY2zjxVD15rDA5nGbMn3A==}
+  '@tanstack/react-query@5.85.6':
+    resolution: {integrity: sha512-VUAag4ERjh+qlmg0wNivQIVCZUrYndqYu3/wPCVZd4r0E+1IqotbeyGTc+ICroL/PqbpSaGZg02zSWYfcvxbdA==}
     peerDependencies:
       react: ^18 || ^19
 
-  '@tanstack/react-router@1.131.28':
-    resolution: {integrity: sha512-vWExhrqHJuT9v+6/2DCQ4pVvPaYoLazMNw8WXiLNuzBXh1FuEoIGaW3jw3DEP0OJCmMiWtTi34NzQnakkQZlQg==}
+  '@tanstack/react-router@1.131.31':
+    resolution: {integrity: sha512-fN71d3BfRD46fpPwaoTf1hcuVWU9bJV5x6y2yyzaz9qDttwZR5RmPK/oi5zSo7o3kvWp4CND9bVjBzSK1BaUcg==}
     engines: {node: '>=12'}
     peerDependencies:
       react: '>=18.0.0 || >=19.0.0'
@@ -4148,8 +4159,8 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/router-core@1.131.28':
-    resolution: {integrity: sha512-f+vdfr3WKSS/BcqgI5s4vZg9xYb7NkvIolkaMELrbz3l+khkw1aTjx8wqCHRY4dqwIAxq+iZBZtMWXA7pztGJg==}
+  '@tanstack/router-core@1.131.30':
+    resolution: {integrity: sha512-fBHn6MSqodYZfky7Z4UyXaxYdIom2QpwaBmra9eM9SRUHmbSCQJ2CESQzGzxFDENtvtyXGsSpGbe7k7GTJctKw==}
     engines: {node: '>=12'}
 
   '@tanstack/store@0.7.4':
@@ -4646,30 +4657,18 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
-  '@wagmi/connectors@5.9.8':
-    resolution: {integrity: sha512-FA/xmfWDT36Sm24GcZzm51D6oRf2XpBgEQhQajKDFcZpkSKIcwKDqqWyNXdSENdgbDcLKC49fFwoVKZT+K88hw==}
+  '@wagmi/connectors@5.9.9':
+    resolution: {integrity: sha512-6+eqU7P2OtxU2PkIw6kHojfYYUJykYG2K5rSkzVh29RDCAjhJqGEZW5f1b8kV5rUBORip1NpST8QTBNi96JHGQ==}
     peerDependencies:
-      '@wagmi/core': 2.20.2
+      '@wagmi/core': 2.20.3
       typescript: '>=5.0.4'
       viem: 2.x
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@wagmi/core@2.20.1':
-    resolution: {integrity: sha512-uuwc+rlqwyxrpDiw17pdL1YXv0Cx3y1R2SoBF/SuxrYZqTGMNDx00sVcvB51p+orXCcEWsDwZsCwUpaPkOHqqw==}
-    peerDependencies:
-      '@tanstack/query-core': '>=5.0.0'
-      typescript: '>=5.0.4'
-      viem: 2.x
-    peerDependenciesMeta:
-      '@tanstack/query-core':
-        optional: true
-      typescript:
-        optional: true
-
-  '@wagmi/core@2.20.2':
-    resolution: {integrity: sha512-bnFDoOTd3ZWQb5cGNSM+Q6ZqWCPxaA+09je9oSuUM6hIWg7rDKWrRtNE9DCmqiEK/fMsKtdfisyrKukKbji5ZQ==}
+  '@wagmi/core@2.20.3':
+    resolution: {integrity: sha512-gsbuHnWxf0AYZISvR8LvF/vUCIq6/ZwT5f5/FKd6wLA7Wq05NihCvmQpIgrcVbpSJPL67wb6S8fXm3eJGJA1vQ==}
     peerDependencies:
       '@tanstack/query-core': '>=5.0.0'
       typescript: '>=5.0.4'
@@ -5390,8 +5389,8 @@ packages:
   camelize@1.0.1:
     resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
 
-  caniuse-lite@1.0.30001737:
-    resolution: {integrity: sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==}
+  caniuse-lite@1.0.30001739:
+    resolution: {integrity: sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==}
 
   canonicalize@2.1.0:
     resolution: {integrity: sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==}
@@ -5811,6 +5810,19 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   dotenv-cli@10.0.0:
     resolution: {integrity: sha512-lnOnttzfrzkRx2echxJHQRB6vOAMSCzzZg79IxpC00tU42wZPuZkQxNNrrwVAxaQZIIh001l4PxVlCrBxngBzA==}
     hasBin: true
@@ -5857,8 +5869,8 @@ packages:
   elliptic@6.6.1:
     resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
 
-  elysia@1.3.20:
-    resolution: {integrity: sha512-7j2w/1NALKu1KOPDFEIKaSLZ2gcL92Ij/POssDOglZO04rFFQ3unvBjUVYTrMMKbDn+/tLd5OXuSUztK+pcEtQ==}
+  elysia@1.3.21:
+    resolution: {integrity: sha512-LLfDSoVA5fBoqKQfMJyzmHLkya8zMbEYwd7DS7v2iQB706mgzWg0gufXl58cFALErcvSayplrkDvjkmlYTkIZQ==}
     peerDependencies:
       exact-mirror: '>= 0.0.9'
       file-type: '>= 20.0.0'
@@ -5900,6 +5912,14 @@ packages:
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   env-schema@5.2.1:
     resolution: {integrity: sha512-gWMNrQ3dVHAZcCx7epiFwgXcyfBh4heD/6+OK3bEbke3uL+KqwYA9nUOwzJyRZh1cJOFcwdPuY1n0GKSFlSWAg==}
@@ -6512,8 +6532,8 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-east-asian-width@1.3.0:
-    resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
+  get-east-asian-width@1.3.1:
+    resolution: {integrity: sha512-R1QfovbPsKmosqTnPoRFiJ7CF9MLRgb53ChvMZm+r4p76/+8yKDy17qLL2PKInORy2RkZZekuK0efYgmzTkXyQ==}
     engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
@@ -6671,11 +6691,26 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  html-dom-parser@5.1.1:
+    resolution: {integrity: sha512-+o4Y4Z0CLuyemeccvGN4bAO20aauB2N9tFEAep5x4OW34kV4PTarBHm6RL02afYt2BMKcr0D2Agep8S3nJPIBg==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
+  html-react-parser@5.2.6:
+    resolution: {integrity: sha512-qcpPWLaSvqXi+TndiHbCa+z8qt0tVzjMwFGFBAa41ggC+ZA5BHaMIeMJla9g3VSp4SmiZb9qyQbmbpHYpIfPOg==}
+    peerDependencies:
+      '@types/react': 0.14 || 15 || 16 || 17 || 18 || 19
+      react: 0.14 || 15 || 16 || 17 || 18 || 19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  htmlparser2@10.0.0:
+    resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
 
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
@@ -6787,6 +6822,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.4:
+    resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -6874,8 +6912,8 @@ packages:
     resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
     engines: {node: '>=12'}
 
-  is-fullwidth-code-point@5.0.0:
-    resolution: {integrity: sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==}
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
 
   is-generator-function@1.1.0:
@@ -7225,8 +7263,8 @@ packages:
   listenercount@1.0.1:
     resolution: {integrity: sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==}
 
-  listr2@9.0.2:
-    resolution: {integrity: sha512-VVd7cS6W+vLJu2wmq4QmfVj14Iep7cz4r/OWNk36Aq5ZOY7G8/BfCrQFexcwB1OIxB3yERiePfE/REBjEFulag==}
+  listr2@9.0.3:
+    resolution: {integrity: sha512-0aeh5HHHgmq1KRdMMDHfhMWQmIT/m7nRDTlxlFqni2Sp0had9baqsjJRvDGdlvgd6NmPE0nPloOipiQJGFtTHQ==}
     engines: {node: '>=20.0.0'}
 
   lit-element@4.2.1:
@@ -8187,6 +8225,9 @@ packages:
       '@types/react':
         optional: true
 
+  react-property@2.0.2:
+    resolution: {integrity: sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==}
+
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
@@ -8390,8 +8431,8 @@ packages:
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
 
-  rollup@4.49.0:
-    resolution: {integrity: sha512-3IVq0cGJ6H7fKXXEdVt+RcYvRCt8beYY9K1760wGQwSAHZcS9eot1zDG5axUbcp/kWRi5zKIIDX8MoKv/TzvZA==}
+  rollup@4.50.0:
+    resolution: {integrity: sha512-/Zl4D8zPifNmyGzJS+3kVoyXeDeT/GrsJM94sACNg9RtUE0hrHa1bNPtRSrfHTMH5HjRzce6K7rlTh3Khiw+pw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -8792,6 +8833,12 @@ packages:
   strtok3@10.3.4:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
+
+  style-to-js@1.1.17:
+    resolution: {integrity: sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==}
+
+  style-to-object@1.0.9:
+    resolution: {integrity: sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==}
 
   styled-components@6.1.19:
     resolution: {integrity: sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==}
@@ -9477,8 +9524,8 @@ packages:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
 
-  wagmi@2.16.8:
-    resolution: {integrity: sha512-442yAXQJ2bEHPN7Z/AwDUo0bVsWAgGtux7jQmA49oE1ur6Q0IusJZdCmzP/PxxeB3fXEJt1TwXLpRkR6yjuRVA==}
+  wagmi@2.16.9:
+    resolution: {integrity: sha512-5NbjvuNNhT0t0lQsDD5otQqZ5RZBM1UhInHoBq/Lpnr6xLLa8AWxYqHg5oZtGCdiUNltys11iBOS6z4mLepIqw==}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
@@ -9832,16 +9879,16 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.2
 
-  '@abstract-foundation/agw-react@1.9.0(900b6c4b605cbc63a33b27f6d0d41013)':
+  '@abstract-foundation/agw-react@1.9.0(b2bb8a28b6f1532b169cc7aa0a3cfc80)':
     dependencies:
       '@abstract-foundation/agw-client': 1.9.0(abitype@1.0.9(typescript@5.9.2)(zod@3.25.76))(typescript@5.9.2)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
-      '@privy-io/cross-app-connect': 0.2.3(969a2555d0c9e84fbe224599b0e3e494)
-      '@privy-io/react-auth': 2.22.0(@abstract-foundation/agw-client@1.9.0(abitype@1.0.9(typescript@5.9.2)(zod@3.25.76))(typescript@5.9.2)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)))(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bs58@6.0.0)(bufferutil@4.0.9)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@tanstack/react-query': 5.85.5(react@19.1.1)
+      '@privy-io/cross-app-connect': 0.2.3(1bf9665fd2981e65352a5f75666aa5a8)
+      '@privy-io/react-auth': 2.24.0(@abstract-foundation/agw-client@1.9.0(abitype@1.0.9(typescript@5.9.2)(zod@3.25.76))(typescript@5.9.2)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)))(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bs58@6.0.0)(bufferutil@4.0.9)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@tanstack/react-query': 5.85.6(react@19.1.1)
       react: 19.1.1
       secp256k1: 5.0.1
       viem: 2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi: 2.16.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.5)(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      wagmi: 2.16.9(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.6)(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -10788,10 +10835,10 @@ snapshots:
       typescript: 5.9.2
       viem: 2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
 
-  '@bigmi/client@0.5.2(@tanstack/query-core@5.85.5)(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))':
+  '@bigmi/client@0.5.2(@tanstack/query-core@5.85.6)(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))':
     dependencies:
       '@bigmi/core': 0.5.2(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))
-      '@tanstack/query-core': 5.85.5
+      '@tanstack/query-core': 5.85.6
       eventemitter3: 5.0.1
       zustand: 5.0.8(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(use-sync-external-store@1.4.0(react@19.1.1))
     transitivePeerDependencies:
@@ -10802,10 +10849,10 @@ snapshots:
       - typescript
       - use-sync-external-store
 
-  '@bigmi/client@0.5.2(@tanstack/query-core@5.85.5)(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))':
+  '@bigmi/client@0.5.2(@tanstack/query-core@5.85.6)(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))':
     dependencies:
       '@bigmi/core': 0.5.2(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))
-      '@tanstack/query-core': 5.85.5
+      '@tanstack/query-core': 5.85.6
       eventemitter3: 5.0.1
       zustand: 5.0.8(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
     transitivePeerDependencies:
@@ -10846,11 +10893,11 @@ snapshots:
       - typescript
       - use-sync-external-store
 
-  '@bigmi/react@0.5.2(@tanstack/query-core@5.85.5)(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))':
+  '@bigmi/react@0.5.2(@tanstack/query-core@5.85.6)(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))':
     dependencies:
-      '@bigmi/client': 0.5.2(@tanstack/query-core@5.85.5)(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))
+      '@bigmi/client': 0.5.2(@tanstack/query-core@5.85.6)(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))
       '@bigmi/core': 0.5.2(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))
-      '@tanstack/react-query': 5.85.5(react@19.1.1)
+      '@tanstack/react-query': 5.85.6(react@19.1.1)
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
     transitivePeerDependencies:
@@ -10953,9 +11000,9 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
-  '@elysiajs/eden@1.3.3(elysia@1.3.20(exact-mirror@0.2.0(@sinclair/typebox@0.34.40))(file-type@21.0.0)(typescript@5.9.2))':
+  '@elysiajs/eden@1.3.3(elysia@1.3.21(exact-mirror@0.2.0(@sinclair/typebox@0.34.41))(file-type@21.0.0)(typescript@5.9.2))':
     dependencies:
-      elysia: 1.3.20(exact-mirror@0.2.0(@sinclair/typebox@0.34.40))(file-type@21.0.0)(typescript@5.9.2)
+      elysia: 1.3.21(exact-mirror@0.2.0(@sinclair/typebox@0.34.41))(file-type@21.0.0)(typescript@5.9.2)
 
   '@emnapi/core@1.5.0':
     dependencies:
@@ -11888,7 +11935,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lifi/explorer@0.4.0(1d1d2f31a47dbc4ef181ea6e976dc515)':
+  '@lifi/explorer@0.4.0(443d4a98bc398b101fbf2c3a6df4868c)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.1.12)(react@19.1.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
@@ -11899,10 +11946,10 @@ snapshots:
       '@mui/system': 7.3.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
       '@mui/utils': 7.3.1(@types/react@19.1.12)(react@19.1.1)
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)
-      '@tanstack/react-query': 5.85.5(react@19.1.1)
-      '@tanstack/react-router': 1.131.28(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@tanstack/react-query': 5.85.6(react@19.1.1)
+      '@tanstack/react-router': 1.131.31(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tanstack/react-virtual': 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@wagmi/core': 2.20.1(@tanstack/query-core@5.85.5)(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/core': 2.20.3(@tanstack/query-core@5.85.6)(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
       bignumber.js: 9.3.1
       bs58: 6.0.0
       ky: 1.9.1
@@ -11983,23 +12030,23 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@lifi/wallet-management@3.15.1(2253da81c6352ac10ab8fdaad0f0396a)':
+  '@lifi/wallet-management@3.15.1(6563757cbdaa3e0d35dfbfaa24256b29)':
     dependencies:
-      '@bigmi/client': 0.5.2(@tanstack/query-core@5.85.5)(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))
+      '@bigmi/client': 0.5.2(@tanstack/query-core@5.85.6)(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))
       '@bigmi/core': 0.5.2(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))
-      '@bigmi/react': 0.5.2(@tanstack/query-core@5.85.5)(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))
+      '@bigmi/react': 0.5.2(@tanstack/query-core@5.85.6)(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))
       '@emotion/react': 11.14.0(@types/react@19.1.12)(react@19.1.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
       '@lifi/sdk': 3.11.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       '@mui/icons-material': 7.3.1(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
       '@mui/material': 7.3.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@mui/system': 7.3.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
-      '@mysten/dapp-kit': 0.17.6(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(babel-plugin-macros@3.1.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
+      '@mysten/dapp-kit': 0.17.6(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(babel-plugin-macros@3.1.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
       '@mysten/wallet-standard': 0.16.13(typescript@5.9.2)
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-react': 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(bs58@6.0.0)(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10))(react@19.1.1)
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)
-      '@tanstack/react-query': 5.85.5(react@19.1.1)
+      '@tanstack/react-query': 5.85.6(react@19.1.1)
       i18next: 25.4.2(typescript@5.9.2)
       mitt: 3.0.1
       react: 19.1.1
@@ -12007,7 +12054,7 @@ snapshots:
       react-i18next: 15.7.3(i18next@25.4.2(typescript@5.9.2))(react-dom@19.1.1(react@19.1.1))(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10))(react@19.1.1)(typescript@5.9.2)
       use-sync-external-store: 1.5.0(react@19.1.1)
       viem: 2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi: 2.16.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.5)(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      wagmi: 2.16.9(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.6)(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       zustand: 5.0.8(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
     transitivePeerDependencies:
       - '@gql.tada/svelte-support'
@@ -12025,25 +12072,25 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@lifi/widget@3.29.1(534c746f8745bae7d18f451c050fda9d)':
+  '@lifi/widget@3.29.1(ad9c7bb7a0bd60375e43334dfe0a508f)':
     dependencies:
-      '@bigmi/client': 0.5.2(@tanstack/query-core@5.85.5)(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))
+      '@bigmi/client': 0.5.2(@tanstack/query-core@5.85.6)(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))
       '@bigmi/core': 0.5.2(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))
-      '@bigmi/react': 0.5.2(@tanstack/query-core@5.85.5)(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))
+      '@bigmi/react': 0.5.2(@tanstack/query-core@5.85.6)(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))
       '@emotion/react': 11.14.0(@types/react@19.1.12)(react@19.1.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
       '@lifi/sdk': 3.11.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
-      '@lifi/wallet-management': 3.15.1(2253da81c6352ac10ab8fdaad0f0396a)
+      '@lifi/wallet-management': 3.15.1(6563757cbdaa3e0d35dfbfaa24256b29)
       '@mui/icons-material': 7.3.1(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
       '@mui/material': 7.3.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@mui/system': 7.3.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
-      '@mysten/dapp-kit': 0.17.6(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(babel-plugin-macros@3.1.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
+      '@mysten/dapp-kit': 0.17.6(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(babel-plugin-macros@3.1.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
       '@mysten/sui': 1.37.5(typescript@5.9.2)
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-coinbase': 0.1.23(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-react': 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(bs58@6.0.0)(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10))(react@19.1.1)
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)
-      '@tanstack/react-query': 5.85.5(react@19.1.1)
+      '@tanstack/react-query': 5.85.6(react@19.1.1)
       '@tanstack/react-virtual': 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       i18next: 25.4.2(typescript@5.9.2)
       microdiff: 1.5.0
@@ -12055,7 +12102,7 @@ snapshots:
       react-router-dom: 6.30.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react-transition-group: 4.4.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       viem: 2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi: 2.16.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.5)(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      wagmi: 2.16.9(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.6)(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       zustand: 5.0.8(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(use-sync-external-store@1.4.0(react@19.1.1))
     transitivePeerDependencies:
       - '@gql.tada/svelte-support'
@@ -12090,16 +12137,16 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@mdx-js/react@3.1.0(@types/react@19.1.12)(react@19.1.1)':
+  '@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.1.1)':
     dependencies:
       '@types/mdx': 2.0.13
       '@types/react': 19.1.12
       react: 19.1.1
 
-  '@merkl/api@1.1.2(exact-mirror@0.2.0(@sinclair/typebox@0.34.40))(file-type@21.0.0)(typescript@5.9.2)':
+  '@merkl/api@1.1.2(exact-mirror@0.2.0(@sinclair/typebox@0.34.41))(file-type@21.0.0)(typescript@5.9.2)':
     dependencies:
-      '@elysiajs/eden': 1.3.3(elysia@1.3.20(exact-mirror@0.2.0(@sinclair/typebox@0.34.40))(file-type@21.0.0)(typescript@5.9.2))
-      elysia: 1.3.20(exact-mirror@0.2.0(@sinclair/typebox@0.34.40))(file-type@21.0.0)(typescript@5.9.2)
+      '@elysiajs/eden': 1.3.3(elysia@1.3.21(exact-mirror@0.2.0(@sinclair/typebox@0.34.41))(file-type@21.0.0)(typescript@5.9.2))
+      elysia: 1.3.21(exact-mirror@0.2.0(@sinclair/typebox@0.34.41))(file-type@21.0.0)(typescript@5.9.2)
     transitivePeerDependencies:
       - exact-mirror
       - file-type
@@ -12556,7 +12603,7 @@ snapshots:
       '@mysten/utils': 0.1.1
       '@scure/base': 1.2.6
 
-  '@mysten/dapp-kit@0.17.6(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(babel-plugin-macros@3.1.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)':
+  '@mysten/dapp-kit@0.17.6(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(babel-plugin-macros@3.1.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)':
     dependencies:
       '@mysten/slush-wallet': 0.1.23(typescript@5.9.2)
       '@mysten/sui': 1.37.5(typescript@5.9.2)
@@ -12565,7 +12612,7 @@ snapshots:
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.12)(react@19.1.1)
-      '@tanstack/react-query': 5.85.5(react@19.1.1)
+      '@tanstack/react-query': 5.85.6(react@19.1.1)
       '@vanilla-extract/css': 1.17.4(babel-plugin-macros@3.1.0)
       '@vanilla-extract/dynamic': 2.1.5
       '@vanilla-extract/recipes': 0.5.7(@vanilla-extract/css@1.17.4(babel-plugin-macros@3.1.0))
@@ -13016,7 +13063,7 @@ snapshots:
 
   '@privy-io/chains@0.0.2': {}
 
-  '@privy-io/cross-app-connect@0.2.3(969a2555d0c9e84fbe224599b0e3e494)':
+  '@privy-io/cross-app-connect@0.2.3(1bf9665fd2981e65352a5f75666aa5a8)':
     dependencies:
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.3.2
@@ -13024,14 +13071,14 @@ snapshots:
       fflate: 0.8.2
       viem: 2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
-      '@rainbow-me/rainbowkit': 2.2.8(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react@19.1.12)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.16.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.5)(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
-      '@wagmi/core': 2.20.1(@tanstack/query-core@5.85.5)(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@rainbow-me/rainbowkit': 2.2.8(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.16.9(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.6)(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
+      '@wagmi/core': 2.20.3(@tanstack/query-core@5.85.6)(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
 
   '@privy-io/ethereum@0.0.2(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       viem: 2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
 
-  '@privy-io/js-sdk-core@0.54.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@privy-io/js-sdk-core@0.54.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       '@ethersproject/abstract-signer': 5.8.0
       '@ethersproject/bignumber': 5.8.0
@@ -13041,7 +13088,7 @@ snapshots:
       '@ethersproject/units': 5.8.0
       '@privy-io/api-base': 1.6.1
       '@privy-io/chains': 0.0.2
-      '@privy-io/public-api': 2.44.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)
+      '@privy-io/public-api': 2.44.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)
       canonicalize: 2.1.0
       eventemitter3: 5.0.1
       fetch-retry: 6.0.0
@@ -13057,7 +13104,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@privy-io/public-api@2.44.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)':
+  '@privy-io/public-api@2.44.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@privy-io/api-base': 1.6.1
       bs58: 5.0.0
@@ -13069,7 +13116,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@privy-io/react-auth@2.22.0(@abstract-foundation/agw-client@1.9.0(abitype@1.0.9(typescript@5.9.2)(zod@3.25.76))(typescript@5.9.2)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)))(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bs58@6.0.0)(bufferutil@4.0.9)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@privy-io/react-auth@2.24.0(@abstract-foundation/agw-client@1.9.0(abitype@1.0.9(typescript@5.9.2)(zod@3.25.76))(typescript@5.9.2)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)))(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bs58@6.0.0)(bufferutil@4.0.9)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@base-org/account': 1.1.1(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@coinbase/wallet-sdk': 4.3.2
@@ -13081,8 +13128,8 @@ snapshots:
       '@privy-io/api-base': 1.6.1
       '@privy-io/chains': 0.0.2
       '@privy-io/ethereum': 0.0.2(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
-      '@privy-io/js-sdk-core': 0.54.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
-      '@privy-io/public-api': 2.44.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)
+      '@privy-io/js-sdk-core': 0.54.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@privy-io/public-api': 2.44.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)
       '@reown/appkit': 1.8.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@scure/base': 1.2.6
       '@simplewebauthn/browser': 9.0.1
@@ -13411,9 +13458,9 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@rainbow-me/rainbowkit@2.2.8(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react@19.1.12)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.16.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.5)(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))':
+  '@rainbow-me/rainbowkit@2.2.8(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.16.9(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.6)(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))':
     dependencies:
-      '@tanstack/react-query': 5.85.5(react@19.1.1)
+      '@tanstack/react-query': 5.85.6(react@19.1.1)
       '@vanilla-extract/css': 1.17.3(babel-plugin-macros@3.1.0)
       '@vanilla-extract/dynamic': 2.1.4
       '@vanilla-extract/sprinkles': 1.6.4(@vanilla-extract/css@1.17.3(babel-plugin-macros@3.1.0))
@@ -13424,7 +13471,7 @@ snapshots:
       react-remove-scroll: 2.6.2(@types/react@19.1.12)(react@19.1.1)
       ua-parser-js: 1.0.41
       viem: 2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi: 2.16.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.5)(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      wagmi: 2.16.9(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.6)(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
     transitivePeerDependencies:
       - '@types/react'
       - babel-plugin-macros
@@ -14313,9 +14360,9 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.34': {}
 
-  '@rollup/plugin-commonjs@28.0.1(rollup@4.49.0)':
+  '@rollup/plugin-commonjs@28.0.1(rollup@4.50.0)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.49.0)
+      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -14323,82 +14370,85 @@ snapshots:
       magic-string: 0.30.18
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.49.0
+      rollup: 4.50.0
 
-  '@rollup/plugin-inject@5.0.5(rollup@4.49.0)':
+  '@rollup/plugin-inject@5.0.5(rollup@4.50.0)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.49.0)
+      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
       estree-walker: 2.0.2
       magic-string: 0.30.18
     optionalDependencies:
-      rollup: 4.49.0
+      rollup: 4.50.0
 
-  '@rollup/pluginutils@5.2.0(rollup@4.49.0)':
+  '@rollup/pluginutils@5.2.0(rollup@4.50.0)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.49.0
+      rollup: 4.50.0
 
-  '@rollup/rollup-android-arm-eabi@4.49.0':
+  '@rollup/rollup-android-arm-eabi@4.50.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.49.0':
+  '@rollup/rollup-android-arm64@4.50.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.49.0':
+  '@rollup/rollup-darwin-arm64@4.50.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.49.0':
+  '@rollup/rollup-darwin-x64@4.50.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.49.0':
+  '@rollup/rollup-freebsd-arm64@4.50.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.49.0':
+  '@rollup/rollup-freebsd-x64@4.50.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.49.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.50.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.49.0':
+  '@rollup/rollup-linux-arm-musleabihf@4.50.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.49.0':
+  '@rollup/rollup-linux-arm64-gnu@4.50.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.49.0':
+  '@rollup/rollup-linux-arm64-musl@4.50.0':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.49.0':
+  '@rollup/rollup-linux-loongarch64-gnu@4.50.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.49.0':
+  '@rollup/rollup-linux-ppc64-gnu@4.50.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.49.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.50.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.49.0':
+  '@rollup/rollup-linux-riscv64-musl@4.50.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.49.0':
+  '@rollup/rollup-linux-s390x-gnu@4.50.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.49.0':
+  '@rollup/rollup-linux-x64-gnu@4.50.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.49.0':
+  '@rollup/rollup-linux-x64-musl@4.50.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.49.0':
+  '@rollup/rollup-openharmony-arm64@4.50.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.49.0':
+  '@rollup/rollup-win32-arm64-msvc@4.50.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.49.0':
+  '@rollup/rollup-win32-ia32-msvc@4.50.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.50.0':
     optional: true
 
   '@rtsao/scc@1.1.0': {}
@@ -14567,7 +14617,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.36.0
-      '@rollup/plugin-commonjs': 28.0.1(rollup@4.49.0)
+      '@rollup/plugin-commonjs': 28.0.1(rollup@4.50.0)
       '@sentry-internal/browser-utils': 9.46.0
       '@sentry/core': 9.46.0
       '@sentry/node': 9.46.0
@@ -14578,7 +14628,7 @@ snapshots:
       chalk: 3.0.0
       next: 15.5.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       resolve: 1.22.8
-      rollup: 4.49.0
+      rollup: 4.50.0
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
       - '@opentelemetry/context-async-hooks'
@@ -14688,7 +14738,7 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
-  '@sinclair/typebox@0.34.40':
+  '@sinclair/typebox@0.34.41':
     optional: true
 
   '@sinonjs/commons@3.0.1':
@@ -14959,7 +15009,7 @@ snapshots:
 
   '@storybook/addon-docs@9.1.3(@types/react@19.1.12)(storybook@9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1)))':
     dependencies:
-      '@mdx-js/react': 3.1.0(@types/react@19.1.12)(react@19.1.1)
+      '@mdx-js/react': 3.1.1(@types/react@19.1.12)(react@19.1.1)
       '@storybook/csf-plugin': 9.1.3(storybook@9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1)))
       '@storybook/icons': 1.4.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@storybook/react-dom-shim': 9.1.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1)))
@@ -15013,11 +15063,11 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@storybook/nextjs-vite@9.1.2(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(next@15.5.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.49.0)(storybook@9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1))':
+  '@storybook/nextjs-vite@9.1.2(@babel/core@7.28.3)(babel-plugin-macros@3.1.0)(next@15.5.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.50.0)(storybook@9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1))':
     dependencies:
       '@storybook/builder-vite': 9.1.2(storybook@9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1))
       '@storybook/react': 9.1.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)
-      '@storybook/react-vite': 9.1.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.49.0)(storybook@9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1))
+      '@storybook/react-vite': 9.1.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.50.0)(storybook@9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1))
       next: 15.5.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
@@ -15045,10 +15095,10 @@ snapshots:
       react-dom: 19.1.1(react@19.1.1)
       storybook: 9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1))
 
-  '@storybook/react-vite@9.1.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.49.0)(storybook@9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1))':
+  '@storybook/react-vite@9.1.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.50.0)(storybook@9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.2)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1))
-      '@rollup/pluginutils': 5.2.0(rollup@4.49.0)
+      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
       '@storybook/builder-vite': 9.1.2(storybook@9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1))
       '@storybook/react': 9.1.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.6.2)(utf-8-validate@5.0.10)(vite@7.1.3(@types/node@24.3.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)
       find-up: 7.0.0
@@ -15199,18 +15249,18 @@ snapshots:
 
   '@tanstack/history@1.131.2': {}
 
-  '@tanstack/query-core@5.85.5': {}
+  '@tanstack/query-core@5.85.6': {}
 
-  '@tanstack/react-query@5.85.5(react@19.1.1)':
+  '@tanstack/react-query@5.85.6(react@19.1.1)':
     dependencies:
-      '@tanstack/query-core': 5.85.5
+      '@tanstack/query-core': 5.85.6
       react: 19.1.1
 
-  '@tanstack/react-router@1.131.28(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@tanstack/react-router@1.131.31(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@tanstack/history': 1.131.2
       '@tanstack/react-store': 0.7.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@tanstack/router-core': 1.131.28
+      '@tanstack/router-core': 1.131.30
       isbot: 5.1.30
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
@@ -15230,7 +15280,7 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@tanstack/router-core@1.131.28':
+  '@tanstack/router-core@1.131.30':
     dependencies:
       '@tanstack/history': 1.131.2
       '@tanstack/store': 0.7.4
@@ -15853,7 +15903,7 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@wagmi/connectors@5.9.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@types/react@19.1.12)(@wagmi/core@2.20.2(@tanstack/query-core@5.85.5)(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
+  '@wagmi/connectors@5.9.9(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@types/react@19.1.12)(@wagmi/core@2.20.3(@tanstack/query-core@5.85.6)(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@base-org/account': 1.1.1(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@coinbase/wallet-sdk': 4.3.6(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -15861,7 +15911,7 @@ snapshots:
       '@metamask/sdk': 0.32.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@wagmi/core': 2.20.2(@tanstack/query-core@5.85.5)(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/core': 2.20.3(@tanstack/query-core@5.85.6)(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@walletconnect/ethereum-provider': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
       viem: 2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -15897,29 +15947,14 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@wagmi/core@2.20.1(@tanstack/query-core@5.85.5)(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@wagmi/core@2.20.3(@tanstack/query-core@5.85.6)(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.2)
       viem: 2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.0(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(use-sync-external-store@1.4.0(react@19.1.1))
     optionalDependencies:
-      '@tanstack/query-core': 5.85.5
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-      - use-sync-external-store
-
-  '@wagmi/core@2.20.2(@tanstack/query-core@5.85.5)(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))':
-    dependencies:
-      eventemitter3: 5.0.1
-      mipd: 0.0.7(typescript@5.9.2)
-      viem: 2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
-      zustand: 5.0.0(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(use-sync-external-store@1.4.0(react@19.1.1))
-    optionalDependencies:
-      '@tanstack/query-core': 5.85.5
+      '@tanstack/query-core': 5.85.6
       typescript: 5.9.2
     transitivePeerDependencies:
       - '@types/react'
@@ -17701,7 +17736,7 @@ snapshots:
 
   browserslist@4.25.4:
     dependencies:
-      caniuse-lite: 1.0.30001737
+      caniuse-lite: 1.0.30001739
       electron-to-chromium: 1.5.211
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.4)
@@ -17784,7 +17819,7 @@ snapshots:
 
   camelize@1.0.1: {}
 
-  caniuse-lite@1.0.30001737: {}
+  caniuse-lite@1.0.30001739: {}
 
   canonicalize@2.1.0: {}
 
@@ -18152,6 +18187,24 @@ snapshots:
       '@babel/runtime': 7.28.3
       csstype: 3.1.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   dotenv-cli@10.0.0:
     dependencies:
       cross-spawn: 7.0.6
@@ -18209,15 +18262,15 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
-  elysia@1.3.20(exact-mirror@0.2.0(@sinclair/typebox@0.34.40))(file-type@21.0.0)(typescript@5.9.2):
+  elysia@1.3.21(exact-mirror@0.2.0(@sinclair/typebox@0.34.41))(file-type@21.0.0)(typescript@5.9.2):
     dependencies:
       cookie: 1.0.2
-      exact-mirror: 0.2.0(@sinclair/typebox@0.34.40)
+      exact-mirror: 0.2.0(@sinclair/typebox@0.34.41)
       fast-decode-uri-component: 1.0.1
       file-type: 21.0.0
       typescript: 5.9.2
     optionalDependencies:
-      '@sinclair/typebox': 0.34.40
+      '@sinclair/typebox': 0.34.41
       openapi-types: 12.1.3
 
   emoji-regex@10.5.0: {}
@@ -18258,6 +18311,10 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.3
+
+  entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   env-schema@5.2.1:
     dependencies:
@@ -18978,9 +19035,9 @@ snapshots:
 
   events@3.3.0: {}
 
-  exact-mirror@0.2.0(@sinclair/typebox@0.34.40):
+  exact-mirror@0.2.0(@sinclair/typebox@0.34.41):
     optionalDependencies:
-      '@sinclair/typebox': 0.34.40
+      '@sinclair/typebox': 0.34.41
 
   execa@5.1.1:
     dependencies:
@@ -19210,7 +19267,7 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-east-asian-width@1.3.0: {}
+  get-east-asian-width@1.3.1: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -19398,11 +19455,33 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  html-dom-parser@5.1.1:
+    dependencies:
+      domhandler: 5.0.3
+      htmlparser2: 10.0.0
+
   html-escaper@2.0.2: {}
 
   html-parse-stringify@3.0.1:
     dependencies:
       void-elements: 3.1.0
+
+  html-react-parser@5.2.6(@types/react@19.1.12)(react@19.1.1):
+    dependencies:
+      domhandler: 5.0.3
+      html-dom-parser: 5.1.1
+      react: 19.1.1
+      react-property: 2.0.2
+      style-to-js: 1.1.17
+    optionalDependencies:
+      '@types/react': 19.1.12
+
+  htmlparser2@10.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 6.0.1
 
   http-errors@2.0.0:
     dependencies:
@@ -19511,6 +19590,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.4: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -19596,9 +19677,9 @@ snapshots:
 
   is-fullwidth-code-point@4.0.0: {}
 
-  is-fullwidth-code-point@5.0.0:
+  is-fullwidth-code-point@5.1.0:
     dependencies:
-      get-east-asian-width: 1.3.0
+      get-east-asian-width: 1.3.1
 
   is-generator-function@1.1.0:
     dependencies:
@@ -19986,7 +20067,7 @@ snapshots:
       commander: 14.0.0
       debug: 4.4.1
       lilconfig: 3.1.3
-      listr2: 9.0.2
+      listr2: 9.0.3
       micromatch: 4.0.8
       nano-spawn: 1.0.2
       pidtree: 0.6.0
@@ -19997,7 +20078,7 @@ snapshots:
 
   listenercount@1.0.1: {}
 
-  listr2@9.0.2:
+  listr2@9.0.3:
     dependencies:
       cli-truncate: 4.0.0
       colorette: 2.0.20
@@ -20423,7 +20504,7 @@ snapshots:
     dependencies:
       '@next/env': 15.5.2
       '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001737
+      caniuse-lite: 1.0.30001739
       postcss: 8.4.31
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
@@ -21134,6 +21215,8 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  react-property@2.0.2: {}
+
   react-refresh@0.14.2: {}
 
   react-refresh@0.17.0: {}
@@ -21346,35 +21429,36 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rollup-plugin-polyfill-node@0.13.0(rollup@4.49.0):
+  rollup-plugin-polyfill-node@0.13.0(rollup@4.50.0):
     dependencies:
-      '@rollup/plugin-inject': 5.0.5(rollup@4.49.0)
-      rollup: 4.49.0
+      '@rollup/plugin-inject': 5.0.5(rollup@4.50.0)
+      rollup: 4.50.0
 
-  rollup@4.49.0:
+  rollup@4.50.0:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.49.0
-      '@rollup/rollup-android-arm64': 4.49.0
-      '@rollup/rollup-darwin-arm64': 4.49.0
-      '@rollup/rollup-darwin-x64': 4.49.0
-      '@rollup/rollup-freebsd-arm64': 4.49.0
-      '@rollup/rollup-freebsd-x64': 4.49.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.49.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.49.0
-      '@rollup/rollup-linux-arm64-gnu': 4.49.0
-      '@rollup/rollup-linux-arm64-musl': 4.49.0
-      '@rollup/rollup-linux-loongarch64-gnu': 4.49.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.49.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.49.0
-      '@rollup/rollup-linux-riscv64-musl': 4.49.0
-      '@rollup/rollup-linux-s390x-gnu': 4.49.0
-      '@rollup/rollup-linux-x64-gnu': 4.49.0
-      '@rollup/rollup-linux-x64-musl': 4.49.0
-      '@rollup/rollup-win32-arm64-msvc': 4.49.0
-      '@rollup/rollup-win32-ia32-msvc': 4.49.0
-      '@rollup/rollup-win32-x64-msvc': 4.49.0
+      '@rollup/rollup-android-arm-eabi': 4.50.0
+      '@rollup/rollup-android-arm64': 4.50.0
+      '@rollup/rollup-darwin-arm64': 4.50.0
+      '@rollup/rollup-darwin-x64': 4.50.0
+      '@rollup/rollup-freebsd-arm64': 4.50.0
+      '@rollup/rollup-freebsd-x64': 4.50.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.50.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.50.0
+      '@rollup/rollup-linux-arm64-gnu': 4.50.0
+      '@rollup/rollup-linux-arm64-musl': 4.50.0
+      '@rollup/rollup-linux-loongarch64-gnu': 4.50.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.50.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.50.0
+      '@rollup/rollup-linux-riscv64-musl': 4.50.0
+      '@rollup/rollup-linux-s390x-gnu': 4.50.0
+      '@rollup/rollup-linux-x64-gnu': 4.50.0
+      '@rollup/rollup-linux-x64-musl': 4.50.0
+      '@rollup/rollup-openharmony-arm64': 4.50.0
+      '@rollup/rollup-win32-arm64-msvc': 4.50.0
+      '@rollup/rollup-win32-ia32-msvc': 4.50.0
+      '@rollup/rollup-win32-x64-msvc': 4.50.0
       fsevents: 2.3.3
 
   rpc-websockets@9.1.3:
@@ -21633,7 +21717,7 @@ snapshots:
   slice-ansi@7.1.0:
     dependencies:
       ansi-styles: 6.2.1
-      is-fullwidth-code-point: 5.0.0
+      is-fullwidth-code-point: 5.1.0
 
   socket.io-client@4.8.1(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:
@@ -21768,7 +21852,7 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.5.0
-      get-east-asian-width: 1.3.0
+      get-east-asian-width: 1.3.1
       strip-ansi: 7.1.0
 
   string.prototype.includes@2.0.1:
@@ -21864,6 +21948,14 @@ snapshots:
   strtok3@10.3.4:
     dependencies:
       '@tokenizer/token': 0.3.0
+
+  style-to-js@1.1.17:
+    dependencies:
+      style-to-object: 1.0.9
+
+  style-to-object@1.0.9:
+    dependencies:
+      inline-style-parser: 0.2.4
 
   styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
@@ -22078,7 +22170,7 @@ snapshots:
       joycon: 3.1.1
       postcss-load-config: 4.0.2(postcss@8.5.6)
       resolve-from: 5.0.0
-      rollup: 4.49.0
+      rollup: 4.50.0
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tree-kill: 1.2.2
@@ -22493,7 +22585,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.49.0
+      rollup: 4.50.0
       tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 24.3.0
@@ -22548,11 +22640,11 @@ snapshots:
 
   void-elements@3.1.0: {}
 
-  wagmi@2.16.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.5)(@tanstack/react-query@5.85.5(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76):
+  wagmi@2.16.9(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.85.6)(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76):
     dependencies:
-      '@tanstack/react-query': 5.85.5(react@19.1.1)
-      '@wagmi/connectors': 5.9.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@types/react@19.1.12)(@wagmi/core@2.20.2(@tanstack/query-core@5.85.5)(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
-      '@wagmi/core': 2.20.2(@tanstack/query-core@5.85.5)(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@tanstack/react-query': 5.85.6(react@19.1.1)
+      '@wagmi/connectors': 5.9.9(@react-native-async-storage/async-storage@1.24.0(react-native@0.81.1(@babel/core@7.28.3)(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)))(@types/react@19.1.12)(@wagmi/core@2.20.3(@tanstack/query-core@5.85.6)(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.9)(encoding@0.1.13)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      '@wagmi/core': 2.20.3(@tanstack/query-core@5.85.6)(@types/react@19.1.12)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
       react: 19.1.1
       use-sync-external-store: 1.4.0(react@19.1.1)
       viem: 2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)

--- a/src/app/ui/mission/MissionDetails.tsx
+++ b/src/app/ui/mission/MissionDetails.tsx
@@ -89,6 +89,7 @@ export const MissionDetails: FC<MissionDetailsProps> = ({ mission, tasks }) => {
             slug={missionDisplayData.slug}
             title={missionDisplayData.title}
             description={missionDisplayData.description}
+            descriptionRichText={missionDisplayData.descriptionRichText}
             participants={missionDisplayData.participants}
             imageUrl={missionDisplayData.imageUrl}
             rewardGroups={missionDisplayData.rewardGroups}

--- a/src/components/Blog/CustomRichBlocks.tsx
+++ b/src/components/Blog/CustomRichBlocks.tsx
@@ -67,6 +67,7 @@ interface RichElement<T> {
 type ParagraphElement = RichElement<ParagraphProps>;
 type QuoteElement = RichElement<QuoteProps>;
 
+// @deprecated use RichBlocks instead
 export const CustomRichBlocks = ({
   id,
   content,

--- a/src/components/Cards/EntityCard/EntityCard.stories.tsx
+++ b/src/components/Cards/EntityCard/EntityCard.stories.tsx
@@ -73,7 +73,7 @@ const participants = [
   },
 ];
 
-const description = [
+const descriptionRichText = [
   {
     type: 'paragraph',
     children: [
@@ -110,13 +110,13 @@ const description = [
       },
     ],
   },
-] as QuestData['Description'];
+] as QuestData['DescriptionRichText'];
 
 const commonProps = {
   id: 'example-card',
   slug: 'example-entity-card',
   title: 'Explore Aerodrome on multiple chains',
-  description,
+  descriptionRichText,
   imageUrl:
     'https://strapi.jumper.exchange/uploads/AI_Memecoins_and_Crypto_f98c61b932.png',
   participants,

--- a/src/components/Cards/EntityCard/EntityCard.stories.tsx
+++ b/src/components/Cards/EntityCard/EntityCard.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { EntityCard } from './EntityCard';
 import { Badge } from '../../Badge/Badge';
 import { BadgeVariant } from 'src/components/Badge/Badge.styles';
+import { QuestData } from 'src/types/strapi';
 
 const meta: Meta<typeof EntityCard> = {
   title: 'Components/Cards/Mission cards',
@@ -72,12 +73,50 @@ const participants = [
   },
 ];
 
+const description = [
+  {
+    type: 'paragraph',
+    children: [
+      {
+        type: 'text',
+        text: 'Aerodrome is a decentralized exchange where you can execute ',
+      },
+      {
+        type: 'text',
+        text: 'low-fee swaps, ',
+        bold: true,
+      },
+      {
+        type: 'text',
+        text: 'deposit tokens to ',
+      },
+      {
+        type: 'text',
+        text: 'earn rewards',
+        bold: true,
+      },
+      {
+        type: 'text',
+        text: ', and ',
+      },
+      {
+        type: 'text',
+        text: '<span style="color: var(--jumper-palette-textAccent2)">actively participate</span> ',
+        bold: true,
+      },
+      {
+        type: 'text',
+        text: 'in the onchain economy.',
+      },
+    ],
+  },
+] as QuestData['Description'];
+
 const commonProps = {
   id: 'example-card',
   slug: 'example-entity-card',
   title: 'Explore Aerodrome on multiple chains',
-  description:
-    'Aerodrome is a decentralized exchange where you can execute low-fee swaps, deposit tokens to earn rewards, and actively participate in the onchain economy.',
+  description,
   imageUrl:
     'https://strapi.jumper.exchange/uploads/AI_Memecoins_and_Crypto_f98c61b932.png',
   participants,

--- a/src/components/Cards/EntityCard/EntityCard.styles.tsx
+++ b/src/components/Cards/EntityCard/EntityCard.styles.tsx
@@ -83,6 +83,19 @@ export const StyledWideEntityCardTitle = styled(StyledEntityCardTitleBase)(
   }),
 );
 
+export const StyledEntityCardDescription = styled(Typography)(({ theme }) => ({
+  ...theme.typography.bodyMedium,
+  color: (theme.vars || theme).palette.text.secondary,
+}));
+
+export const StyledWideEntityCardDescriptionWrapper = styled(Box)(
+  ({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+  }),
+);
+
 // Link
 
 export const StyledEntityCardLink = styled(Link)(({ theme }) => ({

--- a/src/components/Cards/EntityCard/EntityCard.styles.tsx
+++ b/src/components/Cards/EntityCard/EntityCard.styles.tsx
@@ -83,11 +83,6 @@ export const StyledWideEntityCardTitle = styled(StyledEntityCardTitleBase)(
   }),
 );
 
-export const StyledEntityCardDescription = styled(Typography)(({ theme }) => ({
-  ...theme.typography.bodyMedium,
-  color: (theme.vars || theme).palette.text.secondary,
-}));
-
 // Link
 
 export const StyledEntityCardLink = styled(Link)(({ theme }) => ({

--- a/src/components/Cards/EntityCard/EntityCard.types.ts
+++ b/src/components/Cards/EntityCard/EntityCard.types.ts
@@ -22,6 +22,7 @@ export interface EntityCardProps {
   title?: string;
   isLoading?: boolean;
   description?: QuestData['Description'];
+  descriptionRichText?: QuestData['DescriptionRichText'];
   imageUrl?: string;
   variant?: EntityCardVariant;
   badge?: ReactNode;

--- a/src/components/Cards/EntityCard/EntityCard.types.ts
+++ b/src/components/Cards/EntityCard/EntityCard.types.ts
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { QuestData } from 'src/types/strapi';
 
 export type Reward = {
   value: string;
@@ -20,7 +21,7 @@ export interface EntityCardProps {
   slug?: string;
   title?: string;
   isLoading?: boolean;
-  description?: string;
+  description?: QuestData['Description'];
   imageUrl?: string;
   variant?: EntityCardVariant;
   badge?: ReactNode;

--- a/src/components/Cards/EntityCard/variants/WideEntityCard.tsx
+++ b/src/components/Cards/EntityCard/variants/WideEntityCard.tsx
@@ -15,6 +15,8 @@ import {
   StyledEntityCardLink,
   BaseSkeleton,
   StyledEntityCardBadgeContainer,
+  StyledWideEntityCardDescriptionWrapper,
+  StyledEntityCardDescription,
 } from '../EntityCard.styles';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import { WideEntityCardSkeleton } from './WideEntityCardSkeleton';
@@ -26,6 +28,7 @@ export const WideEntityCard: FC<Omit<EntityCardProps, 'type'>> = ({
   badge,
   title,
   description,
+  descriptionRichText,
   rewardGroups,
   participants,
   partnerLink,
@@ -36,6 +39,22 @@ export const WideEntityCard: FC<Omit<EntityCardProps, 'type'>> = ({
   if (isLoading) {
     return <WideEntityCardSkeleton fullWidth />;
   }
+
+  const renderDescription = !!description ? (
+    <StyledEntityCardDescription>{description}</StyledEntityCardDescription>
+  ) : !!descriptionRichText ? (
+    <StyledWideEntityCardDescriptionWrapper>
+      <RichBlocks
+        content={descriptionRichText}
+        blockSx={{
+          paragraph: (theme) => ({
+            ...theme.typography.bodyMedium,
+            color: (theme.vars || theme).palette.text.secondary,
+          }),
+        }}
+      />
+    </StyledWideEntityCardDescriptionWrapper>
+  ) : null;
 
   return (
     <StyledEntityCard
@@ -123,15 +142,7 @@ export const WideEntityCard: FC<Omit<EntityCardProps, 'type'>> = ({
             })}
           </StyledRewardsContainer>
         )}
-        <RichBlocks
-          content={description}
-          blockSx={{
-            paragraph: (theme) => ({
-              ...theme.typography.bodyMedium,
-              color: (theme.vars || theme).palette.text.secondary,
-            }),
-          }}
-        />
+        {renderDescription}
         {partnerLink && (
           <StyledEntityCardLink target="_blank" href={partnerLink.url}>
             {partnerLink.label}

--- a/src/components/Cards/EntityCard/variants/WideEntityCard.tsx
+++ b/src/components/Cards/EntityCard/variants/WideEntityCard.tsx
@@ -6,7 +6,6 @@ import {
   StyledEntityCardImage,
   StyledEntityCardImageContainer,
   StyledWideEntityCardTitle,
-  StyledEntityCardDescription,
   StyledWideParticipantAvatar,
   StyledParticipantsContainer,
   StyledRewardAvatar,
@@ -20,6 +19,7 @@ import {
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import { WideEntityCardSkeleton } from './WideEntityCardSkeleton';
 import { ENTITY_CARD_SIZES } from '../constants';
+import { RichBlocks } from 'src/components/RichBlocks/RichBlocks';
 
 export const WideEntityCard: FC<Omit<EntityCardProps, 'type'>> = ({
   imageUrl,
@@ -123,7 +123,15 @@ export const WideEntityCard: FC<Omit<EntityCardProps, 'type'>> = ({
             })}
           </StyledRewardsContainer>
         )}
-        <StyledEntityCardDescription>{description}</StyledEntityCardDescription>
+        <RichBlocks
+          content={description}
+          blockSx={{
+            paragraph: (theme) => ({
+              ...theme.typography.bodyMedium,
+              color: (theme.vars || theme).palette.text.secondary,
+            }),
+          }}
+        />
         {partnerLink && (
           <StyledEntityCardLink target="_blank" href={partnerLink.url}>
             {partnerLink.label}

--- a/src/components/RichBlocks/RichBlocks.stories.tsx
+++ b/src/components/RichBlocks/RichBlocks.stories.tsx
@@ -1,0 +1,389 @@
+import { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { RichBlocks } from './RichBlocks';
+import { RichBlocksVariant } from './types';
+
+const meta: Meta<typeof RichBlocks> = {
+  title: 'Components/RichBlocks',
+  component: RichBlocks,
+  parameters: {
+    layout: 'padded',
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RichBlocks>;
+
+export const Paragraphs: Story = {
+  args: {
+    content: [
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'text',
+            text: 'This is the first paragraph with some sample text. It demonstrates how the RichBlocks component renders paragraph content.',
+            bold: false,
+            italic: false,
+            underline: false,
+            strikethrough: false,
+          },
+        ],
+      },
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'text',
+            text: 'This is the second paragraph. It shows that multiple paragraphs can be rendered sequentially. The component handles each paragraph block separately.',
+            bold: false,
+            italic: false,
+            underline: false,
+            strikethrough: false,
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export const ParagraphsMixedStyling: Story = {
+  args: {
+    content: [
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'text',
+            text: 'This is normal text, ',
+            bold: false,
+            italic: false,
+            underline: false,
+            strikethrough: false,
+          },
+          {
+            type: 'text',
+            text: 'this is bold text, ',
+            bold: true,
+            italic: false,
+            underline: false,
+            strikethrough: false,
+          },
+          {
+            type: 'text',
+            text: 'this is italic text, ',
+            bold: false,
+            italic: true,
+            underline: false,
+            strikethrough: false,
+          },
+          {
+            type: 'text',
+            text: 'and this is <span style="color: purple; fontSize: 12px">styled</span> text',
+            bold: false,
+            italic: false,
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export const Headings: Story = {
+  args: {
+    content: [
+      {
+        type: 'heading',
+        level: 1,
+        children: [
+          {
+            type: 'text',
+            text: 'This is the first heading',
+          },
+        ],
+      },
+      {
+        type: 'heading',
+        level: 2,
+        children: [
+          {
+            type: 'text',
+            text: 'This is the second heading',
+          },
+        ],
+      },
+      {
+        type: 'heading',
+        level: 3,
+        children: [
+          {
+            type: 'text',
+            text: 'This is the third heading',
+          },
+        ],
+      },
+      {
+        type: 'heading',
+        level: 4,
+        children: [
+          {
+            type: 'text',
+            text: 'This is the fourth heading',
+          },
+        ],
+      },
+      {
+        type: 'heading',
+        level: 5,
+        children: [
+          {
+            type: 'text',
+            text: 'This is the fifth heading',
+          },
+        ],
+      },
+      {
+        type: 'heading',
+        level: 6,
+        children: [
+          {
+            type: 'text',
+            text: 'This is the sixth heading',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export const HeadingWithLink: Story = {
+  args: {
+    content: [
+      {
+        type: 'heading',
+        level: 1,
+        children: [
+          {
+            type: 'text',
+            text: 'This is the first heading ',
+          },
+          {
+            type: 'link',
+            url: 'https://www.google.com',
+            children: [
+              {
+                type: 'text',
+                text: 'with a link',
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ' and more text',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export const HeadingWithCustomStyling: Story = {
+  args: {
+    content: [
+      {
+        type: 'heading',
+        level: 1,
+        children: [
+          {
+            type: 'text',
+            text: 'This is the first heading ',
+          },
+          {
+            type: 'link',
+            url: 'https://www.google.com',
+            children: [
+              {
+                type: 'text',
+                text: 'with a link',
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: ' and more text',
+          },
+        ],
+      },
+    ],
+    blockSx: {
+      heading: {
+        a: { textDecoration: 'none' },
+      },
+    },
+  },
+};
+
+export const Quotes: Story = {
+  args: {
+    content: [
+      {
+        type: 'quote',
+        children: [
+          {
+            type: 'text',
+            text: 'This is a quote',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export const BlogArticleImages: Story = {
+  args: {
+    content: [
+      {
+        type: 'image',
+        image: {
+          name: 'AI_Memecoins_and_Crypto',
+          alternativeText: 'AI Memecoins and Crypto illustration',
+          caption: 'AI-powered cryptocurrency and memecoin trading',
+          width: 800,
+          height: 600,
+          formats: {
+            small: {
+              url: 'https://strapi.jumper.exchange/uploads/small_AI_Memecoins_and_Crypto_f98c61b932.png',
+              width: 400,
+              height: 300,
+              hash: 'small_hash_123',
+              ext: '.png',
+              mime: 'image/png',
+              size: 45.2,
+            },
+            medium: {
+              url: 'https://strapi.jumper.exchange/uploads/medium_AI_Memecoins_and_Crypto_f98c61b932.png',
+              width: 600,
+              height: 450,
+              hash: 'medium_hash_123',
+              ext: '.png',
+              mime: 'image/png',
+              size: 89.7,
+            },
+            large: {
+              url: 'https://strapi.jumper.exchange/uploads/large_AI_Memecoins_and_Crypto_f98c61b932.png',
+              width: 800,
+              height: 600,
+              hash: 'large_hash_123',
+              ext: '.png',
+              mime: 'image/png',
+              size: 156.3,
+            },
+            thumbnail: {
+              url: 'https://strapi.jumper.exchange/uploads/thumb_AI_Memecoins_and_Crypto_f98c61b932.png',
+              width: 150,
+              height: 150,
+              hash: 'thumb_hash_123',
+              ext: '.png',
+              mime: 'image/png',
+              size: 12.8,
+            },
+          },
+          hash: 'AI_Memecoins_and_Crypto_f98c61b932',
+          ext: '.png',
+          mime: 'image/png',
+          size: 156.3,
+          url: 'https://strapi.jumper.exchange/uploads/AI_Memecoins_and_Crypto_f98c61b932.png',
+          previewUrl:
+            'https://strapi.jumper.exchange/uploads/AI_Memecoins_and_Crypto_f98c61b932.png',
+          provider: 'local',
+          provider_metadata: {},
+          createdAt: '2024-11-18T10:00:00.000Z',
+          updatedAt: '2024-11-18T10:00:00.000Z',
+        },
+        children: [
+          {
+            type: 'text',
+            text: '',
+          },
+        ],
+      },
+    ],
+    variant: RichBlocksVariant.BlogArticle,
+  },
+};
+
+export const BlogArticleCTA: Story = {
+  args: {
+    content: [
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'text',
+            text: '<JUMPER_CTA title="Jumper" url="https://jumper.exchange" />',
+          },
+        ],
+      },
+    ],
+    variant: RichBlocksVariant.BlogArticle,
+  },
+};
+
+export const BlogArticleWidget: Story = {
+  args: {
+    content: [
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'text',
+            text: '<WIDGET fromChain="1" fromToken="USDC" toChain="1" toToken="USDC" fromAmount="100" />',
+          },
+        ],
+      },
+    ],
+    variant: RichBlocksVariant.BlogArticle,
+  },
+};
+
+const instructionsJSON = [
+  {
+    title: 'Step 1',
+    step: '1',
+    link: { label: 'Connect Wallet', url: 'https://jumper.exchange' },
+  },
+  {
+    title: 'Step 2',
+    step: '2',
+    link: { label: 'Select Token', url: 'https://jumper.exchange' },
+  },
+  {
+    title: 'Step 3',
+    step: '3',
+    link: { label: 'Select Amount', url: 'https://jumper.exchange' },
+  },
+  {
+    title: 'Step 4',
+    step: '4',
+    link: { label: 'Review Transaction', url: 'https://jumper.exchange' },
+  },
+];
+
+export const BlogArticleInstructions: Story = {
+  args: {
+    content: [
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'text',
+            text: `<INSTRUCTIONS ${JSON.stringify(instructionsJSON)} />`,
+          },
+        ],
+      },
+    ],
+    variant: RichBlocksVariant.BlogArticle,
+  },
+};

--- a/src/components/RichBlocks/RichBlocks.style.ts
+++ b/src/components/RichBlocks/RichBlocks.style.ts
@@ -1,0 +1,207 @@
+import Box from '@mui/material/Box';
+import { alpha, darken, styled } from '@mui/material/styles';
+import { Link } from '../Link';
+import Typography, { TypographyProps } from '@mui/material/Typography';
+import { urbanist } from 'src/fonts/fonts';
+import { IconButtonPrimary } from '../IconButton';
+
+// Heading styles
+
+interface HeadingProps extends TypographyProps {
+  level?: number;
+}
+
+export const Heading = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== 'level',
+})<HeadingProps>(({ theme }) => ({
+  color: (theme.vars || theme).palette.alpha800.main,
+  a: {
+    fontWeight: 600,
+    color: (theme.vars || theme).palette.text.primary,
+    textDecorationColor: alpha(theme.palette.primary.main, 0.04),
+    transition: 'all 0.3s ease-in-out',
+  },
+  'a:hover': {
+    textDecorationColor: (theme.vars || theme).palette.primary.main,
+    color: (theme.vars || theme).palette.primary.main,
+  },
+  '& a:not(:first-child)': {
+    marginLeft: theme.spacing(0.5),
+  },
+  variants: [
+    {
+      props: ({ level }) => level === 1,
+      style: {
+        marginTop: theme.spacing(12),
+        marginBottom: theme.spacing(6),
+      },
+    },
+    {
+      props: ({ level }) => level === 2,
+      style: {
+        marginTop: theme.spacing(8),
+        marginBottom: theme.spacing(3),
+      },
+    },
+    {
+      props: ({ level }) => level === 3,
+      style: {
+        marginTop: theme.spacing(6),
+        marginBottom: theme.spacing(2),
+      },
+    },
+    {
+      props: ({ level }) => level === 4,
+      style: {
+        marginTop: theme.spacing(4),
+        marginBottom: theme.spacing(1.5),
+      },
+    },
+    {
+      props: ({ level }) => level === 5,
+      style: {
+        marginTop: theme.spacing(3),
+        marginBottom: theme.spacing(1),
+      },
+    },
+    {
+      props: ({ level }) => level === 6,
+      style: {
+        marginTop: theme.spacing(2),
+        marginBottom: theme.spacing(0.5),
+      },
+    },
+  ],
+}));
+
+// Paragraph styles
+
+export const ParagraphBlockContainer = styled(Box)(({}) => ({}));
+
+export const ParagraphLink = styled(Link)(({ theme }) => ({
+  marginLeft: theme.spacing(0.75),
+  color: (theme.vars || theme).palette.accent1Alt.main,
+  fontWeight: 600,
+  cursor: 'pointer',
+  display: 'inline',
+  ':first-child': {
+    marginLeft: 0,
+  },
+  ...theme.applyStyles('light', {
+    color: (theme.vars || theme).palette.primary.main,
+  }),
+}));
+
+// Paragraph
+interface ParagraphProps extends TypographyProps {
+  bold?: boolean;
+  underline?: boolean;
+  strikethrough?: boolean;
+  italic?: boolean;
+  quote?: boolean;
+}
+
+export const Paragraph = styled(Typography, {
+  shouldForwardProp: (prop) =>
+    prop !== 'bold' &&
+    prop !== 'italic' &&
+    prop !== 'quote' &&
+    prop !== 'underline' &&
+    prop !== 'strikethrough',
+})<ParagraphProps>(({ underline, strikethrough }) => {
+  // TODO: Fix this
+  const textDecoration = underline
+    ? 'underline'
+    : strikethrough
+      ? 'line-through'
+      : 'auto';
+  return {
+    display: 'inline',
+    fontSize: 'inherit',
+    lineHeight: 'inherit',
+    fontFamily: 'inherit',
+    fontWeight: 'inherit',
+    color: 'inherit',
+    fontStyle: 'normal',
+    textDecoration: textDecoration,
+    variants: [
+      {
+        props: ({ bold }) => bold,
+        style: {
+          fontWeight: 700,
+        },
+      },
+      {
+        props: ({ italic, quote }) => italic || quote,
+        style: {
+          fontStyle: 'italic',
+        },
+      },
+    ],
+  };
+});
+
+// CTA styles
+
+export const CtaContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  padding: theme.spacing(8),
+  gap: theme.spacing(1.5),
+  cursor: 'pointer',
+  overflow: 'hidden',
+  textAlign: 'center',
+  margin: theme.spacing(6, 0),
+  transition: 'background-color 250ms',
+  borderRadius: '16px',
+  //todo: add to theme
+  backgroundColor: alpha(theme.palette.white.main, 0.08),
+  '&:hover': {
+    cursor: 'pointer',
+    //todo: add to theme
+    backgroundColor: alpha(theme.palette.white.main, 0.16),
+    ...theme.applyStyles('light', {
+      backgroundColor: darken('#F9F5FF', 0.02),
+    }),
+  },
+  [theme.breakpoints.up('sm')]: {
+    gap: theme.spacing(4),
+    flexDirection: 'row',
+  },
+  ...theme.applyStyles('light', {
+    backgroundColor: '#F9F5FF',
+  }),
+}));
+
+export const CtaTitle = styled(Box)(({ theme }) => ({
+  fontFamily: urbanist.style.fontFamily,
+  fontWeight: 700,
+  color: (theme.vars || theme).palette.accent1Alt.main,
+  fontSize: '32px',
+  lineHeight: '38px',
+  userSelect: 'none',
+  [theme.breakpoints.up('sm')]: {
+    fontSize: '40px',
+    lineHeight: '56px',
+    textDecoration: 'auto',
+  },
+  ...theme.applyStyles('light', {
+    color: (theme.vars || theme).palette.primary.main,
+  }),
+}));
+
+export const CtaButton = styled(IconButtonPrimary)(({ theme }) => ({
+  [theme.breakpoints.up('sm')]: {
+    display: 'flex',
+  },
+}));
+
+// Widget styles
+
+export const WidgetHeader = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  marginBottom: theme.spacing(3),
+}));

--- a/src/components/RichBlocks/RichBlocks.tsx
+++ b/src/components/RichBlocks/RichBlocks.tsx
@@ -1,0 +1,61 @@
+import { BlocksRenderer } from '@strapi/blocks-react-renderer';
+import type { RootNode } from 'node_modules/@strapi/blocks-react-renderer/dist/BlocksRenderer';
+import { FC } from 'react';
+import { ParagraphBlock } from './blocks/ParagraphBlock';
+import { SxProps, Theme } from '@mui/material/styles';
+import { HeadingBlock } from './blocks/HeadingBlock';
+import { QuoteBlock } from './blocks/QuoteBlock';
+import { ImageBlock } from './blocks/ImageBlock';
+import { ImageProps, RichBlocksVariant, TrackingKeys } from './types';
+
+interface RichBlocksProps {
+  content: RootNode[] | undefined;
+  blockSx?: {
+    paragraph?: SxProps<Theme>;
+    heading?: SxProps<Theme>;
+    quote?: SxProps<Theme>;
+    image?: SxProps<Theme>;
+  };
+  trackingKeys?: TrackingKeys;
+  variant?: RichBlocksVariant;
+}
+
+// @TODO use this also for blog article
+export const RichBlocks: FC<RichBlocksProps> = ({
+  content,
+  blockSx,
+  trackingKeys,
+  variant = RichBlocksVariant.Mission,
+}) => {
+  if (!content) {
+    return null;
+  }
+  return (
+    <BlocksRenderer
+      content={content}
+      blocks={{
+        heading: (props) => (
+          <HeadingBlock {...props} sx={blockSx?.heading} variant={variant} />
+        ),
+        paragraph: (props) => (
+          <ParagraphBlock
+            {...props}
+            sx={blockSx?.paragraph}
+            trackingKeys={trackingKeys}
+            variant={variant}
+          />
+        ),
+        quote: (props) => (
+          <QuoteBlock {...props} sx={blockSx?.quote} variant={variant} />
+        ),
+        image: (props) => (
+          <ImageBlock
+            {...(props as unknown as ImageProps)}
+            sx={blockSx?.image}
+            variant={variant}
+          />
+        ),
+      }}
+    />
+  );
+};

--- a/src/components/RichBlocks/RichBlocks.tsx
+++ b/src/components/RichBlocks/RichBlocks.tsx
@@ -30,6 +30,7 @@ export const RichBlocks: FC<RichBlocksProps> = ({
   if (!content) {
     return null;
   }
+
   return (
     <BlocksRenderer
       content={content}

--- a/src/components/RichBlocks/blocks/HeadingBlock.tsx
+++ b/src/components/RichBlocks/blocks/HeadingBlock.tsx
@@ -1,0 +1,33 @@
+import { FC } from 'react';
+import generateKey from 'src/app/lib/generateKey';
+import { CommonBlockProps, HeadingProps } from '../types';
+import { Heading } from '../RichBlocks.style';
+
+interface HeadingBlockProps extends HeadingProps, CommonBlockProps {}
+
+const isValidHeadingLevel = (level: number): level is 1 | 2 | 3 | 4 | 5 | 6 => {
+  return level >= 1 && level <= 6;
+};
+
+export const HeadingBlock: FC<HeadingBlockProps> = ({
+  children,
+  level,
+  sx,
+}) => {
+  if (!children) {
+    return null;
+  }
+
+  const validLevel = isValidHeadingLevel(level) ? level : 1;
+
+  return (
+    <Heading
+      level={level}
+      variant={`h${validLevel}`}
+      sx={sx}
+      key={generateKey('heading')}
+    >
+      {children}
+    </Heading>
+  );
+};

--- a/src/components/RichBlocks/blocks/ImageBlock.tsx
+++ b/src/components/RichBlocks/blocks/ImageBlock.tsx
@@ -1,0 +1,18 @@
+import { FC } from 'react';
+import { Lightbox } from 'src/components/Lightbox';
+import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
+import { CommonBlockProps, ImageProps, RichBlocksVariant } from '../types';
+
+interface ImageBlockProps extends ImageProps, CommonBlockProps {}
+
+export const ImageBlock: FC<ImageBlockProps> = ({ image, variant }) => {
+  if (variant !== RichBlocksVariant.BlogArticle) {
+    return null;
+  }
+
+  const baseUrl = getStrapiBaseUrl();
+  if (!baseUrl) {
+    return null;
+  }
+  return <Lightbox imageData={image} baseUrl={baseUrl} />;
+};

--- a/src/components/RichBlocks/blocks/ParagraphBlock.tsx
+++ b/src/components/RichBlocks/blocks/ParagraphBlock.tsx
@@ -1,0 +1,62 @@
+import { FC, PropsWithChildren } from 'react';
+import { ParagraphBlockContainer } from '../RichBlocks.style';
+import {
+  CommonBlockProps,
+  ParagraphProps,
+  RichBlocksVariant,
+  TrackingKeys,
+} from '../types';
+import { ParagraphRenderer } from '../renderers/ParagraphRenderer';
+import { CTARenderer } from '../renderers/CTARenderer';
+import { WidgetRenderer } from '../renderers/WidgetRenderer';
+import { InstructionsRenderer } from '../renderers/InstructionsRenderer';
+
+interface ParagraphBlockProps extends PropsWithChildren, CommonBlockProps {
+  trackingKeys?: TrackingKeys;
+}
+
+export const ParagraphBlock: FC<ParagraphBlockProps> = ({
+  children,
+  sx,
+  trackingKeys,
+  variant,
+}) => {
+  if (!Array.isArray(children)) {
+    return null;
+  }
+  const paragraphChildren = children as Array<{ props: ParagraphProps }>;
+
+  if (
+    paragraphChildren[0].props.text.includes('<JUMPER_CTA') &&
+    variant === RichBlocksVariant.BlogArticle
+  ) {
+    return (
+      <CTARenderer
+        text={paragraphChildren[0].props.text}
+        trackingKeys={trackingKeys?.cta}
+      />
+    );
+  }
+
+  if (
+    paragraphChildren[0].props.text.includes('<WIDGET') &&
+    variant === RichBlocksVariant.BlogArticle
+  ) {
+    return <WidgetRenderer text={paragraphChildren[0].props.text} />;
+  }
+
+  if (
+    paragraphChildren[0].props.text.includes('<INSTRUCTIONS') &&
+    variant === RichBlocksVariant.BlogArticle
+  ) {
+    return <InstructionsRenderer text={paragraphChildren[0].props.text} />;
+  }
+
+  return (
+    <ParagraphBlockContainer sx={sx}>
+      {paragraphChildren.map((el, index) => (
+        <ParagraphRenderer key={index} element={el} />
+      ))}
+    </ParagraphBlockContainer>
+  );
+};

--- a/src/components/RichBlocks/blocks/ParagraphBlock.tsx
+++ b/src/components/RichBlocks/blocks/ParagraphBlock.tsx
@@ -24,6 +24,11 @@ export const ParagraphBlock: FC<ParagraphBlockProps> = ({
   if (!Array.isArray(children)) {
     return null;
   }
+
+  if (children.length === 1 && children[0].props.text === '') {
+    return null;
+  }
+
   const paragraphChildren = children as Array<{ props: ParagraphProps }>;
 
   if (

--- a/src/components/RichBlocks/blocks/QuoteBlock.tsx
+++ b/src/components/RichBlocks/blocks/QuoteBlock.tsx
@@ -1,0 +1,21 @@
+import { FC, PropsWithChildren } from 'react';
+import { CommonBlockProps, QuoteProps } from '../types';
+import generateKey from 'src/app/lib/generateKey';
+import { Paragraph, ParagraphBlockContainer } from '../RichBlocks.style';
+
+interface QuoteBlockProps extends PropsWithChildren, CommonBlockProps {}
+
+export const QuoteBlock: FC<QuoteBlockProps> = ({ children, sx }) => {
+  if (!Array.isArray(children)) {
+    return null;
+  }
+  const quoteChildren = children as Array<{ props: QuoteProps }>;
+
+  return quoteChildren.map((el) => (
+    <ParagraphBlockContainer sx={sx} key={generateKey('quote')}>
+      <Paragraph as="q" quote>
+        {el.props.text}
+      </Paragraph>
+    </ParagraphBlockContainer>
+  ));
+};

--- a/src/components/RichBlocks/renderers/CTARenderer.tsx
+++ b/src/components/RichBlocks/renderers/CTARenderer.tsx
@@ -1,0 +1,72 @@
+import { FC } from 'react';
+import { TrackingKeys } from '../types';
+import { IconButtonPrimary } from '@/components/IconButton.style';
+import { useTranslation } from 'react-i18next';
+import { useUserTracking } from 'src/hooks/userTracking/useUserTracking';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import Link from 'next/link';
+import {
+  TrackingCategory,
+  TrackingAction,
+  TrackingEventParameter,
+} from 'src/const/trackingKeys';
+import { CtaContainer, CtaTitle } from '../RichBlocks.style';
+
+interface CTARendererProps {
+  text: string;
+  trackingKeys?: TrackingKeys['cta'];
+}
+
+export const CTARenderer: FC<CTARendererProps> = ({ text, trackingKeys }) => {
+  // Regular expressions to extract title and url strings
+  const titleRegex = /title="(.*?)"/;
+  const urlRegex = /url="(.*?)"/;
+
+  // Extract title and url strings using regular expressions
+  const titleMatch = text.match(titleRegex);
+  const urlMatch = text.match(urlRegex);
+
+  // Check if matches were found and extract strings
+  const title = titleMatch?.[1];
+  const url = urlMatch ? urlMatch[1] : undefined;
+
+  const trackingKeysWithDefaults = {
+    category: TrackingCategory.BlogArticle,
+    action: TrackingAction.ClickBlogCTA,
+    label: 'click-blog-cta',
+    ...(trackingKeys || {}),
+    data: {
+      [TrackingEventParameter.ArticleTitle]: title || '',
+      [TrackingEventParameter.ArticleID]: '',
+      ...(trackingKeys?.data || {}),
+    },
+  };
+
+  const { t } = useTranslation();
+  const { trackEvent } = useUserTracking();
+
+  const handleClick = () => {
+    trackEvent({
+      category: trackingKeysWithDefaults.category,
+      action: trackingKeysWithDefaults.action,
+      label: trackingKeysWithDefaults.label,
+      data: trackingKeysWithDefaults.data,
+    });
+  };
+  return (
+    <Link style={{ textDecoration: 'none' }} href={url || '/'}>
+      <CtaContainer onClick={handleClick}>
+        <CtaTitle>{title ?? t('blog.jumperCta')}</CtaTitle>
+        <IconButtonPrimary onClick={handleClick}>
+          <ArrowForwardIcon
+            sx={(theme) => ({
+              width: '28px',
+              height: '28px',
+              color: (theme.vars || theme).palette.white.main,
+            })}
+          />
+        </IconButtonPrimary>
+      </CtaContainer>
+    </Link>
+  );
+};

--- a/src/components/RichBlocks/renderers/HtmlRenderer.tsx
+++ b/src/components/RichBlocks/renderers/HtmlRenderer.tsx
@@ -1,0 +1,23 @@
+import { FC } from 'react';
+import parse from 'html-react-parser';
+import { Paragraph } from '../RichBlocks.style';
+import type { ParagraphProps } from '../types';
+
+interface HtmlRendererProps extends ParagraphProps {}
+
+export const HtmlRenderer: FC<HtmlRendererProps> = ({
+  text,
+  italic,
+  strikethrough,
+  underline,
+  bold,
+}) => (
+  <Paragraph
+    italic={italic}
+    strikethrough={strikethrough}
+    underline={underline}
+    bold={bold}
+  >
+    {parse(text)}
+  </Paragraph>
+);

--- a/src/components/RichBlocks/renderers/InstructionsRenderer.tsx
+++ b/src/components/RichBlocks/renderers/InstructionsRenderer.tsx
@@ -1,0 +1,34 @@
+import { FC } from 'react';
+import generateKey from 'src/app/lib/generateKey';
+import {
+  InstructionsAccordion,
+  type InstructionItemProps,
+} from 'src/components/Blog/CTAs/InstructionsAccordion/InstructionsAccordion';
+
+interface InstructionsRendererProps {
+  text: string;
+}
+
+export const InstructionsRenderer: FC<InstructionsRendererProps> = ({
+  text,
+}) => {
+  const instructions_array: InstructionItemProps[] = [];
+  try {
+    let jso = text.replace('<INSTRUCTIONS ', '').replace('/>', '');
+
+    // Parse the JSON string and push each parsed object into the instructions_array
+    JSON.parse(jso).forEach((obj: InstructionItemProps) => {
+      instructions_array.push(obj);
+    });
+  } catch (error) {
+    console.error('Error parsing instructions', error);
+    return null;
+  }
+
+  return (
+    <InstructionsAccordion
+      data={instructions_array}
+      key={generateKey('instructions')}
+    />
+  );
+};

--- a/src/components/RichBlocks/renderers/LinkRenderer.tsx
+++ b/src/components/RichBlocks/renderers/LinkRenderer.tsx
@@ -1,0 +1,13 @@
+import { FC } from 'react';
+import { ParagraphLink } from '../RichBlocks.style';
+
+interface LinkRendererProps {
+  content: {
+    url: string;
+    children: Array<{ text: string }>;
+  };
+}
+
+export const LinkRenderer: FC<LinkRendererProps> = ({ content }) => (
+  <ParagraphLink href={content.url}>{content.children[0].text}</ParagraphLink>
+);

--- a/src/components/RichBlocks/renderers/ParagraphRenderer.tsx
+++ b/src/components/RichBlocks/renderers/ParagraphRenderer.tsx
@@ -1,0 +1,25 @@
+import { FC } from 'react';
+import { LinkRenderer } from './LinkRenderer';
+import { HtmlRenderer } from './HtmlRenderer';
+import { TextRenderer } from './TextRenderer';
+import type { ParagraphProps } from '../types';
+
+interface ParagraphRendererProps {
+  element: { props: ParagraphProps };
+}
+
+export const ParagraphRenderer: FC<ParagraphRendererProps> = ({ element }) => {
+  const { props } = element;
+
+  if (!props.text) return null;
+
+  if (props.content?.type === 'link') {
+    return <LinkRenderer content={props.content} />;
+  }
+
+  if (props.text.includes('<') && props.text.includes('>')) {
+    return <HtmlRenderer {...props} />;
+  }
+
+  return <TextRenderer {...props} />;
+};

--- a/src/components/RichBlocks/renderers/TextRenderer.tsx
+++ b/src/components/RichBlocks/renderers/TextRenderer.tsx
@@ -1,0 +1,39 @@
+import { FC, isValidElement, ReactElement } from 'react';
+import { Paragraph } from '../RichBlocks.style';
+import newlineToBr from 'src/utils/newlineToBr';
+import generateKey from 'src/app/lib/generateKey';
+import type { ParagraphProps } from '../types';
+
+interface TextRendererProps extends ParagraphProps {}
+
+export const TextRenderer: FC<TextRendererProps> = ({
+  text,
+  italic,
+  strikethrough,
+  underline,
+  bold,
+}) => {
+  const nl2brText: Array<ReactElement | string> = newlineToBr(text);
+
+  return (
+    <>
+      {nl2brText.map((line, lineIndex) => {
+        if (isValidElement(line) && line.type === 'br') {
+          return line;
+        }
+
+        return (
+          <Paragraph
+            italic={italic}
+            strikethrough={strikethrough}
+            underline={underline}
+            bold={bold}
+            key={generateKey(`paragraph-line-${lineIndex}`)}
+          >
+            {line}
+          </Paragraph>
+        );
+      })}
+    </>
+  );
+};

--- a/src/components/RichBlocks/renderers/WidgetRenderer.tsx
+++ b/src/components/RichBlocks/renderers/WidgetRenderer.tsx
@@ -1,0 +1,71 @@
+import { FC } from 'react';
+import { WidgetHeader } from '../RichBlocks.style';
+import { Widget } from 'src/components/Widgets/Widget';
+import { WalletButtons } from 'src/components/Navbar/components/Buttons/WalletButtons';
+import config from 'src/config/env-config';
+
+interface WidgetRendererProps {
+  text: string;
+}
+
+export interface WidgetRouteSettings {
+  fromChain?: number;
+  fromToken?: string;
+  toChain?: number;
+  toToken?: string;
+  fromAmount?: string;
+  allowChains?: string;
+}
+
+export const WidgetRenderer: FC<WidgetRendererProps> = ({ text }) => {
+  const props: WidgetRouteSettings = {};
+  const propRegex =
+    /(?:fromAmount|fromChain|fromToken|toChain|toToken|allowChains)="([^"]*)"/g;
+
+  const setProp = <K extends keyof WidgetRouteSettings>(
+    prop: K,
+    value: WidgetRouteSettings[K],
+  ) => {
+    props[prop] = value;
+  };
+
+  try {
+    let match;
+    while ((match = propRegex.exec(text)) !== null) {
+      const [, value] = match;
+      const prop = match[0].split('=')[0];
+      if (prop) {
+        setProp(prop as keyof WidgetRouteSettings, value);
+      }
+    }
+  } catch (error) {
+    console.error('Error integrating widget into blog article', error);
+    return null;
+  }
+
+  const { fromChain, fromToken, toChain, toToken, fromAmount, allowChains } =
+    props;
+
+  const allowChainsArray = (allowChains || '')
+    .split(',')
+    .map((el) => parseInt(el))
+    .filter((num) => !isNaN(num));
+
+  return (
+    <>
+      <WidgetHeader>
+        <WalletButtons />
+      </WidgetHeader>
+      <Widget
+        starterVariant="default"
+        fromChain={fromChain}
+        fromToken={fromToken}
+        toChain={toChain}
+        fromAmount={fromAmount}
+        toToken={toToken}
+        allowChains={allowChainsArray}
+        widgetIntegrator={config.NEXT_PUBLIC_WIDGET_INTEGRATOR_BLOG}
+      />
+    </>
+  );
+};

--- a/src/components/RichBlocks/types.ts
+++ b/src/components/RichBlocks/types.ts
@@ -1,0 +1,58 @@
+import { ReactNode } from 'react';
+import type { StrapiMediaAttributes } from '@/types/strapi';
+import {
+  TrackingCategory,
+  TrackingAction,
+  TrackingEventParameter,
+} from 'src/const/trackingKeys';
+import { SxProps, Theme } from '@mui/material/styles';
+
+export enum RichBlocksVariant {
+  BlogArticle = 'blogArticle',
+  Mission = 'mission',
+}
+
+export interface HeadingProps {
+  children?: ReactNode;
+  level: number;
+  [key: string]: any;
+}
+
+export interface ParagraphProps {
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strikethrough?: boolean;
+  content?: {
+    type: string;
+    url: string;
+    children: Array<{ text: string }>;
+  };
+  [key: string]: any;
+}
+
+export interface QuoteProps {
+  children: Array<{ text: string }>;
+  [key: string]: any;
+}
+
+export interface ImageProps {
+  image: StrapiMediaAttributes;
+}
+
+export interface TrackingKeys {
+  cta?: {
+    category: TrackingCategory;
+    action: TrackingAction;
+    label: string;
+    data: {
+      [key in TrackingEventParameter]: string;
+    };
+  };
+}
+
+export interface CommonBlockProps {
+  variant?: RichBlocksVariant;
+  sx?: SxProps<Theme>;
+}

--- a/src/components/Zap/ZapDetails.tsx
+++ b/src/components/Zap/ZapDetails.tsx
@@ -84,6 +84,7 @@ export const ZapDetails: FC<ZapDetailsProps> = ({ market, tasks }) => {
             slug={zapDisplayData.slug}
             title={zapDisplayData.title}
             description={zapDisplayData.description}
+            descriptionRichText={zapDisplayData.descriptionRichText}
             participants={zapDisplayData.participants}
             imageUrl={zapDisplayData.imageUrl}
             rewardGroups={zapDisplayData.rewardGroups}

--- a/src/hooks/quests/useFormatDisplayQuestData.ts
+++ b/src/hooks/quests/useFormatDisplayQuestData.ts
@@ -6,12 +6,13 @@ import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
 import { useFormatDisplayRewardsData } from './useFormatDisplayRewardsData';
 import { QuestData } from 'src/types/strapi';
 import { Chain } from 'src/types/questDetails';
+import { RootNode } from 'node_modules/@strapi/blocks-react-renderer/dist/BlocksRenderer';
 
 interface DisplayQuestData {
   id: string;
   slug: string;
   title: string;
-  description: string;
+  description: RootNode[];
   info: string;
   startDate: string;
   endDate: string;
@@ -95,7 +96,7 @@ export function useFormatDisplayQuestData(
       id: id.toString(),
       slug: Slug,
       title: Title || '',
-      description: Description || '',
+      description: Description || [],
       info: Information || '',
       startDate: StartDate || '',
       endDate: EndDate || '',

--- a/src/hooks/quests/useFormatDisplayQuestData.ts
+++ b/src/hooks/quests/useFormatDisplayQuestData.ts
@@ -12,7 +12,8 @@ interface DisplayQuestData {
   id: string;
   slug: string;
   title: string;
-  description: RootNode[];
+  description: string;
+  descriptionRichText: RootNode[];
   info: string;
   startDate: string;
   endDate: string;
@@ -61,6 +62,7 @@ export function useFormatDisplayQuestData(
       id,
       Title,
       Description,
+      DescriptionRichText,
       Information,
       Slug,
       StartDate,
@@ -96,7 +98,8 @@ export function useFormatDisplayQuestData(
       id: id.toString(),
       slug: Slug,
       title: Title || '',
-      description: Description || [],
+      description: Description || '',
+      descriptionRichText: DescriptionRichText || [],
       info: Information || '',
       startDate: StartDate || '',
       endDate: EndDate || '',

--- a/src/types/loyaltyPass.ts
+++ b/src/types/loyaltyPass.ts
@@ -87,7 +87,7 @@ export interface CustomInformation {
 export type QuestAttributes = {
   UID: string;
   Title: string;
-  Description?: string;
+  Description?: RootNode[];
   Link: string;
   Category?: string;
   Points: number;

--- a/src/types/loyaltyPass.ts
+++ b/src/types/loyaltyPass.ts
@@ -87,7 +87,8 @@ export interface CustomInformation {
 export type QuestAttributes = {
   UID: string;
   Title: string;
-  Description?: RootNode[];
+  DescriptionRichText?: RootNode[];
+  Description?: string;
   Link: string;
   Category?: string;
   Points: number;

--- a/src/types/strapi.ts
+++ b/src/types/strapi.ts
@@ -300,7 +300,8 @@ export interface QuestData {
   documentId: string;
   UID: string;
   Title: string;
-  Description: RootNode[];
+  DescriptionRichText: RootNode[];
+  Description: string;
   Link: string;
   Image?: StrapiMediaData;
   Category: string | null;

--- a/src/types/strapi.ts
+++ b/src/types/strapi.ts
@@ -300,7 +300,7 @@ export interface QuestData {
   documentId: string;
   UID: string;
   Title: string;
-  Description: string;
+  Description: RootNode[];
   Link: string;
   Image?: StrapiMediaData;
   Category: string | null;
@@ -310,7 +310,6 @@ export interface QuestData {
   StartDate: string;
   Slug: string;
   Label: string;
-  Steps: RootNode[];
   Information: string | null;
   CustomInformation: any;
   BannerImage?: StrapiMediaData;

--- a/src/utils/strapi/strapiHelper.ts
+++ b/src/utils/strapi/strapiHelper.ts
@@ -1,37 +1,19 @@
 import config from '@/config/env-config';
 
 export function getStrapiBaseUrl() {
-  if (config.NEXT_PUBLIC_STRAPI_DEVELOP === 'true') {
-    // Use local Strapi URL for development environment
-    if (!config.NEXT_PUBLIC_LOCAL_STRAPI_URL) {
-      console.error('Local Strapi URL is not provided.');
-      throw new Error('Local Strapi URL is not provided.');
-    }
-    return `${config.NEXT_PUBLIC_LOCAL_STRAPI_URL}`;
-  } else {
-    // Use default Strapi URL for other environments
-    if (!config.NEXT_PUBLIC_STRAPI_URL) {
-      console.error('Strapi URL is not provided.');
-      throw new Error('Strapi URL is not provided.');
-    }
-    return `${config.NEXT_PUBLIC_STRAPI_URL}`;
+  // Use default Strapi URL for other environments
+  if (!config.NEXT_PUBLIC_STRAPI_URL) {
+    console.error('Strapi URL is not provided.');
+    throw new Error('Strapi URL is not provided.');
   }
+  return `${config.NEXT_PUBLIC_STRAPI_URL}`;
 }
 
 export function getStrapiApiAccessToken() {
-  if (config.NEXT_PUBLIC_STRAPI_DEVELOP === 'true') {
-    // Check local development token
-    if (!config.NEXT_PUBLIC_LOCAL_STRAPI_API_TOKEN) {
-      console.error('Local Strapi API token is not provided.');
-      throw new Error('Local Strapi API token is not provided.');
-    }
-    return config.NEXT_PUBLIC_LOCAL_STRAPI_API_TOKEN;
-  } else {
-    // Check production token
-    if (!config.NEXT_PUBLIC_STRAPI_API_TOKEN) {
-      console.error('Strapi API token is not provided.');
-      throw new Error('Strapi API token is not provided.');
-    }
-    return config.NEXT_PUBLIC_STRAPI_API_TOKEN;
+  // Check production token
+  if (!config.NEXT_PUBLIC_STRAPI_API_TOKEN) {
+    console.error('Strapi API token is not provided.');
+    throw new Error('Strapi API token is not provided.');
   }
+  return config.NEXT_PUBLIC_STRAPI_API_TOKEN;
 }


### PR DESCRIPTION
Issue: https://lifi.atlassian.net/browse/LF-15286

Needs: https://github.com/jumperexchange/strapi-cms/pull/71

> [!IMPORTANT]
> DO NOT MERGE until
> - strapi PR is merged
> - all existing missions have their descriptions migrated

## Testing steps

1. Run `pnpm build-storybook`
2. Run `pnpm storybook`
3. Check the `Components/Rich Blocks` stories - there are stories also added for the blog article elements
4. Now check the `Components/Cards/Mission card` for the wide variant as this one should display rich text description
