### PR TITLE
feat: add widget change settings action tracking

### DIFF
--- a/src/app/ui/mission/MissionWidget/MissionWidget.tsx
+++ b/src/app/ui/mission/MissionWidget/MissionWidget.tsx
@@ -58,6 +58,7 @@ export const MissionWidget: FC<MissionWidgetProps> = ({
             routeExecutionCompleted:
               TrackingAction.OnRouteExecutionCompletedMission,
             routeExecutionFailed: TrackingAction.OnRouteExecutionFailedMission,
+            changeSettings: TrackingAction.OnChangeSettingsMission,
           }}
           trackingDataActionKeys={{
             routeExecutionStarted:

--- a/src/components/Widgets/WidgetEvents.tsx
+++ b/src/components/Widgets/WidgetEvents.tsx
@@ -22,6 +22,7 @@ import type {
   ContactSupport,
   RouteExecutionUpdate,
   RouteHighValueLossUpdate,
+  SettingUpdated,
 } from '@lifi/widget';
 import { useWidgetEvents, WidgetEvent } from '@lifi/widget';
 import { useEffect, useRef, useState } from 'react';
@@ -32,6 +33,7 @@ import { useContributionStore } from 'src/stores/contribution/ContributionStore'
 import { useRouteStore } from 'src/stores/route/RouteStore';
 import { TransformedRoute } from 'src/types/internal';
 import { handleRouteData } from 'src/utils/routes';
+import { parseWidgetSettingsToTrackingData } from 'src/utils/tracking/widget';
 
 export function WidgetEvents() {
   const previousRoutesRef = useRef<JumperEventData>({});
@@ -334,6 +336,16 @@ export function WidgetEvents() {
       }
     };
 
+    const onChangeSettings = (settings: SettingUpdated) => {
+      trackEvent({
+        category: TrackingCategory.WidgetEvent,
+        action: TrackingAction.OnChangeSettings,
+        label: 'change_settings',
+        enableAddressable: true,
+        data: parseWidgetSettingsToTrackingData(settings),
+      });
+    };
+
     const onPageEntered = async (pageType: any) => {
       // Reset contribution state when entering a new page
       setContributed(false);
@@ -367,6 +379,7 @@ export function WidgetEvents() {
       onDestinationChainTokenSelection,
     );
     widgetEvents.on(WidgetEvent.PageEntered, onPageEntered);
+    widgetEvents.on(WidgetEvent.SettingUpdated, onChangeSettings);
     // widgetEvents.on(WidgetEvent.RouteSelected, onRouteSelected);
     // widgetEvents.on(WidgetEvent.TokenSearch, onTokenSearch);
 
@@ -410,6 +423,7 @@ export function WidgetEvents() {
       // widgetEvents.off(WidgetEvent.WidgetExpanded, onWidgetExpanded);
       widgetEvents.off(WidgetEvent.AvailableRoutes, onAvailableRoutes);
       widgetEvents.off(WidgetEvent.PageEntered, onPageEntered);
+      widgetEvents.off(WidgetEvent.SettingUpdated, onChangeSettings);
     };
   }, [
     activeTab,

--- a/src/const/trackingKeys.ts
+++ b/src/const/trackingKeys.ts
@@ -28,6 +28,7 @@ export enum TrackingAction {
   OnAvailableRoutes = 'action_available_routes',
   OnTokenSearch = 'action_token_search',
   OnLowAddressActivityConfirmed = 'action_on_low_address_activity_confirmed',
+  OnChangeSettings = 'action_change_settings',
   ClickContribute = 'action_contribute',
   ContributeImpression = 'action_contribute_impression',
   ContributeSuccess = 'action_contribute_success',
@@ -38,6 +39,7 @@ export enum TrackingAction {
   OnRouteExecutionStartedMission = 'action_on_route_exec_started_mission',
   OnRouteExecutionCompletedMission = 'action_on_route_exec_completed_mission',
   OnRouteExecutionFailedMission = 'action_on_route_exec_failed_mission',
+  OnChangeSettingsMission = 'action_change_settings_mission',
 
   // Zap Widget
   OnSourceChainAndTokenSelectionZap = 'action_on_source_selection_zap',
@@ -45,6 +47,7 @@ export enum TrackingAction {
   OnRouteExecutionStartedZap = 'action_on_route_exec_started_zap',
   OnRouteExecutionCompletedZap = 'action_on_route_exec_completed_zap',
   OnRouteExecutionFailedZap = 'action_on_route_exec_failed_zap',
+  OnChangeSettingsZap = 'action_change_settings_zap',
 
   // Welcome_Screen
   ShowWelcomeMessageScreen = 'action_show_welcome_screen',
@@ -176,6 +179,18 @@ export enum TrackingEventParameter {
   SourceTokenSelection = 'param_source_token',
   DestinationChainSelection = 'param_destination_chain',
   DestinationTokenSelection = 'param_destination_token',
+  GasPriceSettings = 'param_gas_price',
+  SlippageLevelSettings = 'param_slippage_level',
+  SlippageStatusSettings = 'param_slippage_status',
+  RoutePrioritySettings = 'param_route_priority',
+  EnableAutoRefuelSettings = 'param_enable_auto_refuel',
+  EnabledBridgesSettings = 'param_enabled_bridges',
+  EnabledExchangesSettings = 'param_enabled_exchanges',
+  DisabledBridgesSettings = 'param_disabled_bridges',
+  DisabledExchangesSettings = 'param_disabled_exchanges',
+  UpdatedSetting = 'param_updated_setting',
+  NewSettingValue = 'param_new_setting_value',
+  PreviousSettingValue = 'param_previous_setting_value',
 
   // Pageload:
   PageloadSource = 'param_pageload_source',

--- a/src/utils/tracking/widget.ts
+++ b/src/utils/tracking/widget.ts
@@ -1,0 +1,44 @@
+import { SettingUpdated } from '@lifi/widget';
+import { isObject } from 'lodash';
+import { TrackingEventParameter } from 'src/const/trackingKeys';
+
+const stringifyValue = (value: any): string => {
+  if (Array.isArray(value)) {
+    return value.join(',');
+  }
+  if (isObject(value)) {
+    return JSON.stringify(value);
+  }
+  return value?.toString() ?? '';
+};
+
+export const parseWidgetSettingsToTrackingData = (settings: SettingUpdated) => {
+  const isAutoSlippage = settings.newSettings.slippage === 'auto';
+  return {
+    [TrackingEventParameter.GasPriceSettings]:
+      settings.newSettings.gasPrice ?? '',
+    [TrackingEventParameter.SlippageLevelSettings]: isAutoSlippage
+      ? ''
+      : (settings.newSettings.slippage ?? ''),
+    [TrackingEventParameter.SlippageStatusSettings]: isAutoSlippage
+      ? 'auto'
+      : 'manual',
+    [TrackingEventParameter.RoutePrioritySettings]:
+      settings.newSettings.routePriority ?? '',
+    [TrackingEventParameter.EnableAutoRefuelSettings]:
+      settings.newSettings.enabledAutoRefuel ?? '',
+    [TrackingEventParameter.EnabledBridgesSettings]:
+      settings.newSettings.enabledBridges?.join(',') ?? '',
+    [TrackingEventParameter.EnabledExchangesSettings]:
+      settings.newSettings.enabledExchanges?.join(',') ?? '',
+    [TrackingEventParameter.DisabledBridgesSettings]:
+      settings.newSettings.disabledBridges?.join(',') ?? '',
+    [TrackingEventParameter.DisabledExchangesSettings]:
+      settings.newSettings.disabledExchanges?.join(',') ?? '',
+    [TrackingEventParameter.UpdatedSetting]: settings.setting ?? '',
+    [TrackingEventParameter.NewSettingValue]: stringifyValue(settings.newValue),
+    [TrackingEventParameter.PreviousSettingValue]: stringifyValue(
+      settings.oldValue,
+    ),
+  };
+};


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-15369

## Testing steps
1. Go to `/zap/morpho-katana-usdc-ioana`
2. Open the network tab and filter for `users/events`
3. Try changing some widget settings
4. Notice the event should have the action `action_change_settings_zap` and the data should include all the widget settings
<img width="694" height="519" alt="Screenshot 2025-09-03 at 17 23 59" src="https://github.com/user-attachments/assets/a8348f28-855f-46d6-9ae1-789bfa0e2c3e" />

5. Go to `/missions/test123`
6. Select a `Bridge/Swap` task and repeat steps `2.-3.`
7. The event should have the action `action_change_settings_mission`

8. Go to the main widget on `/`
9. Repeat steps `2.-3.`
10. The event should have the action `action_change_settings`