### PR TITLE
fix: rich block not rendering links

### DIFF
--- a/src/components/RichBlocks/renderers/HtmlRenderer.tsx
+++ b/src/components/RichBlocks/renderers/HtmlRenderer.tsx
@@ -17,6 +17,7 @@ export const HtmlRenderer: FC<HtmlRendererProps> = ({
     strikethrough={strikethrough}
     underline={underline}
     bold={bold}
+    as="div"
   >
     {parse(text)}
   </Paragraph>

--- a/src/components/RichBlocks/renderers/ParagraphRenderer.tsx
+++ b/src/components/RichBlocks/renderers/ParagraphRenderer.tsx
@@ -11,11 +11,11 @@ interface ParagraphRendererProps {
 export const ParagraphRenderer: FC<ParagraphRendererProps> = ({ element }) => {
   const { props } = element;
 
-  if (!props.text) return null;
-
   if (props.content?.type === 'link') {
     return <LinkRenderer content={props.content} />;
   }
+
+  if (!props.text) return null;
 
   if (props.text.includes('<') && props.text.includes('>')) {
     return <HtmlRenderer {...props} />;


### PR DESCRIPTION
## Testing steps

1. Please head to `/missions/test123`
2. Now time to check the card description
<img width="606" height="598" alt="Screenshot 2025-09-17 at 21 27 24" src="https://github.com/user-attachments/assets/c3c45865-73de-4c8f-8260-f2c860817dc9" />

3. Check the link is properly rendered
4. Also check there are no errors in the console due to the `h1` being rendered - previosuly there was an error thrown due to having a `<h1>` nested inside a `<p>` which is invalid html structure
