### PR TITLE
fix: zap withdraw widget styling + prevent form submission on empty value

### DIFF
--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -1,7 +1,7 @@
 'use client';
 import type { ButtonProps as MuiButtonProps } from '@mui/material';
-import { Button as MuiButton, alpha } from '@mui/material'; //ButtonProps
-import { styled } from '@mui/material/styles';
+import { alpha, styled } from '@mui/material/styles';
+import MuiButton, { buttonClasses } from '@mui/material/Button';
 
 const ButtonBase = styled(MuiButton)<MuiButtonProps>(({ theme }) => ({
   borderRadius: '24px',
@@ -32,6 +32,22 @@ export const ButtonSecondary = styled(ButtonBase)(({ theme }) => ({
   backgroundColor: (theme.vars || theme).palette.bgQuaternary.main,
   '&:hover': {
     backgroundColor: (theme.vars || theme).palette.bgQuaternary.hover,
+  },
+}));
+
+export const ButtonTertiary = styled(MuiButton)(({ theme }) => ({
+  height: 40,
+  fontSize: 14,
+  color: theme.vars.palette.text.primary,
+  backgroundColor: (theme.vars || theme).palette.alpha100.main,
+  '&:hover, &:active': {
+    backgroundColor: (theme.vars || theme).palette.alpha200.main,
+  },
+  [`&.${buttonClasses.loading}:disabled`]: {
+    backgroundColor: (theme.vars || theme).palette.alpha100.main,
+  },
+  [`.${buttonClasses.loadingIndicator}`]: {
+    color: (theme.vars || theme).palette.text.primary,
   },
 }));
 

--- a/src/components/Cards/SelectCard/SelectCard.styles.ts
+++ b/src/components/Cards/SelectCard/SelectCard.styles.ts
@@ -1,9 +1,9 @@
 import Box, { BoxProps } from '@mui/material/Box';
+import Card from '@mui/material/Card';
 import InputBase, { InputBaseProps } from '@mui/material/InputBase';
 import InputLabel from '@mui/material/InputLabel';
 import Typography from '@mui/material/Typography';
 import { styled, Theme } from '@mui/material/styles';
-import { fontSize, fontWeight } from '@mui/system';
 
 export enum SelectCardMode {
   Display = 'display',
@@ -14,13 +14,14 @@ interface SelectCardContainerProps extends BoxProps {
   isClickable?: boolean;
 }
 
-export const SelectCardContainer = styled(Box, {
+export const SelectCardContainer = styled(Card, {
   shouldForwardProp: (prop) => prop !== 'isClickable',
 })<SelectCardContainerProps>(({ theme, isClickable }) => ({
   borderRadius: theme.shape.borderRadius,
   boxShadow: theme.shadows[2],
   background: (theme.vars || theme).palette.surface2.main,
   padding: theme.spacing(2),
+  position: 'relative',
   display: 'flex',
   flexDirection: 'column',
   gap: theme.spacing(1),
@@ -48,10 +49,7 @@ export const SelectCardLabel = styled(InputLabel)(({ theme }) => ({
 }));
 
 export const SelectCardDescription = styled(Typography)(({ theme }) => ({
-  color: (theme.vars || theme).palette.alphaLight800.main,
-  ...theme.applyStyles('light', {
-    color: (theme.vars || theme).palette.alphaDark800.main,
-  }),
+  color: (theme.vars || theme).palette.alpha800.main,
 }));
 
 export const getPlaceholderTextStyles = (theme: Theme) => ({

--- a/src/components/Cards/SelectCard/SelectCard.types.ts
+++ b/src/components/Cards/SelectCard/SelectCard.types.ts
@@ -5,7 +5,7 @@ export interface SelectCardBaseProps {
   label?: string;
   value?: string;
   placeholder: string;
-  description?: string;
+  description?: ReactNode;
   startAdornment?: ReactNode;
   endAdornment?: ReactNode;
   mode: SelectCardMode;

--- a/src/components/Cards/SelectCard/mode/SelectCardDisplay.tsx
+++ b/src/components/Cards/SelectCard/mode/SelectCardDisplay.tsx
@@ -27,11 +27,14 @@ export const SelectCardDisplay: FC<SelectCardDisplayProps> = ({
           <SelectCardDisplayValue showPlaceholder={!!placeholder && !value}>
             {value ?? placeholder}
           </SelectCardDisplayValue>
-          {description && (
-            <SelectCardDescription variant="bodyXSmall">
-              {description}
-            </SelectCardDescription>
-          )}
+          {description &&
+            (typeof description === 'string' ? (
+              <SelectCardDescription variant="bodyXSmall">
+                {description}
+              </SelectCardDescription>
+            ) : (
+              description
+            ))}
         </SelectCardValueContainer>
         {endAdornment}
       </SelectCardContentContainer>

--- a/src/components/Cards/SelectCard/mode/SelectCardInput.tsx
+++ b/src/components/Cards/SelectCard/mode/SelectCardInput.tsx
@@ -42,11 +42,14 @@ export const SelectCardInput: FC<SelectCardInputProps> = ({
             onFocus={onFocus}
             isAmount={isAmount}
           />
-          {description && (
-            <SelectCardDescription variant="bodyXSmall">
-              {description}
-            </SelectCardDescription>
-          )}
+          {description &&
+            (typeof description === 'string' ? (
+              <SelectCardDescription variant="bodyXSmall">
+                {description}
+              </SelectCardDescription>
+            ) : (
+              description
+            ))}
         </SelectCardValueContainer>
         {endAdornment}
       </SelectCardContentContainer>

--- a/src/components/Zap/ZapWidgetStack.tsx
+++ b/src/components/Zap/ZapWidgetStack.tsx
@@ -101,7 +101,12 @@ export const ZapWidgetStack: FC<ZapWidgetStackProps> = ({
               </ClientOnly>
             )}
             sx={{
-              mb: 3
+              mb: 3,
+              width: '100%',
+              '&.MuiTabs-root .MuiTab-root': {
+                width: '100%',
+                maxWidth: '100%',
+              },
             }}
           />
         </Box>

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawForm.tsx
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawForm.tsx
@@ -1,6 +1,6 @@
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { WithdrawFormContainer } from './WithdrawWidget.style';
-import { AbiParameter, parseUnits } from 'viem';
+import { AbiParameter, formatUnits, parseUnits } from 'viem';
 import { Button } from 'src/components/Button/Button';
 import { ConnectButton } from 'src/components/ConnectButton';
 import {
@@ -23,6 +23,7 @@ export const WithdrawForm: FC<WithdrawFormProps> = ({
   errorMessage,
   projectData,
   balance,
+  lpTokenDecimals,
   token,
   poolName,
   overrideStyle,
@@ -37,6 +38,14 @@ export const WithdrawForm: FC<WithdrawFormProps> = ({
   const { switchChainAsync } = useSwitchChain();
   const { token: tokenInfo } = useToken(token.chainId, token.address);
 
+  const maxFormattedAmount = useMemo(() => {
+    return parseFloat(formatUnits(BigInt(balance), lpTokenDecimals));
+  }, [balance, lpTokenDecimals]);
+
+  const maxAmount = useMemo(() => {
+    return BigInt(balance);
+  }, [balance]);
+
   const helperText = useMemo(
     () => ({
       left: 'Available balance',
@@ -44,6 +53,18 @@ export const WithdrawForm: FC<WithdrawFormProps> = ({
     }),
     [balance],
   );
+
+  const hintEndAdornment = useMemo(() => {
+    return (
+      `/ ` +
+      Intl.NumberFormat('en-US', {
+        notation: 'compact',
+        useGrouping: true,
+        minimumFractionDigits: 0,
+        maximumFractionDigits: maxFormattedAmount > 1 ? 1 : 4,
+      }).format(maxFormattedAmount)
+    );
+  }, [maxFormattedAmount]);
 
   const shouldSwitchChain = useMemo(() => {
     if (!!projectData?.address && account?.chainId !== projectData?.chainId) {
@@ -92,7 +113,7 @@ export const WithdrawForm: FC<WithdrawFormProps> = ({
       <WithdrawInput
         name="withdrawValue"
         placeholder="0"
-        label={`Redeem from ${poolName || 'Pool'}`}
+        label={`Withdraw from ${poolName || 'Pool'}`}
         errorMessage={errorMessage}
         priceUSD={tokenInfo?.priceUSD}
         endAdornment={
@@ -100,15 +121,16 @@ export const WithdrawForm: FC<WithdrawFormProps> = ({
           !!balance &&
           parseFloat(balance) > 0 && (
             <WithdrawInputEndAdornment
-              balance={balance}
               mainColor={overrideStyle?.mainColor}
               setValue={setValue}
+              maxAmount={maxAmount}
+              decimals={lpTokenDecimals}
             />
           )
         }
         value={value}
         onSetValue={setValue}
-        maxValue={balance}
+        maxValue={maxFormattedAmount.toString()}
         startAdornment={
           token?.logoURI && (
             <BadgeWithChain
@@ -118,6 +140,7 @@ export const WithdrawForm: FC<WithdrawFormProps> = ({
             />
           )
         }
+        hintEndAdornment={hintEndAdornment}
       />
       {!account?.isConnected ? (
         <ConnectButton sx={(theme) => ({ marginTop: theme.spacing(2) })} />

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawForm.tsx
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawForm.tsx
@@ -16,6 +16,12 @@ import { useUserTracking } from 'src/hooks/userTracking/useUserTracking';
 import { TrackingCategory } from 'src/const/trackingKeys';
 import WithdrawInputEndAdornment from './WithdrawInputEndAdornment';
 import { WithdrawFormProps } from './WithdrawWidget.types';
+import { Theme } from '@mui/material/styles';
+
+const buttonStyles = (theme: Theme) => ({
+  marginTop: theme.spacing(2),
+  '&:hover': { boxShadow: 'none' },
+});
 
 export const WithdrawForm: FC<WithdrawFormProps> = ({
   sendWithdrawTx,
@@ -146,10 +152,10 @@ export const WithdrawForm: FC<WithdrawFormProps> = ({
         hintEndAdornment={hintEndAdornment}
       />
       {!account?.isConnected ? (
-        <ConnectButton sx={(theme) => ({ marginTop: theme.spacing(2) })} />
+        <ConnectButton sx={buttonStyles} />
       ) : shouldSwitchChain ? (
         <Button
-          styles={(theme) => ({ marginTop: theme.spacing(2) })}
+          styles={buttonStyles}
           muiVariant="contained"
           onClick={() => handleSwitchChain(projectData?.chainId)}
         >
@@ -161,7 +167,7 @@ export const WithdrawForm: FC<WithdrawFormProps> = ({
           loading={isSubmitLoading}
           disabled={balance === '0' || isSubmitDisabled}
           muiVariant="contained"
-          styles={(theme) => ({ marginTop: theme.spacing(2) })}
+          styles={buttonStyles}
         >
           {submitLabel}
         </Button>

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawForm.tsx
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawForm.tsx
@@ -98,6 +98,9 @@ export const WithdrawForm: FC<WithdrawFormProps> = ({
   const handleSubmit = useCallback(
     (event: React.FormEvent) => {
       event.preventDefault();
+      if (!value) {
+        return;
+      }
       try {
         updateSuccessDataRef();
         sendWithdrawTx(value);

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawInput.tsx
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawInput.tsx
@@ -3,8 +3,13 @@ import InputLabel from '@mui/material/InputLabel';
 import Typography from '@mui/material/Typography';
 import { FC, useMemo, ReactNode } from 'react';
 import { SelectCard } from 'src/components/Cards/SelectCard/SelectCard';
-import { SelectCardMode } from 'src/components/Cards/SelectCard/SelectCard.styles';
+import {
+  SelectCardDescription,
+  SelectCardMode,
+} from 'src/components/Cards/SelectCard/SelectCard.styles';
 import { WidgetFormHelperText } from './WithdrawWidget.style';
+import { currencyFormatter } from 'src/utils/formatNumbers';
+import Box from '@mui/material/Box';
 
 interface WithdrawInputProps {
   label?: string;
@@ -17,6 +22,7 @@ interface WithdrawInputProps {
   maxValue?: string;
   startAdornment?: ReactNode;
   endAdornment?: ReactNode;
+  hintEndAdornment?: string;
 }
 
 const NUM_DECIMALS = 1;
@@ -32,6 +38,7 @@ export const WithdrawInput: FC<WithdrawInputProps> = ({
   maxValue,
   startAdornment,
   endAdornment,
+  hintEndAdornment,
 }) => {
   const formattedErrorMessage = useMemo(() => {
     if (maxValue && (parseFloat(value) ?? 0) > parseFloat(maxValue)) {
@@ -54,14 +61,13 @@ export const WithdrawInput: FC<WithdrawInputProps> = ({
 
   const hint = useMemo(() => {
     return valueUSD
-      ? Intl.NumberFormat('en-US', {
-          style: 'currency',
+      ? currencyFormatter('en-US', {
           notation: 'compact',
           currency: 'USD',
           useGrouping: true,
           minimumFractionDigits: 2,
           maximumFractionDigits: parseFloat(valueUSD) > 2 ? 2 : 4,
-        }).format(parseFloat(valueUSD))
+        })(parseFloat(valueUSD))
       : 'NA';
   }, [valueUSD]);
 
@@ -84,6 +90,7 @@ export const WithdrawInput: FC<WithdrawInputProps> = ({
           variant="titleSmall"
           sx={(theme) => ({
             color: (theme.vars || theme).palette.text.primary,
+            whiteSpace: 'break-spaces',
           })}
         >
           {label}
@@ -96,7 +103,24 @@ export const WithdrawInput: FC<WithdrawInputProps> = ({
         mode={SelectCardMode.Input}
         placeholder={placeholder}
         value={value}
-        description={hint}
+        label="Amount"
+        description={
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              gap: 1,
+            }}
+          >
+            <SelectCardDescription variant="bodyXSmall">
+              {hint}
+            </SelectCardDescription>
+            <SelectCardDescription variant="bodyXSmall">
+              {hintEndAdornment}
+            </SelectCardDescription>
+          </Box>
+        }
         startAdornment={startAdornment}
         endAdornment={endAdornment}
         onChange={handleInputChange}

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawInputEndAdornment.tsx
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawInputEndAdornment.tsx
@@ -1,43 +1,54 @@
 import Box from '@mui/material/Box';
-import { MaxButton, MaxValue } from './WithdrawWidget.style';
-import type { Dispatch, SetStateAction } from 'react';
+import { ButtonContainer, MaxButton } from './WithdrawWidget.style';
+import { useMemo, type Dispatch, type SetStateAction } from 'react';
+import { formatUnits } from 'viem';
 
 interface WithdrawInputEndAdornmentProps {
-  balance: string;
   mainColor?: string;
   setValue: Dispatch<SetStateAction<string>>;
+  decimals: number;
+  maxAmount: bigint;
 }
 
 function WithdrawInputEndAdornment({
-  balance,
   mainColor,
   setValue,
+  decimals,
+  maxAmount,
 }: WithdrawInputEndAdornmentProps) {
+  const handlePercentage = (percentage: number) => {
+    if (maxAmount && decimals) {
+      const percentageAmount = (maxAmount * BigInt(percentage)) / 100n;
+      setValue(formatUnits(percentageAmount, decimals));
+    }
+  };
+
+  const handleMax = () => {
+    if (maxAmount && decimals) {
+      setValue(formatUnits(maxAmount, decimals));
+    }
+  };
+
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 0.75,
         mt: 'auto',
       }}
     >
-      <MaxButton
-        aria-label="menu"
-        mainColor={mainColor}
-        onClick={() => setValue(balance ?? '0')}
-      >
-        max
-      </MaxButton>
-      <MaxValue variant="bodyXSmall" color="textSecondary">
-        /{' '}
-        {Intl.NumberFormat('en-US', {
-          notation: 'compact',
-          useGrouping: true,
-          minimumFractionDigits: 0,
-          maximumFractionDigits: parseFloat(balance) > 1 ? 1 : 4,
-        }).format(parseFloat(balance))}
-      </MaxValue>
+      <ButtonContainer>
+        <MaxButton onClick={() => handlePercentage(25)} data-delay="0">
+          25%
+        </MaxButton>
+        <MaxButton onClick={() => handlePercentage(50)} data-delay="1">
+          50%
+        </MaxButton>
+        <MaxButton onClick={() => handlePercentage(75)} data-delay="2">
+          75%
+        </MaxButton>
+        <MaxButton onClick={handleMax} data-delay="3">
+          max
+        </MaxButton>
+      </ButtonContainer>
     </Box>
   );
 }

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.style.ts
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.style.ts
@@ -1,51 +1,18 @@
 import Box from '@mui/material/Box';
-import Button, { ButtonProps } from '@mui/material/Button';
 import FormHelperText from '@mui/material/FormHelperText';
-import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material/styles';
+import { cardClasses } from '@mui/material/Card';
+import { ButtonTertiary } from 'src/components/Button';
 
-export const WithdrawWidgetBox = styled(Box)(({ theme }) => ({
+export const WithdrawWidgetBox = styled(Box)(() => ({
   display: 'flex',
   flexGrow: 1,
   flexDirection: 'column',
-  gap: '16px',
-  [theme.breakpoints.up('md')]: {
-    minWidth: 416,
-    maxWidth: 'unset',
-  },
 }));
 
-export const WithdrawFormContainer = styled(Box)(({ theme }) => ({
+export const WithdrawFormContainer = styled(Box)(() => ({
   display: 'flex',
   flexDirection: 'column',
-  padding: theme.spacing(3),
-}));
-
-interface MaxButtonProps extends ButtonProps {
-  mainColor?: string;
-}
-
-export const MaxButton = styled(Button, {
-  shouldForwardProp: (prop) => prop !== 'mainColor',
-})<MaxButtonProps>(({ theme, mainColor }) => ({
-  ...theme.typography.bodySmallStrong,
-  fontWeight: 600,
-  padding: theme.spacing(0.5, 1),
-  minWidth: 'unset',
-  height: 'auto',
-  color: (theme.vars || theme).palette.text.primary,
-  backgroundColor: mainColor ?? (theme.vars || theme).palette.bgQuaternary.main,
-  '&:hover': {
-    backgroundColor:
-      mainColor ?? (theme.vars || theme).palette.bgQuaternary.hover,
-  },
-  ...theme.applyStyles('light', {
-    color: (theme.vars || theme).palette.primary.main,
-  }),
-}));
-
-export const MaxValue = styled(Typography)(({ theme }) => ({
-  textAlign: 'right',
 }));
 
 export const WidgetFormHelperText = styled(FormHelperText)(({ theme }) => ({
@@ -59,5 +26,77 @@ export const WidgetFormHelperText = styled(FormHelperText)(({ theme }) => ({
   },
   [theme.breakpoints.up('md')]: {
     maxWidth: '100%',
+  },
+}));
+
+export const ButtonContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  gap: theme.spacing(0.5),
+  position: 'absolute',
+  top: theme.spacing(2),
+  right: theme.spacing(2),
+  zIndex: theme.zIndex.drawer,
+}));
+
+export const MaxButton = styled(ButtonTertiary)(({ theme }) => ({
+  padding: theme.spacing(0.5, 1, 0.5, 1),
+  margin: theme.spacing(0, 0, 0, 0.5),
+  lineHeight: 1,
+  fontSize: theme.typography.bodyXSmall.fontSize,
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  minWidth: 'unset',
+  height: 24,
+  opacity: 0,
+  transform: 'scale(0.85) translateY(-10px)',
+  transition:
+    'opacity 200ms cubic-bezier(0.4, 0, 0.2, 1), transform 200ms cubic-bezier(0.4, 0, 0.2, 1)',
+  '&[data-delay="0"]': {
+    [`.${cardClasses.root}:hover &`]: {
+      opacity: 1,
+      transform: 'scale(1) translateY(0)',
+      transitionDelay: '75ms',
+    },
+    [`.${cardClasses.root}:not(:hover) &`]: {
+      opacity: 0,
+      transform: 'scale(0.85) translateY(-10px)',
+      transitionDelay: '0ms',
+    },
+  },
+  '&[data-delay="1"]': {
+    [`.${cardClasses.root}:hover &`]: {
+      opacity: 1,
+      transform: 'scale(1) translateY(0)',
+      transitionDelay: '50ms',
+    },
+    [`.${cardClasses.root}:not(:hover) &`]: {
+      opacity: 0,
+      transform: 'scale(0.85) translateY(-10px)',
+      transitionDelay: '25ms',
+    },
+  },
+  '&[data-delay="2"]': {
+    [`.${cardClasses.root}:hover &`]: {
+      opacity: 1,
+      transform: 'scale(1) translateY(0)',
+      transitionDelay: '25ms',
+    },
+    [`.${cardClasses.root}:not(:hover) &`]: {
+      opacity: 0,
+      transform: 'scale(0.85) translateY(-10px)',
+      transitionDelay: '50ms',
+    },
+  },
+  '&[data-delay="3"]': {
+    [`.${cardClasses.root}:hover &`]: {
+      opacity: 1,
+      transform: 'scale(1) translateY(0)',
+      transitionDelay: '0ms',
+    },
+    [`.${cardClasses.root}:not(:hover) &`]: {
+      opacity: 0,
+      transform: 'scale(0.85) translateY(-10px)',
+      transitionDelay: '75ms',
+    },
   },
 }));

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.tsx
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.tsx
@@ -9,6 +9,7 @@ import { useAccount } from '@lifi/wallet-management';
 import { useChains } from 'src/hooks/useChains';
 import { useMemo } from 'react';
 import { TxConfirmation } from '../TxConfirmation/TxConfirmation';
+import { SectionCardContainer } from 'src/components/Cards/SectionCard/SectionCard.style';
 
 export interface WithdrawWidgetProps {
   poolName?: string;
@@ -54,42 +55,43 @@ export const WithdrawWidget: React.FC<WithdrawWidgetProps> = ({
   });
 
   return (
-    <WithdrawWidgetBox>
-      <WithdrawForm
-        submitLabel={'Redeem'} // This belongs to contractCalls[0].label
-        errorMessage={txError?.name}
-        sendWithdrawTx={sendWithdrawTx}
-        successDataRef={successDataRef}
-        isSubmitDisabled={isWriteContractDataPending}
-        isSubmitLoading={
-          isTransactionReceiptLoading || isWriteContractDataPending
-        }
-        refetchPosition={refetchPosition}
-        projectData={projectData}
-        token={token}
-        poolName={poolName}
-        balance={
-          depositTokenData
-            ? formatUnits(BigInt(depositTokenData), lpTokenDecimals)
-            : '0.00'
-        }
-      />
-
-      {isTransactionReceiptSuccess && (
-        <TxConfirmation
-          description={'Withdraw successful'}
-          link={`${chain?.metamask.blockExplorerUrls?.[0] ?? 'https://etherscan.io/'}tx/${txHash}`}
-          success={!!isWriteContractDataSuccess && !isWriteContractDataPending}
+    <SectionCardContainer>
+      <WithdrawWidgetBox>
+        <WithdrawForm
+          submitLabel={'Redeem'} // This belongs to contractCalls[0].label
+          errorMessage={txError?.name}
+          sendWithdrawTx={sendWithdrawTx}
+          successDataRef={successDataRef}
+          isSubmitDisabled={isWriteContractDataPending}
+          isSubmitLoading={
+            isTransactionReceiptLoading || isWriteContractDataPending
+          }
+          refetchPosition={refetchPosition}
+          projectData={projectData}
+          token={token}
+          poolName={poolName}
+          balance={depositTokenData?.toString() ?? '0'}
+          lpTokenDecimals={lpTokenDecimals}
         />
-      )}
 
-      {!isTransactionReceiptSuccess && txHash && (
-        <TxConfirmation
-          description={'Check on explorer'}
-          link={`${chain?.metamask.blockExplorerUrls?.[0] ?? 'https://etherscan.io/'}tx/${txHash}`}
-          success={false}
-        />
-      )}
-    </WithdrawWidgetBox>
+        {isTransactionReceiptSuccess && (
+          <TxConfirmation
+            description={'Withdraw successful'}
+            link={`${chain?.metamask.blockExplorerUrls?.[0] ?? 'https://etherscan.io/'}tx/${txHash}`}
+            success={
+              !!isWriteContractDataSuccess && !isWriteContractDataPending
+            }
+          />
+        )}
+
+        {!isTransactionReceiptSuccess && txHash && (
+          <TxConfirmation
+            description={'Check on explorer'}
+            link={`${chain?.metamask.blockExplorerUrls?.[0] ?? 'https://etherscan.io/'}tx/${txHash}`}
+            success={false}
+          />
+        )}
+      </WithdrawWidgetBox>
+    </SectionCardContainer>
   );
 };

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.types.ts
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.types.ts
@@ -41,4 +41,5 @@ export interface WithdrawFormProps {
   isSubmitDisabled?: boolean;
   isSubmitLoading?: boolean;
   submitLabel?: string;
+  lpTokenDecimals: number;
 }


### PR DESCRIPTION
Issues tackled:

- Prevent form submission if value is empty: https://www.notion.so/lifi/DEVELOP-Redeem-button-is-not-disabled-when-amount-field-is-0-271f0ff14ac7804ab03eff79c1e7b23e
- Max button for which I actually used the same styling/logic as for the widget https://www.notion.so/lifi/DEVELOP-Max-amount-is-splitted-into-two-rows-on-Withdraw-tab-271f0ff14ac7800ea923e44a804b0bd1
- Set the horizontal tabs to full column width