### PR TITLE
fix: prevent task verification when form fields are empty

### DIFF
--- a/src/app/ui/mission/MissionTask.tsx
+++ b/src/app/ui/mission/MissionTask.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useRef } from 'react';
+import { FC, useCallback, useEffect, useRef } from 'react';
 import { TaskVerificationWithApy } from 'src/types/loyaltyPass';
 import { TaskCard } from 'src/components/Cards/TaskCard/TaskCard';
 import { Badge } from 'src/components/Badge/Badge';
@@ -52,6 +52,16 @@ export const MissionTask: FC<MissionTaskProps> = ({
     return () => clearTimeout(timeout);
   }, [isPending]);
 
+  const onTaskVerificationClick = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      onClick();
+      handleVerifyTask();
+    },
+    [onClick, handleVerifyTask],
+  );
+
   const getVariant = () => {
     if (isSuccess || isVerified) return BadgeVariant.Success;
     if (isPending) return BadgeVariant.Disabled;
@@ -97,7 +107,7 @@ export const MissionTask: FC<MissionTaskProps> = ({
             startIcon={getIcon()}
             variant={getVariant()}
             onClick={
-              !isSuccess && !isVerified ? () => handleVerifyTask() : undefined
+              !isSuccess && !isVerified ? onTaskVerificationClick : undefined
             }
           />
         )

--- a/src/app/ui/mission/MissionWidget/MissionForm.tsx
+++ b/src/app/ui/mission/MissionWidget/MissionForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, FormEvent } from 'react';
+import { useState, useMemo, useCallback, FormEvent, useEffect } from 'react';
 import z from 'zod';
 import FormControl from '@mui/material/FormControl';
 
@@ -29,6 +29,7 @@ export const MissionForm = () => {
     currentActiveTaskId,
     currentActiveTaskName,
     missionId,
+    setTaskFormState,
   } = useMissionStore();
   const { t } = useTranslation();
   const taskCTATextWithFallback =
@@ -51,6 +52,12 @@ export const MissionForm = () => {
     const result = schema.safeParse(formValues);
     return result.success;
   }, [formValues, schema]);
+
+  useEffect(() => {
+    if (currentActiveTaskId) {
+      setTaskFormState(currentActiveTaskId, true, isFormValid);
+    }
+  }, [currentActiveTaskId, isFormValid, setTaskFormState]);
 
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -12,7 +12,7 @@ export interface BadgeProps {
   label: ReactNode;
   variant?: BadgeVariant;
   size?: BadgeSize;
-  onClick?: () => void;
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
 }
 
 export const Badge: FC<BadgeProps> = ({

--- a/src/hooks/tasksVerification/useEnhancedTasks.ts
+++ b/src/hooks/tasksVerification/useEnhancedTasks.ts
@@ -30,6 +30,7 @@ export const useEnhancedTasks = (
     setIsCurrentActiveTaskCompleted,
     setCurrentTaskWidgetFormParams,
     setCurrentTaskInstructionParams,
+    setTaskFormState,
   } = useMissionStore();
 
   const currentActiveTaskId = useMissionStore(
@@ -61,6 +62,7 @@ export const useEnhancedTasks = (
       setCurrentActiveTask(task.uuid, taskType, taskName);
       const isTaskVerified = checkIsTaskVerified(task);
       setIsCurrentActiveTaskCompleted(isTaskVerified);
+      setTaskFormState(task.uuid, !!widgetParams.inputs?.length, false);
 
       setCurrentTaskWidgetFormParams({
         allowBridge: widgetParams.allowBridge ?? undefined,
@@ -89,6 +91,7 @@ export const useEnhancedTasks = (
     },
     [
       setCurrentActiveTask,
+      setTaskFormState,
       setCurrentTaskWidgetFormParams,
       setCurrentTaskInstructionParams,
       checkIsTaskVerified,

--- a/src/hooks/tasksVerification/useVerifyTaskWithSharedState.ts
+++ b/src/hooks/tasksVerification/useVerifyTaskWithSharedState.ts
@@ -13,6 +13,7 @@ import { useUserTracking } from '../userTracking';
 import { useVerifyTask } from './useVerifyTask';
 import { useQueryClient } from '@tanstack/react-query';
 import { updateVerifiedTasksQueryCache } from './useGetVerifiedTasks';
+import { useMissionStore } from 'src/stores/mission';
 
 export const useVerifyTaskWithSharedState = (
   missionId: string,
@@ -21,6 +22,7 @@ export const useVerifyTaskWithSharedState = (
 ) => {
   const { account } = useAccount();
   const { trackEvent } = useUserTracking();
+  const { getTaskFormState } = useMissionStore();
 
   const accountAddress = account?.address;
 
@@ -53,6 +55,12 @@ export const useVerifyTaskWithSharedState = (
 
   const handleVerifyTask = useCallback(
     (extraParams?: { [key: string]: string }) => {
+      const { hasForm, isFormValid } = getTaskFormState(taskId);
+
+      if (hasForm && !isFormValid) {
+        return;
+      }
+
       trackEvent({
         category: TrackingCategory.Quests,
         action: TrackingAction.ClickMissionVerify,
@@ -78,7 +86,7 @@ export const useVerifyTaskWithSharedState = (
         additionalFields: extraParams || {},
       });
     },
-    [missionId, taskId, taskName, accountAddress],
+    [missionId, taskId, taskName, accountAddress, getTaskFormState],
   );
 
   const handleReset = useCallback(() => {

--- a/src/stores/mission/MissionStore.tsx
+++ b/src/stores/mission/MissionStore.tsx
@@ -16,6 +16,17 @@ interface MissionState {
   isCurrentActiveTaskCompleted: boolean;
   setIsCurrentActiveTaskCompleted: (isCompleted: boolean) => void;
 
+  taskFormStates: Record<string, { hasForm: boolean; isFormValid: boolean }>;
+  setTaskFormState: (
+    taskId: string,
+    hasForm: boolean,
+    isFormValid: boolean,
+  ) => void;
+  getTaskFormState: (taskId: string) => {
+    hasForm: boolean;
+    isFormValid: boolean;
+  };
+
   taskTitle?: string;
   taskDescription?: string;
   taskDescriptionCTAText?: string;
@@ -95,7 +106,7 @@ interface MissionState {
 }
 
 export const useMissionStore = createWithEqualityFn<MissionState>(
-  (set) => ({
+  (set, get) => ({
     currentActiveTaskId: undefined,
     currentActiveTaskType: undefined,
     currentActiveTaskName: undefined,
@@ -103,6 +114,21 @@ export const useMissionStore = createWithEqualityFn<MissionState>(
     isCurrentActiveTaskCompleted: false,
     setIsCurrentActiveTaskCompleted: (isCurrentActiveTaskCompleted) =>
       set({ isCurrentActiveTaskCompleted }),
+
+    taskFormStates: {},
+    setTaskFormState: (taskId, hasForm, isFormValid) =>
+      set((state) => ({
+        taskFormStates: {
+          ...state.taskFormStates,
+          [taskId]: { hasForm, isFormValid },
+        },
+      })),
+    getTaskFormState: (taskId) => {
+      const state = get();
+      return (
+        state.taskFormStates[taskId] || { hasForm: false, isFormValid: true }
+      );
+    },
 
     destinationChain: undefined,
     destinationToken: undefined,
@@ -155,6 +181,7 @@ export const useMissionStore = createWithEqualityFn<MissionState>(
         currentActiveTaskType: undefined,
         currentActiveTaskName: undefined,
         isCurrentActiveTaskCompleted: false,
+        taskFormStates: {},
       }),
   }),
   Object.is,


### PR DESCRIPTION
fix: prevent task verification when form fields are empty
Jira https://lifi.atlassian.net/browse/LF-15391

## Problem
The `Verify` badge on task cards could be clicked even when required form fields were empty. While the `Verify` button in the widget was properly disabled, the badge remained clickable, causing verification and tracking events to be sent with incomplete data.

## Solution
- Added per-task form state management to the Mission store
- Task verification now checks if the current task has form requirements and validates completion before proceeding
- Form state is tracked per task ID to handle multiple tasks correctly
- Verification is bypassed until all required form fields are completed

## Next Steps
- Add task form state initialization on mission selection to pre-populate form state for all tasks
- Add disabled state to the badge component itself (requires design approval)


## Testing Steps
1. Go to `/missions/win-a-solana-seeker`
2. Select the `Off-chain task`
3. Do not enter anything in the field
4. Click on the `Verify` badge on the task card
5. No posthog event or task verification request should be sent