### PR TITLE
fix: zap wait for calls status improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@fingerprintjs/fingerprintjs": "^3.4.2",
     "@headlessui/react": "^2.2.7",
     "@lifi/explorer": "^0.4.0",
-    "@lifi/sdk": "^3.11.3",
+    "@lifi/sdk": "^3.12.0",
     "@lifi/wallet-management": "^3.15.1",
     "@lifi/widget": "^3.29.1",
     "@merkl/api": "1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0(443d4a98bc398b101fbf2c3a6df4868c)
       '@lifi/sdk':
-        specifier: ^3.11.3
-        version: 3.11.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+        specifier: ^3.12.0
+        version: 3.12.0(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       '@lifi/wallet-management':
         specifier: ^3.15.1
         version: 3.15.1(6563757cbdaa3e0d35dfbfaa24256b29)
@@ -2199,8 +2199,8 @@ packages:
       '@tanstack/react-query': ^5.48.0
       react: 19.0.0
 
-  '@lifi/sdk@3.11.4':
-    resolution: {integrity: sha512-xUQvBbytiF2NjS+Plz5yHhZfOiETp4mVXcJv/98OBB3NZVtoRy1lKo30BP7X2hwStXbdmRTU6eW51Dhp7OA7Vw==}
+  '@lifi/sdk@3.12.0':
+    resolution: {integrity: sha512-ABa9vFKFrHKZjBOCLPhomancyIv6HiVCvGNaJ/Yd5CTN2uJYrFX0SE2oFDpc56wPuSJZG+87TpH62fdF2jd+LA==}
     peerDependencies:
       '@solana/wallet-adapter-base': ^0.9.0
       '@solana/web3.js': ^1.98.0
@@ -11939,7 +11939,7 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.1.12)(react@19.1.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
-      '@lifi/sdk': 3.11.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      '@lifi/sdk': 3.12.0(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       '@mui/icons-material': 7.3.1(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
       '@mui/lab': 7.0.0-beta.16(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@mui/material': 7.3.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -11969,7 +11969,7 @@ snapshots:
       - viem
       - zod
 
-  '@lifi/sdk@3.11.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
+  '@lifi/sdk@3.12.0(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@bigmi/core': 0.5.2(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))
       '@bitcoinerlab/secp256k1': 1.2.0
@@ -11995,7 +11995,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@lifi/sdk@3.11.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
+  '@lifi/sdk@3.12.0(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@bigmi/core': 0.5.2(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))
       '@bitcoinerlab/secp256k1': 1.2.0
@@ -12037,7 +12037,7 @@ snapshots:
       '@bigmi/react': 0.5.2(@tanstack/query-core@5.85.6)(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))
       '@emotion/react': 11.14.0(@types/react@19.1.12)(react@19.1.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
-      '@lifi/sdk': 3.11.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      '@lifi/sdk': 3.12.0(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       '@mui/icons-material': 7.3.1(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
       '@mui/material': 7.3.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@mui/system': 7.3.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
@@ -12079,7 +12079,7 @@ snapshots:
       '@bigmi/react': 0.5.2(@tanstack/query-core@5.85.6)(@tanstack/react-query@5.85.6(react@19.1.1))(@types/react@19.1.12)(bs58@6.0.0)(immer@10.1.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))
       '@emotion/react': 11.14.0(@types/react@19.1.12)(react@19.1.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
-      '@lifi/sdk': 3.11.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      '@lifi/sdk': 3.12.0(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.2)(utf-8-validate@5.0.10))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.36.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       '@lifi/wallet-management': 3.15.1(6563757cbdaa3e0d35dfbfaa24256b29)
       '@mui/icons-material': 7.3.1(@mui/material@7.3.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
       '@mui/material': 7.3.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -20704,7 +20704,7 @@ snapshots:
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.2
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0

--- a/src/providers/ZapInitProvider/WalletClient/methods.spec.ts
+++ b/src/providers/ZapInitProvider/WalletClient/methods.spec.ts
@@ -149,6 +149,44 @@ describe('waitForCallsStatus', () => {
     });
   }, 5000);
 
+  it('should return fallback if waitForSupertransactionReceipt fails and explorer returns FAILED status for destination chain', async () => {
+    const originalTxHash = '0x000';
+    const biconomyTxHash = `${originalTxHash}_biconomy`;
+
+    // First call fails
+    mockMeeClient.waitForSupertransactionReceipt.mockRejectedValueOnce(
+      new Error('First attempt failed'),
+    );
+
+    // Explorer responds with FAILED status (should stop retry)
+    mockMeeClient.request.mockResolvedValue({
+      userOps: [
+        createUserOp('MINED_SUCCESS'),
+        createUserOp('MINED_SUCCESS'),
+        createUserOp('FAILED'),
+      ],
+    });
+
+    const result = await waitForCallsStatus(
+      createTestParams(biconomyTxHash),
+      mockMeeClient,
+      undefined,
+      mockExtraParams,
+    );
+
+    expect(result.status).toBe('success');
+    expect(result.receipts).toHaveLength(1);
+    expect(result.receipts[0].status).toBe('success');
+    expect(result.receipts[0].transactionHash).toBe(biconomyTxHash);
+    expect(result.receipts[0].transactionLink).toBeUndefined();
+    expect(mockMeeClient.waitForSupertransactionReceipt).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(mockMeeClient.request).toHaveBeenCalledWith(
+      getExplorerRequestOptions(originalTxHash),
+    );
+  });
+
   it('should return fallback if waitForSupertransactionReceipt fails and explorer returns FAILED status', async () => {
     const originalTxHash = '0x000';
     const biconomyTxHash = `${originalTxHash}_biconomy`;
@@ -170,11 +208,11 @@ describe('waitForCallsStatus', () => {
       mockExtraParams,
     );
 
-    expect(result.status).toBe('success');
+    expect(result.status).toBe('failed');
     expect(result.receipts).toHaveLength(1);
-    expect(result.receipts[0].status).toBe('success');
+    expect(result.receipts[0].status).toBe('reverted');
     expect(result.receipts[0].transactionHash).toBe(biconomyTxHash);
-    expect(result.receipts[0].transactionLink).toBeUndefined();
+    expect(result.receipts[0].transactionLink).toContain(originalTxHash);
     expect(mockMeeClient.waitForSupertransactionReceipt).toHaveBeenCalledTimes(
       1,
     );
@@ -202,11 +240,11 @@ describe('waitForCallsStatus', () => {
       mockExtraParams,
     );
 
-    expect(result.status).toBe('success');
+    expect(result.status).toBe('failed');
     expect(result.receipts).toHaveLength(1);
-    expect(result.receipts[0].status).toBe('success');
+    expect(result.receipts[0].status).toBe('reverted');
     expect(result.receipts[0].transactionHash).toBe(biconomyTxHash);
-    expect(result.receipts[0].transactionLink).toBeUndefined();
+    expect(result.receipts[0].transactionLink).toContain(originalTxHash);
     expect(mockMeeClient.waitForSupertransactionReceipt).toHaveBeenCalledTimes(
       1,
     );
@@ -234,11 +272,11 @@ describe('waitForCallsStatus', () => {
       mockExtraParams,
     );
 
-    expect(result.status).toBe('success');
+    expect(result.status).toBe('failed');
     expect(result.receipts).toHaveLength(1);
-    expect(result.receipts[0].status).toBe('success');
+    expect(result.receipts[0].status).toBe('reverted');
     expect(result.receipts[0].transactionHash).toBe(biconomyTxHash);
-    expect(result.receipts[0].transactionLink).toBeUndefined();
+    expect(result.receipts[0].transactionLink).toContain(originalTxHash);
     expect(mockMeeClient.waitForSupertransactionReceipt).toHaveBeenCalledTimes(
       1,
     );

--- a/src/providers/ZapInitProvider/WalletClient/methods.spec.ts
+++ b/src/providers/ZapInitProvider/WalletClient/methods.spec.ts
@@ -114,47 +114,23 @@ describe('waitForCallsStatus', () => {
     );
   });
 
-  it('should return failed if timeout is reached', async () => {
-    const originalTxHash = '0x000';
-    const biconomyTxHash = `${originalTxHash}_biconomy`;
-
-    mockMeeClient.waitForSupertransactionReceipt.mockImplementation(
-      () =>
-        new Promise((_, reject) =>
-          setTimeout(() => reject(new Error('Timeout')), 1000),
-        ),
-    );
-
-    mockMeeClient.request.mockResolvedValue({
-      userOps: [createUserOp('PENDING')],
-    });
-
-    const result = await waitForCallsStatus(
-      createTestParams(biconomyTxHash, 50),
-      mockMeeClient,
-      undefined,
-      mockExtraParams,
-    );
-
-    expect(result.status).toBe('failed');
-    expect(result.receipts).toHaveLength(0);
-    expect(mockMeeClient.waitForSupertransactionReceipt).toHaveBeenCalled();
-    expect(mockMeeClient.request).not.toHaveBeenCalled();
-  });
-
   it('should retry if waitForSupertransactionReceipt fails but explorer returns pending status', async () => {
     const originalTxHash = '0x000';
     const biconomyTxHash = `${originalTxHash}_biconomy`;
 
     // First call fails, second call succeeds
-    mockMeeClient.waitForSupertransactionReceipt
-      .mockRejectedValueOnce(new Error('First attempt failed'))
-      .mockResolvedValueOnce(createMockReceipt());
+    mockMeeClient.waitForSupertransactionReceipt.mockRejectedValueOnce(
+      new Error('waitForSupertransactionReceipt failed'),
+    );
 
     // Explorer responds with pending status (should trigger retry)
-    mockMeeClient.request.mockResolvedValue({
-      userOps: [createUserOp('PENDING')],
-    });
+    mockMeeClient.request
+      .mockResolvedValueOnce({
+        userOps: [createUserOp('PENDING', true)],
+      })
+      .mockResolvedValueOnce({
+        userOps: [createUserOp('MINED_SUCCESS', true)],
+      });
 
     const result = await waitForCallsStatus(
       createTestParams(biconomyTxHash),
@@ -165,16 +141,15 @@ describe('waitForCallsStatus', () => {
 
     expect(result.status).toBe('success');
     expect(result.statusCode).toBe(200);
-    expect(result.receipts).toHaveLength(mockReceipts.length);
-    expect(mockMeeClient.waitForSupertransactionReceipt).toHaveBeenCalledTimes(
-      2,
-    );
-    expect(mockMeeClient.request).toHaveBeenCalledWith(
-      getExplorerRequestOptions(originalTxHash),
-    );
-  });
+    expect(result.receipts).toHaveLength(1);
+    expect(mockMeeClient.request).toHaveBeenCalledTimes(2);
+    expect(mockMeeClient.request).toHaveBeenLastCalledWith({
+      path: `explorer/${originalTxHash}`,
+      method: 'GET',
+    });
+  }, 5000);
 
-  it('should return failed if waitForSupertransactionReceipt fails and explorer returns FAILED status', async () => {
+  it('should return fallback if waitForSupertransactionReceipt fails and explorer returns FAILED status', async () => {
     const originalTxHash = '0x000';
     const biconomyTxHash = `${originalTxHash}_biconomy`;
 
@@ -195,7 +170,11 @@ describe('waitForCallsStatus', () => {
       mockExtraParams,
     );
 
-    expect(result.status).toBe('failed');
+    expect(result.status).toBe('success');
+    expect(result.receipts).toHaveLength(1);
+    expect(result.receipts[0].status).toBe('success');
+    expect(result.receipts[0].transactionHash).toBe(biconomyTxHash);
+    expect(result.receipts[0].transactionLink).toBeUndefined();
     expect(mockMeeClient.waitForSupertransactionReceipt).toHaveBeenCalledTimes(
       1,
     );
@@ -204,7 +183,7 @@ describe('waitForCallsStatus', () => {
     );
   });
 
-  it('should return success if waitForSupertransactionReceipt fails but explorer returns MINED_SUCCESS status for cleanup op', async () => {
+  it('should return fallback if waitForSupertransactionReceipt fails but explorer returns MINED_SUCCESS status for cleanup op', async () => {
     const originalTxHash = '0x000';
     const biconomyTxHash = `${originalTxHash}_biconomy`;
 
@@ -224,7 +203,10 @@ describe('waitForCallsStatus', () => {
     );
 
     expect(result.status).toBe('success');
-    expect(result.receipts).toHaveLength(0);
+    expect(result.receipts).toHaveLength(1);
+    expect(result.receipts[0].status).toBe('success');
+    expect(result.receipts[0].transactionHash).toBe(biconomyTxHash);
+    expect(result.receipts[0].transactionLink).toBeUndefined();
     expect(mockMeeClient.waitForSupertransactionReceipt).toHaveBeenCalledTimes(
       1,
     );
@@ -233,7 +215,7 @@ describe('waitForCallsStatus', () => {
     );
   });
 
-  it('should return failed if waitForSupertransactionReceipt fails and explorer returns MINED_FAIL status for cleanup op', async () => {
+  it('should return fallback if waitForSupertransactionReceipt fails and explorer returns MINED_FAIL status for cleanup op', async () => {
     const originalTxHash = '0x000';
     const biconomyTxHash = `${originalTxHash}_biconomy`;
 
@@ -252,9 +234,11 @@ describe('waitForCallsStatus', () => {
       mockExtraParams,
     );
 
-    expect(result.status).toBe('failed');
-    expect(result.statusCode).toBe(500);
-    expect(result.receipts).toHaveLength(0);
+    expect(result.status).toBe('success');
+    expect(result.receipts).toHaveLength(1);
+    expect(result.receipts[0].status).toBe('success');
+    expect(result.receipts[0].transactionHash).toBe(biconomyTxHash);
+    expect(result.receipts[0].transactionLink).toBeUndefined();
     expect(mockMeeClient.waitForSupertransactionReceipt).toHaveBeenCalledTimes(
       1,
     );

--- a/src/providers/ZapInitProvider/WalletClient/methods.spec.ts
+++ b/src/providers/ZapInitProvider/WalletClient/methods.spec.ts
@@ -178,7 +178,7 @@ describe('waitForCallsStatus', () => {
     expect(result.receipts).toHaveLength(1);
     expect(result.receipts[0].status).toBe('success');
     expect(result.receipts[0].transactionHash).toBe(biconomyTxHash);
-    expect(result.receipts[0].transactionLink).toBeUndefined();
+    expect(result.receipts[0].transactionLink).toContain(originalTxHash);
     expect(mockMeeClient.waitForSupertransactionReceipt).toHaveBeenCalledTimes(
       1,
     );

--- a/src/providers/ZapInitProvider/WalletClient/methods.ts
+++ b/src/providers/ZapInitProvider/WalletClient/methods.ts
@@ -1,8 +1,9 @@
 import {
   BaseGetSupertransactionReceiptPayload,
   MeeClient,
+  MeeFilledUserOpDetails,
   MultichainSmartAccount,
-  parseTransactionStatus,
+  UserOpStatus,
   WaitForSupertransactionReceiptPayload,
 } from '@biconomy/abstractjs';
 import {
@@ -23,6 +24,10 @@ import { TransactionReceipt, zeroAddress } from 'viem';
 import { isSameToken } from '../utils';
 import { findChain } from 'src/utils/chains/findChain';
 import { executeQuoteStrategy } from './quotes';
+import { minutesToMilliseconds } from 'date-fns';
+import { TIMEOUT_IN_MINUTES } from '../constants';
+import { retryWithTimeout } from 'src/utils/retryWithTimeout';
+import { RetryStoppedError } from 'src/utils/errors';
 
 type ExtendedTransactionReceipt = Partial<TransactionReceipt> &
   Pick<TransactionReceipt, 'status' | 'transactionHash'> & {
@@ -30,6 +35,11 @@ type ExtendedTransactionReceipt = Partial<TransactionReceipt> &
   };
 
 const BICONOMY_TRANSACTION_HASH_SUFFIX = '_biconomy';
+
+const hasPendingStatus = (status: string) => status === 'PENDING';
+
+const hasFailedStatus = (status: string) =>
+  ['FAILED', 'MINED_FAIL'].includes(status);
 
 const getFormattedTransactionHash = (hash: string) =>
   hash.includes(BICONOMY_TRANSACTION_HASH_SUFFIX)
@@ -41,15 +51,20 @@ const processTransactionReceipt = (
   receipt: WaitForSupertransactionReceiptPayload | null,
   hash: EVMAddress,
   extraParams: SendCallsExtraParams,
-  hasFailedCleanUpUserOps?: boolean,
 ) => {
   if (!receipt) {
     return {
       atomic: true,
       id: getFormattedTransactionHash(hash),
-      status: hasFailedCleanUpUserOps ? 'failed' : 'success',
-      statusCode: hasFailedCleanUpUserOps ? 500 : 200,
-      receipts: [],
+      status: 'success',
+      statusCode: 200,
+      receipts: [
+        {
+          transactionHash: getFormattedTransactionHash(hash),
+          transactionLink: undefined,
+          status: 'success' as const,
+        },
+      ],
     };
   }
 
@@ -342,78 +357,49 @@ export const waitForCallsStatus = async (
     );
   }
 
-  const { id, timeout = 60000 } = args;
-  const startTime = Date.now();
+  const { id } = args;
+  const timeout = minutesToMilliseconds(TIMEOUT_IN_MINUTES);
   const originalId = id.replace(
     BICONOMY_TRANSACTION_HASH_SUFFIX,
     '',
   ) as EVMAddress;
 
-  let cleanUpUserOps;
+  try {
+    const receipt = await meeClientParam.waitForSupertransactionReceipt({
+      hash: originalId,
+    });
+    return processTransactionReceipt(receipt, originalId, extraParams);
+  } catch (error) {
+    console.error('🔍 waitForSupertransactionReceipt failed:', error);
 
-  do {
     try {
-      const receipt = await meeClientParam.waitForSupertransactionReceipt({
-        hash: originalId,
-      });
-      return processTransactionReceipt(receipt, originalId, extraParams);
-    } catch (error) {
-      console.error('🔍 waitForSupertransactionReceipt failed:', error);
-
-      // Check if timeout has passed
-      if (Date.now() - startTime >= timeout) {
-        console.warn('🔍 Timeout exceeded, stopping retries');
-        break;
-      }
-
-      // Check explorer status to see if we should retry
-      try {
+      await retryWithTimeout(async () => {
+        // Check explorer status to see if we should retry
         const explorerResponse =
           await meeClientParam.request<BaseGetSupertransactionReceiptPayload>({
             path: `explorer/${originalId}`,
             method: 'GET',
           });
 
-        cleanUpUserOps = explorerResponse.userOps.filter(
-          (userOp) => userOp.isCleanUpUserOp,
+        const hasPendingOps = explorerResponse.userOps.some((userOp) =>
+          hasPendingStatus(userOp.executionStatus),
         );
 
-        const metaStatus = await parseTransactionStatus(
-          explorerResponse.userOps,
-        );
-
-        // Only stop retrying if transaction has clearly failed
-        if (['FAILED', 'MINED_FAIL'].includes(metaStatus.status)) {
-          console.warn(
-            'Transaction failed, no retry needed:',
-            metaStatus.status,
-          );
-          break;
+        if (hasPendingOps) {
+          throw new Error('Transaction still processing, retrying...');
         }
 
-        console.warn(
-          '🔍 Transaction still processing or receipts not ready, retrying...',
+        throw new RetryStoppedError(
+          'Transaction has final status, no retry needed',
         );
-      } catch (explorerError) {
-        console.error('🔍 Explorer check failed:', explorerError);
-        // Continue retrying even if explorer check fails
-      }
+      }, timeout);
+    } catch (explorerError) {
+      console.error('🔍 Explorer check failed:', explorerError);
+      // Continue retrying even if explorer check fails
     }
-  } while (true);
+  }
 
-  const hasFailedCleanUpUserOps =
-    !cleanUpUserOps ||
-    !cleanUpUserOps.length ||
-    cleanUpUserOps.some((userOp) =>
-      ['FAILED', 'MINED_FAIL'].includes(userOp.executionStatus),
-    );
-
-  return processTransactionReceipt(
-    null,
-    originalId,
-    extraParams,
-    hasFailedCleanUpUserOps,
-  );
+  return processTransactionReceipt(null, originalId, extraParams);
 };
 
 export const walletMethods: WalletMethodsRef = {

--- a/src/providers/ZapInitProvider/WalletClient/methods.ts
+++ b/src/providers/ZapInitProvider/WalletClient/methods.ts
@@ -59,7 +59,7 @@ const processTransactionReceipt = (
       return {
         atomic: true,
         id: getFormattedTransactionHash(hash),
-        status: 'failed',
+        status: 'failure',
         statusCode: 400,
         receipts: [
           {
@@ -79,7 +79,7 @@ const processTransactionReceipt = (
       receipts: [
         {
           transactionHash: getFormattedTransactionHash(hash),
-          transactionLink: undefined,
+          transactionLink: getMeeScanLink(hash),
           status: 'success' as const,
         },
       ],

--- a/src/providers/ZapInitProvider/WalletClient/methods.ts
+++ b/src/providers/ZapInitProvider/WalletClient/methods.ts
@@ -1,5 +1,6 @@
 import {
   BaseGetSupertransactionReceiptPayload,
+  getMeeScanLink,
   MeeClient,
   MeeFilledUserOpDetails,
   MultichainSmartAccount,
@@ -51,8 +52,25 @@ const processTransactionReceipt = (
   receipt: WaitForSupertransactionReceiptPayload | null,
   hash: EVMAddress,
   extraParams: SendCallsExtraParams,
+  hasFailedNonCleanUpUserOps?: boolean,
 ) => {
   if (!receipt) {
+    if (hasFailedNonCleanUpUserOps) {
+      return {
+        atomic: true,
+        id: getFormattedTransactionHash(hash),
+        status: 'failed',
+        statusCode: 400,
+        receipts: [
+          {
+            transactionHash: getFormattedTransactionHash(hash),
+            transactionLink: getMeeScanLink(hash),
+            status: 'reverted' as const,
+          },
+        ],
+      };
+    }
+
     return {
       atomic: true,
       id: getFormattedTransactionHash(hash),
@@ -364,6 +382,8 @@ export const waitForCallsStatus = async (
     '',
   ) as EVMAddress;
 
+  let nonCleanUpUserOps: (MeeFilledUserOpDetails & UserOpStatus)[] = [];
+
   try {
     const receipt = await meeClientParam.waitForSupertransactionReceipt({
       hash: originalId,
@@ -380,6 +400,10 @@ export const waitForCallsStatus = async (
             path: `explorer/${originalId}`,
             method: 'GET',
           });
+
+        nonCleanUpUserOps = explorerResponse.userOps.filter(
+          (userOp) => !userOp.isCleanUpUserOp,
+        );
 
         const hasPendingOps = explorerResponse.userOps.some((userOp) =>
           hasPendingStatus(userOp.executionStatus),
@@ -399,7 +423,16 @@ export const waitForCallsStatus = async (
     }
   }
 
-  return processTransactionReceipt(null, originalId, extraParams);
+  const hasFailedNonCleanUpUserOps = nonCleanUpUserOps
+    ?.slice(0, 2)
+    .some((userOp) => hasFailedStatus(userOp.executionStatus));
+
+  return processTransactionReceipt(
+    null,
+    originalId,
+    extraParams,
+    hasFailedNonCleanUpUserOps,
+  );
 };
 
 export const walletMethods: WalletMethodsRef = {

--- a/src/providers/ZapInitProvider/WalletClient/quotes.ts
+++ b/src/providers/ZapInitProvider/WalletClient/quotes.ts
@@ -7,6 +7,8 @@ import {
 import { createEIP7702Authorization } from './utils';
 import { Token } from '@lifi/sdk';
 import { EVMAddress } from 'src/types/internal';
+import { TIMEOUT_IN_MINUTES } from '../constants';
+import { minutesToSeconds } from 'date-fns';
 
 interface QuoteExecutionParams {
   meeClientParam: MeeClient;
@@ -21,7 +23,6 @@ interface QuoteExecutionParams {
   requestedAmount: bigint;
 }
 
-const minutesToSeconds = (input: number) => input * 60;
 const millisecondsToSeconds = (input: number) => input / 1000;
 
 const executeEmbeddedWalletQuote = async (
@@ -96,7 +97,7 @@ const executeRegularWalletQuote = async (
     },
     instructions,
     lowerBoundTimestamp: now,
-    upperBoundTimestamp: now + minutesToSeconds(2),
+    upperBoundTimestamp: now + minutesToSeconds(TIMEOUT_IN_MINUTES),
   };
 
   const usageInBasisPoints =

--- a/src/providers/ZapInitProvider/constants.ts
+++ b/src/providers/ZapInitProvider/constants.ts
@@ -19,3 +19,5 @@ export const abiNumericTypes = [
   'int16',
   'int8',
 ];
+
+export const TIMEOUT_IN_MINUTES = 2;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,7 @@
+export class RetryStoppedError extends Error {
+  static errorName = 'RetryStoppedError';
+  constructor(message: string) {
+    super(message);
+    this.name = RetryStoppedError.errorName;
+  }
+}

--- a/src/utils/retryWithTimeout.ts
+++ b/src/utils/retryWithTimeout.ts
@@ -1,0 +1,52 @@
+import { RetryStoppedError } from './errors';
+
+export const retryWithTimeout = async <T>(
+  callback: () => Promise<T>,
+  maxTimeoutMs: number,
+  baseDelay: number = 2000,
+): Promise<T> => {
+  const now = Date.now();
+  const startTime = now;
+  const endTime = startTime + maxTimeoutMs;
+  let attempt = 0;
+
+  while (true) {
+    try {
+      return await callback();
+    } catch (error) {
+      if (
+        error instanceof RetryStoppedError ||
+        (error as Error).name === RetryStoppedError.errorName
+      ) {
+        console.warn('Retry stopped:', (error as Error).message);
+        throw error;
+      }
+
+      const elapsedTime = Date.now() - startTime;
+      const remainingTime = endTime - Date.now();
+
+      console.error(
+        `Attempt ${attempt + 1} failed after ${elapsedTime}ms:`,
+        error,
+      );
+
+      if (remainingTime <= 0) {
+        console.error(
+          `Max timeout of ${maxTimeoutMs}ms reached, operation failed`,
+        );
+        throw error;
+      }
+
+      const delay = Math.min(baseDelay * Math.pow(2, attempt), 10000);
+
+      if (delay <= 0) {
+        console.error('No time remaining for retry');
+        throw error;
+      }
+
+      console.warn(`Retrying in ${delay}ms... (${remainingTime}ms remaining)`);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      attempt++;
+    }
+  }
+};


### PR DESCRIPTION
Currently need to fix the `FAILED` status from the backend PR as otherwise the widget enters in an infinite loop.

Sister PR https://github.com/jumperexchange/jumper-backend/pull/437

## Testing steps

1. In order to easily test this, please comment `lines 99-100` in `src/providers/ZapInitProvider/WalletClient/quotes.ts`
<img width="667" height="293" alt="Screenshot 2025-09-01 at 20 13 09" src="https://github.com/user-attachments/assets/61f0bb58-51b8-483d-89cd-b2590dbdc6cb" />

2. Now try depositing using `LINK` on `Base` for zap `http://localhost:3000/zap/morpho-katana-usdc-ioana`
3. Given the bounds are not set, most likely the 2nd transaction from the supertx should fail
4. If the tx fails, you should see a `partial` bridge successful message in the widget UI
5. You can also try running the unit tests to confirm the `waitForCallsStatus` behaves as expected for the failing first tx from the super tx.
6. To do so run `pnpm test:unit` - will add this to the github actions in another PR