### PR TITLE
feat: add an event on posthog to show wallet balance overview

### DIFF
--- a/src/components/Menus/WalletMenu/WalletCard.tsx
+++ b/src/components/Menus/WalletMenu/WalletCard.tsx
@@ -156,17 +156,7 @@ export const WalletCard = ({ account }: WalletCardProps) => {
           disabled={isMultisigEnvironment}
           onClick={() => handleCopyButton()}
           sx={(theme) => ({
-            background: 'transparent',
-            ...theme.applyStyles("light", {
-              background: (theme.vars || theme).palette.white.main
-            }),
-            '&:hover': {
-              background:
-              (theme.vars || theme).palette.alphaLight300.main,
-              ...theme.applyStyles("light", {
-                background: (theme.vars || theme).palette.white.main
-              })
-            },
+            background: 'transparent !important',
           })}
         >
           <Typography variant="bodySmallStrong" sx={{ fontSize: '16px' }}>

--- a/src/const/trackingKeys.ts
+++ b/src/const/trackingKeys.ts
@@ -14,6 +14,7 @@ export enum TrackingAction {
   OpenJumperScan = 'action_open_jumper_scan',
   SwitchChain = 'action_switch_chain',
   PortfolioLoaded = 'action_portfolio_loaded',
+  PortfolioOverview = 'action_portfolio_balance_overview',
 
   // Widget
   OnRouteSelected = 'action_on_route_selected',
@@ -290,4 +291,12 @@ export enum TrackingEventParameter {
   //Banner
   ActiveCampaign = 'param_banner_campaign',
   ActiveCampaignBanner = 'param_campaign_banner_campaign',
+
+  // Portfolio
+  PortfolioTotalBalanceUSD = 'param_portfolio_total_balance_usd',
+  PortfolioNumberOfTokens = 'param_portfolio_nb_of_tokens',
+  PortfolioNumberOfChains = 'param_portfolio_nb_of_chains',
+  PortfolioNativeTokensBalanceUSD = 'param_portfolio_native_tokens_balance_usd',
+  PortfolioStableTokensBalanceUSD = 'param_portfolio_stable_tokens_balance_usd',
+  PortfolioOtherTokensBalanceUSD = 'param_portfolio_other_tokens_balance_usd',
 }

--- a/src/hooks/usePrevious.ts
+++ b/src/hooks/usePrevious.ts
@@ -1,0 +1,9 @@
+import { useEffect, useRef } from 'react';
+
+export const usePrevious = <T>(value: T): T | undefined => {
+  const ref = useRef<T>(value);
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+};

--- a/src/utils/getTokens/usePortfolioTokens.ts
+++ b/src/utils/getTokens/usePortfolioTokens.ts
@@ -9,12 +9,18 @@ import type { ExtendedTokenAmount } from '@/utils/getTokens';
 import index from '@/utils/getTokens';
 import { arraysEqual } from '@/utils/getTokens/utils';
 import { useAccount } from '@lifi/wallet-management';
+import { ChainId } from '@lifi/widget';
 import { useQueries } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
+import { useChains } from 'src/hooks/useChains';
+import { parsePortfolioDataToTrackingData } from '../tracking/portfolio';
+import { zeroAddress } from 'viem';
+import { usePrevious } from 'src/hooks/usePrevious';
 
 export function usePortfolioTokens() {
   const { trackEvent } = useUserTracking();
   const { accounts } = useAccount();
+  const { getChainById } = useChains();
   const {
     getFormattedCacheTokens,
     setCacheTokens,
@@ -23,6 +29,7 @@ export function usePortfolioTokens() {
     setForceRefresh,
   } = usePortfolioStore((state) => state);
   const hasTrackedSuccess = useRef(false);
+  const hasTrackedPortfolioOverview = useRef(false);
 
   const handleProgress = (
     account: string,
@@ -47,7 +54,14 @@ export function usePortfolioTokens() {
     (query) => !query.isFetching && query.isSuccess,
   );
   const isFetching = queries.every((query) => query.isFetching);
+  const isPrevFetching = usePrevious(isFetching);
   const refetch = () => queries.map((query) => query.refetch());
+  const shouldSendTrackingEvent = isPrevFetching && !isFetching && isSuccess;
+
+  const data =
+    getFormattedCacheTokens(accounts).cache.length === 0
+      ? queries.map((query) => query.data ?? []).flat()
+      : getFormattedCacheTokens(accounts).cache;
 
   // Useful to refresh after bridging something
   useEffect(() => {
@@ -79,23 +93,63 @@ export function usePortfolioTokens() {
   }, [accounts]);
 
   useEffect(() => {
-    if (isSuccess && !hasTrackedSuccess.current) {
-      hasTrackedSuccess.current = true;
-      trackEvent({
-        category: TrackingCategory.Wallet,
-        action: TrackingAction.PortfolioLoaded,
-        label: 'portfolio_balance_loaded',
-        data: {
-          [TrackingEventParameter.Status]: 'success',
-          [TrackingEventParameter.Timestamp]: new Date().toUTCString(),
-        },
-      });
+    if (hasTrackedSuccess.current || !shouldSendTrackingEvent) {
+      return;
     }
-  }, [isSuccess, trackEvent]);
+
+    hasTrackedSuccess.current = true;
+
+    trackEvent({
+      category: TrackingCategory.Wallet,
+      action: TrackingAction.PortfolioLoaded,
+      label: 'portfolio_balance_loaded',
+      data: {
+        [TrackingEventParameter.Status]: 'success',
+        [TrackingEventParameter.Timestamp]: new Date().toUTCString(),
+      },
+    });
+  }, [shouldSendTrackingEvent, trackEvent]);
+
+  useEffect(() => {
+    if (hasTrackedPortfolioOverview.current || !shouldSendTrackingEvent) {
+      return;
+    }
+
+    hasTrackedPortfolioOverview.current = true;
+
+    const { totalValue: totalBalanceUSD } = getFormattedCacheTokens(accounts);
+
+    const returnNativeTokenAddresses = (chainsIds: ChainId[]) =>
+      chainsIds.map(
+        (chainId) => getChainById(chainId)?.nativeToken?.address ?? zeroAddress,
+      );
+
+    const trackingData = parsePortfolioDataToTrackingData(
+      totalBalanceUSD,
+      data,
+      returnNativeTokenAddresses,
+    );
+
+    trackEvent({
+      category: TrackingCategory.WalletMenu,
+      action: TrackingAction.PortfolioOverview,
+      label: 'portfolio_balance_overview',
+      enableAddressable: true,
+      data: trackingData,
+    });
+  }, [
+    shouldSendTrackingEvent,
+    accounts,
+    JSON.stringify(data),
+    getFormattedCacheTokens,
+    getChainById,
+    trackEvent,
+  ]);
 
   // Reset the tracking flag when accounts change
   useEffect(() => {
     hasTrackedSuccess.current = false;
+    hasTrackedPortfolioOverview.current = false;
   }, [accounts]);
 
   return {
@@ -103,9 +157,6 @@ export function usePortfolioTokens() {
     isSuccess,
     isFetching,
     refetch,
-    data:
-      getFormattedCacheTokens(accounts).cache.length === 0
-        ? queries.map((query) => query.data ?? []).flat()
-        : getFormattedCacheTokens(accounts).cache,
+    data,
   };
 }

--- a/src/utils/tracking/portfolio.ts
+++ b/src/utils/tracking/portfolio.ts
@@ -1,0 +1,63 @@
+import { ChainId } from '@lifi/widget';
+import { TrackingEventParameter } from 'src/const/trackingKeys';
+import { CacheToken } from 'src/types/portfolio';
+
+const FLEXIBLE_STABLE_COINS_REGEX =
+  /^.*(USD|EUR|XAU|YEN|IDR|CHF|CAD|CNH|MXN).*$/;
+
+const FIXED_STABLE_COINS_REGEX =
+  /^(DAI|GHO|MNEE|AMPL|FEI|DJED|VAI|FLX|STDN|ESD|BAC|BUCK|DOLA|BRZ|QGOLD|MIM|FXD|ZARP|EDLC|ONC|MTR|MIMATIC|BLC|JPYC|SBC|KBC|TRYB|PAR|ISR|GYD|UXD)$/;
+
+export const parsePortfolioDataToTrackingData = (
+  portfolioTotalBalanceUSD: number,
+  tokens: CacheToken[],
+  getNativeTokenAddresses: (chainIds: ChainId[]) => string[],
+) => {
+  const numberOfTokens = tokens.length;
+
+  // Single pass to collect all data
+  const chainIds = new Set<ChainId>();
+  const portfolioNativeTokensAddresses = new Set<string>();
+  let nativeTokensBalanceUSD = 0;
+  let stableTokensBalanceUSD = 0;
+  let otherTokensBalanceUSD = 0;
+
+  for (const token of tokens) {
+    for (const chain of token.chains) {
+      chainIds.add(chain.chainId);
+    }
+  }
+
+  const nativeTokenAddresses = getNativeTokenAddresses(Array.from(chainIds));
+  nativeTokenAddresses.forEach((addr) =>
+    portfolioNativeTokensAddresses.add(addr),
+  );
+
+  for (const token of tokens) {
+    const balance = token.cumulatedTotalUSD ?? 0;
+
+    if (portfolioNativeTokensAddresses.has(token.address ?? '')) {
+      nativeTokensBalanceUSD += balance;
+    } else if (
+      FIXED_STABLE_COINS_REGEX.test(token.symbol) ||
+      FLEXIBLE_STABLE_COINS_REGEX.test(token.symbol)
+    ) {
+      stableTokensBalanceUSD += balance;
+    } else {
+      otherTokensBalanceUSD += balance;
+    }
+  }
+
+  return {
+    [TrackingEventParameter.PortfolioTotalBalanceUSD]:
+      portfolioTotalBalanceUSD.toFixed(2),
+    [TrackingEventParameter.PortfolioNumberOfTokens]: numberOfTokens,
+    [TrackingEventParameter.PortfolioNumberOfChains]: chainIds.size,
+    [TrackingEventParameter.PortfolioNativeTokensBalanceUSD]:
+      nativeTokensBalanceUSD.toFixed(2),
+    [TrackingEventParameter.PortfolioStableTokensBalanceUSD]:
+      stableTokensBalanceUSD.toFixed(2),
+    [TrackingEventParameter.PortfolioOtherTokensBalanceUSD]:
+      otherTokensBalanceUSD.toFixed(2),
+  };
+};


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-15412

## Overview
Added the new posthog event and refactored the code to send the events having `action_portfolio_balance_overview` and `action_portfolio_loaded` actions only once when the balance has finished loading

## Testing steps

1. Open wallet menu
<img width="1110" height="895" alt="Screenshot 2025-09-17 at 15 41 23" src="https://github.com/user-attachments/assets/40ed6763-89cf-43dd-82d7-b1030367b8a1" />

2. Wait for the balance to finish loading
3. Open network tab and filter for `events`
4. Last send event should have action `action_portfolio_balance_overview`
<img width="783" height="443" alt="Screenshot 2025-09-17 at 15 42 04" src="https://github.com/user-attachments/assets/3ccb287a-4739-4c11-af68-8b7963048dbc" />

5. Close and re-open the wallet menu and check no extra event having this action has been sent
6. Regression test the event having the action `action_portfolio_loaded`
