### PR TITLE
chore: include lifi error code key to tx tracking

### DIFF
--- a/src/const/trackingKeys.ts
+++ b/src/const/trackingKeys.ts
@@ -207,6 +207,7 @@ export enum TrackingEventParameter {
   // Transaction:
   Action = 'param_action',
   ErrorCode = 'param_error_code',
+  ErrorCodeKey = 'param_error_code_key',
   ErrorMessage = 'param_error_message',
   FeeCost = 'param_fee_cost',
   FeeCostFormatted = 'param_fee_cost_formatted',

--- a/src/hooks/useJumperTracking.ts
+++ b/src/hooks/useJumperTracking.ts
@@ -53,6 +53,7 @@ export interface JumperDataTrackTransactionProps {
   action: string;
   browserFingerprint: string;
   errorCode?: string | number;
+  errorCodeKey?: string;
   errorMessage?: string;
   exchange?: string;
   fromAmount: number;
@@ -128,6 +129,7 @@ export const useJumperTracking = () => {
       action: data.action,
       browserFingerprint: data.browserFingerprint,
       errorCode: data.errorCode,
+      errorCodeKey: data.errorCodeKey,
       errorMessage: data.errorMessage,
       exchange: data.exchange,
       fromAmount: data.fromAmount,

--- a/src/hooks/userTracking/useUserTracking.ts
+++ b/src/hooks/userTracking/useUserTracking.ts
@@ -172,6 +172,7 @@ export function useUserTracking(): UserTracking {
           // data from handleRouteTrackingData:
           action: data[TrackingEventParameter.Action] ?? action ?? '',
           errorCode: data[TrackingEventParameter.ErrorCode],
+          errorCodeKey: data[TrackingEventParameter.ErrorCodeKey],
           errorMessage: data[TrackingEventParameter.ErrorMessage],
           exchange: data[TrackingEventParameter.Exchange],
           feeCost: data[TrackingEventParameter.FeeCost],

--- a/src/types/userTracking.ts
+++ b/src/types/userTracking.ts
@@ -48,6 +48,7 @@ export interface TrackTransactionDataProps {
   // Optional properties (conditionally present) - sorted alphabetically
   [TrackingEventParameter.Action]?: string;
   [TrackingEventParameter.ErrorCode]?: string;
+  [TrackingEventParameter.ErrorCodeKey]?: string;
   [TrackingEventParameter.ErrorMessage]?: string;
   [TrackingEventParameter.Exchange]?: string;
   [TrackingEventParameter.FeeCost]?: number;

--- a/src/utils/routes/routeProcess.ts
+++ b/src/utils/routes/routeProcess.ts
@@ -1,8 +1,9 @@
-import type {
-  LiFiStep,
-  LiFiStepExtended,
-  Process,
-  RouteExtended,
+import {
+  LiFiErrorCode,
+  type LiFiStep,
+  type LiFiStepExtended,
+  type Process,
+  type RouteExtended,
 } from '@lifi/sdk';
 import { TrackingEventParameter } from 'src/const/trackingKeys';
 import { getDetailInformation } from './routeUtils';
@@ -14,6 +15,18 @@ interface GetProcessInformationType {
   [TrackingEventParameter.ErrorCode]?: string;
   [TrackingEventParameter.ErrorMessage]?: string;
 }
+
+const findErrorKeyFromErrorCode = (code?: string | number) => {
+  if (!code) return null;
+
+  return (
+    Object.keys(LiFiErrorCode).find(
+      (key) =>
+        LiFiErrorCode[key as keyof typeof LiFiErrorCode].toString() ===
+        code.toString(),
+    ) || null
+  );
+};
 
 export const getProcessInformation = (
   route: RouteExtended,
@@ -37,9 +50,13 @@ export const getProcessInformation = (
             errorMessage.indexOf('data:'),
           );
         }
+        const errorCodeKey = findErrorKeyFromErrorCode(process.error?.code);
         errors = {
           ...(process.error?.code && {
             [TrackingEventParameter.ErrorCode]: process.error?.code,
+          }),
+          ...(errorCodeKey && {
+            [TrackingEventParameter.ErrorCodeKey]: errorCodeKey,
           }),
           ...(errorMessage && {
             [TrackingEventParameter.ErrorMessage]: errorMessage.trim(),

--- a/src/utils/routes/routeProcess.ts
+++ b/src/utils/routes/routeProcess.ts
@@ -7,32 +7,33 @@ import {
 } from '@lifi/sdk';
 import { TrackingEventParameter } from 'src/const/trackingKeys';
 import { getDetailInformation } from './routeUtils';
+import { findKey } from 'lodash';
 
 interface GetProcessInformationType {
   [TrackingEventParameter.TransactionHash]?: string;
   [TrackingEventParameter.TransactionLink]?: string;
   [TrackingEventParameter.TransactionStatus]?: string;
   [TrackingEventParameter.ErrorCode]?: string;
+  [TrackingEventParameter.ErrorCodeKey]?: string;
   [TrackingEventParameter.ErrorMessage]?: string;
 }
 
-const findErrorKeyFromErrorCode = (code?: string | number) => {
+const findErrorKeyFromErrorCode = (code?: string) => {
   if (!code) return null;
 
-  return (
-    Object.keys(LiFiErrorCode).find(
-      (key) =>
-        LiFiErrorCode[key as keyof typeof LiFiErrorCode].toString() ===
-        code.toString(),
-    ) || null
-  );
+  return findKey(LiFiErrorCode, (value) => value.toString() === code) ?? null;
 };
 
 export const getProcessInformation = (
   route: RouteExtended,
 ): GetProcessInformationType => {
-  let processData = {};
-  let errors = {};
+  let processData: GetProcessInformationType = {};
+  let errors: Pick<
+    GetProcessInformationType,
+    | TrackingEventParameter.ErrorCode
+    | TrackingEventParameter.ErrorCodeKey
+    | TrackingEventParameter.ErrorMessage
+  > = {};
   const txHashes: string[] = [];
   const txLinks: string[] = [];
   const txStatuses: string[] = [];
@@ -50,18 +51,18 @@ export const getProcessInformation = (
             errorMessage.indexOf('data:'),
           );
         }
-        const errorCodeKey = findErrorKeyFromErrorCode(process.error?.code);
-        errors = {
-          ...(process.error?.code && {
-            [TrackingEventParameter.ErrorCode]: process.error?.code,
-          }),
-          ...(errorCodeKey && {
-            [TrackingEventParameter.ErrorCodeKey]: errorCodeKey,
-          }),
-          ...(errorMessage && {
-            [TrackingEventParameter.ErrorMessage]: errorMessage.trim(),
-          }),
-        };
+        const errorCode = process.error?.code?.toString();
+        const errorCodeKey = findErrorKeyFromErrorCode(errorCode);
+
+        if (errorCode) {
+          errors[TrackingEventParameter.ErrorCode] = errorCode;
+        }
+        if (errorCodeKey) {
+          errors[TrackingEventParameter.ErrorCodeKey] = errorCodeKey;
+        }
+        if (errorMessage) {
+          errors[TrackingEventParameter.ErrorMessage] = errorMessage.trim();
+        }
 
         // Collect transaction data in arrays
         if (process.txHash) {
@@ -77,18 +78,28 @@ export const getProcessInformation = (
     }
   });
 
-  processData = {
-    ...(txHashes.length > 0 && {
-      [TrackingEventParameter.TransactionHash]: txHashes.join(','),
-    }),
-    ...(txLinks.length > 0 && {
-      [TrackingEventParameter.TransactionLink]: txLinks.join(','),
-    }),
-    ...(txStatuses.length > 0 && {
-      [TrackingEventParameter.TransactionStatus]: txStatuses.join(','),
-    }),
-    ...errors,
-  };
+  if (errors[TrackingEventParameter.ErrorCode]) {
+    processData[TrackingEventParameter.ErrorCode] =
+      errors[TrackingEventParameter.ErrorCode];
+  }
+  if (errors[TrackingEventParameter.ErrorCodeKey]) {
+    processData[TrackingEventParameter.ErrorCodeKey] =
+      errors[TrackingEventParameter.ErrorCodeKey];
+  }
+  if (errors[TrackingEventParameter.ErrorMessage]) {
+    processData[TrackingEventParameter.ErrorMessage] =
+      errors[TrackingEventParameter.ErrorMessage];
+  }
+  if (txHashes.length > 0) {
+    processData[TrackingEventParameter.TransactionHash] = txHashes.join(',');
+  }
+  if (txLinks.length > 0) {
+    processData[TrackingEventParameter.TransactionLink] = txLinks.join(',');
+  }
+  if (txStatuses.length > 0) {
+    processData[TrackingEventParameter.TransactionStatus] =
+      txStatuses.join(',');
+  }
 
   return processData;
 };


### PR DESCRIPTION
Given the route process error code is not very informative, if lifi has a key for the error code, we send also that as a parameter for the wallet tx tracking

Sister PR https://github.com/jumperexchange/jumper-backend/pull/478