### PR TITLE
feat: add deposit modal and button

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,7 @@
+<style>
+  html,
+  body.sb-main-fullscreen,
+  body.sb-main-fullscreen #storybook-root {
+    height: 100%;
+  }
+</style>

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -37,6 +37,8 @@ const preview: Preview = {
       },
     },
 
+    layout: 'fullscreen',
+
     a11y: {
       // 'todo' - show a11y violations in the test UI only
       // 'error' - fail CI on a11y violations

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -10,7 +10,7 @@ import {
 type ButtonVariant = 'primary' | 'secondary' | 'transparent';
 type ButtonSize = 'small' | 'medium' | 'large';
 
-interface ButtonProps {
+export interface ButtonProps {
   variant?: ButtonVariant;
   styles?: SxProps<Theme>;
   id?: string;

--- a/src/components/Widgets/variants/base/ZapWidget/ZapDepositWidget.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapDepositWidget.tsx
@@ -20,7 +20,6 @@ import { WidgetProps } from '../Widget.types';
 import { WidgetSkeleton } from '../WidgetSkeleton';
 import { ZapDepositSettings } from './ZapDepositSettings';
 import { ZapPlaceholderWidget } from './ZapPlaceholderWidget';
-import { useTokens } from 'src/hooks/useTokens';
 
 interface ZapDepositWidgetProps extends WidgetProps {}
 
@@ -31,8 +30,6 @@ export const ZapDepositWidget: FC<ZapDepositWidgetProps> = ({
   const projectData = useMemo(() => {
     return customInformation?.projectData;
   }, [customInformation?.projectData]);
-
-  const { getNativeTokenForChain } = useTokens();
 
   const {
     isInitialized,

--- a/src/components/Widgets/variants/widgetConfig/hooks.ts
+++ b/src/components/Widgets/variants/widgetConfig/hooks.ts
@@ -56,6 +56,7 @@ export function useLiFiWidgetConfig(ctx: ConfigContext = {}): WidgetConfig {
         ...(base.hiddenUI ?? []),
         ...(ctx.baseOverrides?.hiddenUI ?? []),
       ],
+      theme: merge({}, base.theme ?? {}, ctx.theme ?? {}),
     });
   }, [base, overrides, ctx.baseOverrides]);
 }

--- a/src/components/composite/DepositButton/DepositButton.stories.tsx
+++ b/src/components/composite/DepositButton/DepositButton.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { DepositButton } from './DepositButton';
+import { action } from 'storybook/internal/actions';
+import { DepositButtonDisplayMode } from './DepositButton.types';
+
+const meta = {
+  component: DepositButton,
+  title: 'Composite/Deposit Button',
+  args: {
+    onClick: action('on-click'),
+  },
+  argTypes: {
+    displayMode: {
+      control: { type: 'select' },
+      options: Object.values(DepositButtonDisplayMode),
+    },
+  },
+} satisfies Meta<typeof DepositButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    displayMode: DepositButtonDisplayMode.IconAndLabel,
+    label: 'Quick deposit',
+  },
+};
+
+export const IconOnly: Story = {
+  args: {
+    displayMode: DepositButtonDisplayMode.IconOnly,
+  },
+};
+
+export const LabelOnly: Story = {
+  args: {
+    displayMode: DepositButtonDisplayMode.LabelOnly,
+    label: 'Quick deposit',
+  },
+};

--- a/src/components/composite/DepositButton/DepositButton.styles.tsx
+++ b/src/components/composite/DepositButton/DepositButton.styles.tsx
@@ -1,0 +1,47 @@
+import Box from '@mui/material/Box';
+import { styled } from '@mui/material/styles';
+import { ButtonProps } from 'src/components/Button';
+import BoltIcon from 'src/components/illustrations/BoltIcon';
+
+interface DepositIconProps {
+  size: ButtonProps['size'];
+}
+
+export const DepositIcon = styled(BoltIcon, {
+  shouldForwardProp: (prop) => prop !== 'size',
+})<DepositIconProps>(() => ({
+  variants: [
+    {
+      props: ({ size }) => size === 'small',
+      style: {
+        width: 17,
+        height: 19,
+      },
+    },
+    {
+      props: ({ size }) => size === 'medium',
+      style: {
+        width: 22,
+        height: 24,
+      },
+    },
+    {
+      props: ({ size }) => size === 'large',
+      style: {
+        width: 24,
+        height: 28,
+      },
+    },
+  ],
+}));
+
+export const DepositButtonContentWrapper = styled(Box)(() => ({
+  padding: 0.2,
+  display: 'flex',
+  alignItems: 'center',
+  flexDirection: 'row',
+}));
+
+export const DepositButtonLabelWrapper = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(0.5, 1.5),
+}));

--- a/src/components/composite/DepositButton/DepositButton.tsx
+++ b/src/components/composite/DepositButton/DepositButton.tsx
@@ -1,0 +1,44 @@
+import { FC } from 'react';
+import { Button, ButtonProps } from 'src/components/Button';
+import {
+  DepositButtonDisplayMode,
+  DepositButtonProps,
+} from './DepositButton.types';
+import Box from '@mui/material/Box';
+import {
+  DepositButtonContentWrapper,
+  DepositButtonLabelWrapper,
+  DepositIcon,
+} from './DepositButton.styles';
+
+export const DepositButton: FC<DepositButtonProps> = ({
+  displayMode = DepositButtonDisplayMode.IconAndLabel,
+  size = 'medium',
+  label,
+  onClick,
+  ...props
+}) => {
+  const showLabel = displayMode !== DepositButtonDisplayMode.IconOnly;
+  const showIcon = displayMode !== DepositButtonDisplayMode.LabelOnly;
+  const renderedIcon = <DepositIcon size={size} />;
+  const renderedLabel = (
+    <DepositButtonLabelWrapper>{label}</DepositButtonLabelWrapper>
+  );
+
+  return (
+    <Button
+      {...props}
+      styles={{
+        ...(props.styles || {}),
+        minWidth: 'auto',
+      }}
+      variant="primary"
+      onClick={onClick}
+    >
+      <DepositButtonContentWrapper>
+        {showLabel && renderedLabel}
+        {showIcon && renderedIcon}
+      </DepositButtonContentWrapper>
+    </Button>
+  );
+};

--- a/src/components/composite/DepositButton/DepositButton.types.ts
+++ b/src/components/composite/DepositButton/DepositButton.types.ts
@@ -1,0 +1,13 @@
+import { ButtonProps } from 'src/components/Button/Button';
+
+export enum DepositButtonDisplayMode {
+  IconOnly = 'icon-only',
+  LabelOnly = 'label-only',
+  IconAndLabel = 'icon-and-label',
+}
+
+export interface DepositButtonProps extends ButtonProps {
+  onClick: () => void;
+  displayMode?: DepositButtonDisplayMode;
+  label?: string;
+}

--- a/src/components/composite/DepositFlow/DepositFlow.tsx
+++ b/src/components/composite/DepositFlow/DepositFlow.tsx
@@ -1,0 +1,43 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import {
+  EarnOpportunityExtended,
+  useDepositFlowStore,
+} from 'src/stores/depositFlow/DepositFlowStore';
+import { DepositButton } from '../DepositButton/DepositButton';
+import { DepositButtonProps } from '../DepositButton/DepositButton.types';
+import { DepositModal } from '../DepositModal/DepositModal';
+
+export const DepositFlowModal = () => {
+  const { selectedEarnOpportunity, isModalOpen, closeModal } =
+    useDepositFlowStore((state) => state);
+
+  if (!selectedEarnOpportunity) {
+    return null;
+  }
+
+  return (
+    <DepositModal
+      isOpen={isModalOpen}
+      onClose={closeModal}
+      earnOpportunity={selectedEarnOpportunity!}
+    />
+  );
+};
+
+interface DepositFlowButtonProps extends Omit<DepositButtonProps, 'onClick'> {
+  earnOpportunity: EarnOpportunityExtended;
+}
+export const DepositFlowButton: FC<DepositFlowButtonProps> = ({
+  earnOpportunity,
+}) => {
+  const { t } = useTranslation();
+  const openModal = useDepositFlowStore((state) => state.openModal);
+  return (
+    <DepositButton
+      onClick={() => openModal(earnOpportunity)}
+      label={t('buttons.depositButtonLabel')}
+    />
+  );
+};

--- a/src/components/composite/DepositModal/DepositModal.stories.tsx
+++ b/src/components/composite/DepositModal/DepositModal.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useState } from 'react';
+
+import { DepositModal } from './DepositModal';
+import { action } from 'storybook/internal/actions';
+import { ConnectButton } from 'src/components/ConnectButton';
+import { useIsDisconnected } from 'src/components/Navbar/hooks';
+import { WalletMenuToggle } from 'src/components/Navbar/components/Buttons/WalletMenuToggle';
+import { DepositButton } from '../DepositButton/DepositButton';
+
+const meta = {
+  component: DepositModal,
+  title: 'Composite/Deposit Modal',
+  args: {
+    onClose: action('on-close'),
+  },
+} satisfies Meta<typeof DepositModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    isOpen: true,
+    earnOpportunity: {
+      name: 'morpho',
+      protocol: {
+        name: 'morpho',
+        product: 'morpho',
+        version: '1.0.0',
+        logo: 'logo',
+      },
+      address: '0xC5e7AB07030305fc925175b25B93b285d40dCdFf',
+      url: 'https://morpho.org/',
+      positionUrl:
+        'https://app.morpho.org/katana/vault/0xC5e7AB07030305fc925175b25B93b285d40dCdFf/gauntlet-weth',
+      minFromAmountUSD: 0.29,
+      asset: {
+        name: 'Asset',
+        symbol: 'ASSET',
+        decimals: 18,
+        logo: 'logo',
+        address: '0xC5e7AB07030305fc925175b25B93b285d40dCdFf',
+        chain: { chainId: 747474, chainKey: 'katana' },
+      },
+    },
+  },
+};
+
+export const WithToggleAndConnectButton: Story = {
+  render: (args) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const isDisconnected = useIsDisconnected();
+
+    return (
+      <div>
+        {isDisconnected ? <ConnectButton /> : <WalletMenuToggle />}
+        <DepositButton
+          onClick={() => setIsOpen(!isOpen)}
+          label="Quick deposit"
+        />
+        <DepositModal
+          {...args}
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+        />
+      </div>
+    );
+  },
+  args: {
+    isOpen: false,
+    earnOpportunity: {
+      name: 'morpho',
+      protocol: {
+        name: 'morpho',
+        product: 'morpho',
+        version: '1.0.0',
+        logo: 'logo',
+      },
+      address: '0xC5e7AB07030305fc925175b25B93b285d40dCdFf',
+      url: 'https://morpho.org/',
+      positionUrl:
+        'https://app.morpho.org/katana/vault/0xC5e7AB07030305fc925175b25B93b285d40dCdFf/gauntlet-weth',
+      minFromAmountUSD: 0.29,
+      asset: {
+        name: 'Asset',
+        symbol: 'ASSET',
+        decimals: 18,
+        logo: 'logo',
+        address: '0xC5e7AB07030305fc925175b25B93b285d40dCdFf',
+        chain: { chainId: 747474, chainKey: 'katana' },
+      },
+    },
+  },
+};

--- a/src/components/composite/DepositModal/DepositModal.stories.tsx
+++ b/src/components/composite/DepositModal/DepositModal.stories.tsx
@@ -7,6 +7,8 @@ import { ConnectButton } from 'src/components/ConnectButton';
 import { useIsDisconnected } from 'src/components/Navbar/hooks';
 import { WalletMenuToggle } from 'src/components/Navbar/components/Buttons/WalletMenuToggle';
 import { DepositButton } from '../DepositButton/DepositButton';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
 
 const meta = {
   component: DepositModal,
@@ -53,18 +55,21 @@ export const WithToggleAndConnectButton: Story = {
     const isDisconnected = useIsDisconnected();
 
     return (
-      <div>
-        {isDisconnected ? <ConnectButton /> : <WalletMenuToggle />}
-        <DepositButton
-          onClick={() => setIsOpen(!isOpen)}
-          label="Quick deposit"
-        />
+      <Box sx={{ p: 2 }}>
+        <Stack direction="row" spacing={2}>
+          {isDisconnected ? <ConnectButton /> : <WalletMenuToggle />}
+          <DepositButton
+            onClick={() => setIsOpen(!isOpen)}
+            label="Quick deposit"
+          />
+        </Stack>
+
         <DepositModal
           {...args}
           isOpen={isOpen}
           onClose={() => setIsOpen(false)}
         />
-      </div>
+      </Box>
     );
   },
   args: {

--- a/src/components/composite/DepositModal/DepositModal.styles.tsx
+++ b/src/components/composite/DepositModal/DepositModal.styles.tsx
@@ -1,0 +1,22 @@
+import Box from '@mui/material/Box';
+import { styled } from '@mui/material/styles';
+import { IconButton } from 'src/components/IconButton';
+
+export const CenteredWrapper = styled(Box)(({ theme }) => ({
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+}));
+
+export const CloseIconButton = styled(IconButton)(({ theme }) => ({
+  width: '40px',
+  height: '40px',
+  color: `${(theme.vars || theme).palette.buttonAlphaDarkAction} !important`,
+  backgroundColor: `${(theme.vars || theme).palette.buttonAlphaDarkBg} !important`,
+  ...theme.applyStyles('light', {
+    color: `${(theme.vars || theme).palette.buttonAlphaLightAction} !important`,
+    backgroundColor: `${(theme.vars || theme).palette.buttonAlphaLightBg} !important`,
+  }),
+  transition: 'opacity 0.3s',
+}));

--- a/src/components/composite/DepositModal/DepositModal.styles.tsx
+++ b/src/components/composite/DepositModal/DepositModal.styles.tsx
@@ -7,6 +7,7 @@ export const CenteredWrapper = styled(Box)(({ theme }) => ({
   top: '50%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
+  outline: 'none',
 }));
 
 export const CloseIconButton = styled(IconButton)(({ theme }) => ({

--- a/src/components/composite/DepositModal/DepositModal.tsx
+++ b/src/components/composite/DepositModal/DepositModal.tsx
@@ -10,41 +10,7 @@ import { CenteredWrapper, CloseIconButton } from './DepositModal.styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { TaskType } from 'src/types/strapi';
 import { motion } from 'framer-motion';
-
-export interface Protocol {
-  name: string;
-  product: string;
-  version: string;
-  logo: string;
-}
-
-export interface Chain {
-  chainId: number;
-  chainKey: string;
-}
-
-export interface Token {
-  name: string;
-  symbol: string;
-  decimals: number;
-  logo: string;
-  address: string;
-  chain: Chain;
-}
-
-// @TODO need to import from backend types when available
-export interface EarnOpportunity {
-  name: string;
-  asset: Token;
-  protocol: Protocol;
-  url: string;
-  description: string;
-  tags: string[];
-  rewards: string[];
-  lpToken: Token;
-  slug: string;
-  featured: boolean;
-}
+import { EarnOpportunity } from 'src/types/jumper-backend';
 
 interface DepositModalProps {
   onClose: () => void;
@@ -122,8 +88,8 @@ export const DepositModal: FC<DepositModalProps> = ({
                 ctx={{
                   theme: {
                     container: {
-                      maxHeight: 'calc(100vh - 10rem)',
-                      minWidth: 400,
+                      maxHeight: 'calc(100vh - 6rem)',
+                      minWidth: '100%',
                       maxWidth: 400,
                     },
                   },

--- a/src/components/composite/DepositModal/DepositModal.tsx
+++ b/src/components/composite/DepositModal/DepositModal.tsx
@@ -1,0 +1,141 @@
+import Box from '@mui/material/Box';
+import Modal from '@mui/material/Modal';
+import { FC, useMemo } from 'react';
+import { ClientOnly } from 'src/components/ClientOnly';
+import { ZapDepositWidget } from 'src/components/Widgets/variants/base/ZapWidget/ZapDepositWidget';
+import { WidgetTrackingProvider } from 'src/providers/WidgetTrackingProvider';
+import { ZapInitProvider } from 'src/providers/ZapInitProvider/ZapInitProvider';
+import CloseIcon from '@mui/icons-material/Close';
+import { CenteredWrapper, CloseIconButton } from './DepositModal.styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { TaskType } from 'src/types/strapi';
+import { motion } from 'framer-motion';
+
+export interface Protocol {
+  name: string;
+  product: string;
+  version: string;
+  logo: string;
+}
+
+export interface Chain {
+  chainId: number;
+  chainKey: string;
+}
+
+export interface Token {
+  name: string;
+  symbol: string;
+  decimals: number;
+  logo: string;
+  address: string;
+  chain: Chain;
+}
+
+// @TODO need to import from backend types when available
+export interface EarnOpportunity {
+  name: string;
+  asset: Token;
+  protocol: Protocol;
+  url: string;
+  description: string;
+  tags: string[];
+  rewards: string[];
+  lpToken: Token;
+  slug: string;
+  featured: boolean;
+}
+
+interface DepositModalProps {
+  onClose: () => void;
+  isOpen: boolean;
+  earnOpportunity: Pick<
+    EarnOpportunity,
+    'name' | 'asset' | 'protocol' | 'url'
+  > & {
+    minFromAmountUSD: number;
+    positionUrl: string;
+    address: string;
+  };
+}
+
+const motionConfig = {
+  initial: {
+    opacity: 0,
+  },
+  animate: {
+    opacity: 1,
+  },
+  transition: {
+    visualDuration: 0.5,
+    delay: 0.1,
+  },
+  style: {
+    position: 'absolute',
+    top: '0',
+    right: '0',
+    x: '100%',
+    y: '-100%',
+  },
+} as const;
+
+export const DepositModal: FC<DepositModalProps> = ({
+  onClose,
+  isOpen,
+  earnOpportunity,
+}) => {
+  const isMobile = useMediaQuery((theme) => theme.breakpoints.down('sm'));
+  const customInformation = useMemo(() => {
+    return {
+      projectData: {
+        chain: earnOpportunity.asset.chain.chainKey,
+        chainId: earnOpportunity.asset.chain.chainId,
+        address: earnOpportunity.address,
+        project: earnOpportunity.protocol.name,
+        integrator: `zap.${earnOpportunity.protocol.name}`,
+        integratorLink: earnOpportunity.url,
+        integratorPositionLink: earnOpportunity.positionUrl,
+        minFromAmountUSD: earnOpportunity.minFromAmountUSD,
+      },
+    };
+  }, [earnOpportunity]);
+
+  return (
+    <WidgetTrackingProvider>
+      <ZapInitProvider projectData={customInformation.projectData}>
+        <Modal open={isOpen} onClose={onClose}>
+          <CenteredWrapper>
+            {!isMobile && (
+              <motion.div {...motionConfig}>
+                <CloseIconButton onClick={onClose}>
+                  <CloseIcon
+                    sx={{
+                      width: '24px',
+                      height: '24px',
+                    }}
+                  />
+                </CloseIconButton>
+              </motion.div>
+            )}
+            <ClientOnly>
+              <ZapDepositWidget
+                ctx={{
+                  theme: {
+                    container: {
+                      maxHeight: 'calc(100vh - 10rem)',
+                      minWidth: 400,
+                      maxWidth: 400,
+                    },
+                  },
+                  taskType: TaskType.Zap,
+                  overrideHeader: 'Quick deposit',
+                }}
+                customInformation={customInformation}
+              />
+            </ClientOnly>
+          </CenteredWrapper>
+        </Modal>
+      </ZapInitProvider>
+    </WidgetTrackingProvider>
+  );
+};

--- a/src/components/illustrations/BoltIcon.tsx
+++ b/src/components/illustrations/BoltIcon.tsx
@@ -2,13 +2,14 @@ import { SvgIconProps } from '@mui/material/SvgIcon';
 
 interface BoltIconProps extends SvgIconProps {}
 
-const BoltIcon = ({ height, width }: BoltIconProps) => (
+const BoltIcon = ({ height, width, ...props }: BoltIconProps) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={width || 28}
     height={height || 28}
     fill="none"
     viewBox="0 0 28 28"
+    {...props}
   >
     <path
       fill="currentColor"

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -1,304 +1,307 @@
 interface Resources {
-  "language": {
-    "language": {
-      "key": "Language",
-      "value": "English"
-    }
-  },
-  "translation": {
-    "abstractAlert": {
-      "buttonText": "Check the docs",
-      "subtitle": "The Abstract Wallet only exist on Abstract. Don't use this address on any other blockchain, you will lose your funds.",
-      "title": "This wallet only works on Abstract!"
-    },
-    "blog": {
-      "allCategories": "All",
-      "categories": "Categories",
-      "copiedLink": "Copied Link",
-      "faq": "FAQ",
-      "goToArticle": "Go to article",
-      "jumperCta": "Try jumper.exchange",
-      "minRead": "{{minRead}} min read",
-      "openApp": "Open app",
-      "recentPosts": "Recent Posts",
-      "seeAllPosts": "See all posts",
-      "shareFb": "Share article on Facebook",
-      "shareLink": "Share the link",
-      "shareLinkedIn": "Share article on LinkedIn",
-      "shareX": "Share article on X",
-      "similarPosts": "Similar Posts",
-      "subtitle": "TL;DR step-by-step guides to DeFi and crypto for all levels",
-      "title": "Tips and tutorials"
-    },
-    "button": {
-      "connectAnotherWallet": "Connect another wallet",
-      "goBack": "Go back",
-      "manageYourPosition": "Manage your position",
-      "okay": "Okay"
-    },
-    "campaign": {
-      "missions": {
-        "title": "Missions"
-      },
-      "stats": {
-        "missions": "Missions",
-        "rewards": "Rewards",
-        "totalRewards": "Total rewards"
-      }
-    },
-    "completedMissionsInformation": {
-      "description": "As Jumper organize ad-hoc campaigns, the missions are updated on a monthly basis to create the associated graphics. Keep in mind: XP coming from specific campaigns will be updated on a monthly basis as well.",
-      "title": ""
-    },
-    "contribution": {
-      "confirm": "Confirm",
-      "custom": "Custom",
-      "description": "Show your appreciation by adding a contribution. 100% of it goes to improve Jumper.",
-      "error": {
-        "amountTooSmall": "The contribution amount is too small for this token. Please try a larger amount.",
-        "errorSending": "Error sending contribution:",
-        "invalidTokenPrice": "Invalid token price",
-        "noFeeAddress": "No contribution fee address configured for this chain."
-      },
-      "thankYou": "Thank you!",
-      "title": "Contribute"
-    },
-    "discordBanner": {
-      "ctaButton": "Join our Discord",
-      "ctaHeadline": "Join our Discord to learn more"
-    },
-    "error": {
-      "message": "Something went wrong. Please try reloading the page. If the problem persists, contact our support."
-    },
-    "featureCard": {
-      "learnMore": "Learn more"
-    },
-    "format": {
-      "currency": "{{value, currencyExt(currency: USD)}}",
-      "date": "{{value, dateExt(month: long)}}",
-      "decimal": "{{value, decimalExt(maximumFractionDigits: 3)}}",
-      "decimal2Digit": "{{value, decimalExt(maximumFractionDigits: 2)}}",
-      "percent": "{{value, percentExt()}}",
-      "shortDate": "{{value, dateExt(month: short)}}"
-    },
-    "leaderboard": {
-      "connectWallet": "Connect wallet",
-      "description": "The leaderboard is updated on a daily basis.",
-      "rankCtaConnect": "Where do you rank?",
-      "title": "Leaderboard",
-      "updatedLabel": "Updated: {{date}}"
-    },
-    "missions": {
-      "available": "Available Missions",
-      "completed": "Completed Missions",
-      "mission": {
-        "completed": {
-          "description": "All tasks in this mission have been verified and completed.",
-          "title": "Mission completed"
-        }
-      },
-      "status": {
-        "daysLeft_one": "{{count}} day left",
-        "daysLeft_other": "{{count}} days left",
-        "hoursLeft_one": "{{count}} hour left",
-        "hoursLeft_other": "{{count}} hours left",
-        "minutesLeft_one": "{{count}} minute left",
-        "minutesLeft_other": "{{count}} minutes left",
-        "new": "New",
-        "upcoming": "Upcoming"
-      },
-      "tasks": {
-        "action": {
-          "go": "Go",
-          "verify": "Verify"
-        },
-        "completed": {
-          "description": "This task has been verified and completed.",
-          "title": "Task completed"
-        },
-        "status": {
-          "verified": "Verified",
-          "verify": "Verify"
-        },
-        "type": "{{type}} task",
-        "typeFallback": "Task",
-        "typeOptional": "Optional task"
-      },
-      "wrapperCard": {
-        "explore_one": "Explore {{count}} mission",
-        "explore_other": "Explore {{count}} missions",
-        "title": "Missions"
-      }
-    },
-    "multisig": {
-      "connected": {
-        "description": "Please notify other wallet participants to be ready to sign.",
-        "title": "Multisig wallet connected"
-      },
-      "transactionInitiated": {
-        "description": "Please notify other multisig wallet participants to sign before the transaction expires.",
-        "title": "Multiple signatures required"
-      }
-    },
-    "navbar": {
-      "connect": "Connect",
-      "developers": {
-        "documentation": "Documentation",
-        "github": "GitHub"
-      },
-      "links": {
-        "back": "Back",
-        "buy": "Buy",
-        "dashboard": "Dashboard",
-        "exchange": "Exchange",
-        "missions": "Missions",
-        "refuel": "Gas"
-      },
-      "navbarMenu": {
-        "brandAssets": "Brand Assets",
-        "developers": "Developers",
-        "learn": "Learn",
-        "profile": "Profile",
-        "resources": "Resources",
-        "scan": "Scan",
-        "support": "Support",
-        "theme": "Theme"
-      },
-      "seeAllWallets": "See all wallets",
-      "statsCards": {
-        "bridges": "Bridges",
-        "chains": "Chains",
-        "dexs": "DEXs"
-      },
-      "themes": {
-        "dark": "Dark",
-        "darkModeDisabled": "Dark mode is disabled for this theme",
-        "default": "Default",
-        "light": "Light",
-        "lightModeDisabled": "Light mode is disabled for this theme",
-        "switchToDark": "Switch to dark mode",
-        "switchToLight": "Switch to light mode",
-        "switchToSystem": "Switch to system mode",
-        "system": "System",
-        "systemModeDisabled": "System mode is disabled for this theme"
-      },
-      "walletMenu": {
-        "chains": "Chains",
-        "connectAnotherWallet": "Connect another wallet",
-        "copiedMsg": "Copied",
-        "copy": "Copy",
-        "disconnect": "Disconnect",
-        "explore": "Explore",
-        "numberOfChains": "{{numberOfChains}} chains",
-        "refreshBalances": "Refresh balances",
-        "switchChain": "Switch Chain",
-        "totalBalance": "Total balance",
-        "totalBalanceRefresh": "Click here to restart the indexing of your tokens now.",
-        "totalBalanceTooltip": "Your total balance may not always be accurate due to potential indexing issues. We're on it!",
-        "walletNotInstalled": "{{wallet}} is not installed"
-      },
-      "walletSelectMenu": {
-        "connectWallet": "Connect a wallet",
-        "ecosystemSelectMenu": {
-          "noEcosystemAdapter": "No appropriate ecosystem adapter found",
-          "selectEcosystem": "Select wallet ecosystem"
-        },
-        "wallets": "Wallets"
-      },
-      "welcome": {
-        "cta": "Get started",
-        "subtitle": "<0>4x audited</0> multi-chain liquidity aggregator",
-        "title": "Find the best route"
-      }
-    },
-    "profile_page": {
-      "achievements": "Achievements",
-      "availableRewards": "Available Rewards",
-      "campaigns": "Campaigns",
-      "copyAddress": "Copy wallet address",
-      "level": "Level",
-      "levelInfo": "A higher level increases your odds to win rewards from raffles, perks, partners, rewards and more.",
-      "levelWithValue": "Level {{level}}",
-      "mobileDescription": "The Jumper Loyalty Pass page is not available on small screens yet. We are working on it.",
-      "mobileTitle": "Only available on Desktop",
-      "noData": {
-        "caption": "Start your journey by completing missions, swapping tokens, and bridging across chains to unlock unique achievements and earn XP.",
-        "cta": "Start swapping",
-        "description": "No {{entity}} yet? Let's change that!"
-      },
-      "open": "Open {{tool}}",
-      "perks": "Perks",
-      "pointsInfo": "XP is your score for interacting with Jumper. As you gain XP points, your level goes up. XP coming from Jumper transactions is updated on a daily basis.",
-      "rank": "Rank",
-      "rankInfo": "Rank is your position in the leaderboard. Gain XP and move upward in the leaderboard.",
-      "rewards": "Rewards Earned",
-      "shareProfile": "Share profile",
-      "tooltips": {
-        "unlockAtLevel": "Unlocked at Level {{level}}"
-      },
-      "unlocked": "Unlocked"
-    },
-    "promo": {
-      "new": "New"
-    },
-    "questCard": {
-      "action": {
-        "bridge_oor": "bridging",
-        "chain_oor": "exploring chains",
-        "swap_oor": "swapping",
-        "transact_oor": "trading"
-      },
-      "completed": "Completed",
-      "earnedXPDescription": "You've unlocked {{earnedXP}}XP by {{action}} so far this month and this has been added to your total XP balance.",
-      "join": "Join",
-      "xpToEarnDescription": "Complete the progress bar by {{action}} to earn +{{xpToEarn}} addtional XP this month."
-    },
-    "seiAlert": {
-      "buttonText": "Link Wallet",
-      "subtitle": "To use SEI EVM, you need to link your wallet address to the SEI ecosystem.",
-      "title": "Linking of SEI EVM wallet required"
-    },
-    "solanaAlert": {
-      "subtitle": "Currently only USDC and USDT can be bridged to and from Solana.",
-      "title": "Limited Solana token support"
-    },
-    "tooltips": {
-      "apy": "Expected yearly return rate of the tokens invested.",
-      "boostedApy": "{{baseApy}}% is the expected yearly return rate of the underlying tokens invested. The extra {{boostedApy}}% in rewards - distributed in another token - are paid exclusively to the participant of this zap campaign.",
-      "deposit": "The token on which the market is defined and yield accrues on.",
-      "deposited": "The token you have deposited into this market.",
-      "lockupPeriod": "Once deposited, your position is subject to an {{formattedLockupPeriod}} lock-up period before you can withdraw the funds.",
-      "tvl": "Total value of crypto assets deposited in this market."
-    },
-    "widget": {
-      "depositCard": {
-        "apy": "Base APR",
-        "boostedApy": "Boosted APR",
-        "lockupPeriod": "Lockup period",
-        "token": "Asset",
-        "tvl": "TVL"
-      },
-      "zap": {
-        "placeholder": {
-          "comingSoon": "Coming soon",
-          "embedded-multisig": {
-            "description": "We are working on adding support for embedded and smart contract wallets. In the mean time please use a different wallet to complete this mission.",
-            "title": "Your wallet is currently not supported"
-          },
-          "non-evm": {
-            "description": "We are working on adding support for non-EVM wallets. In the mean time please use a different wallet to complete this mission.",
-            "title": "Your wallet is currently not supported"
-          }
-        },
-        "sendToAddressName": "Deposit into {{name}}",
-        "sentToAddressName": "Deposited into {{name}}",
-        "tabs": {
-          "deposit": "Deposit",
-          "withdraw": "Withdraw"
-        }
-      }
-    }
-  }
+  language: {
+    language: {
+      key: 'Language';
+      value: 'English';
+    };
+  };
+  translation: {
+    abstractAlert: {
+      buttonText: 'Check the docs';
+      subtitle: "The Abstract Wallet only exist on Abstract. Don't use this address on any other blockchain, you will lose your funds.";
+      title: 'This wallet only works on Abstract!';
+    };
+    blog: {
+      allCategories: 'All';
+      categories: 'Categories';
+      copiedLink: 'Copied Link';
+      faq: 'FAQ';
+      goToArticle: 'Go to article';
+      jumperCta: 'Try jumper.exchange';
+      minRead: '{{minRead}} min read';
+      openApp: 'Open app';
+      recentPosts: 'Recent Posts';
+      seeAllPosts: 'See all posts';
+      shareFb: 'Share article on Facebook';
+      shareLink: 'Share the link';
+      shareLinkedIn: 'Share article on LinkedIn';
+      shareX: 'Share article on X';
+      similarPosts: 'Similar Posts';
+      subtitle: 'TL;DR step-by-step guides to DeFi and crypto for all levels';
+      title: 'Tips and tutorials';
+    };
+    button: {
+      connectAnotherWallet: 'Connect another wallet';
+      goBack: 'Go back';
+      manageYourPosition: 'Manage your position';
+      okay: 'Okay';
+    };
+    buttons: {
+      depositButtonLabel: 'Quick deposit';
+    };
+    campaign: {
+      missions: {
+        title: 'Missions';
+      };
+      stats: {
+        missions: 'Missions';
+        rewards: 'Rewards';
+        totalRewards: 'Total rewards';
+      };
+    };
+    completedMissionsInformation: {
+      description: 'As Jumper organize ad-hoc campaigns, the missions are updated on a monthly basis to create the associated graphics. Keep in mind: XP coming from specific campaigns will be updated on a monthly basis as well.';
+      title: '';
+    };
+    contribution: {
+      confirm: 'Confirm';
+      custom: 'Custom';
+      description: 'Show your appreciation by adding a contribution. 100% of it goes to improve Jumper.';
+      error: {
+        amountTooSmall: 'The contribution amount is too small for this token. Please try a larger amount.';
+        errorSending: 'Error sending contribution:';
+        invalidTokenPrice: 'Invalid token price';
+        noFeeAddress: 'No contribution fee address configured for this chain.';
+      };
+      thankYou: 'Thank you!';
+      title: 'Contribute';
+    };
+    discordBanner: {
+      ctaButton: 'Join our Discord';
+      ctaHeadline: 'Join our Discord to learn more';
+    };
+    error: {
+      message: 'Something went wrong. Please try reloading the page. If the problem persists, contact our support.';
+    };
+    featureCard: {
+      learnMore: 'Learn more';
+    };
+    format: {
+      currency: '{{value, currencyExt(currency: USD)}}';
+      date: '{{value, dateExt(month: long)}}';
+      decimal: '{{value, decimalExt(maximumFractionDigits: 3)}}';
+      decimal2Digit: '{{value, decimalExt(maximumFractionDigits: 2)}}';
+      percent: '{{value, percentExt()}}';
+      shortDate: '{{value, dateExt(month: short)}}';
+    };
+    leaderboard: {
+      connectWallet: 'Connect wallet';
+      description: 'The leaderboard is updated on a daily basis.';
+      rankCtaConnect: 'Where do you rank?';
+      title: 'Leaderboard';
+      updatedLabel: 'Updated: {{date}}';
+    };
+    missions: {
+      available: 'Available Missions';
+      completed: 'Completed Missions';
+      mission: {
+        completed: {
+          description: 'All tasks in this mission have been verified and completed.';
+          title: 'Mission completed';
+        };
+      };
+      status: {
+        daysLeft_one: '{{count}} day left';
+        daysLeft_other: '{{count}} days left';
+        hoursLeft_one: '{{count}} hour left';
+        hoursLeft_other: '{{count}} hours left';
+        minutesLeft_one: '{{count}} minute left';
+        minutesLeft_other: '{{count}} minutes left';
+        new: 'New';
+        upcoming: 'Upcoming';
+      };
+      tasks: {
+        action: {
+          go: 'Go';
+          verify: 'Verify';
+        };
+        completed: {
+          description: 'This task has been verified and completed.';
+          title: 'Task completed';
+        };
+        status: {
+          verified: 'Verified';
+          verify: 'Verify';
+        };
+        type: '{{type}} task';
+        typeFallback: 'Task';
+        typeOptional: 'Optional task';
+      };
+      wrapperCard: {
+        explore_one: 'Explore {{count}} mission';
+        explore_other: 'Explore {{count}} missions';
+        title: 'Missions';
+      };
+    };
+    multisig: {
+      connected: {
+        description: 'Please notify other wallet participants to be ready to sign.';
+        title: 'Multisig wallet connected';
+      };
+      transactionInitiated: {
+        description: 'Please notify other multisig wallet participants to sign before the transaction expires.';
+        title: 'Multiple signatures required';
+      };
+    };
+    navbar: {
+      connect: 'Connect';
+      developers: {
+        documentation: 'Documentation';
+        github: 'GitHub';
+      };
+      links: {
+        back: 'Back';
+        buy: 'Buy';
+        dashboard: 'Dashboard';
+        exchange: 'Exchange';
+        missions: 'Missions';
+        refuel: 'Gas';
+      };
+      navbarMenu: {
+        brandAssets: 'Brand Assets';
+        developers: 'Developers';
+        learn: 'Learn';
+        profile: 'Profile';
+        resources: 'Resources';
+        scan: 'Scan';
+        support: 'Support';
+        theme: 'Theme';
+      };
+      seeAllWallets: 'See all wallets';
+      statsCards: {
+        bridges: 'Bridges';
+        chains: 'Chains';
+        dexs: 'DEXs';
+      };
+      themes: {
+        dark: 'Dark';
+        darkModeDisabled: 'Dark mode is disabled for this theme';
+        default: 'Default';
+        light: 'Light';
+        lightModeDisabled: 'Light mode is disabled for this theme';
+        switchToDark: 'Switch to dark mode';
+        switchToLight: 'Switch to light mode';
+        switchToSystem: 'Switch to system mode';
+        system: 'System';
+        systemModeDisabled: 'System mode is disabled for this theme';
+      };
+      walletMenu: {
+        chains: 'Chains';
+        connectAnotherWallet: 'Connect another wallet';
+        copiedMsg: 'Copied';
+        copy: 'Copy';
+        disconnect: 'Disconnect';
+        explore: 'Explore';
+        numberOfChains: '{{numberOfChains}} chains';
+        refreshBalances: 'Refresh balances';
+        switchChain: 'Switch Chain';
+        totalBalance: 'Total balance';
+        totalBalanceRefresh: 'Click here to restart the indexing of your tokens now.';
+        totalBalanceTooltip: "Your total balance may not always be accurate due to potential indexing issues. We're on it!";
+        walletNotInstalled: '{{wallet}} is not installed';
+      };
+      walletSelectMenu: {
+        connectWallet: 'Connect a wallet';
+        ecosystemSelectMenu: {
+          noEcosystemAdapter: 'No appropriate ecosystem adapter found';
+          selectEcosystem: 'Select wallet ecosystem';
+        };
+        wallets: 'Wallets';
+      };
+      welcome: {
+        cta: 'Get started';
+        subtitle: '<0>4x audited</0> multi-chain liquidity aggregator';
+        title: 'Find the best route';
+      };
+    };
+    profile_page: {
+      achievements: 'Achievements';
+      availableRewards: 'Available Rewards';
+      campaigns: 'Campaigns';
+      copyAddress: 'Copy wallet address';
+      level: 'Level';
+      levelInfo: 'A higher level increases your odds to win rewards from raffles, perks, partners, rewards and more.';
+      levelWithValue: 'Level {{level}}';
+      mobileDescription: 'The Jumper Loyalty Pass page is not available on small screens yet. We are working on it.';
+      mobileTitle: 'Only available on Desktop';
+      noData: {
+        caption: 'Start your journey by completing missions, swapping tokens, and bridging across chains to unlock unique achievements and earn XP.';
+        cta: 'Start swapping';
+        description: "No {{entity}} yet? Let's change that!";
+      };
+      open: 'Open {{tool}}';
+      perks: 'Perks';
+      pointsInfo: 'XP is your score for interacting with Jumper. As you gain XP points, your level goes up. XP coming from Jumper transactions is updated on a daily basis.';
+      rank: 'Rank';
+      rankInfo: 'Rank is your position in the leaderboard. Gain XP and move upward in the leaderboard.';
+      rewards: 'Rewards Earned';
+      shareProfile: 'Share profile';
+      tooltips: {
+        unlockAtLevel: 'Unlocked at Level {{level}}';
+      };
+      unlocked: 'Unlocked';
+    };
+    promo: {
+      new: 'New';
+    };
+    questCard: {
+      action: {
+        bridge_oor: 'bridging';
+        chain_oor: 'exploring chains';
+        swap_oor: 'swapping';
+        transact_oor: 'trading';
+      };
+      completed: 'Completed';
+      earnedXPDescription: "You've unlocked {{earnedXP}}XP by {{action}} so far this month and this has been added to your total XP balance.";
+      join: 'Join';
+      xpToEarnDescription: 'Complete the progress bar by {{action}} to earn +{{xpToEarn}} addtional XP this month.';
+    };
+    seiAlert: {
+      buttonText: 'Link Wallet';
+      subtitle: 'To use SEI EVM, you need to link your wallet address to the SEI ecosystem.';
+      title: 'Linking of SEI EVM wallet required';
+    };
+    solanaAlert: {
+      subtitle: 'Currently only USDC and USDT can be bridged to and from Solana.';
+      title: 'Limited Solana token support';
+    };
+    tooltips: {
+      apy: 'Expected yearly return rate of the tokens invested.';
+      boostedApy: '{{baseApy}}% is the expected yearly return rate of the underlying tokens invested. The extra {{boostedApy}}% in rewards - distributed in another token - are paid exclusively to the participant of this zap campaign.';
+      deposit: 'The token on which the market is defined and yield accrues on.';
+      deposited: 'The token you have deposited into this market.';
+      lockupPeriod: 'Once deposited, your position is subject to an {{formattedLockupPeriod}} lock-up period before you can withdraw the funds.';
+      tvl: 'Total value of crypto assets deposited in this market.';
+    };
+    widget: {
+      depositCard: {
+        apy: 'Base APR';
+        boostedApy: 'Boosted APR';
+        lockupPeriod: 'Lockup period';
+        token: 'Asset';
+        tvl: 'TVL';
+      };
+      zap: {
+        placeholder: {
+          comingSoon: 'Coming soon';
+          'embedded-multisig': {
+            description: 'We are working on adding support for embedded and smart contract wallets. In the mean time please use a different wallet to complete this mission.';
+            title: 'Your wallet is currently not supported';
+          };
+          'non-evm': {
+            description: 'We are working on adding support for non-EVM wallets. In the mean time please use a different wallet to complete this mission.';
+            title: 'Your wallet is currently not supported';
+          };
+        };
+        sendToAddressName: 'Deposit into {{name}}';
+        sentToAddressName: 'Deposited into {{name}}';
+        tabs: {
+          deposit: 'Deposit';
+          withdraw: 'Withdraw';
+        };
+      };
+    };
+  };
 }
 
 export default Resources;

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -290,5 +290,8 @@
         }
       }
     }
+  },
+  "buttons": {
+    "depositButtonLabel": "Quick deposit"
   }
 }

--- a/src/stores/depositFlow/DepositFlowStore.ts
+++ b/src/stores/depositFlow/DepositFlowStore.ts
@@ -1,0 +1,39 @@
+import { createWithEqualityFn } from 'zustand/traditional';
+import { shallow } from 'zustand/shallow';
+import { EarnOpportunity } from 'src/types/jumper-backend';
+
+export interface EarnOpportunityExtended extends EarnOpportunity {
+  minFromAmountUSD: number;
+  positionUrl: string;
+  address: string;
+}
+
+interface DepositFlowState {
+  isModalOpen: boolean;
+  selectedEarnOpportunity: EarnOpportunityExtended | null;
+
+  openModal: (earnOpportunity: EarnOpportunityExtended) => void;
+  closeModal: () => void;
+}
+
+export const useDepositFlowStore = createWithEqualityFn<DepositFlowState>(
+  (set) => ({
+    isModalOpen: false,
+    selectedEarnOpportunity: null,
+
+    openModal: (earnOpportunity: EarnOpportunityExtended) => {
+      set({
+        isModalOpen: true,
+        selectedEarnOpportunity: earnOpportunity,
+      });
+    },
+
+    closeModal: () => {
+      set({
+        isModalOpen: false,
+        // selectedEarnOpportunity: null,
+      });
+    },
+  }),
+  shallow,
+);

--- a/src/theme/paletteDark.ts
+++ b/src/theme/paletteDark.ts
@@ -89,8 +89,8 @@ export const paletteDark = {
   buttonAlphaLightBg: baseColors.alphaLight900.main,
   buttonAlphaLightAction: baseColors.alphaLight100.main,
 
-  buttonAlphaDarkBg: baseColors.alphaLight900.main,
-  buttonAlphaDarkAction: baseColors.alphaLight100.main,
+  buttonAlphaDarkBg: baseColors.alphaLight100.main,
+  buttonAlphaDarkAction: baseColors.alphaLight900.main,
 
   buttonDisabledBg: baseColors.alphaLight100.main,
   buttonDisabledAction: baseColors.alphaLight500.main,


### PR DESCRIPTION
Issues: https://lifi.atlassian.net/browse/LF-15297 and https://lifi.atlassian.net/browse/LF-15298

> [!NOTE]
> I've added a max height for the moment for the deposit modal but this might be removed once we start using it

## Testing steps
1. Go to the storybook preview link
2. Check the deposit button
3. Check the deposit modal (for checking a bit the behaviour you need to connect the wallet first, but no need to make a deposit)

Figma links: 
- [Deposit modal](https://www.figma.com/design/JUaT4CQ9YSCQ4IWsQQSRIK/Earn?node-id=384-166562&m=dev)
- Deposit button is across the Figma file with 3 variants: only icon, icon and text, only text
