### PR TITLE
fix: routes not queried after initial route selection

### DIFF
--- a/src/components/Widgets/variants/base/ZapWidget/ZapDepositBackendWidget.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapDepositBackendWidget.tsx
@@ -26,6 +26,7 @@ import uniqBy from 'lodash/uniqBy';
 import { useZapAllLpTokens } from 'src/hooks/zaps/useZapAllLpTokens';
 import { ZapPlaceholderWidget } from './ZapPlaceholderWidget';
 import { useShowZapPlaceholderWidget } from './hooks';
+import { ZapDepositSettings } from './ZapDepositSettings';
 
 interface ZapDepositBackendWidgetProps extends WidgetProps {}
 
@@ -164,29 +165,6 @@ export const ZapDepositBackendWidget: FC<ZapDepositBackendWidgetProps> = ({
   }, [sourceChainToken, allowedChains]);
 
   useEffect(() => {
-    if (!formRef.current) {
-      return;
-    }
-
-    if (toChain) {
-      formRef.current?.setFieldValue('toChain', toChain, {
-        setUrlSearchParam: true,
-      });
-    }
-
-    if (toToken) {
-      formRef.current?.setFieldValue('toToken', toToken, {
-        setUrlSearchParam: true,
-      });
-    }
-
-    // @Note: Since we now use formRef to set/reset values, we no longer need ZapDepositSettings
-    // which relies on setFieldValue. However, contractCalls still needs to be set either through
-    // this method or setFieldValue - any other approach will prevent routes from being fetched.
-    formRef.current?.setFieldValue('contractCalls' as any, []);
-  }, [toChain, toToken]);
-
-  useEffect(() => {
     setDestinationChainTokenForTracking({
       chainId: toChain,
       tokenAddress: toToken,
@@ -261,8 +239,15 @@ export const ZapDepositBackendWidget: FC<ZapDepositBackendWidgetProps> = ({
       formRef={formRef}
       config={widgetConfig}
       integrator={widgetConfig.integrator}
+      contractComponent={
+        <ZapDepositSettings
+          toChain={toChain}
+          toToken={toToken}
+          contractCalls={[]}
+        />
+      }
     />
   ) : (
-    <WidgetSkeleton />
+    <WidgetSkeleton config={widgetConfig} />
   );
 };


### PR DESCRIPTION
After some more testing discovered that after selecting a route for zap execution, when going back to execute another route, no routes were fetched anymore. This is likely due to some fields clearing for `toToken`/`toChain`/`contractCalls`, so put back in place the `ZapDepositSettings`.

## Testing steps
1. Go to `/zap/morpho-katana-usdc-ioana`
2. Select a token
3. Enter an amount
4. Try to deposit, but no need to go through with the tx, so you can reject the signature
5. Go back to the token selection screen
6. Repeat steps `2-4` and make sure a route shows up or at least the call for routes is triggered
