### PR TITLE
fix: zap missing time bounds

### DIFF
--- a/src/providers/ZapInitProvider/WalletClient/quotes.ts
+++ b/src/providers/ZapInitProvider/WalletClient/quotes.ts
@@ -21,6 +21,9 @@ interface QuoteExecutionParams {
   requestedAmount: bigint;
 }
 
+const minutesToSeconds = (input: number) => input * 60;
+const millisecondsToSeconds = (input: number) => input / 1000;
+
 const executeEmbeddedWalletQuote = async (
   params: QuoteExecutionParams,
 ): Promise<string> => {
@@ -77,6 +80,9 @@ const executeRegularWalletQuote = async (
     userBalance,
   } = params;
 
+  // The biconomy sdk requires the timestamp to be in seconds and throws an error if not using integer
+  const now = Math.ceil(millisecondsToSeconds(Date.now()));
+
   const fusionQuoteParams: GetFusionQuoteParams = {
     trigger: {
       tokenAddress: currentRouteFromToken.address as EVMAddress,
@@ -89,6 +95,8 @@ const executeRegularWalletQuote = async (
       chainId: currentChainId,
     },
     instructions,
+    lowerBoundTimestamp: now,
+    upperBoundTimestamp: now + minutesToSeconds(2),
   };
 
   const usageInBasisPoints =


### PR DESCRIPTION
Previously all `LNK` or `WETH` on `BASE` deposits were failing 
https://meescan.biconomy.io/details/0x1265432d71978ec7f2fb29e3516f622bfe7850497f1c94e28f6b143f28b0fd06
https://meescan.biconomy.io/details/0xdfd133aa31be04edd14643c4d5bacee3e2a4284b1f2209ec0913c1f521b9d224

Using time bounds solved the deposit of `LNK` on `Base`

<img width="512" height="841" alt="Screenshot 2025-08-29 at 13 19 09" src="https://github.com/user-attachments/assets/97344e77-f7f8-4b2f-a2be-24b05f624094" />
