### PR TITLE
fix: migrate configs to zap be widget

### DIFF
--- a/src/components/Widgets/variants/base/ZapWidget/hooks.ts
+++ b/src/components/Widgets/variants/base/ZapWidget/hooks.ts
@@ -1,0 +1,31 @@
+import { ChainType } from '@lifi/sdk';
+import { Account, useAccount } from '@lifi/wallet-management';
+import { useEffect, useState } from 'react';
+import { useMultisig } from 'src/hooks/useMultisig';
+import { checkIsEmbeddedWallet } from 'src/utils/wallets/checkIsEmbeddedWallet';
+
+export const useShowZapPlaceholderWidget = (account: Account) => {
+  const { checkMultisigEnvironment } = useMultisig();
+  const [isMultisigEnvironment, setIsMultisigEnvironment] = useState(false);
+  const [isEmbeddedWallet, setIsEmbeddedWallet] = useState(false);
+
+  useEffect(() => {
+    const checkEnvironment = async () => {
+      const _isMultisigEnvironment = await checkMultisigEnvironment();
+      setIsMultisigEnvironment(_isMultisigEnvironment);
+    };
+
+    checkEnvironment();
+  }, [checkMultisigEnvironment]);
+
+  useEffect(() => {
+    const checkEmbeddedWallet = async () => {
+      const _isEmbeddedWallet = checkIsEmbeddedWallet(account);
+      setIsEmbeddedWallet(_isEmbeddedWallet);
+    };
+
+    checkEmbeddedWallet();
+  }, [account]);
+
+  return isMultisigEnvironment || isEmbeddedWallet;
+};

--- a/src/utils/wallets/checkIsEmbeddedWallet.ts
+++ b/src/utils/wallets/checkIsEmbeddedWallet.ts
@@ -1,0 +1,44 @@
+import { Account } from '@lifi/wallet-management';
+
+const EMBEDDED_WALLETS = [
+  'magic',
+  'privy',
+  'dynamic',
+  'thirdweb',
+  'particle',
+  'web3auth',
+  'fireblocks',
+  'fortmatic',
+  'torus',
+  'capsule',
+  'turnkey',
+  'dfns',
+];
+
+export const checkIsEmbeddedWallet = (account: Account) => {
+  if (!account?.connector) return false;
+
+  const connector = account.connector as any;
+
+  // Check explicit flags first
+  if (
+    connector.isEmbedded === true ||
+    connector.custodial === true ||
+    connector.options?.isEmbedded === true
+  ) {
+    return true;
+  }
+
+  // If explicitly injected, it's external
+  if (connector.isInjected === true || connector.type === 'injected') {
+    return false;
+  }
+
+  // Check by wallet name/id
+  const name = (connector.name || '').toLowerCase();
+  const id = (connector.id || '').toLowerCase();
+
+  return EMBEDDED_WALLETS.some(
+    (wallet) => name.includes(wallet) || id.includes(wallet),
+  );
+};


### PR DESCRIPTION
Fixes: https://www.notion.so/lifi/DEVELOP-No-error-is-shown-when-non-evm-wallet-is-connected-271f0ff14ac7801bacf5cf2a0771a99b

+ adds support modal back when clicking on contact support