### PR TITLE
feat: add on route selected and chain pinned - LF-14810 & LF-15119

### DIFF
--- a/src/components/Widgets/PosthogTracker.ts
+++ b/src/components/Widgets/PosthogTracker.ts
@@ -1,11 +1,11 @@
 'use client';
+import type { ChainPinned, RouteSelected } from '@lifi/widget';
 import {
   TrackingAction,
   TrackingCategory,
   TrackingEventParameter,
-} from '@/const/trackingKeys';
-import { UserTracking } from '@/hooks/userTracking';
-import type { ChainPinned, RouteSelected } from '@lifi/widget';
+} from 'src/const/trackingKeys';
+import { UserTracking } from 'src/hooks/userTracking';
 import { handleRouteData } from 'src/utils/routes';
 
 export interface PosthogTrackerProps extends UserTracking {}

--- a/src/components/Widgets/PosthogTracker.ts
+++ b/src/components/Widgets/PosthogTracker.ts
@@ -1,0 +1,53 @@
+'use client';
+import {
+  TrackingAction,
+  TrackingCategory,
+  TrackingEventParameter,
+} from '@/const/trackingKeys';
+import { UserTracking } from '@/hooks/userTracking';
+import type { ChainPinned, RouteSelected } from '@lifi/widget';
+import { handleRouteData } from 'src/utils/routes';
+
+export interface PosthogTrackerProps extends UserTracking {}
+
+export interface PosthogTracker {
+  onRouteSelected: (route: RouteSelected) => Promise<void>;
+  onChainPinned: (chainPinned: ChainPinned) => Promise<void>;
+}
+
+export const makePosthogTracker = ({
+  trackTransaction,
+  trackEvent,
+}: PosthogTrackerProps): PosthogTracker => {
+  const onRouteSelected = async ({ route, routes }: RouteSelected) => {
+    const position = routes.findIndex((r) => r.id === route.id);
+    const data = handleRouteData(route, {
+      [TrackingEventParameter.RoutePosition]: position,
+      [TrackingEventParameter.TransactionStatus]: 'SELECTED',
+    });
+
+    trackTransaction({
+      category: TrackingCategory.WidgetEvent,
+      action: TrackingAction.OnRouteSelected,
+      label: 'route_selected',
+      data,
+    });
+  };
+
+  const onChainPinned = async ({ chainId, pinned }: ChainPinned) => {
+    trackEvent({
+      category: TrackingCategory.WidgetEvent,
+      action: TrackingAction.OnChainPinned,
+      label: 'chain_pinned',
+      data: {
+        [TrackingEventParameter.ChainId]: chainId,
+        [TrackingEventParameter.Pinned]: pinned,
+      },
+    });
+  };
+
+  return {
+    onRouteSelected,
+    onChainPinned,
+  };
+};

--- a/src/components/Widgets/WidgetEvents.tsx
+++ b/src/components/Widgets/WidgetEvents.tsx
@@ -18,6 +18,7 @@ import type { RouteExtended } from '@lifi/sdk';
 import { type Route } from '@lifi/sdk';
 import { useAccount } from '@lifi/wallet-management';
 import type {
+  ChainPinned,
   ChainTokenSelected,
   ContactSupport,
   RouteExecutionUpdate,
@@ -357,6 +358,18 @@ export function WidgetEvents() {
       });
     };
 
+    const onChainPinned = async ({ chainId, pinned }: ChainPinned) => {
+      trackEvent({
+        category: TrackingCategory.WidgetEvent,
+        action: TrackingAction.OnChainPinned,
+        label: 'chain_pinned',
+        data: {
+          [TrackingEventParameter.ChainId]: chainId,
+          [TrackingEventParameter.Pinned]: pinned,
+        },
+      });
+    };
+
     widgetEvents.on(WidgetEvent.RouteExecutionStarted, onRouteExecutionStarted);
     widgetEvents.on(
       WidgetEvent.LowAddressActivityConfirmed,
@@ -386,6 +399,7 @@ export function WidgetEvents() {
     widgetEvents.on(WidgetEvent.PageEntered, onPageEntered);
     widgetEvents.on(WidgetEvent.SettingUpdated, onChangeSettings);
     widgetEvents.on(WidgetEvent.RouteSelected, onRouteSelected);
+    widgetEvents.on(WidgetEvent.ChainPinned, onChainPinned);
 
     return () => {
       widgetEvents.off(
@@ -426,6 +440,7 @@ export function WidgetEvents() {
       widgetEvents.off(WidgetEvent.PageEntered, onPageEntered);
       widgetEvents.off(WidgetEvent.SettingUpdated, onChangeSettings);
       widgetEvents.off(WidgetEvent.RouteSelected, onRouteSelected);
+      widgetEvents.off(WidgetEvent.ChainPinned, onChainPinned);
     };
   }, [
     activeTab,

--- a/src/components/Widgets/WidgetEvents.tsx
+++ b/src/components/Widgets/WidgetEvents.tsx
@@ -223,17 +223,6 @@ export function WidgetEvents() {
       setSourceChainToken(sourceChainData);
     };
 
-    // const onWidgetExpanded = async (expanded: boolean) => {
-    //   expanded &&
-    //     trackEvent({
-    //       category: TrackingCategory.WidgetEvent,
-    //       action: TrackingAction.OnWidgetExpanded,
-    //       label: `widget_expanded`,
-    //       enableAddressable: true,
-    //       data: {},
-    //     });
-    // };
-
     const onDestinationChainTokenSelection = async (
       toChainData: ChainTokenSelected,
     ) => {
@@ -397,9 +386,6 @@ export function WidgetEvents() {
     widgetEvents.on(WidgetEvent.PageEntered, onPageEntered);
     widgetEvents.on(WidgetEvent.SettingUpdated, onChangeSettings);
     widgetEvents.on(WidgetEvent.RouteSelected, onRouteSelected);
-    // widgetEvents.on(WidgetEvent.TokenSearch, onTokenSearch);
-
-    // widgetEvents.on(WidgetEvent.WidgetExpanded, onWidgetExpanded);
 
     return () => {
       widgetEvents.off(
@@ -436,7 +422,6 @@ export function WidgetEvents() {
         WidgetEvent.LowAddressActivityConfirmed,
         onLowAddressActivityConfirmed,
       );
-      // widgetEvents.off(WidgetEvent.WidgetExpanded, onWidgetExpanded);
       widgetEvents.off(WidgetEvent.AvailableRoutes, onAvailableRoutes);
       widgetEvents.off(WidgetEvent.PageEntered, onPageEntered);
       widgetEvents.off(WidgetEvent.SettingUpdated, onChangeSettings);

--- a/src/components/Widgets/WidgetEvents.tsx
+++ b/src/components/Widgets/WidgetEvents.tsx
@@ -18,16 +18,14 @@ import type { RouteExtended } from '@lifi/sdk';
 import { type Route } from '@lifi/sdk';
 import { useAccount } from '@lifi/wallet-management';
 import type {
-  ChainPinned,
   ChainTokenSelected,
   ContactSupport,
   RouteExecutionUpdate,
   RouteHighValueLossUpdate,
-  RouteSelected,
   SettingUpdated,
 } from '@lifi/widget';
 import { useWidgetEvents, WidgetEvent } from '@lifi/widget';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { shallowEqualObjects } from 'shallow-equal';
 import { GoldenRouteModal } from 'src/components/GoldenRouteModal/GoldenRouteModal';
 import type { JumperEventData } from 'src/hooks/useJumperTracking';
@@ -36,6 +34,7 @@ import { useRouteStore } from 'src/stores/route/RouteStore';
 import { TransformedRoute } from 'src/types/internal';
 import { handleRouteData } from 'src/utils/routes';
 import { parseWidgetSettingsToTrackingData } from 'src/utils/tracking/widget';
+import { makePosthogTracker } from './PosthogTracker';
 
 export function WidgetEvents() {
   const previousRoutesRef = useRef<JumperEventData>({});
@@ -73,6 +72,10 @@ export function WidgetEvents() {
   const { setContributed, setContributionDisplayed } = useContributionStore(
     (state) => state,
   );
+
+  const posthogTracker = useMemo(() => {
+    return makePosthogTracker({ trackTransaction, trackEvent });
+  }, [trackTransaction, trackEvent]);
 
   useEffect(() => {
     const onRouteExecutionStarted = async (route: RouteExtended) => {
@@ -343,33 +346,6 @@ export function WidgetEvents() {
       setContributionDisplayed(false);
     };
 
-    const onRouteSelected = async ({ route, routes }: RouteSelected) => {
-      const position = routes.findIndex((r) => r.id === route.id);
-      const data = handleRouteData(route, {
-        [TrackingEventParameter.RoutePosition]: position,
-        [TrackingEventParameter.TransactionStatus]: 'SELECTED',
-      });
-
-      trackTransaction({
-        category: TrackingCategory.WidgetEvent,
-        action: TrackingAction.OnRouteSelected,
-        label: 'route_selected',
-        data,
-      });
-    };
-
-    const onChainPinned = async ({ chainId, pinned }: ChainPinned) => {
-      trackEvent({
-        category: TrackingCategory.WidgetEvent,
-        action: TrackingAction.OnChainPinned,
-        label: 'chain_pinned',
-        data: {
-          [TrackingEventParameter.ChainId]: chainId,
-          [TrackingEventParameter.Pinned]: pinned,
-        },
-      });
-    };
-
     widgetEvents.on(WidgetEvent.RouteExecutionStarted, onRouteExecutionStarted);
     widgetEvents.on(
       WidgetEvent.LowAddressActivityConfirmed,
@@ -398,8 +374,8 @@ export function WidgetEvents() {
     );
     widgetEvents.on(WidgetEvent.PageEntered, onPageEntered);
     widgetEvents.on(WidgetEvent.SettingUpdated, onChangeSettings);
-    widgetEvents.on(WidgetEvent.RouteSelected, onRouteSelected);
-    widgetEvents.on(WidgetEvent.ChainPinned, onChainPinned);
+    widgetEvents.on(WidgetEvent.RouteSelected, posthogTracker.onRouteSelected);
+    widgetEvents.on(WidgetEvent.ChainPinned, posthogTracker.onChainPinned);
 
     return () => {
       widgetEvents.off(
@@ -439,8 +415,11 @@ export function WidgetEvents() {
       widgetEvents.off(WidgetEvent.AvailableRoutes, onAvailableRoutes);
       widgetEvents.off(WidgetEvent.PageEntered, onPageEntered);
       widgetEvents.off(WidgetEvent.SettingUpdated, onChangeSettings);
-      widgetEvents.off(WidgetEvent.RouteSelected, onRouteSelected);
-      widgetEvents.off(WidgetEvent.ChainPinned, onChainPinned);
+      widgetEvents.off(
+        WidgetEvent.RouteSelected,
+        posthogTracker.onRouteSelected,
+      );
+      widgetEvents.off(WidgetEvent.ChainPinned, posthogTracker.onChainPinned);
     };
   }, [
     activeTab,

--- a/src/components/Widgets/WidgetEvents.tsx
+++ b/src/components/Widgets/WidgetEvents.tsx
@@ -24,7 +24,7 @@ import type {
   RouteHighValueLossUpdate,
   SettingUpdated,
 } from '@lifi/widget';
-import { useWidgetEvents, WidgetEvent } from '@lifi/widget';
+import { useWidgetEvents } from '@lifi/widget';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { shallowEqualObjects } from 'shallow-equal';
 import { GoldenRouteModal } from 'src/components/GoldenRouteModal/GoldenRouteModal';
@@ -35,6 +35,11 @@ import { TransformedRoute } from 'src/types/internal';
 import { handleRouteData } from 'src/utils/routes';
 import { parseWidgetSettingsToTrackingData } from 'src/utils/tracking/widget';
 import { makePosthogTracker } from './PosthogTracker';
+import {
+  setupWidgetEvents,
+  teardownWidgetEvents,
+  WidgetEventsConfig,
+} from './WidgetEventsManager';
 
 export function WidgetEvents() {
   const previousRoutesRef = useRef<JumperEventData>({});
@@ -78,7 +83,7 @@ export function WidgetEvents() {
   }, [trackTransaction, trackEvent]);
 
   useEffect(() => {
-    const onRouteExecutionStarted = async (route: RouteExtended) => {
+    const routeExecutionStarted = async (route: RouteExtended) => {
       const data = handleRouteData(route, {
         [TrackingEventParameter.Action]: 'execution_start',
         [TrackingEventParameter.TransactionStatus]: 'STARTED',
@@ -94,7 +99,7 @@ export function WidgetEvents() {
       }
     };
 
-    const onRouteExecutionUpdated = async (update: RouteExecutionUpdate) => {
+    const routeExecutionUpdated = async (update: RouteExecutionUpdate) => {
       // check if multisig and open the modal
       const isMultisigRouteActive = shouldOpenMultisigSignatureModal(
         update.route,
@@ -104,7 +109,7 @@ export function WidgetEvents() {
       }
     };
 
-    const onRouteExecutionCompleted = async (route: RouteExtended) => {
+    const routeExecutionCompleted = async (route: RouteExtended) => {
       //to do: if route is not lifi then refetch position of destination token??
 
       if (route.id) {
@@ -162,7 +167,7 @@ export function WidgetEvents() {
       }
     };
 
-    const onRouteExecutionFailed = async (update: RouteExecutionUpdate) => {
+    const routeExecutionFailed = async (update: RouteExecutionUpdate) => {
       const data = handleRouteData(update.route, {
         [TrackingEventParameter.Action]: 'execution_failed',
         [TrackingEventParameter.TransactionStatus]: 'FAILED',
@@ -180,7 +185,7 @@ export function WidgetEvents() {
       });
     };
 
-    const onRouteHighValueLoss = (update: RouteHighValueLossUpdate) => {
+    const routeHighValueLoss = (update: RouteHighValueLossUpdate) => {
       trackEvent({
         action: TrackingAction.OnRouteHighValueLoss,
         category: TrackingCategory.WidgetEvent,
@@ -199,17 +204,11 @@ export function WidgetEvents() {
       });
     };
 
-    const onRouteContactSupport = (supportId: ContactSupport) => {
+    const contactSupport = (supportId: ContactSupport) => {
       setSupportModalState(true);
     };
 
-    const onMultisigChainTokenSelected = (
-      destinationData: ChainTokenSelected,
-    ) => {
-      setDestinationChain(destinationData.chainId);
-    };
-
-    const onSourceChainTokenSelection = async (
+    const sourceChainTokenSelected = async (
       sourceChainData: ChainTokenSelected,
     ) => {
       trackEvent({
@@ -227,7 +226,13 @@ export function WidgetEvents() {
       setSourceChainToken(sourceChainData);
     };
 
-    const onDestinationChainTokenSelection = async (
+    const destinationChainTokenSelectedMultisig = (
+      destinationData: ChainTokenSelected,
+    ) => {
+      setDestinationChain(destinationData.chainId);
+    };
+
+    const destinationChainTokenSelectedRaw = async (
       toChainData: ChainTokenSelected,
     ) => {
       trackEvent({
@@ -245,7 +250,14 @@ export function WidgetEvents() {
       setDestinationChainToken(toChainData);
     };
 
-    const onLowAddressActivityConfirmed = async (props: {
+    const destinationChainTokenSelected = async (
+      destinationData: ChainTokenSelected,
+    ) => {
+      destinationChainTokenSelectedMultisig(destinationData);
+      destinationChainTokenSelectedRaw(destinationData);
+    };
+
+    const lowAddressActivityConfirmed = async (props: {
       address: string;
       chainId: number;
     }) => {
@@ -261,7 +273,7 @@ export function WidgetEvents() {
       });
     };
 
-    const onAvailableRoutes = async (availableRoutes: Route[]) => {
+    const availableRoutes = async (availableRoutes: Route[]) => {
       // current available routes
       const newObj: JumperEventData = {
         [TrackingEventParameter.FromToken]: sourceChainToken.tokenAddress || '',
@@ -330,7 +342,7 @@ export function WidgetEvents() {
       }
     };
 
-    const onChangeSettings = (settings: SettingUpdated) => {
+    const settingUpdated = (settings: SettingUpdated) => {
       trackEvent({
         category: TrackingCategory.WidgetEvent,
         action: TrackingAction.OnChangeSettings,
@@ -340,86 +352,33 @@ export function WidgetEvents() {
       });
     };
 
-    const onPageEntered = async (pageType: any) => {
+    const pageEntered = async (pageType: unknown) => {
       // Reset contribution state when entering a new page
       setContributed(false);
       setContributionDisplayed(false);
     };
 
-    widgetEvents.on(WidgetEvent.RouteExecutionStarted, onRouteExecutionStarted);
-    widgetEvents.on(
-      WidgetEvent.LowAddressActivityConfirmed,
-      onLowAddressActivityConfirmed,
-    );
-    widgetEvents.on(WidgetEvent.RouteExecutionUpdated, onRouteExecutionUpdated);
-    widgetEvents.on(
-      WidgetEvent.RouteExecutionCompleted,
-      onRouteExecutionCompleted,
-    );
-    widgetEvents.on(WidgetEvent.AvailableRoutes, onAvailableRoutes);
-    widgetEvents.on(WidgetEvent.RouteExecutionFailed, onRouteExecutionFailed);
-    widgetEvents.on(WidgetEvent.RouteHighValueLoss, onRouteHighValueLoss);
-    widgetEvents.on(WidgetEvent.ContactSupport, onRouteContactSupport);
-    widgetEvents.on(
-      WidgetEvent.DestinationChainTokenSelected,
-      onMultisigChainTokenSelected,
-    );
-    widgetEvents.on(
-      WidgetEvent.SourceChainTokenSelected,
-      onSourceChainTokenSelection,
-    );
-    widgetEvents.on(
-      WidgetEvent.DestinationChainTokenSelected,
-      onDestinationChainTokenSelection,
-    );
-    widgetEvents.on(WidgetEvent.PageEntered, onPageEntered);
-    widgetEvents.on(WidgetEvent.SettingUpdated, onChangeSettings);
-    widgetEvents.on(WidgetEvent.RouteSelected, posthogTracker.onRouteSelected);
-    widgetEvents.on(WidgetEvent.ChainPinned, posthogTracker.onChainPinned);
+    const config: WidgetEventsConfig = {
+      routeExecutionStarted,
+      routeExecutionUpdated,
+      routeExecutionCompleted,
+      routeExecutionFailed,
+      routeHighValueLoss,
+      contactSupport,
+      sourceChainTokenSelected,
+      destinationChainTokenSelected,
+      lowAddressActivityConfirmed,
+      availableRoutes,
+      settingUpdated,
+      pageEntered,
+      routeSelected: posthogTracker.onRouteSelected,
+      chainPinned: posthogTracker.onChainPinned,
+    };
+
+    setupWidgetEvents(config, widgetEvents);
 
     return () => {
-      widgetEvents.off(
-        WidgetEvent.RouteExecutionStarted,
-        onRouteExecutionStarted,
-      );
-      widgetEvents.off(
-        WidgetEvent.RouteExecutionUpdated,
-        onRouteExecutionUpdated,
-      );
-      widgetEvents.off(
-        WidgetEvent.RouteExecutionCompleted,
-        onRouteExecutionCompleted,
-      );
-      widgetEvents.off(
-        WidgetEvent.RouteExecutionFailed,
-        onRouteExecutionFailed,
-      );
-      widgetEvents.off(WidgetEvent.RouteHighValueLoss, onRouteHighValueLoss);
-      widgetEvents.off(WidgetEvent.ContactSupport, onRouteContactSupport);
-      widgetEvents.off(
-        WidgetEvent.DestinationChainTokenSelected,
-        onMultisigChainTokenSelected,
-      );
-      widgetEvents.off(
-        WidgetEvent.SourceChainTokenSelected,
-        onSourceChainTokenSelection,
-      );
-      widgetEvents.off(
-        WidgetEvent.DestinationChainTokenSelected,
-        onDestinationChainTokenSelection,
-      );
-      widgetEvents.off(
-        WidgetEvent.LowAddressActivityConfirmed,
-        onLowAddressActivityConfirmed,
-      );
-      widgetEvents.off(WidgetEvent.AvailableRoutes, onAvailableRoutes);
-      widgetEvents.off(WidgetEvent.PageEntered, onPageEntered);
-      widgetEvents.off(WidgetEvent.SettingUpdated, onChangeSettings);
-      widgetEvents.off(
-        WidgetEvent.RouteSelected,
-        posthogTracker.onRouteSelected,
-      );
-      widgetEvents.off(WidgetEvent.ChainPinned, posthogTracker.onChainPinned);
+      teardownWidgetEvents(config, widgetEvents);
     };
   }, [
     activeTab,

--- a/src/components/Widgets/WidgetEvents.tsx
+++ b/src/components/Widgets/WidgetEvents.tsx
@@ -22,6 +22,7 @@ import type {
   ContactSupport,
   RouteExecutionUpdate,
   RouteHighValueLossUpdate,
+  RouteSelected,
   SettingUpdated,
 } from '@lifi/widget';
 import { useWidgetEvents, WidgetEvent } from '@lifi/widget';
@@ -352,6 +353,21 @@ export function WidgetEvents() {
       setContributionDisplayed(false);
     };
 
+    const onRouteSelected = async ({ route, routes }: RouteSelected) => {
+      const position = routes.findIndex((r) => r.id === route.id);
+      const data = handleRouteData(route, {
+        [TrackingEventParameter.RoutePosition]: position,
+        [TrackingEventParameter.TransactionStatus]: 'SELECTED',
+      });
+
+      trackTransaction({
+        category: TrackingCategory.WidgetEvent,
+        action: TrackingAction.OnRouteSelected,
+        label: 'route_selected',
+        data,
+      });
+    };
+
     widgetEvents.on(WidgetEvent.RouteExecutionStarted, onRouteExecutionStarted);
     widgetEvents.on(
       WidgetEvent.LowAddressActivityConfirmed,
@@ -380,7 +396,7 @@ export function WidgetEvents() {
     );
     widgetEvents.on(WidgetEvent.PageEntered, onPageEntered);
     widgetEvents.on(WidgetEvent.SettingUpdated, onChangeSettings);
-    // widgetEvents.on(WidgetEvent.RouteSelected, onRouteSelected);
+    widgetEvents.on(WidgetEvent.RouteSelected, onRouteSelected);
     // widgetEvents.on(WidgetEvent.TokenSearch, onTokenSearch);
 
     // widgetEvents.on(WidgetEvent.WidgetExpanded, onWidgetExpanded);
@@ -424,6 +440,7 @@ export function WidgetEvents() {
       widgetEvents.off(WidgetEvent.AvailableRoutes, onAvailableRoutes);
       widgetEvents.off(WidgetEvent.PageEntered, onPageEntered);
       widgetEvents.off(WidgetEvent.SettingUpdated, onChangeSettings);
+      widgetEvents.off(WidgetEvent.RouteSelected, onRouteSelected);
     };
   }, [
     activeTab,

--- a/src/components/Widgets/WidgetEventsManager.ts
+++ b/src/components/Widgets/WidgetEventsManager.ts
@@ -1,0 +1,27 @@
+import type { WidgetEvent, widgetEvents, WidgetEvents } from '@lifi/widget';
+
+export type WidgetEventsConfig = {
+  [K in WidgetEvent]?: (data: WidgetEvents[K]) => void;
+};
+
+export type WidgetEventEmitter = typeof widgetEvents; // delegate that type to the widget library
+
+export const setupWidgetEvents = (
+  config: WidgetEventsConfig,
+  widgetEvents: WidgetEventEmitter,
+) => {
+  Object.entries(config).forEach(([event, handler]) => {
+    // @ts-expect-error - typescript won't let us easily type: event is a WidgetEvent, and handler is EXACTLY the corresponding function.
+    widgetEvents.on(event, handler);
+  });
+};
+
+export const teardownWidgetEvents = (
+  config: WidgetEventsConfig,
+  widgetEvents: WidgetEventEmitter,
+) => {
+  Object.entries(config).forEach(([event, handler]) => {
+    // @ts-expect-error - See the setup version
+    widgetEvents.off(event, handler);
+  });
+};

--- a/src/const/trackingKeys.ts
+++ b/src/const/trackingKeys.ts
@@ -33,6 +33,7 @@ export enum TrackingAction {
   ClickContribute = 'action_contribute',
   ContributeImpression = 'action_contribute_impression',
   ContributeSuccess = 'action_contribute_success',
+  OnChainPinned = 'action_on_chain_pinned',
 
   // Mission Widget
   OnSourceChainAndTokenSelectionMission = 'action_on_source_selection_mission',
@@ -192,6 +193,7 @@ export enum TrackingEventParameter {
   UpdatedSetting = 'param_updated_setting',
   NewSettingValue = 'param_new_setting_value',
   PreviousSettingValue = 'param_previous_setting_value',
+  Pinned = 'param_pinned',
 
   // Pageload:
   PageloadSource = 'param_pageload_source',

--- a/src/hooks/userTracking/useUserTracking.ts
+++ b/src/hooks/userTracking/useUserTracking.ts
@@ -165,7 +165,7 @@ export function useUserTracking() {
           referrer: document?.referrer,
           abtests: activeAbTests,
           // data from handleRouteTrackingData:
-          action: data[TrackingEventParameter.Action] || '',
+          action: data[TrackingEventParameter.Action] ?? action ?? '',
           errorCode: data[TrackingEventParameter.ErrorCode],
           errorMessage: data[TrackingEventParameter.ErrorMessage],
           exchange: data[TrackingEventParameter.Exchange],

--- a/src/hooks/userTracking/useUserTracking.ts
+++ b/src/hooks/userTracking/useUserTracking.ts
@@ -72,7 +72,12 @@ const addressableEvent = ({
     );
 };
 
-export function useUserTracking() {
+export interface UserTracking {
+  trackEvent: (event: TrackEventProps) => Promise<void>;
+  trackTransaction: (transaction: TrackTransactionProps) => Promise<void>;
+}
+
+export function useUserTracking(): UserTracking {
   const { account } = useAccount();
   const isDesktop = useMediaQuery(
     (theme: Theme) => theme?.breakpoints.up('md') || '0',

--- a/src/providers/WidgetTrackingProvider.tsx
+++ b/src/providers/WidgetTrackingProvider.tsx
@@ -7,9 +7,9 @@ import {
   WidgetEvent,
 } from '@lifi/widget';
 import {
+  createContext,
   FC,
   PropsWithChildren,
-  createContext,
   useCallback,
   useContext,
   useEffect,
@@ -17,10 +17,10 @@ import {
   useRef,
 } from 'react';
 import {
-  TrackingCategory,
   TrackingAction,
-  TrackingEventParameter,
+  TrackingCategory,
   TrackingEventDataAction,
+  TrackingEventParameter,
 } from 'src/const/trackingKeys';
 import { useUserTracking } from 'src/hooks/userTracking';
 import { TransformedRoute } from 'src/types/internal';
@@ -260,61 +260,38 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
   const widgetEvents = useWidgetEvents();
 
   useEffect(() => {
-    function onSourceChainAndTokenSelection(
-      sourceChainToken: ChainTokenSelected,
-    ) {
-      trackSourceToken(sourceChainToken);
-    }
-
-    function onAvailableRoutes(availableRoutes: Route[]) {
-      trackAvailableRoutes(availableRoutes);
-    }
-    function onRouteExecutionStarted(route: Route) {
-      trackRouteExecutionStarted(route);
-    }
-
-    function onRouteExecutionCompleted(route: Route) {
-      trackRouteExecutionCompleted(route);
-    }
-
-    function onRouteExecutionFailed(
-      routeExecutionUpdate: RouteExecutionUpdate,
-    ) {
-      trackRouteExecutionFailed(routeExecutionUpdate);
-    }
-
-    widgetEvents.on(WidgetEvent.RouteExecutionStarted, onRouteExecutionStarted);
-    widgetEvents.on(WidgetEvent.RouteExecutionFailed, onRouteExecutionFailed);
     widgetEvents.on(
-      WidgetEvent.SourceChainTokenSelected,
-      onSourceChainAndTokenSelection,
+      WidgetEvent.RouteExecutionStarted,
+      trackRouteExecutionStarted,
     );
-    widgetEvents.on(WidgetEvent.AvailableRoutes, onAvailableRoutes);
+    widgetEvents.on(
+      WidgetEvent.RouteExecutionFailed,
+      trackRouteExecutionFailed,
+    );
+    widgetEvents.on(WidgetEvent.SourceChainTokenSelected, trackSourceToken);
+    widgetEvents.on(WidgetEvent.AvailableRoutes, trackAvailableRoutes);
 
     widgetEvents.on(
       WidgetEvent.RouteExecutionCompleted,
-      onRouteExecutionCompleted,
+      trackRouteExecutionCompleted,
     );
 
     widgetEvents.on(WidgetEvent.SettingUpdated, trackChangeSettings);
 
     return () => {
-      widgetEvents.off(
-        WidgetEvent.SourceChainTokenSelected,
-        onSourceChainAndTokenSelection,
-      );
-      widgetEvents.off(WidgetEvent.AvailableRoutes, onAvailableRoutes);
+      widgetEvents.off(WidgetEvent.SourceChainTokenSelected, trackSourceToken);
+      widgetEvents.off(WidgetEvent.AvailableRoutes, trackAvailableRoutes);
       widgetEvents.off(
         WidgetEvent.RouteExecutionStarted,
-        onRouteExecutionStarted,
+        trackRouteExecutionStarted,
       );
       widgetEvents.off(
         WidgetEvent.RouteExecutionCompleted,
-        onRouteExecutionCompleted,
+        trackRouteExecutionCompleted,
       );
       widgetEvents.off(
         WidgetEvent.RouteExecutionFailed,
-        onRouteExecutionFailed,
+        trackRouteExecutionFailed,
       );
       widgetEvents.off(WidgetEvent.SettingUpdated, trackChangeSettings);
     };

--- a/src/providers/WidgetTrackingProvider.tsx
+++ b/src/providers/WidgetTrackingProvider.tsx
@@ -16,6 +16,7 @@ import {
   useMemo,
   useRef,
 } from 'react';
+import { makePosthogTracker } from 'src/components/Widgets/PosthogTracker';
 import {
   TrackingAction,
   TrackingCategory,
@@ -86,6 +87,9 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
   const sourceChainToken = useRef<ChainTokenSelected | null>(null);
   const destinationChainToken = useRef<ChainTokenSelected | null>(null);
   const isRoutesForCurrentSourceTokenTracked = useRef(false);
+  const posthogTracker = useMemo(() => {
+    return makePosthogTracker({ trackTransaction, trackEvent });
+  }, [trackTransaction, trackEvent]);
 
   const trackSourceToken = useCallback(
     (sourceToken: ChainTokenSelected) => {
@@ -278,6 +282,9 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
 
     widgetEvents.on(WidgetEvent.SettingUpdated, trackChangeSettings);
 
+    widgetEvents.on(WidgetEvent.RouteSelected, posthogTracker.onRouteSelected);
+    widgetEvents.on(WidgetEvent.ChainPinned, posthogTracker.onChainPinned);
+
     return () => {
       widgetEvents.off(WidgetEvent.SourceChainTokenSelected, trackSourceToken);
       widgetEvents.off(WidgetEvent.AvailableRoutes, trackAvailableRoutes);
@@ -294,6 +301,11 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
         trackRouteExecutionFailed,
       );
       widgetEvents.off(WidgetEvent.SettingUpdated, trackChangeSettings);
+      widgetEvents.off(
+        WidgetEvent.RouteSelected,
+        posthogTracker.onRouteSelected,
+      );
+      widgetEvents.off(WidgetEvent.ChainPinned, posthogTracker.onChainPinned);
     };
   }, [
     widgetEvents,

--- a/src/providers/WidgetTrackingProvider.tsx
+++ b/src/providers/WidgetTrackingProvider.tsx
@@ -4,7 +4,6 @@ import {
   RouteExecutionUpdate,
   SettingUpdated,
   useWidgetEvents,
-  WidgetEvent,
 } from '@lifi/widget';
 import {
   createContext,
@@ -17,6 +16,11 @@ import {
   useRef,
 } from 'react';
 import { makePosthogTracker } from 'src/components/Widgets/PosthogTracker';
+import {
+  setupWidgetEvents,
+  teardownWidgetEvents,
+  WidgetEventsConfig,
+} from 'src/components/Widgets/WidgetEventsManager';
 import {
   TrackingAction,
   TrackingCategory,
@@ -91,7 +95,7 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
     return makePosthogTracker({ trackTransaction, trackEvent });
   }, [trackTransaction, trackEvent]);
 
-  const trackSourceToken = useCallback(
+  const sourceChainTokenSelected = useCallback(
     (sourceToken: ChainTokenSelected) => {
       trackEvent({
         category: TrackingCategory.WidgetEvent,
@@ -115,7 +119,7 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
     [trackEvent, trackingActionKeys.sourceChainAndTokenSelection],
   );
 
-  const trackAvailableRoutes = useCallback(
+  const availableRoutes = useCallback(
     (availableRoutes: Route[]) => {
       if (isRoutesForCurrentSourceTokenTracked.current) {
         return;
@@ -173,7 +177,7 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
     [trackEvent, trackingActionKeys.availableRoutes],
   );
 
-  const trackRouteExecutionStarted = useCallback(
+  const routeExecutionStarted = useCallback(
     (route: Route) => {
       if (route.id) {
         trackTransaction({
@@ -196,7 +200,7 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
     ],
   );
 
-  const trackRouteExecutionCompleted = useCallback(
+  const routeExecutionCompleted = useCallback(
     (route: Route) => {
       trackTransaction({
         category: TrackingCategory.WidgetEvent,
@@ -218,7 +222,7 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
     ],
   );
 
-  const trackRouteExecutionFailed = useCallback(
+  const routeExecutionFailed = useCallback(
     (update: RouteExecutionUpdate) => {
       trackTransaction({
         category: TrackingCategory.WidgetEvent,
@@ -241,7 +245,7 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
     ],
   );
 
-  const trackChangeSettings = useCallback(
+  const settingUpdated = useCallback(
     (settings: SettingUpdated) => {
       trackEvent({
         category: TrackingCategory.WidgetEvent,
@@ -264,57 +268,32 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
   const widgetEvents = useWidgetEvents();
 
   useEffect(() => {
-    widgetEvents.on(
-      WidgetEvent.RouteExecutionStarted,
-      trackRouteExecutionStarted,
-    );
-    widgetEvents.on(
-      WidgetEvent.RouteExecutionFailed,
-      trackRouteExecutionFailed,
-    );
-    widgetEvents.on(WidgetEvent.SourceChainTokenSelected, trackSourceToken);
-    widgetEvents.on(WidgetEvent.AvailableRoutes, trackAvailableRoutes);
+    const config: WidgetEventsConfig = {
+      sourceChainTokenSelected,
+      availableRoutes,
+      routeExecutionStarted,
+      routeExecutionCompleted,
+      routeExecutionFailed,
+      settingUpdated,
+      routeSelected: posthogTracker.onRouteSelected,
+      chainPinned: posthogTracker.onChainPinned,
+    };
 
-    widgetEvents.on(
-      WidgetEvent.RouteExecutionCompleted,
-      trackRouteExecutionCompleted,
-    );
-
-    widgetEvents.on(WidgetEvent.SettingUpdated, trackChangeSettings);
-
-    widgetEvents.on(WidgetEvent.RouteSelected, posthogTracker.onRouteSelected);
-    widgetEvents.on(WidgetEvent.ChainPinned, posthogTracker.onChainPinned);
+    setupWidgetEvents(config, widgetEvents);
 
     return () => {
-      widgetEvents.off(WidgetEvent.SourceChainTokenSelected, trackSourceToken);
-      widgetEvents.off(WidgetEvent.AvailableRoutes, trackAvailableRoutes);
-      widgetEvents.off(
-        WidgetEvent.RouteExecutionStarted,
-        trackRouteExecutionStarted,
-      );
-      widgetEvents.off(
-        WidgetEvent.RouteExecutionCompleted,
-        trackRouteExecutionCompleted,
-      );
-      widgetEvents.off(
-        WidgetEvent.RouteExecutionFailed,
-        trackRouteExecutionFailed,
-      );
-      widgetEvents.off(WidgetEvent.SettingUpdated, trackChangeSettings);
-      widgetEvents.off(
-        WidgetEvent.RouteSelected,
-        posthogTracker.onRouteSelected,
-      );
-      widgetEvents.off(WidgetEvent.ChainPinned, posthogTracker.onChainPinned);
+      teardownWidgetEvents(config, widgetEvents);
     };
   }, [
     widgetEvents,
-    trackSourceToken,
-    trackAvailableRoutes,
-    trackRouteExecutionStarted,
-    trackRouteExecutionCompleted,
-    trackRouteExecutionFailed,
-    trackChangeSettings,
+    sourceChainTokenSelected,
+    availableRoutes,
+    routeExecutionStarted,
+    routeExecutionCompleted,
+    routeExecutionFailed,
+    settingUpdated,
+    posthogTracker.onRouteSelected,
+    posthogTracker.onChainPinned,
   ]);
 
   const value = useMemo(

--- a/src/types/userTracking.ts
+++ b/src/types/userTracking.ts
@@ -79,8 +79,3 @@ export interface TokenSearchProps {
   value: string;
   tokens: TokenAmount[];
 }
-
-export interface RouteSelectedProps {
-  route: Route;
-  routes: Route[];
-}

--- a/src/utils/routes/handleRouteData.ts
+++ b/src/utils/routes/handleRouteData.ts
@@ -91,7 +91,7 @@ export const handleRouteData = (
   }
 
   const gasCostUSDNumber = Number(gasCostUSD);
-  if (gasCostUSDNumber) {
+  if (!isNaN(gasCostUSDNumber)) {
     routeData[TrackingEventParameter.GasCostUSD] = gasCostUSDNumber;
   }
 

--- a/src/utils/routes/handleRouteData.ts
+++ b/src/utils/routes/handleRouteData.ts
@@ -37,7 +37,21 @@ export const handleRouteData = (
   );
   const priceImpact = calcPriceImpact(route);
 
-  const routeData = {
+  // Note(laurent): the rest of this function code was reworked to fix type issues,
+  // it was producing incorrect types. There are too many checks according to types,
+  // For example we're checking that stepTools is an array despite the type being
+  // `string[]` already. I'm keeping these checks as is, in case runtime types are different.
+  let steps = 'missing';
+  if (Array.isArray(stepTools) && stepTools.length > 0) {
+    steps = stepTools.join(',');
+  }
+
+  let transactionId = 'missing';
+  if (Array.isArray(includedStepIds) && includedStepIds.length > 0) {
+    transactionId = includedStepIds.join(',');
+  }
+
+  const routeData: TrackTransactionDataProps = {
     [TrackingEventParameter.FromAmount]: route.fromAmount,
     [TrackingEventParameter.FromAmountUSD]: route.fromAmountUSD,
     [TrackingEventParameter.FromChainId]: route.fromChainId,
@@ -47,39 +61,51 @@ export const handleRouteData = (
     [TrackingEventParameter.RouteId]: routeId,
     [TrackingEventParameter.Slippage]: priceImpact,
     [TrackingEventParameter.StepIds]: stepIds.join(','),
+    [TrackingEventParameter.Steps]: steps,
+    [TrackingEventParameter.Time]: duration || -1,
     [TrackingEventParameter.ToAmount]: toAmount,
     [TrackingEventParameter.ToAmountFormatted]: toAmountFormatted,
     [TrackingEventParameter.ToAmountMin]: route.toAmountMin,
     [TrackingEventParameter.ToAmountUSD]: toAmountUSD,
     [TrackingEventParameter.ToChainId]: route.toChainId,
     [TrackingEventParameter.ToToken]: route.toToken.address,
+    [TrackingEventParameter.TransactionId]: transactionId,
     [TrackingEventParameter.TransactionStatus]: routeStatus || '',
     [TrackingEventParameter.Type]: type,
-    ...(duration && { [TrackingEventParameter.Time]: duration }),
-    ...(Array.isArray(route.tags) &&
-      route.tags.length > 0 && {
-        [TrackingEventParameter.Tags]: route.tags.join(','),
-      }),
-    ...(Array.isArray(includedStepIds) &&
-      includedStepIds.length > 0 && {
-        [TrackingEventParameter.TransactionId]: includedStepIds.join(','),
-      }),
-    ...(Array.isArray(stepTools) &&
-      stepTools.length > 0 && {
-        [TrackingEventParameter.Steps]: stepTools.join(','),
-      }),
-    ...(integrator && { [TrackingEventParameter.Integrator]: integrator }),
-    ...(gasCost && { [TrackingEventParameter.GasCost]: gasCost }),
-    ...(gasCostFormatted && {
-      [TrackingEventParameter.GasCostFormatted]: gasCostFormatted,
-    }),
-    ...(gasCostUSD && { [TrackingEventParameter.GasCostUSD]: gasCostUSD }),
-    ...(feeCost && { [TrackingEventParameter.FeeCost]: feeCost }),
-    ...(feeCostFormatted && {
-      [TrackingEventParameter.FeeCostFormatted]: feeCostFormatted,
-    }),
-    ...(feeCostUSD && { [TrackingEventParameter.FeeCostUSD]: feeCostUSD }),
   };
+
+  if (Array.isArray(route.tags) && route.tags.length > 0) {
+    routeData[TrackingEventParameter.Tags] = route.tags.join(',');
+  }
+
+  if (integrator) {
+    routeData[TrackingEventParameter.Integrator] = integrator;
+  }
+
+  if (gasCost) {
+    routeData[TrackingEventParameter.GasCost] = gasCost;
+  }
+
+  if (gasCostFormatted) {
+    routeData[TrackingEventParameter.GasCostFormatted] = gasCostFormatted;
+  }
+
+  const gasCostUSDNumber = Number(gasCostUSD);
+  if (gasCostUSDNumber) {
+    routeData[TrackingEventParameter.GasCostUSD] = gasCostUSDNumber;
+  }
+
+  if (feeCost) {
+    routeData[TrackingEventParameter.FeeCost] = feeCost;
+  }
+
+  if (feeCostFormatted) {
+    routeData[TrackingEventParameter.FeeCostFormatted] = feeCostFormatted;
+  }
+
+  if (feeCostUSD) {
+    routeData[TrackingEventParameter.FeeCostUSD] = feeCostUSD;
+  }
 
   const processData = getProcessInformation(route);
 
@@ -87,5 +113,5 @@ export const handleRouteData = (
     ...routeData,
     ...processData,
     ...customData,
-  } as TrackTransactionDataProps;
+  };
 };


### PR DESCRIPTION
Closes https://lifi.atlassian.net/browse/LF-14810
Closes https://lifi.atlassian.net/browse/LF-15119

- [x] Add back "on route selected" events and introduce "chain pinned" events
- [x] Introduce basics for a posthog tracker that cares "only" about moving events around, not internal state, can be wrapped with more code (hence the data driven approach)
- [x] Introduce a WidgetEventsManager and its config to make it data-driven (easier to reuse, wrap, and move around)
- [x] Update WidgetEvents and WidgetTrackingProvider to use that new system

**Test:**

- select a route, check posthog, the event should be visible in posthog
- pin a few chains in the widget, then unpin some, the events should be visible in posthog

Note on testing posthog: https://www.notion.so/lifi/Test-Posthog-Events-270f0ff14ac7804d898dfe606a75af12

Example:

<img width="300" src="https://github.com/user-attachments/assets/59b260dd-4b40-45c9-a042-60b8bd548de5" />
