### PR TITLE
feat: interactive filters - 15665

### DIFF
--- a/src/app/ui/earn/EarnFilteringContext.tsx
+++ b/src/app/ui/earn/EarnFilteringContext.tsx
@@ -30,6 +30,7 @@ export interface EarnFilteringContextType extends EarnFilteringParams {
   filter: EarnOpportunityFilter;
   updateFilter: (filter: EarnOpportunityFilter) => void;
   showForYou: boolean;
+  usedYourAddress: boolean;
   toggleForYou: () => void;
   forYou: EarnOpportunityWithLatestAnalytics[];
   forYouLoading: boolean;
@@ -44,6 +45,7 @@ export const EarnFilteringContext = createContext<EarnFilteringContextType>({
   filter: {},
   updateFilter: () => {},
   showForYou: false,
+  usedYourAddress: false,
   toggleForYou: () => {},
   forYou: [],
   forYouLoading: false,
@@ -65,6 +67,8 @@ export const EarnFilteringProvider = ({
   children: React.ReactNode;
 }) => {
   const address: Hex | undefined = useAccountAddress();
+  const usedYourAddress = address !== undefined;
+
   const [initialData, setInitialData] = useState<
     EarnOpportunityWithLatestAnalytics[]
   >([]);
@@ -122,6 +126,7 @@ export const EarnFilteringProvider = ({
     filter,
     updateFilter,
     showForYou,
+    usedYourAddress,
     toggleForYou,
     forYou: forYou.data ?? [],
     forYouLoading: forYou.isLoading,

--- a/src/app/ui/earn/EarnOpportunitiesAll.tsx
+++ b/src/app/ui/earn/EarnOpportunitiesAll.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { Grid } from '@mui/material';
+import { useState } from 'react';
 import { EarnCard } from 'src/components/Cards/EarnCard/EarnCard';
+import { EarnCardVariant } from 'src/components/Cards/EarnCard/EarnCard.types';
 import { AtLeastNWhenLoading } from 'src/components/Cards/EarnCard/variants/shared';
 import { EarnFilterBar } from 'src/components/EarnFilter/EarnFilterBar';
 import {
@@ -18,6 +20,8 @@ const EarnOpportunitiesAll_ = () => {
     showForYou,
     toggleForYou,
   } = useEarnFiltering();
+
+  const [variant, setVariant] = useState<EarnCardVariant>('compact');
 
   const formatedTotalMarkets = totalMarkets.toLocaleString();
 
@@ -50,7 +54,7 @@ const EarnOpportunitiesAll_ = () => {
     return (
       <div>
         <h1>All</h1>
-        <EarnFilterBar />
+        <EarnFilterBar variant={variant} setVariant={setVariant} />
         <Grid container spacing={2}>
           {items.map((item, index) => (
             <Grid key={index} size={{ xs: 12, sm: 4 }}>

--- a/src/app/ui/earn/EarnOpportunitiesAll.tsx
+++ b/src/app/ui/earn/EarnOpportunitiesAll.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Grid } from '@mui/material';
+import { Card, CardContent, Grid } from '@mui/material';
 import { useState } from 'react';
 import { EarnCard } from 'src/components/Cards/EarnCard/EarnCard';
 import { EarnCardVariant } from 'src/components/Cards/EarnCard/EarnCard.types';
@@ -23,7 +23,7 @@ const EarnOpportunitiesAll_ = () => {
 
   const [variant, setVariant] = useState<EarnCardVariant>('compact');
 
-  const formatedTotalMarkets = totalMarkets.toLocaleString();
+  const gridSize = variant === 'compact' ? { xs: 12, sm: 4 } : { xs: 12 };
 
   const ForYou = () => {
     const items = AtLeastNWhenLoading(forYou, forYouLoading, 3, Infinity);
@@ -31,14 +31,13 @@ const EarnOpportunitiesAll_ = () => {
 
     return (
       <div>
-        <h1>For You</h1>
         <Grid container spacing={2}>
           {items.map((item, index) => (
-            <Grid key={index} size={{ xs: 12, sm: 4 }}>
+            <Grid key={index} size={gridSize}>
               {item == null ? (
-                <EarnCard variant="compact" isLoading={true} data={null} />
+                <EarnCard variant={variant} isLoading={true} data={null} />
               ) : (
-                <EarnCard variant="compact" isLoading={false} data={item} />
+                <EarnCard variant={variant} isLoading={false} data={item} />
               )}
             </Grid>
           ))}
@@ -53,15 +52,13 @@ const EarnOpportunitiesAll_ = () => {
 
     return (
       <div>
-        <h1>All</h1>
-        <EarnFilterBar variant={variant} setVariant={setVariant} />
         <Grid container spacing={2}>
           {items.map((item, index) => (
-            <Grid key={index} size={{ xs: 12, sm: 4 }}>
+            <Grid key={index} size={gridSize}>
               {item == null ? (
-                <EarnCard variant="compact" isLoading={true} data={null} />
+                <EarnCard variant={variant} isLoading={true} data={null} />
               ) : (
-                <EarnCard variant="compact" isLoading={false} data={item} />
+                <EarnCard variant={variant} isLoading={false} data={item} />
               )}
             </Grid>
           ))}
@@ -71,17 +68,19 @@ const EarnOpportunitiesAll_ = () => {
   };
 
   return (
-    <div>
-      <h1>Markets</h1>
-      <p>
-        Explore curated and comprehensive ways to put your assets to work across{' '}
-        {formatedTotalMarkets}+ markets
-      </p>
-      <button onClick={toggleForYou}>
-        {showForYou ? 'Show All' : 'Show For You'}
-      </button>
-      {showForYou ? <ForYou /> : <All />}
-    </div>
+    <Card
+      sx={{
+        borderRadius: 2,
+        boxShadow: 1,
+        overflow: 'visible',
+        marginTop: 2,
+      }}
+    >
+      <CardContent sx={{ padding: 0 }}>
+        <EarnFilterBar variant={variant} setVariant={setVariant} />
+      </CardContent>
+      <CardContent>{showForYou ? <ForYou /> : <All />}</CardContent>
+    </Card>
   );
 };
 

--- a/src/app/ui/earn/EarnOpportunitiesAll.tsx
+++ b/src/app/ui/earn/EarnOpportunitiesAll.tsx
@@ -2,7 +2,7 @@
 import { Grid } from '@mui/material';
 import { EarnCard } from 'src/components/Cards/EarnCard/EarnCard';
 import { AtLeastNWhenLoading } from 'src/components/Cards/EarnCard/variants/shared';
-import { EarnFilter } from './EarnFilter';
+import { EarnFilterBar } from 'src/components/EarnFilter/EarnFilterBar';
 import {
   EarnFilteringProvider,
   useEarnFiltering,
@@ -50,7 +50,7 @@ const EarnOpportunitiesAll_ = () => {
     return (
       <div>
         <h1>All</h1>
-        <EarnFilter />
+        <EarnFilterBar />
         <Grid container spacing={2}>
           {items.map((item, index) => (
             <Grid key={index} size={{ xs: 12, sm: 4 }}>

--- a/src/components/EarnFilter/EarnFilterBar.stories.tsx
+++ b/src/components/EarnFilter/EarnFilterBar.stories.tsx
@@ -1,17 +1,28 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { EarnFilterBar } from './EarnFilterBar';
+import { useState } from 'react';
 import { EarnFilteringContext } from '../../app/ui/earn/EarnFilteringContext';
+import { EarnCardVariant } from '../Cards/EarnCard/EarnCard.types';
+import { EarnFilterBar } from './EarnFilterBar';
 
 const meta = {
   component: EarnFilterBar,
   title: 'Earn/FilterBar',
   decorators: [
-    (Story) => (
-      <EarnFilteringContext.Provider value={mockContextValue}>
-        <Story />
-      </EarnFilteringContext.Provider>
-    ),
+    (Story) => {
+      const [variant, setVariant] = useState<EarnCardVariant>('compact');
+      return (
+        <EarnFilteringContext.Provider value={mockContextValue}>
+          <Story args={{ variant, setVariant }} />
+        </EarnFilteringContext.Provider>
+      );
+    },
   ],
+  argTypes: {
+    variant: {
+      control: { type: 'radio' },
+      options: ['compact', 'list-item', 'top'],
+    },
+  },
 } satisfies Meta<typeof EarnFilterBar>;
 
 export default meta;
@@ -110,101 +121,146 @@ const mockContextValue = {
   },
 };
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    variant: 'compact',
+    setVariant: () => {},
+  },
+};
+
+export const ListView: Story = {
+  args: {
+    variant: 'list-item',
+    setVariant: () => {},
+  },
+};
 
 export const EmptyState: Story = {
+  args: {
+    variant: 'compact',
+    setVariant: () => {},
+  },
   decorators: [
-    (Story) => (
-      <EarnFilteringContext.Provider
-        value={{
-          ...mockContextValue,
-          allChains: [],
-          allProtocols: [],
-          allAssets: [],
-          allTags: [],
-          allAPY: {},
-          totalMarkets: 0,
-        }}
-      >
-        <Story />
-      </EarnFilteringContext.Provider>
-    ),
+    (Story) => {
+      const [variant, setVariant] = useState<EarnCardVariant>('compact');
+      return (
+        <EarnFilteringContext.Provider
+          value={{
+            ...mockContextValue,
+            allChains: [],
+            allProtocols: [],
+            allAssets: [],
+            allTags: [],
+            allAPY: {},
+            totalMarkets: 0,
+          }}
+        >
+          <Story args={{ variant, setVariant }} />
+        </EarnFilteringContext.Provider>
+      );
+    },
   ],
 };
 
 export const LoadingState: Story = {
+  args: {
+    variant: 'compact',
+    setVariant: () => {},
+  },
   decorators: [
-    (Story) => (
-      <EarnFilteringContext.Provider
-        value={{
-          ...mockContextValue,
-          allLoading: true,
-          forYouLoading: true,
-        }}
-      >
-        <Story />
-      </EarnFilteringContext.Provider>
-    ),
+    (Story) => {
+      const [variant, setVariant] = useState<EarnCardVariant>('compact');
+      return (
+        <EarnFilteringContext.Provider
+          value={{
+            ...mockContextValue,
+            allLoading: true,
+            forYouLoading: true,
+          }}
+        >
+          <Story args={{ variant, setVariant }} />
+        </EarnFilteringContext.Provider>
+      );
+    },
   ],
 };
 
 export const MinimalData: Story = {
+  args: {
+    variant: 'list-item',
+    setVariant: () => {},
+  },
   decorators: [
-    (Story) => (
-      <EarnFilteringContext.Provider
-        value={{
-          ...mockContextValue,
-          allChains: [{ chainId: 1, chainKey: 'ethereum' }],
-          allProtocols: [
-            { name: 'Aave', product: 'aave-v3', version: 'v3', logo: '' },
-          ],
-          allAssets: [
-            {
-              name: 'USD Coin',
-              symbol: 'USDC',
-              decimals: 6,
-              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-              logo: '',
-              chain: { chainId: 1, chainKey: 'ethereum' },
-            },
-          ],
-          allTags: ['Staking'],
-          allAPY: { 0.05: 10 },
-          totalMarkets: 1,
-        }}
-      >
-        <Story />
-      </EarnFilteringContext.Provider>
-    ),
+    (Story) => {
+      const [variant, setVariant] = useState<EarnCardVariant>('list-item');
+      return (
+        <EarnFilteringContext.Provider
+          value={{
+            ...mockContextValue,
+            allChains: [{ chainId: 1, chainKey: 'ethereum' }],
+            allProtocols: [
+              { name: 'Aave', product: 'aave-v3', version: 'v3', logo: '' },
+            ],
+            allAssets: [
+              {
+                name: 'USD Coin',
+                symbol: 'USDC',
+                decimals: 6,
+                address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+                logo: '',
+                chain: { chainId: 1, chainKey: 'ethereum' },
+              },
+            ],
+            allTags: ['Staking'],
+            allAPY: { 0.05: 10 },
+            totalMarkets: 1,
+          }}
+        >
+          <Story args={{ variant, setVariant }} />
+        </EarnFilteringContext.Provider>
+      );
+    },
   ],
 };
 
 export const WithActiveFilters: Story = {
+  args: {
+    variant: 'compact',
+    setVariant: () => {},
+  },
   decorators: [
-    (Story) => (
-      <EarnFilteringContext.Provider
-        value={{
-          ...mockContextValue,
-          filter: {
-            chains: [1, 137],
-            protocols: ['Aave', 'Compound'],
-            assets: ['USDC', 'ETH'],
-            tags: ['Staking', 'Earn'],
-            minAPY: 0.05,
-            maxAPY: 0.15,
-          },
-          showForYou: true,
-        }}
-      >
-        <Story />
-      </EarnFilteringContext.Provider>
-    ),
+    (Story) => {
+      const [variant, setVariant] = useState<EarnCardVariant>('compact');
+      return (
+        <EarnFilteringContext.Provider
+          value={{
+            ...mockContextValue,
+            filter: {
+              chains: [1, 137],
+              protocols: ['Aave', 'Compound'],
+              assets: ['USDC', 'ETH'],
+              tags: ['Staking', 'Earn'],
+              minAPY: 0.05,
+              maxAPY: 0.15,
+            },
+            showForYou: true,
+          }}
+        >
+          <Story args={{ variant, setVariant }} />
+        </EarnFilteringContext.Provider>
+      );
+    },
   ],
 };
 
 export const LargeDataSet: Story = {
+  args: {
+    variant: 'compact',
+    setVariant: () => {},
+  },
   decorators: [
     (Story) => {
+      const [variant, setVariant] = useState<EarnCardVariant>('compact');
       const largeChains = Array.from({ length: 20 }, (_, i) => ({
         chainId: i + 1,
         chainKey: `chain-${i + 1}`,
@@ -230,7 +286,7 @@ export const LargeDataSet: Story = {
             totalMarkets: 500,
           }}
         >
-          <Story />
+          <Story args={{ variant, setVariant }} />
         </EarnFilteringContext.Provider>
       );
     },

--- a/src/components/EarnFilter/EarnFilterBar.stories.tsx
+++ b/src/components/EarnFilter/EarnFilterBar.stories.tsx
@@ -1,0 +1,238 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { EarnFilterBar } from './EarnFilterBar';
+import { EarnFilteringContext } from '../../app/ui/earn/EarnFilteringContext';
+
+const meta = {
+  component: EarnFilterBar,
+  title: 'Earn/FilterBar',
+  decorators: [
+    (Story) => (
+      <EarnFilteringContext.Provider value={mockContextValue}>
+        <Story />
+      </EarnFilteringContext.Provider>
+    ),
+  ],
+} satisfies Meta<typeof EarnFilterBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockContextValue = {
+  filter: {},
+  updateFilter: () => {},
+  showForYou: false,
+  toggleForYou: () => {},
+  forYou: [],
+  forYouLoading: false,
+  forYouError: null,
+  all: [],
+  allLoading: false,
+  allError: null,
+  totalMarkets: 150,
+  allChains: [
+    { chainId: 1, chainKey: 'ethereum', name: 'Ethereum' },
+    { chainId: 137, chainKey: 'polygon', name: 'Polygon' },
+    { chainId: 8453, chainKey: 'base', name: 'Base' },
+    { chainId: 42161, chainKey: 'arbitrum', name: 'Arbitrum' },
+    { chainId: 10, chainKey: 'optimism', name: 'Optimism' },
+  ],
+  allProtocols: [
+    {
+      name: 'Morpho',
+      product: 'metamorpho',
+      version: '',
+      logo: 'https://strapi.jumper.exchange/uploads/morpho.png',
+    },
+    {
+      name: 'Aave',
+      product: 'aave-v3',
+      version: 'v3',
+      logo: 'https://strapi.jumper.exchange/uploads/aave.png',
+    },
+    {
+      name: 'Compound',
+      product: 'compound-v3',
+      version: 'v3',
+      logo: 'https://strapi.jumper.exchange/uploads/compound.png',
+    },
+    {
+      name: 'Uniswap',
+      product: 'uniswap-v3',
+      version: 'v3',
+      logo: 'https://strapi.jumper.exchange/uploads/uniswap.png',
+    },
+  ],
+  allAssets: [
+    {
+      name: 'USD Coin',
+      symbol: 'USDC',
+      decimals: 6,
+      address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      logo: 'https://cryptologos.cc/logos/usd-coin-usdc-logo.png',
+      chain: { chainId: 8453, chainKey: 'base' },
+    },
+    {
+      name: 'Ethereum',
+      symbol: 'ETH',
+      decimals: 18,
+      address: '0x0000000000000000000000000000000000000000',
+      logo: 'https://cryptologos.cc/logos/ethereum-eth-logo.png',
+      chain: { chainId: 1, chainKey: 'ethereum' },
+    },
+    {
+      name: 'Wrapped Bitcoin',
+      symbol: 'WBTC',
+      decimals: 8,
+      address: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
+      logo: 'https://cryptologos.cc/logos/wrapped-bitcoin-wbtc-logo.png',
+      chain: { chainId: 1, chainKey: 'ethereum' },
+    },
+    {
+      name: 'Dai Stablecoin',
+      symbol: 'DAI',
+      decimals: 18,
+      address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+      logo: 'https://cryptologos.cc/logos/multi-collateral-dai-dai-logo.png',
+      chain: { chainId: 1, chainKey: 'ethereum' },
+    },
+  ],
+  allTags: ['Staking', 'Earn', 'Yield', 'Lending', 'LP', 'Vault', 'DeFi'],
+  allAPY: {
+    0.01: 5,
+    0.02: 12,
+    0.03: 18,
+    0.05: 25,
+    0.08: 15,
+    0.1: 10,
+    0.15: 8,
+    0.2: 5,
+    0.3: 2,
+  },
+};
+
+export const Default: Story = {};
+
+export const EmptyState: Story = {
+  decorators: [
+    (Story) => (
+      <EarnFilteringContext.Provider
+        value={{
+          ...mockContextValue,
+          allChains: [],
+          allProtocols: [],
+          allAssets: [],
+          allTags: [],
+          allAPY: {},
+          totalMarkets: 0,
+        }}
+      >
+        <Story />
+      </EarnFilteringContext.Provider>
+    ),
+  ],
+};
+
+export const LoadingState: Story = {
+  decorators: [
+    (Story) => (
+      <EarnFilteringContext.Provider
+        value={{
+          ...mockContextValue,
+          allLoading: true,
+          forYouLoading: true,
+        }}
+      >
+        <Story />
+      </EarnFilteringContext.Provider>
+    ),
+  ],
+};
+
+export const MinimalData: Story = {
+  decorators: [
+    (Story) => (
+      <EarnFilteringContext.Provider
+        value={{
+          ...mockContextValue,
+          allChains: [{ chainId: 1, chainKey: 'ethereum' }],
+          allProtocols: [
+            { name: 'Aave', product: 'aave-v3', version: 'v3', logo: '' },
+          ],
+          allAssets: [
+            {
+              name: 'USD Coin',
+              symbol: 'USDC',
+              decimals: 6,
+              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+              logo: '',
+              chain: { chainId: 1, chainKey: 'ethereum' },
+            },
+          ],
+          allTags: ['Staking'],
+          allAPY: { 0.05: 10 },
+          totalMarkets: 1,
+        }}
+      >
+        <Story />
+      </EarnFilteringContext.Provider>
+    ),
+  ],
+};
+
+export const WithActiveFilters: Story = {
+  decorators: [
+    (Story) => (
+      <EarnFilteringContext.Provider
+        value={{
+          ...mockContextValue,
+          filter: {
+            chains: [1, 137],
+            protocols: ['Aave', 'Compound'],
+            assets: ['USDC', 'ETH'],
+            tags: ['Staking', 'Earn'],
+            minAPY: 0.05,
+            maxAPY: 0.15,
+          },
+          showForYou: true,
+        }}
+      >
+        <Story />
+      </EarnFilteringContext.Provider>
+    ),
+  ],
+};
+
+export const LargeDataSet: Story = {
+  decorators: [
+    (Story) => {
+      const largeChains = Array.from({ length: 20 }, (_, i) => ({
+        chainId: i + 1,
+        chainKey: `chain-${i + 1}`,
+        name: `Chain ${i + 1}`,
+      }));
+
+      const largeProtocols = Array.from({ length: 15 }, (_, i) => ({
+        name: `Protocol ${i + 1}`,
+        product: `protocol-${i + 1}`,
+        version: `v${i + 1}`,
+        logo: '',
+      }));
+
+      const largeTags = Array.from({ length: 30 }, (_, i) => `Tag${i + 1}`);
+
+      return (
+        <EarnFilteringContext.Provider
+          value={{
+            ...mockContextValue,
+            allChains: largeChains,
+            allProtocols: largeProtocols,
+            allTags: largeTags,
+            totalMarkets: 500,
+          }}
+        >
+          <Story />
+        </EarnFilteringContext.Provider>
+      );
+    },
+  ],
+};

--- a/src/components/EarnFilter/EarnFilterBar.stories.tsx
+++ b/src/components/EarnFilter/EarnFilterBar.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
     (Story) => {
       const [variant, setVariant] = useState<EarnCardVariant>('compact');
       return (
-        <EarnFilteringContext.Provider value={mockContextValue}>
+        <EarnFilteringContext.Provider value={mockContextValue()}>
           <Story args={{ variant, setVariant }} />
         </EarnFilteringContext.Provider>
       );
@@ -28,97 +28,101 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const mockContextValue = {
-  filter: {},
-  updateFilter: () => {},
-  showForYou: false,
-  toggleForYou: () => {},
-  forYou: [],
-  forYouLoading: false,
-  forYouError: null,
-  all: [],
-  allLoading: false,
-  allError: null,
-  totalMarkets: 150,
-  allChains: [
-    { chainId: 1, chainKey: 'ethereum', name: 'Ethereum' },
-    { chainId: 137, chainKey: 'polygon', name: 'Polygon' },
-    { chainId: 8453, chainKey: 'base', name: 'Base' },
-    { chainId: 42161, chainKey: 'arbitrum', name: 'Arbitrum' },
-    { chainId: 10, chainKey: 'optimism', name: 'Optimism' },
-  ],
-  allProtocols: [
-    {
-      name: 'Morpho',
-      product: 'metamorpho',
-      version: '',
-      logo: 'https://strapi.jumper.exchange/uploads/morpho.png',
+const mockContextValue = () => {
+  const [showForYou, setShowForYou] = useState(false);
+
+  return {
+    filter: {},
+    updateFilter: () => {},
+    showForYou,
+    toggleForYou: () => setShowForYou((current) => !current),
+    forYou: [],
+    forYouLoading: false,
+    forYouError: null,
+    all: [],
+    allLoading: false,
+    allError: null,
+    totalMarkets: 150,
+    allChains: [
+      { chainId: 1, chainKey: 'ethereum', name: 'Ethereum' },
+      { chainId: 137, chainKey: 'polygon', name: 'Polygon' },
+      { chainId: 8453, chainKey: 'base', name: 'Base' },
+      { chainId: 42161, chainKey: 'arbitrum', name: 'Arbitrum' },
+      { chainId: 10, chainKey: 'optimism', name: 'Optimism' },
+    ],
+    allProtocols: [
+      {
+        name: 'Morpho',
+        product: 'metamorpho',
+        version: '',
+        logo: 'https://strapi.jumper.exchange/uploads/morpho.png',
+      },
+      {
+        name: 'Aave',
+        product: 'aave-v3',
+        version: 'v3',
+        logo: 'https://strapi.jumper.exchange/uploads/aave.png',
+      },
+      {
+        name: 'Compound',
+        product: 'compound-v3',
+        version: 'v3',
+        logo: 'https://strapi.jumper.exchange/uploads/compound.png',
+      },
+      {
+        name: 'Uniswap',
+        product: 'uniswap-v3',
+        version: 'v3',
+        logo: 'https://strapi.jumper.exchange/uploads/uniswap.png',
+      },
+    ],
+    allAssets: [
+      {
+        name: 'USD Coin',
+        symbol: 'USDC',
+        decimals: 6,
+        address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+        logo: 'https://cryptologos.cc/logos/usd-coin-usdc-logo.png',
+        chain: { chainId: 8453, chainKey: 'base' },
+      },
+      {
+        name: 'Ethereum',
+        symbol: 'ETH',
+        decimals: 18,
+        address: '0x0000000000000000000000000000000000000000',
+        logo: 'https://cryptologos.cc/logos/ethereum-eth-logo.png',
+        chain: { chainId: 1, chainKey: 'ethereum' },
+      },
+      {
+        name: 'Wrapped Bitcoin',
+        symbol: 'WBTC',
+        decimals: 8,
+        address: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
+        logo: 'https://cryptologos.cc/logos/wrapped-bitcoin-wbtc-logo.png',
+        chain: { chainId: 1, chainKey: 'ethereum' },
+      },
+      {
+        name: 'Dai Stablecoin',
+        symbol: 'DAI',
+        decimals: 18,
+        address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+        logo: 'https://cryptologos.cc/logos/multi-collateral-dai-dai-logo.png',
+        chain: { chainId: 1, chainKey: 'ethereum' },
+      },
+    ],
+    allTags: ['Staking', 'Earn', 'Yield', 'Lending', 'LP', 'Vault', 'DeFi'],
+    allAPY: {
+      0.01: 5,
+      0.02: 12,
+      0.03: 18,
+      0.05: 25,
+      0.08: 15,
+      0.1: 10,
+      0.15: 8,
+      0.2: 5,
+      0.3: 2,
     },
-    {
-      name: 'Aave',
-      product: 'aave-v3',
-      version: 'v3',
-      logo: 'https://strapi.jumper.exchange/uploads/aave.png',
-    },
-    {
-      name: 'Compound',
-      product: 'compound-v3',
-      version: 'v3',
-      logo: 'https://strapi.jumper.exchange/uploads/compound.png',
-    },
-    {
-      name: 'Uniswap',
-      product: 'uniswap-v3',
-      version: 'v3',
-      logo: 'https://strapi.jumper.exchange/uploads/uniswap.png',
-    },
-  ],
-  allAssets: [
-    {
-      name: 'USD Coin',
-      symbol: 'USDC',
-      decimals: 6,
-      address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-      logo: 'https://cryptologos.cc/logos/usd-coin-usdc-logo.png',
-      chain: { chainId: 8453, chainKey: 'base' },
-    },
-    {
-      name: 'Ethereum',
-      symbol: 'ETH',
-      decimals: 18,
-      address: '0x0000000000000000000000000000000000000000',
-      logo: 'https://cryptologos.cc/logos/ethereum-eth-logo.png',
-      chain: { chainId: 1, chainKey: 'ethereum' },
-    },
-    {
-      name: 'Wrapped Bitcoin',
-      symbol: 'WBTC',
-      decimals: 8,
-      address: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
-      logo: 'https://cryptologos.cc/logos/wrapped-bitcoin-wbtc-logo.png',
-      chain: { chainId: 1, chainKey: 'ethereum' },
-    },
-    {
-      name: 'Dai Stablecoin',
-      symbol: 'DAI',
-      decimals: 18,
-      address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
-      logo: 'https://cryptologos.cc/logos/multi-collateral-dai-dai-logo.png',
-      chain: { chainId: 1, chainKey: 'ethereum' },
-    },
-  ],
-  allTags: ['Staking', 'Earn', 'Yield', 'Lending', 'LP', 'Vault', 'DeFi'],
-  allAPY: {
-    0.01: 5,
-    0.02: 12,
-    0.03: 18,
-    0.05: 25,
-    0.08: 15,
-    0.1: 10,
-    0.15: 8,
-    0.2: 5,
-    0.3: 2,
-  },
+  };
 };
 
 export const Default: Story = {
@@ -146,7 +150,7 @@ export const EmptyState: Story = {
       return (
         <EarnFilteringContext.Provider
           value={{
-            ...mockContextValue,
+            ...mockContextValue(),
             allChains: [],
             allProtocols: [],
             allAssets: [],
@@ -173,7 +177,7 @@ export const LoadingState: Story = {
       return (
         <EarnFilteringContext.Provider
           value={{
-            ...mockContextValue,
+            ...mockContextValue(),
             allLoading: true,
             forYouLoading: true,
           }}
@@ -196,7 +200,7 @@ export const MinimalData: Story = {
       return (
         <EarnFilteringContext.Provider
           value={{
-            ...mockContextValue,
+            ...mockContextValue(),
             allChains: [{ chainId: 1, chainKey: 'ethereum' }],
             allProtocols: [
               { name: 'Aave', product: 'aave-v3', version: 'v3', logo: '' },
@@ -234,7 +238,7 @@ export const WithActiveFilters: Story = {
       return (
         <EarnFilteringContext.Provider
           value={{
-            ...mockContextValue,
+            ...mockContextValue(),
             filter: {
               chains: [1, 137],
               protocols: ['Aave', 'Compound'],
@@ -279,7 +283,7 @@ export const LargeDataSet: Story = {
       return (
         <EarnFilteringContext.Provider
           value={{
-            ...mockContextValue,
+            ...mockContextValue(),
             allChains: largeChains,
             allProtocols: largeProtocols,
             allTags: largeTags,

--- a/src/components/EarnFilter/EarnFilterBar.stories.tsx
+++ b/src/components/EarnFilter/EarnFilterBar.stories.tsx
@@ -36,6 +36,7 @@ const mockContextValue = () => {
     updateFilter: () => {},
     showForYou,
     toggleForYou: () => setShowForYou((current) => !current),
+    usedYourAddress: false,
     forYou: [],
     forYouLoading: false,
     forYouError: null,

--- a/src/components/EarnFilter/EarnFilterBar.styles.ts
+++ b/src/components/EarnFilter/EarnFilterBar.styles.ts
@@ -1,0 +1,8 @@
+import { Box, styled } from '@mui/material';
+
+export const EarnFilterBarContainer = styled(Box)(({ theme }) => ({
+  borderRadius: theme.shape.cardBorderRadius,
+  boxShadow: theme.shadows[2],
+  backgroundColor: (theme.vars || theme).palette.surface1.main,
+  padding: theme.spacing(2),
+}));

--- a/src/components/EarnFilter/EarnFilterBar.styles.ts
+++ b/src/components/EarnFilter/EarnFilterBar.styles.ts
@@ -1,8 +1,11 @@
 import { Box, styled } from '@mui/material';
 
 export const EarnFilterBarContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
   borderRadius: theme.shape.cardBorderRadius,
   boxShadow: theme.shadows[2],
   backgroundColor: (theme.vars || theme).palette.surface1.main,
   padding: theme.spacing(2),
+  gap: theme.spacing(2),
 }));

--- a/src/components/EarnFilter/EarnFilterBar.tsx
+++ b/src/components/EarnFilter/EarnFilterBar.tsx
@@ -1,7 +1,7 @@
-import { useEarnFiltering } from './EarnFilteringContext';
+import { useEarnFiltering } from '../../app/ui/earn/EarnFilteringContext';
 
-export const EarnFilter: React.FC<{}> = () => {
-  const { allChains, allProtocols, allAssets, allTags, allAPY, updateFilter } =
+export const EarnFilterBar: React.FC<{}> = () => {
+  const { allChains, allProtocols, allAssets, allTags, allAPY } =
     useEarnFiltering();
 
   return (

--- a/src/components/EarnFilter/EarnFilterBar.tsx
+++ b/src/components/EarnFilter/EarnFilterBar.tsx
@@ -1,10 +1,12 @@
-import { Badge } from 'src/components/Badge/Badge';
 import { Box } from '@mui/system';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useEarnFiltering } from '../../app/ui/earn/EarnFilteringContext';
+import { Badge } from 'src/components/Badge/Badge';
 import { BadgeSize, BadgeVariant } from 'src/components/Badge/Badge.styles';
+import { useEarnFiltering } from '../../app/ui/earn/EarnFilteringContext';
 import { EarnCardVariant } from '../Cards/EarnCard/EarnCard.types';
+import { MultiSelect } from '../core/MultiSelect/MultiSelect';
+import { MultiSelectOption } from '../core/MultiSelect/MultiSelect.types';
 import { TabSelect } from '../core/TabSelect/TabSelect';
 import { TabOption } from '../core/TabSelect/TabSelect.types';
 import { RecommendationIcon } from '../illustrations/RecommendationIcon';
@@ -37,8 +39,8 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
   const isLoggedId = filter?.address !== undefined;
 
   const tabOptions: TabOption[] = [
-    { value: 'all', label: 'All' },
     { value: 'foryou', label: 'For You' },
+    { value: 'all', label: 'All' },
   ];
 
   const handleTabChange = (value: string) => {
@@ -61,37 +63,159 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
           justifyContent: 'space-between',
           alignItems: 'center',
           width: '100%',
+          gap: 2,
         }}
       >
-        <Badge
-          variant={BadgeVariant.Primary}
-          size={BadgeSize.SM}
-          startIcon={<RecommendationIcon height={12} width={12} />}
-        />
-        <Box>{copy}</Box>
-        <EarnListMode variant={variant} setVariant={setVariant} />
+        {/* Left side: Badge and copy */}
+        <Box
+          sx={{
+            display: 'flex',
+            gap: 1.5,
+            alignItems: 'center',
+            flex: 1,
+          }}
+        >
+          <Badge
+            variant={BadgeVariant.Primary}
+            size={BadgeSize.SM}
+            startIcon={<RecommendationIcon height={12} width={12} />}
+          />
+          <Box>{copy}</Box>
+        </Box>
+
+        {/* Right side: List mode */}
+        <Box
+          sx={{
+            display: 'flex',
+            gap: 1.5,
+            alignItems: 'center',
+            flexShrink: 0,
+          }}
+        >
+          <EarnListMode variant={variant} setVariant={setVariant} />
+        </Box>
       </Box>
     );
   };
 
   const All = () => {
+    // Convert data to MultiSelect options
+    const chainOptions: MultiSelectOption[] = allChains.map((chain) => ({
+      value: chain.chainKey,
+      label: chain.chainKey,
+    }));
+
+    const protocolOptions: MultiSelectOption[] = allProtocols.map(
+      (protocol) => ({
+        value: protocol.name,
+        label: protocol.name,
+      }),
+    );
+
+    const tagOptions: MultiSelectOption[] = allTags.map((tag) => ({
+      value: tag,
+      label: tag,
+    }));
+
+    const assetOptions: MultiSelectOption[] = allAssets.map((asset) => ({
+      value: asset.name,
+      label: asset.name,
+    }));
+
+    const apyOptions: MultiSelectOption[] = Object.entries(allAPY).map(
+      ([key, value]) => ({
+        value: key,
+        label: `${key}: ${value}`,
+      }),
+    );
+
     return (
-      <>
-        <EarnListMode variant={variant} setVariant={setVariant} />
-        <EarnFilterSort sortBy={sortBy} setSortBy={setSortBy} />
-        <ul>
-          <li>chains: {allChains.map((x) => x.chainKey).join(', ')}</li>
-          <li>protocols: {allProtocols.map((x) => x.name).join(', ')}</li>
-          <li>assets: {allAssets.map((x) => x.name).join(', ')}</li>
-          <li>tags: {allTags.join(', ')}</li>
-          <li>
-            apy:{' '}
-            {Object.entries(allAPY)
-              .map(([key, value]) => `${key}: ${value}`)
-              .join(', ')}
-          </li>
-        </ul>
-      </>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          width: '100%',
+          gap: 2,
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            gap: 1.5,
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            flex: 1,
+          }}
+        >
+          <MultiSelect
+            options={chainOptions}
+            value={[]}
+            placeholder="Chains"
+            label="Chains"
+            size="small"
+            showChips={true}
+            showCheckbox={true}
+            maxChips={2}
+          />
+
+          <MultiSelect
+            options={protocolOptions}
+            value={[]}
+            placeholder="Protocols"
+            label="Protocols"
+            size="small"
+            showChips={true}
+            showCheckbox={true}
+            maxChips={2}
+          />
+
+          <MultiSelect
+            options={tagOptions}
+            value={[]}
+            placeholder="Tags"
+            label="Tags"
+            size="small"
+            showChips={true}
+            showCheckbox={true}
+            maxChips={2}
+          />
+
+          <MultiSelect
+            options={assetOptions}
+            value={[]}
+            placeholder="Assets"
+            label="Assets"
+            size="small"
+            showChips={true}
+            showCheckbox={true}
+            maxChips={2}
+          />
+
+          <MultiSelect
+            options={apyOptions}
+            value={[]}
+            placeholder="APY"
+            label="APY"
+            size="small"
+            showChips={true}
+            showCheckbox={true}
+            maxChips={2}
+          />
+        </Box>
+
+        <Box
+          sx={{
+            display: 'flex',
+            gap: 1.5,
+            alignItems: 'center',
+            flexShrink: 0,
+          }}
+        >
+          <EarnListMode variant={variant} setVariant={setVariant} />
+          <EarnFilterSort sortBy={sortBy} setSortBy={setSortBy} />
+        </Box>
+      </Box>
     );
   };
 

--- a/src/components/EarnFilter/EarnFilterBar.tsx
+++ b/src/components/EarnFilter/EarnFilterBar.tsx
@@ -180,6 +180,7 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
             label="Chains"
             size="small"
             show="count"
+            data-testid="earn-filter-chain-select"
           />
 
           <MultiSelect
@@ -190,6 +191,7 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
             label="Protocols"
             size="small"
             show="count"
+            data-testid="earn-filter-protocol-select"
           />
 
           <MultiSelect
@@ -200,6 +202,7 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
             label="Tags"
             size="small"
             show="count"
+            data-testid="earn-filter-tag-select"
           />
 
           <MultiSelect
@@ -210,6 +213,7 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
             label="Assets"
             size="small"
             show="count"
+            data-testid="earn-filter-asset-select"
           />
 
           <MultiSelect
@@ -220,6 +224,7 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
             label="APY"
             size="small"
             show="count"
+            data-testid="earn-filter-apy-select"
           />
         </Box>
 
@@ -246,6 +251,7 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
         onChange={handleTabChange}
         variant="standard"
         size="medium"
+        data-testid="earn-filter-tab-select"
       />
       {showForYou ? <ForYou /> : <All />}
     </EarnFilterBarContainer>

--- a/src/components/EarnFilter/EarnFilterBar.tsx
+++ b/src/components/EarnFilter/EarnFilterBar.tsx
@@ -38,7 +38,19 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
   };
 
   const ForYou = () => {
-    return <Box>For You</Box>;
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          width: '100%',
+        }}
+      >
+        <Box>Hello world</Box>
+        <EarnListMode variant={variant} setVariant={setVariant} />
+      </Box>
+    );
   };
 
   const All = () => {

--- a/src/components/EarnFilter/EarnFilterBar.tsx
+++ b/src/components/EarnFilter/EarnFilterBar.tsx
@@ -35,8 +35,8 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
     showForYou,
     toggleForYou,
     filter,
+    usedYourAddress,
   } = useEarnFiltering();
-  const isLoggedId = filter?.address !== undefined;
 
   const tabOptions: TabOption[] = [
     { value: 'foryou', label: 'For You' },
@@ -50,8 +50,10 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
   const ForYou = () => {
     const formatedTotalMarkets = totalMarkets.toLocaleString();
 
-    const copy = isLoggedId
-      ? t('earn.copy.forYouBasedOnActivity')
+    const copy = usedYourAddress
+      ? t('earn.copy.forYouBasedOnActivity', {
+          totalMarkets: formatedTotalMarkets,
+        })
       : t('earn.copy.forYouDefault', { totalMarkets: formatedTotalMarkets });
 
     // TODO: add latest update in backend and render here

--- a/src/components/EarnFilter/EarnFilterBar.tsx
+++ b/src/components/EarnFilter/EarnFilterBar.tsx
@@ -154,8 +154,7 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
             placeholder="Chains"
             label="Chains"
             size="small"
-            showChips={true}
-            showCheckbox={true}
+            show="chips"
             maxChips={2}
           />
 
@@ -165,8 +164,7 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
             placeholder="Protocols"
             label="Protocols"
             size="small"
-            showChips={true}
-            showCheckbox={true}
+            show="chips"
             maxChips={2}
           />
 
@@ -176,8 +174,7 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
             placeholder="Tags"
             label="Tags"
             size="small"
-            showChips={true}
-            showCheckbox={true}
+            show="chips"
             maxChips={2}
           />
 
@@ -187,8 +184,7 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
             placeholder="Assets"
             label="Assets"
             size="small"
-            showChips={true}
-            showCheckbox={true}
+            show="chips"
             maxChips={2}
           />
 
@@ -198,8 +194,7 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
             placeholder="APY"
             label="APY"
             size="small"
-            showChips={true}
-            showCheckbox={true}
+            show="chips"
             maxChips={2}
           />
         </Box>

--- a/src/components/EarnFilter/EarnFilterBar.tsx
+++ b/src/components/EarnFilter/EarnFilterBar.tsx
@@ -1,24 +1,60 @@
+import { Box } from '@mui/system';
+import { useState } from 'react';
 import { useEarnFiltering } from '../../app/ui/earn/EarnFilteringContext';
+import { EarnCardVariant } from '../Cards/EarnCard/EarnCard.types';
+import { EarnFilterBarContainer } from './EarnFilterBar.styles';
+import { EarnFilterSort, SortByOptions } from './EarnFilterSort';
+import { EarnFilterTab } from './EarnFilterTab';
+import { EarnListMode } from './EarnListMode';
 
-export const EarnFilterBar: React.FC<{}> = () => {
-  const { allChains, allProtocols, allAssets, allTags, allAPY } =
-    useEarnFiltering();
+type Props = {
+  variant: EarnCardVariant;
+  setVariant: (variant: EarnCardVariant) => void;
+};
+
+export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
+  // TODO: introduce the loading state?
+  const [sortBy, setSortBy] = useState<SortByOptions>(SortByOptions.APY); // TODO: move to context.
+
+  const {
+    allChains,
+    allProtocols,
+    allAssets,
+    allTags,
+    allAPY,
+    showForYou,
+    toggleForYou,
+  } = useEarnFiltering();
+
+  const ForYou = () => {
+    return <Box>For You</Box>;
+  };
+
+  const All = () => {
+    return (
+      <>
+        <EarnListMode variant={variant} setVariant={setVariant} />
+        <EarnFilterSort sortBy={sortBy} setSortBy={setSortBy} />
+        <ul>
+          <li>chains: {allChains.map((x) => x.chainKey).join(', ')}</li>
+          <li>protocols: {allProtocols.map((x) => x.name).join(', ')}</li>
+          <li>assets: {allAssets.map((x) => x.name).join(', ')}</li>
+          <li>tags: {allTags.join(', ')}</li>
+          <li>
+            apy:{' '}
+            {Object.entries(allAPY)
+              .map(([key, value]) => `${key}: ${value}`)
+              .join(', ')}
+          </li>
+        </ul>
+      </>
+    );
+  };
 
   return (
-    <div>
-      <h1>Filter</h1>
-      <ul>
-        <li>chains: {allChains.map((x) => x.chainKey).join(', ')}</li>
-        <li>protocols: {allProtocols.map((x) => x.name).join(', ')}</li>
-        <li>assets: {allAssets.map((x) => x.name).join(', ')}</li>
-        <li>tags: {allTags.join(', ')}</li>
-        <li>
-          apy:{' '}
-          {Object.entries(allAPY)
-            .map(([key, value]) => `${key}: ${value}`)
-            .join(', ')}
-        </li>
-      </ul>
-    </div>
+    <EarnFilterBarContainer>
+      {/* <EarnFilterTab showForYou={showForYou} toggleForYou={toggleForYou} /> */}
+      {showForYou ? <ForYou /> : <All />}
+    </EarnFilterBarContainer>
   );
 };

--- a/src/components/EarnFilter/EarnFilterBar.tsx
+++ b/src/components/EarnFilter/EarnFilterBar.tsx
@@ -1,12 +1,15 @@
+import { Badge } from 'src/components/Badge/Badge';
 import { Box } from '@mui/system';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useEarnFiltering } from '../../app/ui/earn/EarnFilteringContext';
+import { BadgeSize, BadgeVariant } from 'src/components/Badge/Badge.styles';
 import { EarnCardVariant } from '../Cards/EarnCard/EarnCard.types';
 import { TabSelect } from '../core/TabSelect/TabSelect';
 import { TabOption } from '../core/TabSelect/TabSelect.types';
+import { RecommendationIcon } from '../illustrations/RecommendationIcon';
 import { EarnFilterBarContainer } from './EarnFilterBar.styles';
 import { EarnFilterSort, SortByOptions } from './EarnFilterSort';
-import { EarnFilterTab } from './EarnFilterTab';
 import { EarnListMode } from './EarnListMode';
 
 type Props = {
@@ -15,10 +18,13 @@ type Props = {
 };
 
 export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
+  const { t } = useTranslation();
+
   // TODO: introduce the loading state?
   const [sortBy, setSortBy] = useState<SortByOptions>(SortByOptions.APY); // TODO: move to context.
 
   const {
+    totalMarkets,
     allChains,
     allProtocols,
     allAssets,
@@ -26,7 +32,9 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
     allAPY,
     showForYou,
     toggleForYou,
+    filter,
   } = useEarnFiltering();
+  const isLoggedId = filter?.address !== undefined;
 
   const tabOptions: TabOption[] = [
     { value: 'all', label: 'All' },
@@ -38,6 +46,14 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
   };
 
   const ForYou = () => {
+    const formatedTotalMarkets = totalMarkets.toLocaleString();
+
+    const copy = isLoggedId
+      ? t('earn.copy.forYouBasedOnActivity')
+      : t('earn.copy.forYouDefault', { totalMarkets: formatedTotalMarkets });
+
+    // TODO: add latest update in backend and render here
+
     return (
       <Box
         sx={{
@@ -47,7 +63,12 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
           width: '100%',
         }}
       >
-        <Box>Hello world</Box>
+        <Badge
+          variant={BadgeVariant.Primary}
+          size={BadgeSize.SM}
+          startIcon={<RecommendationIcon height={12} width={12} />}
+        />
+        <Box>{copy}</Box>
         <EarnListMode variant={variant} setVariant={setVariant} />
       </Box>
     );

--- a/src/components/EarnFilter/EarnFilterBar.tsx
+++ b/src/components/EarnFilter/EarnFilterBar.tsx
@@ -35,6 +35,7 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
     showForYou,
     toggleForYou,
     filter,
+    updateFilter,
     usedYourAddress,
   } = useEarnFiltering();
 
@@ -103,7 +104,7 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
   const All = () => {
     // Convert data to MultiSelect options
     const chainOptions: MultiSelectOption[] = allChains.map((chain) => ({
-      value: chain.chainKey,
+      value: `${chain.chainId}`,
       label: chain.chainKey,
     }));
 
@@ -131,6 +132,27 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
       }),
     );
 
+    // Handle filter changes
+    const handleChainChange = (values: string[]) => {
+      updateFilter({ ...filter, chains: values.map(Number) });
+    };
+
+    const handleProtocolChange = (values: string[]) => {
+      updateFilter({ ...filter, protocols: values });
+    };
+
+    const handleTagChange = (values: string[]) => {
+      updateFilter({ ...filter, tags: values });
+    };
+
+    const handleAssetChange = (values: string[]) => {
+      updateFilter({ ...filter, assets: values });
+    };
+
+    const handleAPYChange = (values: string[]) => {
+      // TODO: implement
+    };
+
     return (
       <Box
         sx={{
@@ -152,52 +174,52 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
         >
           <MultiSelect
             options={chainOptions}
-            value={[]}
+            value={filter?.chains?.map(String) ?? []}
+            onChange={handleChainChange}
             placeholder="Chains"
             label="Chains"
             size="small"
-            show="chips"
-            maxChips={2}
+            show="count"
           />
 
           <MultiSelect
             options={protocolOptions}
-            value={[]}
+            value={filter?.protocols || []}
+            onChange={handleProtocolChange}
             placeholder="Protocols"
             label="Protocols"
             size="small"
-            show="chips"
-            maxChips={2}
+            show="count"
           />
 
           <MultiSelect
             options={tagOptions}
-            value={[]}
+            value={filter?.tags || []}
+            onChange={handleTagChange}
             placeholder="Tags"
             label="Tags"
             size="small"
-            show="chips"
-            maxChips={2}
+            show="count"
           />
 
           <MultiSelect
             options={assetOptions}
-            value={[]}
+            value={filter?.assets || []}
+            onChange={handleAssetChange}
             placeholder="Assets"
             label="Assets"
             size="small"
-            show="chips"
-            maxChips={2}
+            show="count"
           />
 
           <MultiSelect
             options={apyOptions}
-            value={[]}
+            value={[]} // TODO: implement
+            onChange={handleAPYChange}
             placeholder="APY"
             label="APY"
             size="small"
-            show="chips"
-            maxChips={2}
+            show="count"
           />
         </Box>
 

--- a/src/components/EarnFilter/EarnFilterBar.tsx
+++ b/src/components/EarnFilter/EarnFilterBar.tsx
@@ -2,6 +2,8 @@ import { Box } from '@mui/system';
 import { useState } from 'react';
 import { useEarnFiltering } from '../../app/ui/earn/EarnFilteringContext';
 import { EarnCardVariant } from '../Cards/EarnCard/EarnCard.types';
+import { TabSelect } from '../core/TabSelect/TabSelect';
+import { TabOption } from '../core/TabSelect/TabSelect.types';
 import { EarnFilterBarContainer } from './EarnFilterBar.styles';
 import { EarnFilterSort, SortByOptions } from './EarnFilterSort';
 import { EarnFilterTab } from './EarnFilterTab';
@@ -25,6 +27,15 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
     showForYou,
     toggleForYou,
   } = useEarnFiltering();
+
+  const tabOptions: TabOption[] = [
+    { value: 'all', label: 'All' },
+    { value: 'foryou', label: 'For You' },
+  ];
+
+  const handleTabChange = (value: string) => {
+    toggleForYou();
+  };
 
   const ForYou = () => {
     return <Box>For You</Box>;
@@ -53,7 +64,13 @@ export const EarnFilterBar: React.FC<Props> = ({ variant, setVariant }) => {
 
   return (
     <EarnFilterBarContainer>
-      {/* <EarnFilterTab showForYou={showForYou} toggleForYou={toggleForYou} /> */}
+      <TabSelect
+        options={tabOptions}
+        value={showForYou ? 'foryou' : 'all'}
+        onChange={handleTabChange}
+        variant="standard"
+        size="medium"
+      />
       {showForYou ? <ForYou /> : <All />}
     </EarnFilterBarContainer>
   );

--- a/src/components/EarnFilter/EarnFilterSort.tsx
+++ b/src/components/EarnFilter/EarnFilterSort.tsx
@@ -1,11 +1,5 @@
-import {
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-  SelectChangeEvent,
-} from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { SingleSelect } from '../core/SingleSelect/SingleSelect';
 
 // TODO: migrate to backend's typing
 export enum SortByOptions {
@@ -21,23 +15,21 @@ type Props = {
 export const EarnFilterSort: React.FC<Props> = ({ sortBy, setSortBy }) => {
   const { t } = useTranslation();
 
-  const handleChange = (event: SelectChangeEvent) => {
-    setSortBy(event.target.value as SortByOptions);
+  const handleChange = (value: string) => {
+    setSortBy(value as SortByOptions);
   };
 
   return (
-    <FormControl variant="outlined" size="small" sx={{ minWidth: 120 }}>
-      <InputLabel id="sort-by-label">{t('earn.sorting.sortBy')}</InputLabel>
-      <Select
-        labelId="sort-by-label"
-        id="sort-by-select"
-        value={sortBy}
-        onChange={handleChange}
-        label={t('earn.sorting.sortBy')}
-      >
-        <MenuItem value={SortByOptions.APY}>{t('earn.sorting.apy')}</MenuItem>
-        <MenuItem value={SortByOptions.TVL}>{t('earn.sorting.tvl')}</MenuItem>
-      </Select>
-    </FormControl>
+    <SingleSelect
+      options={[
+        { value: SortByOptions.APY, label: t('earn.sorting.apy') },
+        { value: SortByOptions.TVL, label: t('earn.sorting.tvl') },
+      ]}
+      value={sortBy}
+      onChange={handleChange}
+      placeholder={t('earn.sorting.sortBy')}
+      label={t('earn.sorting.sortBy')}
+      size="small"
+    />
   );
 };

--- a/src/components/EarnFilter/EarnFilterSort.tsx
+++ b/src/components/EarnFilter/EarnFilterSort.tsx
@@ -30,6 +30,7 @@ export const EarnFilterSort: React.FC<Props> = ({ sortBy, setSortBy }) => {
       placeholder={t('earn.sorting.sortBy')}
       label={t('earn.sorting.sortBy')}
       size="small"
+      data-testid="earn-filter-sort-select"
     />
   );
 };

--- a/src/components/EarnFilter/EarnFilterSort.tsx
+++ b/src/components/EarnFilter/EarnFilterSort.tsx
@@ -1,0 +1,43 @@
+import {
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+// TODO: migrate to backend's typing
+export enum SortByOptions {
+  APY = 'apy',
+  TVL = 'tvl',
+}
+
+type Props = {
+  sortBy: SortByOptions;
+  setSortBy: (sortBy: SortByOptions) => void;
+};
+
+export const EarnFilterSort: React.FC<Props> = ({ sortBy, setSortBy }) => {
+  const { t } = useTranslation();
+
+  const handleChange = (event: SelectChangeEvent) => {
+    setSortBy(event.target.value as SortByOptions);
+  };
+
+  return (
+    <FormControl variant="outlined" size="small" sx={{ minWidth: 120 }}>
+      <InputLabel id="sort-by-label">{t('earn.sorting.sortBy')}</InputLabel>
+      <Select
+        labelId="sort-by-label"
+        id="sort-by-select"
+        value={sortBy}
+        onChange={handleChange}
+        label={t('earn.sorting.sortBy')}
+      >
+        <MenuItem value={SortByOptions.APY}>{t('earn.sorting.apy')}</MenuItem>
+        <MenuItem value={SortByOptions.TVL}>{t('earn.sorting.tvl')}</MenuItem>
+      </Select>
+    </FormControl>
+  );
+};

--- a/src/components/EarnFilter/EarnFilterTab.tsx
+++ b/src/components/EarnFilter/EarnFilterTab.tsx
@@ -1,0 +1,3 @@
+export const EarnFilterTab = () => {
+  return null;
+};

--- a/src/components/EarnFilter/EarnListMode.tsx
+++ b/src/components/EarnFilter/EarnListMode.tsx
@@ -1,0 +1,28 @@
+import GridViewIcon from '@mui/icons-material/GridView';
+import ListIcon from '@mui/icons-material/List';
+import { EarnCardVariant } from '../Cards/EarnCard/EarnCard.types';
+import { IconButton, IconButtonDynamic } from '../IconButton';
+
+type Props = {
+  variant: EarnCardVariant;
+  setVariant: (variant: EarnCardVariant) => void;
+};
+
+export const EarnListMode: React.FC<Props> = ({ variant, setVariant }) => {
+  return (
+    <>
+      <IconButtonDynamic
+        onClick={() => setVariant('list-item')}
+        variant={variant === 'list-item' ? 'primary' : undefined}
+      >
+        <ListIcon />
+      </IconButtonDynamic>
+      <IconButtonDynamic
+        onClick={() => setVariant('compact')}
+        variant={variant === 'compact' ? 'primary' : undefined}
+      >
+        <GridViewIcon />
+      </IconButtonDynamic>
+    </>
+  );
+};

--- a/src/components/EarnFilter/EarnListMode.tsx
+++ b/src/components/EarnFilter/EarnListMode.tsx
@@ -37,6 +37,7 @@ export const EarnListMode: React.FC<Props> = ({ variant, setVariant }) => {
       size="medium"
       showTooltip={true}
       color="primary"
+      data-testid="earn-filter-list-mode-select"
     />
   );
 };

--- a/src/components/EarnFilter/EarnListMode.tsx
+++ b/src/components/EarnFilter/EarnListMode.tsx
@@ -1,7 +1,8 @@
 import GridViewIcon from '@mui/icons-material/GridView';
 import ListIcon from '@mui/icons-material/List';
 import { EarnCardVariant } from '../Cards/EarnCard/EarnCard.types';
-import { IconButton, IconButtonDynamic } from '../IconButton';
+import { IconSelect } from '../core/IconSelect/IconSelect';
+import { IconOption } from '../core/IconSelect/IconSelect.types';
 
 type Props = {
   variant: EarnCardVariant;
@@ -9,20 +10,33 @@ type Props = {
 };
 
 export const EarnListMode: React.FC<Props> = ({ variant, setVariant }) => {
+  const viewOptions: IconOption[] = [
+    {
+      value: 'list-item',
+      icon: <ListIcon />,
+      tooltip: 'List View',
+    },
+    {
+      value: 'compact',
+      icon: <GridViewIcon />,
+      tooltip: 'Grid View',
+    },
+  ];
+
+  const handleChange = (value: string | string[]) => {
+    setVariant(value as EarnCardVariant);
+  };
+
   return (
-    <>
-      <IconButtonDynamic
-        onClick={() => setVariant('list-item')}
-        variant={variant === 'list-item' ? 'primary' : undefined}
-      >
-        <ListIcon />
-      </IconButtonDynamic>
-      <IconButtonDynamic
-        onClick={() => setVariant('compact')}
-        variant={variant === 'compact' ? 'primary' : undefined}
-      >
-        <GridViewIcon />
-      </IconButtonDynamic>
-    </>
+    <IconSelect
+      options={viewOptions}
+      value={variant}
+      onChange={handleChange}
+      selectionMode="radio"
+      variant="text"
+      size="medium"
+      showTooltip={true}
+      color="primary"
+    />
   );
 };

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -18,7 +18,6 @@ export const IconButton = styled(MuiIconButtom)<IconButtonProps>(
 
       ...theme.applyStyles('light', {
         backgroundColor: (theme.vars || theme).palette.alphaDark200.main,
-
       }),
     },
     ...theme.applyStyles('light', {
@@ -70,3 +69,24 @@ export const IconButtonAlpha = styled(IconButton)(({ theme }) => ({
     backgroundColor: theme.palette.alphaDark100.main,
   }),
 }));
+type IconButtonDynamicProps = IconButtonProps & {
+  variant?: 'primary' | 'secondary' | 'alpha';
+};
+
+export const IconButtonDynamic: React.FC<IconButtonDynamicProps> = ({
+  variant,
+  ...props
+}) => {
+  // TODO: this won't animate, replace with a proper component.
+  switch (variant) {
+    case 'primary':
+      return <IconButtonPrimary {...props} />;
+    case 'secondary':
+      return <IconButtonSecondary {...props} />;
+    case 'alpha':
+      return <IconButtonAlpha {...props} />;
+    case undefined:
+      return <IconButton {...props} />;
+  }
+  // TODO: assert never type here
+};

--- a/src/components/core/IconSelect/IconSelect.stories.tsx
+++ b/src/components/core/IconSelect/IconSelect.stories.tsx
@@ -1,0 +1,496 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { IconSelect } from './IconSelect';
+import { IconOption } from './IconSelect.types';
+import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
+import FormatAlignCenterIcon from '@mui/icons-material/FormatAlignCenter';
+import FormatAlignRightIcon from '@mui/icons-material/FormatAlignRight';
+import FormatAlignJustifyIcon from '@mui/icons-material/FormatAlignJustify';
+import FormatBoldIcon from '@mui/icons-material/FormatBold';
+import FormatItalicIcon from '@mui/icons-material/FormatItalic';
+import FormatUnderlinedIcon from '@mui/icons-material/FormatUnderlined';
+import StrikethroughSIcon from '@mui/icons-material/StrikethroughS';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import ViewListIcon from '@mui/icons-material/ViewList';
+import ViewQuiltIcon from '@mui/icons-material/ViewQuilt';
+import ViewColumnIcon from '@mui/icons-material/ViewColumn';
+import LightModeIcon from '@mui/icons-material/LightMode';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
+import SettingsBrightnessIcon from '@mui/icons-material/SettingsBrightness';
+import PaletteIcon from '@mui/icons-material/Palette';
+import BrushIcon from '@mui/icons-material/Brush';
+import ColorLensIcon from '@mui/icons-material/ColorLens';
+import InvertColorsIcon from '@mui/icons-material/InvertColors';
+
+const meta = {
+  title: 'Components/Core/IconSelect',
+  component: IconSelect,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: { type: 'select' },
+      options: ['small', 'medium', 'large'],
+    },
+    color: {
+      control: { type: 'select' },
+      options: ['primary', 'secondary', 'default'],
+    },
+    selectionMode: {
+      control: { type: 'select' },
+      options: ['toggle', 'radio'],
+    },
+    variant: {
+      control: { type: 'select' },
+      options: ['contained', 'outlined', 'text'],
+    },
+    orientation: {
+      control: { type: 'select' },
+      options: ['horizontal', 'vertical', 'grid'],
+    },
+  },
+} satisfies Meta<typeof IconSelect>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const alignmentOptions: IconOption[] = [
+  {
+    value: 'left',
+    icon: <FormatAlignLeftIcon />,
+    tooltip: 'Align Left',
+    label: 'Left',
+  },
+  {
+    value: 'center',
+    icon: <FormatAlignCenterIcon />,
+    tooltip: 'Align Center',
+    label: 'Center',
+  },
+  {
+    value: 'right',
+    icon: <FormatAlignRightIcon />,
+    tooltip: 'Align Right',
+    label: 'Right',
+  },
+  {
+    value: 'justify',
+    icon: <FormatAlignJustifyIcon />,
+    tooltip: 'Justify',
+    label: 'Justify',
+  },
+];
+
+const formattingOptions: IconOption[] = [
+  {
+    value: 'bold',
+    icon: <FormatBoldIcon />,
+    tooltip: 'Bold',
+  },
+  {
+    value: 'italic',
+    icon: <FormatItalicIcon />,
+    tooltip: 'Italic',
+  },
+  {
+    value: 'underlined',
+    icon: <FormatUnderlinedIcon />,
+    tooltip: 'Underlined',
+  },
+  {
+    value: 'strikethrough',
+    icon: <StrikethroughSIcon />,
+    tooltip: 'Strikethrough',
+  },
+];
+
+const viewOptions: IconOption[] = [
+  {
+    value: 'module',
+    icon: <ViewModuleIcon />,
+    tooltip: 'Module View',
+    label: 'Module',
+  },
+  {
+    value: 'list',
+    icon: <ViewListIcon />,
+    tooltip: 'List View',
+    label: 'List',
+  },
+  {
+    value: 'quilt',
+    icon: <ViewQuiltIcon />,
+    tooltip: 'Quilt View',
+    label: 'Quilt',
+  },
+  {
+    value: 'column',
+    icon: <ViewColumnIcon />,
+    tooltip: 'Column View',
+    label: 'Column',
+  },
+];
+
+const themeOptions: IconOption[] = [
+  {
+    value: 'light',
+    icon: <LightModeIcon />,
+    tooltip: 'Light Mode',
+  },
+  {
+    value: 'dark',
+    icon: <DarkModeIcon />,
+    tooltip: 'Dark Mode',
+  },
+  {
+    value: 'auto',
+    icon: <SettingsBrightnessIcon />,
+    tooltip: 'Auto Mode',
+  },
+];
+
+const colorOptions: IconOption[] = [
+  {
+    value: 'red',
+    icon: <PaletteIcon />,
+    color: '#f44336',
+    tooltip: 'Red',
+  },
+  {
+    value: 'blue',
+    icon: <BrushIcon />,
+    color: '#2196f3',
+    tooltip: 'Blue',
+  },
+  {
+    value: 'green',
+    icon: <ColorLensIcon />,
+    color: '#4caf50',
+    tooltip: 'Green',
+  },
+  {
+    value: 'purple',
+    icon: <InvertColorsIcon />,
+    color: '#9c27b0',
+    tooltip: 'Purple',
+  },
+];
+
+export const SingleSelection: Story = {
+  args: {
+    options: alignmentOptions,
+    value: 'left',
+    multiple: false,
+    size: 'medium',
+    variant: 'outlined',
+    showTooltip: true,
+    showLabel: false,
+    selectionMode: 'toggle',
+  },
+};
+
+export const MultipleSelection: Story = {
+  args: {
+    options: formattingOptions,
+    value: ['bold', 'italic'],
+    multiple: true,
+    size: 'medium',
+    variant: 'outlined',
+    showTooltip: true,
+    selectionMode: 'toggle',
+  },
+};
+
+export const WithLabels: Story = {
+  args: {
+    options: viewOptions,
+    value: 'module',
+    multiple: false,
+    size: 'medium',
+    variant: 'outlined',
+    showLabel: true,
+    showTooltip: false,
+    selectionMode: 'toggle',
+  },
+};
+
+export const RadioMode: Story = {
+  args: {
+    options: themeOptions,
+    value: 'light',
+    multiple: false,
+    size: 'medium',
+    variant: 'outlined',
+    selectionMode: 'radio',
+    showTooltip: true,
+  },
+};
+
+export const ColoredIcons: Story = {
+  args: {
+    options: colorOptions,
+    value: 'red',
+    multiple: false,
+    size: 'medium',
+    variant: 'outlined',
+    selectionMode: 'toggle',
+    showTooltip: true,
+  },
+};
+
+export const VerticalOrientation: Story = {
+  args: {
+    options: alignmentOptions,
+    value: 'left',
+    orientation: 'vertical',
+    size: 'medium',
+    variant: 'outlined',
+    selectionMode: 'toggle',
+  },
+};
+
+export const GridLayout: Story = {
+  args: {
+    options: [...alignmentOptions, ...formattingOptions],
+    value: [],
+    multiple: true,
+    orientation: 'grid',
+    columns: 4,
+    size: 'medium',
+    variant: 'outlined',
+    selectionMode: 'radio',
+    showTooltip: true,
+  },
+};
+
+export const SmallSize: Story = {
+  args: {
+    options: themeOptions,
+    value: 'light',
+    size: 'small',
+    variant: 'outlined',
+    selectionMode: 'toggle',
+  },
+};
+
+export const LargeSize: Story = {
+  args: {
+    options: themeOptions,
+    value: 'light',
+    size: 'large',
+    variant: 'outlined',
+    selectionMode: 'toggle',
+  },
+};
+
+export const ContainedVariant: Story = {
+  args: {
+    options: alignmentOptions,
+    value: 'center',
+    variant: 'contained',
+    size: 'medium',
+    selectionMode: 'toggle',
+  },
+};
+
+export const TextVariant: Story = {
+  args: {
+    options: alignmentOptions,
+    value: 'center',
+    variant: 'text',
+    size: 'medium',
+    selectionMode: 'toggle',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    options: alignmentOptions,
+    value: 'left',
+    disabled: true,
+    size: 'medium',
+    variant: 'outlined',
+    selectionMode: 'toggle',
+  },
+};
+
+export const SecondaryColor: Story = {
+  args: {
+    options: formattingOptions,
+    value: ['bold'],
+    multiple: true,
+    color: 'secondary',
+    size: 'medium',
+    variant: 'outlined',
+    selectionMode: 'toggle',
+  },
+};
+
+export const WithDisabledOptions: Story = {
+  args: {
+    options: [
+      ...alignmentOptions.slice(0, 2),
+      { ...alignmentOptions[2], disabled: true },
+      alignmentOptions[3],
+    ],
+    value: 'left',
+    size: 'medium',
+    variant: 'outlined',
+    selectionMode: 'toggle',
+  },
+};
+
+export const InteractiveAlignment: Story = {
+  args: {
+    options: alignmentOptions,
+    value: 'left',
+    selectionMode: 'radio',
+    variant: 'outlined',
+    showTooltip: true,
+  },
+  render: (args) => {
+    const [alignment, setAlignment] = useState(args.value as string);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
+        <IconSelect
+          {...args}
+          value={alignment}
+          onChange={(value) => setAlignment(value as string)}
+        />
+        <div
+          style={{
+            padding: '20px',
+            border: '1px solid #e0e0e0',
+            borderRadius: '4px',
+            textAlign: alignment as any,
+          }}
+        >
+          <h3>Sample Text</h3>
+          <p>This text is aligned according to your selection above.</p>
+          <p>Current alignment: {alignment}</p>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const TextFormatting: Story = {
+  args: {
+    options: formattingOptions,
+    value: ['bold'],
+    multiple: true,
+    selectionMode: 'toggle',
+    variant: 'outlined',
+    showTooltip: true,
+  },
+  render: (args) => {
+    const [formats, setFormats] = useState<string[]>(
+      (args.value as string[]) || ['bold'],
+    );
+
+    const getTextStyle = () => {
+      const styles: React.CSSProperties = {};
+      if (formats.includes('bold')) styles.fontWeight = 'bold';
+      if (formats.includes('italic')) styles.fontStyle = 'italic';
+      if (formats.includes('underlined')) styles.textDecoration = 'underline';
+      if (formats.includes('strikethrough'))
+        styles.textDecoration = 'line-through';
+      return styles;
+    };
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
+        <IconSelect
+          {...args}
+          value={formats}
+          onChange={(value) => setFormats(value as string[])}
+        />
+        <div
+          style={{
+            padding: '20px',
+            border: '1px solid #e0e0e0',
+            borderRadius: '4px',
+          }}
+        >
+          <p style={getTextStyle()}>
+            This text demonstrates the selected formatting options.
+          </p>
+          <p>Active formats: {formats.join(', ') || 'None'}</p>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const ComplexExample: Story = {
+  args: {
+    options: viewOptions,
+    value: 'module',
+    selectionMode: 'radio',
+    variant: 'outlined',
+  },
+  render: () => {
+    const [viewMode, setViewMode] = useState('module');
+    const [theme, setTheme] = useState('light');
+    const [formatting, setFormatting] = useState<string[]>([]);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '32px' }}>
+        <div>
+          <h3>View Mode (Single Selection)</h3>
+          <IconSelect
+            options={viewOptions}
+            value={viewMode}
+            onChange={(value) => setViewMode(value as string)}
+            selectionMode="radio"
+            variant="outlined"
+            showLabel={true}
+            showTooltip={false}
+          />
+        </div>
+
+        <div>
+          <h3>Theme Selection (Radio Mode)</h3>
+          <IconSelect
+            options={themeOptions}
+            value={theme}
+            onChange={(value) => setTheme(value as string)}
+            selectionMode="radio"
+            variant="contained"
+            color="secondary"
+          />
+        </div>
+
+        <div>
+          <h3>Text Formatting (Multiple Selection)</h3>
+          <IconSelect
+            options={formattingOptions}
+            value={formatting}
+            onChange={(value) => setFormatting(value as string[])}
+            multiple={true}
+            selectionMode="toggle"
+            variant="outlined"
+            size="large"
+          />
+        </div>
+
+        <div
+          style={{
+            padding: '20px',
+            border: '1px solid #e0e0e0',
+            borderRadius: '8px',
+            backgroundColor: theme === 'dark' ? '#333' : '#fff',
+            color: theme === 'dark' ? '#fff' : '#333',
+          }}
+        >
+          <h4>Current Settings:</h4>
+          <ul>
+            <li>View: {viewMode}</li>
+            <li>Theme: {theme}</li>
+            <li>Formatting: {formatting.join(', ') || 'None'}</li>
+          </ul>
+        </div>
+      </div>
+    );
+  },
+};

--- a/src/components/core/IconSelect/IconSelect.styles.ts
+++ b/src/components/core/IconSelect/IconSelect.styles.ts
@@ -24,30 +24,6 @@ interface StyledIconButtonProps extends IconButtonProps {
   variant?: 'contained' | 'outlined' | 'text';
 }
 
-const getButtonSize = (size?: 'small' | 'medium' | 'large') => {
-  switch (size) {
-    case 'small':
-      return {
-        width: 40,
-        height: 40,
-        fontSize: '1.25rem',
-      };
-    case 'large':
-      return {
-        width: 64,
-        height: 64,
-        fontSize: '2rem',
-      };
-    case 'medium':
-    default:
-      return {
-        width: 48,
-        height: 48,
-        fontSize: '1.5rem',
-      };
-  }
-};
-
 export const IconSelectContainer = styled(Box, {
   shouldForwardProp: (prop) =>
     prop !== 'orientation' && prop !== 'columns' && prop !== 'fullWidth',

--- a/src/components/core/IconSelect/IconSelect.styles.ts
+++ b/src/components/core/IconSelect/IconSelect.styles.ts
@@ -1,0 +1,247 @@
+import { styled } from '@mui/material/styles';
+import ToggleButton, { ToggleButtonProps } from '@mui/material/ToggleButton';
+import ToggleButtonGroup, {
+  ToggleButtonGroupProps,
+} from '@mui/material/ToggleButtonGroup';
+import IconButton, { IconButtonProps } from '@mui/material/IconButton';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+interface IconSelectContainerProps {
+  orientation?: 'horizontal' | 'vertical' | 'grid';
+  columns?: number;
+  fullWidth?: boolean;
+}
+
+interface StyledToggleButtonProps extends ToggleButtonProps {
+  variant?: 'contained' | 'outlined' | 'text';
+  selectedColor?: 'primary' | 'secondary' | 'default';
+}
+
+interface StyledIconButtonProps extends IconButtonProps {
+  isSelected?: boolean;
+  selectedColor?: 'primary' | 'secondary' | 'default';
+  variant?: 'contained' | 'outlined' | 'text';
+}
+
+const getButtonSize = (size?: 'small' | 'medium' | 'large') => {
+  switch (size) {
+    case 'small':
+      return {
+        width: 40,
+        height: 40,
+        fontSize: '1.25rem',
+      };
+    case 'large':
+      return {
+        width: 64,
+        height: 64,
+        fontSize: '2rem',
+      };
+    case 'medium':
+    default:
+      return {
+        width: 48,
+        height: 48,
+        fontSize: '1.5rem',
+      };
+  }
+};
+
+export const IconSelectContainer = styled(Box, {
+  shouldForwardProp: (prop) =>
+    prop !== 'orientation' && prop !== 'columns' && prop !== 'fullWidth',
+})<IconSelectContainerProps>(({ theme, orientation, columns, fullWidth }) => ({
+  display: orientation === 'grid' ? 'grid' : 'flex',
+  flexDirection: orientation === 'vertical' ? 'column' : 'row',
+  flexWrap: orientation === 'horizontal' ? 'wrap' : undefined,
+  gap: theme.spacing(1),
+  width: fullWidth ? '100%' : 'auto',
+  ...(orientation === 'grid' && {
+    gridTemplateColumns: `repeat(${columns || 'auto-fill'}, minmax(64px, 1fr))`,
+    gridGap: theme.spacing(1),
+  }),
+}));
+
+export const StyledToggleButtonGroup = styled(
+  ToggleButtonGroup,
+)<ToggleButtonGroupProps>(({ theme }) => ({
+  '& .MuiToggleButton-root': {
+    margin: theme.spacing(0.5),
+    border: 0,
+    '&.Mui-disabled': {
+      border: 0,
+    },
+    '&:not(:first-of-type)': {
+      borderRadius: theme.shape.borderRadius,
+    },
+    '&:first-of-type': {
+      borderRadius: theme.shape.borderRadius,
+    },
+  },
+}));
+
+export const StyledToggleButton = styled(ToggleButton, {
+  shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'selectedColor',
+})<StyledToggleButtonProps>(({
+  theme,
+  variant = 'outlined',
+  selectedColor = 'primary',
+}) => {
+  const colorMap = {
+    primary: (theme.vars || theme).palette.primary.main,
+    secondary: (theme.vars || theme).palette.secondary.main,
+    default: (theme.vars || theme).palette.action.active,
+  };
+
+  const contrastTextMap = {
+    primary: (theme.vars || theme).palette.primary.contrastText,
+    secondary: (theme.vars || theme).palette.secondary.contrastText,
+    default: (theme.vars || theme).palette.text.primary,
+  };
+
+  const selectedColorValue = colorMap[selectedColor];
+  const selectedContrastText = contrastTextMap[selectedColor];
+
+  return {
+    color: (theme.vars || theme).palette.text.primary,
+    backgroundColor:
+      variant === 'contained'
+        ? (theme.vars || theme).palette.action.hover
+        : 'transparent',
+    border:
+      variant === 'outlined'
+        ? `1px solid ${(theme.vars || theme).palette.divider}`
+        : 'none',
+    '&:hover': {
+      backgroundColor: (theme.vars || theme).palette.action.hover,
+    },
+    '&.Mui-selected': {
+      color:
+        selectedColor === 'primary' || selectedColor === 'secondary'
+          ? selectedContrastText
+          : selectedColorValue,
+      backgroundColor:
+        selectedColor === 'primary' || selectedColor === 'secondary'
+          ? selectedColorValue
+          : variant === 'contained'
+            ? `${selectedColorValue}20`
+            : variant === 'outlined'
+              ? `${selectedColorValue}10`
+              : 'transparent',
+      border:
+        variant === 'outlined' &&
+        !(selectedColor === 'primary' || selectedColor === 'secondary')
+          ? `2px solid ${selectedColorValue}`
+          : 'none',
+      '&:hover': {
+        color:
+          selectedColor === 'primary' || selectedColor === 'secondary'
+            ? selectedContrastText
+            : selectedColorValue,
+        backgroundColor:
+          selectedColor === 'primary' || selectedColor === 'secondary'
+            ? selectedColorValue
+            : variant === 'contained'
+              ? `${selectedColorValue}30`
+              : `${selectedColorValue}15`,
+      },
+    },
+    '&.Mui-disabled': {
+      opacity: 0.5,
+    },
+    transition: theme.transitions.create(
+      ['background-color', 'box-shadow', 'border-color', 'color'],
+      {
+        duration: theme.transitions.duration.short,
+      },
+    ),
+  };
+});
+
+export const StyledIconButton = styled(IconButton, {
+  shouldForwardProp: (prop) =>
+    prop !== 'isSelected' && prop !== 'selectedColor' && prop !== 'variant',
+})<StyledIconButtonProps>(({
+  theme,
+  isSelected = false,
+  selectedColor = 'primary',
+  variant = 'outlined',
+}) => {
+  const colorMap = {
+    primary: (theme.vars || theme).palette.primary.main,
+    secondary: (theme.vars || theme).palette.secondary.main,
+    default: (theme.vars || theme).palette.action.active,
+  };
+
+  const contrastTextMap = {
+    primary: (theme.vars || theme).palette.primary.contrastText,
+    secondary: (theme.vars || theme).palette.secondary.contrastText,
+    default: (theme.vars || theme).palette.text.primary,
+  };
+
+  const selectedColorValue = colorMap[selectedColor];
+  const selectedContrastText = contrastTextMap[selectedColor];
+
+  return {
+    color: isSelected
+      ? selectedColor === 'primary' || selectedColor === 'secondary'
+        ? selectedContrastText
+        : selectedColorValue
+      : (theme.vars || theme).palette.text.primary,
+    backgroundColor: isSelected
+      ? selectedColor === 'primary' || selectedColor === 'secondary'
+        ? selectedColorValue
+        : variant === 'contained'
+          ? `${selectedColorValue}20`
+          : variant === 'outlined'
+            ? `${selectedColorValue}10`
+            : 'transparent'
+      : 'transparent',
+    border:
+      variant === 'outlined' &&
+      !(selectedColor === 'primary' || selectedColor === 'secondary')
+        ? isSelected
+          ? `2px solid ${selectedColorValue}`
+          : `1px solid ${(theme.vars || theme).palette.divider}`
+        : 'none',
+    '&:hover': {
+      color: isSelected
+        ? selectedColor === 'primary' || selectedColor === 'secondary'
+          ? selectedContrastText
+          : selectedColorValue
+        : (theme.vars || theme).palette.text.primary,
+      backgroundColor: isSelected
+        ? selectedColor === 'primary' || selectedColor === 'secondary'
+          ? selectedColorValue
+          : variant === 'contained'
+            ? `${selectedColorValue}30`
+            : `${selectedColorValue}15`
+        : (theme.vars || theme).palette.action.hover,
+    },
+    '&.Mui-disabled': {
+      opacity: 0.5,
+    },
+    transition: theme.transitions.create(
+      ['background-color', 'box-shadow', 'border-color', 'color'],
+      {
+        duration: theme.transitions.duration.short,
+      },
+    ),
+  };
+});
+
+export const IconWrapper = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: theme.spacing(0.5),
+}));
+
+export const IconLabel = styled(Typography)(({ theme }) => ({
+  fontSize: '0.75rem',
+  textAlign: 'center',
+  marginTop: theme.spacing(0.5),
+  color: 'inherit',
+}));

--- a/src/components/core/IconSelect/IconSelect.tsx
+++ b/src/components/core/IconSelect/IconSelect.tsx
@@ -27,20 +27,21 @@ export const IconSelect: FC<IconSelectProps> = ({
   fullWidth = false,
   className,
   orientation = 'horizontal',
+  'data-testid': dataTestId,
 }) => {
   const [selectedValues, setSelectedValues] = useState<string | string[]>(
-    multiple ? (value as string[]) || [] : (value as string) || ''
+    multiple ? (value as string[]) || [] : (value as string) || '',
   );
 
   useEffect(() => {
     setSelectedValues(
-      multiple ? (value as string[]) || [] : (value as string) || ''
+      multiple ? (value as string[]) || [] : (value as string) || '',
     );
   }, [value, multiple]);
 
   const handleToggleChange = (
     _event: React.MouseEvent<HTMLElement>,
-    newValue: string | string[]
+    newValue: string | string[],
   ) => {
     if (newValue !== null) {
       setSelectedValues(newValue);
@@ -109,6 +110,7 @@ export const IconSelect: FC<IconSelectProps> = ({
         className={className}
         disabled={disabled}
         orientation={orientation === 'vertical' ? 'vertical' : 'horizontal'}
+        data-testid={dataTestId}
       >
         {options.map((option) => (
           <StyledToggleButton
@@ -121,6 +123,9 @@ export const IconSelect: FC<IconSelectProps> = ({
               ...buttonSizeProps,
               color: option.color || undefined,
             }}
+            data-testid={
+              dataTestId ? `${dataTestId}-${option.value}` : undefined
+            }
           >
             {renderIcon(option)}
           </StyledToggleButton>
@@ -136,6 +141,7 @@ export const IconSelect: FC<IconSelectProps> = ({
       fullWidth={fullWidth}
       className={className}
       sx={{ gap: spacing }}
+      data-testid={dataTestId}
     >
       {options.map((option) => (
         <StyledIconButton
@@ -150,6 +156,7 @@ export const IconSelect: FC<IconSelectProps> = ({
             ...buttonSizeProps,
             color: option.color || undefined,
           }}
+          data-testid={dataTestId ? `${dataTestId}-${option.value}` : undefined}
         >
           {renderIcon(option)}
         </StyledIconButton>

--- a/src/components/core/IconSelect/IconSelect.tsx
+++ b/src/components/core/IconSelect/IconSelect.tsx
@@ -1,0 +1,183 @@
+import { FC, useState, useEffect } from 'react';
+import {
+  IconSelectContainer,
+  StyledToggleButtonGroup,
+  StyledToggleButton,
+  StyledIconButton,
+  IconWrapper,
+  IconLabel,
+} from './IconSelect.styles';
+import { IconSelectProps } from './IconSelect.types';
+import Tooltip from '@mui/material/Tooltip';
+
+export const IconSelect: FC<IconSelectProps> = ({
+  options,
+  value,
+  onChange,
+  multiple = false,
+  size = 'medium',
+  spacing = 1,
+  columns,
+  showLabel = false,
+  showTooltip = true,
+  disabled = false,
+  color = 'primary',
+  selectionMode = 'toggle',
+  variant = 'outlined',
+  fullWidth = false,
+  className,
+  orientation = 'horizontal',
+}) => {
+  const [selectedValues, setSelectedValues] = useState<string | string[]>(
+    multiple ? (value as string[]) || [] : (value as string) || ''
+  );
+
+  useEffect(() => {
+    setSelectedValues(
+      multiple ? (value as string[]) || [] : (value as string) || ''
+    );
+  }, [value, multiple]);
+
+  const handleToggleChange = (
+    _event: React.MouseEvent<HTMLElement>,
+    newValue: string | string[]
+  ) => {
+    if (newValue !== null) {
+      setSelectedValues(newValue);
+      if (onChange) {
+        onChange(newValue);
+      }
+    }
+  };
+
+  const handleIconClick = (optionValue: string) => {
+    if (disabled) return;
+
+    if (multiple) {
+      const currentValues = selectedValues as string[];
+      const newValues = currentValues.includes(optionValue)
+        ? currentValues.filter((v) => v !== optionValue)
+        : [...currentValues, optionValue];
+      setSelectedValues(newValues);
+      if (onChange) {
+        onChange(newValues);
+      }
+    } else {
+      const newValue =
+        selectionMode === 'radio' || selectedValues !== optionValue
+          ? optionValue
+          : '';
+      setSelectedValues(newValue);
+      if (onChange) {
+        onChange(newValue);
+      }
+    }
+  };
+
+  const isSelected = (optionValue: string) => {
+    if (multiple) {
+      return (selectedValues as string[]).includes(optionValue);
+    }
+    return selectedValues === optionValue;
+  };
+
+  const renderIcon = (option: any) => {
+    const iconContent = (
+      <IconWrapper>
+        {option.icon}
+        {showLabel && option.label && <IconLabel>{option.label}</IconLabel>}
+      </IconWrapper>
+    );
+
+    return showTooltip && option.tooltip ? (
+      <Tooltip title={option.tooltip} arrow>
+        {iconContent}
+      </Tooltip>
+    ) : (
+      iconContent
+    );
+  };
+
+  const buttonSizeProps = getButtonSize(size);
+
+  if (selectionMode === 'toggle') {
+    return (
+      <StyledToggleButtonGroup
+        value={selectedValues}
+        onChange={handleToggleChange}
+        exclusive={!multiple}
+        className={className}
+        disabled={disabled}
+        orientation={orientation === 'vertical' ? 'vertical' : 'horizontal'}
+      >
+        {options.map((option) => (
+          <StyledToggleButton
+            key={option.value}
+            value={option.value}
+            disabled={disabled || option.disabled}
+            selectedColor={color}
+            variant={variant}
+            sx={{
+              ...buttonSizeProps,
+              color: option.color || undefined,
+            }}
+          >
+            {renderIcon(option)}
+          </StyledToggleButton>
+        ))}
+      </StyledToggleButtonGroup>
+    );
+  }
+
+  return (
+    <IconSelectContainer
+      orientation={orientation}
+      columns={columns}
+      fullWidth={fullWidth}
+      className={className}
+      sx={{ gap: spacing }}
+    >
+      {options.map((option) => (
+        <StyledIconButton
+          key={option.value}
+          onClick={() => handleIconClick(option.value)}
+          disabled={disabled || option.disabled}
+          isSelected={isSelected(option.value)}
+          selectedColor={color}
+          variant={variant}
+          size={size}
+          sx={{
+            ...buttonSizeProps,
+            color: option.color || undefined,
+          }}
+        >
+          {renderIcon(option)}
+        </StyledIconButton>
+      ))}
+    </IconSelectContainer>
+  );
+};
+
+function getButtonSize(size: 'small' | 'medium' | 'large') {
+  switch (size) {
+    case 'small':
+      return {
+        width: 40,
+        height: 40,
+        '& svg': { fontSize: '1.25rem' },
+      };
+    case 'large':
+      return {
+        width: 64,
+        height: 64,
+        '& svg': { fontSize: '2rem' },
+      };
+    case 'medium':
+    default:
+      return {
+        width: 48,
+        height: 48,
+        '& svg': { fontSize: '1.5rem' },
+      };
+  }
+}

--- a/src/components/core/IconSelect/IconSelect.types.ts
+++ b/src/components/core/IconSelect/IconSelect.types.ts
@@ -24,4 +24,5 @@ export interface IconSelectProps {
   fullWidth?: boolean;
   className?: string;
   orientation?: 'horizontal' | 'vertical' | 'grid';
+  'data-testid'?: string;
 }

--- a/src/components/core/IconSelect/IconSelect.types.ts
+++ b/src/components/core/IconSelect/IconSelect.types.ts
@@ -1,0 +1,27 @@
+export interface IconOption {
+  value: string;
+  icon: React.ReactNode;
+  label?: string;
+  tooltip?: string;
+  disabled?: boolean;
+  color?: string;
+}
+
+export interface IconSelectProps {
+  options: IconOption[];
+  value?: string | string[];
+  onChange?: (value: string | string[]) => void;
+  multiple?: boolean;
+  size?: 'small' | 'medium' | 'large';
+  spacing?: number;
+  columns?: number;
+  showLabel?: boolean;
+  showTooltip?: boolean;
+  disabled?: boolean;
+  color?: 'primary' | 'secondary' | 'default';
+  selectionMode?: 'toggle' | 'radio';
+  variant?: 'contained' | 'outlined' | 'text';
+  fullWidth?: boolean;
+  className?: string;
+  orientation?: 'horizontal' | 'vertical' | 'grid';
+}

--- a/src/components/core/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/core/MultiSelect/MultiSelect.stories.tsx
@@ -1,0 +1,235 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { MultiSelect } from './MultiSelect';
+import { MultiSelectOption } from './MultiSelect.types';
+import PersonIcon from '@mui/icons-material/Person';
+import GroupIcon from '@mui/icons-material/Group';
+import WorkIcon from '@mui/icons-material/Work';
+import SchoolIcon from '@mui/icons-material/School';
+
+const meta = {
+  title: 'Components/Core/MultiSelect',
+  component: MultiSelect,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: { type: 'select' },
+      options: ['small', 'medium', 'large'],
+    },
+    variant: {
+      control: { type: 'select' },
+      options: ['outlined', 'filled', 'standard'],
+    },
+  },
+} satisfies Meta<typeof MultiSelect>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const basicOptions: MultiSelectOption[] = [
+  { value: 'option1', label: 'Option 1' },
+  { value: 'option2', label: 'Option 2' },
+  { value: 'option3', label: 'Option 3' },
+  { value: 'option4', label: 'Option 4' },
+  { value: 'option5', label: 'Option 5' },
+  { value: 'option6', label: 'Option 6', disabled: true },
+];
+
+const optionsWithIcons: MultiSelectOption[] = [
+  { value: 'person', label: 'Individual', icon: <PersonIcon /> },
+  { value: 'group', label: 'Team', icon: <GroupIcon /> },
+  { value: 'work', label: 'Professional', icon: <WorkIcon /> },
+  { value: 'school', label: 'Educational', icon: <SchoolIcon /> },
+];
+
+const groupedOptions: MultiSelectOption[] = [
+  { value: 'usa', label: 'United States', group: 'North America' },
+  { value: 'canada', label: 'Canada', group: 'North America' },
+  { value: 'mexico', label: 'Mexico', group: 'North America' },
+  { value: 'uk', label: 'United Kingdom', group: 'Europe' },
+  { value: 'france', label: 'France', group: 'Europe' },
+  { value: 'germany', label: 'Germany', group: 'Europe' },
+  { value: 'japan', label: 'Japan', group: 'Asia' },
+  { value: 'china', label: 'China', group: 'Asia' },
+  { value: 'india', label: 'India', group: 'Asia' },
+];
+
+export const Default: Story = {
+  args: {
+    options: basicOptions,
+    placeholder: 'Select multiple options',
+    label: 'Choose Options',
+    fullWidth: false,
+    size: 'medium',
+    variant: 'outlined',
+    showCheckbox: true,
+    showChips: true,
+  },
+};
+
+export const WithSelectedValues: Story = {
+  args: {
+    options: basicOptions,
+    value: ['option1', 'option3'],
+    label: 'Pre-selected Options',
+    fullWidth: false,
+    size: 'medium',
+    variant: 'outlined',
+    showCheckbox: true,
+    showChips: true,
+  },
+};
+
+export const WithIcons: Story = {
+  args: {
+    options: optionsWithIcons,
+    placeholder: 'Select categories',
+    label: 'Categories',
+    fullWidth: false,
+    size: 'medium',
+    variant: 'outlined',
+    showCheckbox: true,
+    showChips: true,
+  },
+};
+
+export const GroupedOptions: Story = {
+  args: {
+    options: groupedOptions,
+    placeholder: 'Select countries',
+    label: 'Countries',
+    fullWidth: false,
+    size: 'medium',
+    variant: 'outlined',
+    showCheckbox: true,
+    showChips: true,
+  },
+};
+
+export const WithoutCheckboxes: Story = {
+  args: {
+    options: basicOptions,
+    label: 'No Checkboxes',
+    showCheckbox: false,
+    showChips: true,
+    size: 'medium',
+    variant: 'outlined',
+  },
+};
+
+export const WithoutChips: Story = {
+  args: {
+    options: basicOptions,
+    label: 'No Chips Display',
+    showCheckbox: true,
+    showChips: false,
+    size: 'medium',
+    variant: 'outlined',
+  },
+};
+
+export const LimitedChips: Story = {
+  args: {
+    options: basicOptions,
+    value: ['option1', 'option2', 'option3', 'option4', 'option5'],
+    label: 'Max 2 Chips',
+    maxChips: 2,
+    showChips: true,
+    size: 'medium',
+    variant: 'outlined',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    options: basicOptions,
+    value: ['option1', 'option2'],
+    label: 'Disabled MultiSelect',
+    disabled: true,
+    fullWidth: false,
+    size: 'medium',
+    variant: 'outlined',
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    options: basicOptions,
+    label: 'Select with Error',
+    error: true,
+    helperText: 'Please select at least one option',
+    fullWidth: false,
+    size: 'medium',
+    variant: 'outlined',
+  },
+};
+
+export const FullWidth: Story = {
+  args: {
+    options: basicOptions,
+    label: 'Full Width MultiSelect',
+    fullWidth: true,
+    size: 'medium',
+    variant: 'outlined',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    options: basicOptions,
+    label: 'Small MultiSelect',
+    size: 'small',
+    variant: 'outlined',
+  },
+};
+
+export const Filled: Story = {
+  args: {
+    options: basicOptions,
+    label: 'Filled Variant',
+    variant: 'filled',
+    size: 'medium',
+  },
+};
+
+export const Required: Story = {
+  args: {
+    options: basicOptions,
+    label: 'Required Field',
+    required: true,
+    helperText: 'This field is mandatory',
+    size: 'medium',
+    variant: 'outlined',
+  },
+};
+
+export const InteractiveExample: Story = {
+  args: {
+    options: groupedOptions,
+    value: [],
+    label: 'Interactive Country Selector',
+    placeholder: 'Choose countries',
+    showCheckbox: true,
+    showChips: true,
+    maxChips: 3,
+  },
+  render: (args) => {
+    const [selected, setSelected] = useState<string[]>(
+      (args.value as string[]) || [],
+    );
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+        <MultiSelect
+          {...args}
+          value={selected}
+          onChange={setSelected}
+          helperText={`Selected: ${selected.length} countries`}
+        />
+        <div>
+          <strong>Selected values:</strong> {selected.join(', ') || 'None'}
+        </div>
+      </div>
+    );
+  },
+};

--- a/src/components/core/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/core/MultiSelect/MultiSelect.stories.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react';
+import GroupIcon from '@mui/icons-material/Group';
+import PersonIcon from '@mui/icons-material/Person';
+import SchoolIcon from '@mui/icons-material/School';
+import WorkIcon from '@mui/icons-material/Work';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useState } from 'react';
 import { MultiSelect } from './MultiSelect';
 import { MultiSelectOption } from './MultiSelect.types';
-import PersonIcon from '@mui/icons-material/Person';
-import GroupIcon from '@mui/icons-material/Group';
-import WorkIcon from '@mui/icons-material/Work';
-import SchoolIcon from '@mui/icons-material/School';
 
 const meta = {
   title: 'Components/Core/MultiSelect',
@@ -32,7 +32,7 @@ const basicOptions: MultiSelectOption[] = [
   { value: 'option3', label: 'Option 3' },
   { value: 'option4', label: 'Option 4' },
   { value: 'option5', label: 'Option 5' },
-  { value: 'option6', label: 'Option 6', disabled: true },
+  { value: 'option6', label: 'Option 6' },
 ];
 
 const optionsWithIcons: MultiSelectOption[] = [
@@ -43,15 +43,15 @@ const optionsWithIcons: MultiSelectOption[] = [
 ];
 
 const groupedOptions: MultiSelectOption[] = [
-  { value: 'usa', label: 'United States', group: 'North America' },
-  { value: 'canada', label: 'Canada', group: 'North America' },
-  { value: 'mexico', label: 'Mexico', group: 'North America' },
-  { value: 'uk', label: 'United Kingdom', group: 'Europe' },
-  { value: 'france', label: 'France', group: 'Europe' },
-  { value: 'germany', label: 'Germany', group: 'Europe' },
-  { value: 'japan', label: 'Japan', group: 'Asia' },
-  { value: 'china', label: 'China', group: 'Asia' },
-  { value: 'india', label: 'India', group: 'Asia' },
+  { value: 'usa', label: 'United States' },
+  { value: 'canada', label: 'Canada' },
+  { value: 'mexico', label: 'Mexico' },
+  { value: 'uk', label: 'United Kingdom' },
+  { value: 'france', label: 'France' },
+  { value: 'germany', label: 'Germany' },
+  { value: 'japan', label: 'Japan' },
+  { value: 'china', label: 'China' },
+  { value: 'india', label: 'India' },
 ];
 
 export const Default: Story = {
@@ -62,8 +62,7 @@ export const Default: Story = {
     fullWidth: false,
     size: 'medium',
     variant: 'outlined',
-    showCheckbox: true,
-    showChips: true,
+    show: 'chips',
   },
 };
 
@@ -75,8 +74,7 @@ export const WithSelectedValues: Story = {
     fullWidth: false,
     size: 'medium',
     variant: 'outlined',
-    showCheckbox: true,
-    showChips: true,
+    show: 'chips',
   },
 };
 
@@ -88,8 +86,7 @@ export const WithIcons: Story = {
     fullWidth: false,
     size: 'medium',
     variant: 'outlined',
-    showCheckbox: true,
-    showChips: true,
+    show: 'chips',
   },
 };
 
@@ -101,8 +98,7 @@ export const GroupedOptions: Story = {
     fullWidth: false,
     size: 'medium',
     variant: 'outlined',
-    showCheckbox: true,
-    showChips: true,
+    show: 'chips',
   },
 };
 
@@ -110,8 +106,7 @@ export const WithoutCheckboxes: Story = {
   args: {
     options: basicOptions,
     label: 'No Checkboxes',
-    showCheckbox: false,
-    showChips: true,
+    show: 'chips',
     size: 'medium',
     variant: 'outlined',
   },
@@ -121,8 +116,7 @@ export const WithoutChips: Story = {
   args: {
     options: basicOptions,
     label: 'No Chips Display',
-    showCheckbox: true,
-    showChips: false,
+    show: 'chips',
     size: 'medium',
     variant: 'outlined',
   },
@@ -134,7 +128,7 @@ export const LimitedChips: Story = {
     value: ['option1', 'option2', 'option3', 'option4', 'option5'],
     label: 'Max 2 Chips',
     maxChips: 2,
-    showChips: true,
+    show: 'chips',
     size: 'medium',
     variant: 'outlined',
   },
@@ -209,8 +203,7 @@ export const InteractiveExample: Story = {
     value: [],
     label: 'Interactive Country Selector',
     placeholder: 'Choose countries',
-    showCheckbox: true,
-    showChips: true,
+    show: 'chips',
     maxChips: 3,
   },
   render: (args) => {

--- a/src/components/core/MultiSelect/MultiSelect.styles.ts
+++ b/src/components/core/MultiSelect/MultiSelect.styles.ts
@@ -3,48 +3,73 @@ import Select, { SelectProps } from '@mui/material/Select';
 import MenuItem, { MenuItemProps } from '@mui/material/MenuItem';
 import FormControl, { FormControlProps } from '@mui/material/FormControl';
 import InputLabel, { InputLabelProps } from '@mui/material/InputLabel';
-import FormHelperText, { FormHelperTextProps } from '@mui/material/FormHelperText';
+import FormHelperText, {
+  FormHelperTextProps,
+} from '@mui/material/FormHelperText';
 import Chip, { ChipProps } from '@mui/material/Chip';
 import Box from '@mui/material/Box';
-import Checkbox, { CheckboxProps } from '@mui/material/Checkbox';
 
 export const StyledFormControl = styled(FormControl)<FormControlProps>(
   ({ theme }) => ({
     minWidth: 120,
-  })
+  }),
 );
 
-export const StyledSelect = styled(Select)<SelectProps>(({ theme }) => ({
-  '& .MuiOutlinedInput-notchedOutline': {
-    borderColor: (theme.vars || theme).palette.primary.main,
-  },
-  '&:hover .MuiOutlinedInput-notchedOutline': {
-    borderColor: (theme.vars || theme).palette.primary.light,
-  },
-  '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-    borderColor: (theme.vars || theme).palette.primary.dark,
-  },
-  '&.Mui-error .MuiOutlinedInput-notchedOutline': {
-    borderColor: (theme.vars || theme).palette.error.main,
-  },
-}));
+const getPillRadius = (size?: 'small' | 'medium') => {
+  return size === 'small' ? 16 : 20;
+};
 
-export const StyledMenuItem = styled(MenuItem)<MenuItemProps>(
-  ({ theme }) => ({
-    '&.Mui-selected': {
-      backgroundColor: (theme.vars || theme).palette.primary.main + '20',
+export const StyledSelect = styled(Select)<SelectProps>(({ theme, size }) => {
+  const pillRadius = getPillRadius(size as 'small' | 'medium');
+
+  return {
+    backgroundColor: (theme.vars || theme).palette.action.hover,
+    borderRadius: pillRadius,
+    '& .MuiSelect-select': {
+      padding: size === 'small' ? '6px 32px 6px 16px' : '8px 32px 8px 24px',
+      minHeight: size === 'small' ? '20px' : '24px',
     },
-    '&.Mui-selected:hover': {
-      backgroundColor: (theme.vars || theme).palette.primary.main + '30',
+    '& .MuiOutlinedInput-notchedOutline': {
+      border: 'none',
     },
     '&:hover': {
       backgroundColor: (theme.vars || theme).palette.action.hover,
     },
-    '&.Mui-disabled': {
-      opacity: 0.5,
+    '&.Mui-focused': {
+      backgroundColor: (theme.vars || theme).palette.action.hover,
+      '& .MuiOutlinedInput-notchedOutline': {
+        border: `2px solid ${(theme.vars || theme).palette.primary.main}`,
+        borderRadius: pillRadius,
+      },
     },
-  })
-);
+    '&.Mui-error .MuiOutlinedInput-notchedOutline': {
+      border: `2px solid ${(theme.vars || theme).palette.error.main}`,
+      borderRadius: pillRadius,
+    },
+    '& .MuiSelect-icon': {
+      right: size === 'small' ? 8 : 12,
+      color: (theme.vars || theme).palette.text.secondary,
+    },
+  };
+});
+
+export const StyledMenuItem = styled(MenuItem)<MenuItemProps>(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+  '&.Mui-selected': {
+    backgroundColor: 'transparent',
+    '&:hover': {
+      backgroundColor: (theme.vars || theme).palette.action.hover,
+    },
+  },
+  '&:hover': {
+    backgroundColor: (theme.vars || theme).palette.action.hover,
+  },
+  '&.Mui-disabled': {
+    opacity: 0.5,
+  },
+}));
 
 export const StyledInputLabel = styled(InputLabel)<InputLabelProps>(
   ({ theme }) => ({
@@ -54,44 +79,43 @@ export const StyledInputLabel = styled(InputLabel)<InputLabelProps>(
     '&.Mui-error': {
       color: (theme.vars || theme).palette.error.main,
     },
-  })
+  }),
 );
 
-export const StyledFormHelperText = styled(
-  FormHelperText
-)<FormHelperTextProps>(({ theme }) => ({
-  '&.Mui-error': {
-    color: (theme.vars || theme).palette.error.main,
-  },
-}));
+export const StyledFormHelperText = styled(FormHelperText)<FormHelperTextProps>(
+  ({ theme }) => ({
+    '&.Mui-error': {
+      color: (theme.vars || theme).palette.error.main,
+    },
+  }),
+);
 
 export const ChipContainer = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexWrap: 'wrap',
-  gap: 0.5,
+  gap: theme.spacing(0.5),
+  alignItems: 'center',
 }));
 
 export const StyledChip = styled(Chip)<ChipProps>(({ theme }) => ({
-  margin: theme.spacing(0.25),
-  backgroundColor: (theme.vars || theme).palette.primary.main + '20',
+  height: 24,
+  borderRadius: 12,
+  backgroundColor: (theme.vars || theme).palette.background.paper,
+  border: `1px solid ${(theme.vars || theme).palette.divider}`,
+  '& .MuiChip-label': {
+    padding: '0 8px',
+    fontSize: '0.875rem',
+  },
   '& .MuiChip-deleteIcon': {
-    color: (theme.vars || theme).palette.primary.main,
+    fontSize: '1rem',
+    marginRight: 4,
+    marginLeft: -4,
+    color: (theme.vars || theme).palette.text.secondary,
     '&:hover': {
-      color: (theme.vars || theme).palette.primary.dark,
+      color: (theme.vars || theme).palette.text.primary,
     },
   },
 }));
-
-export const StyledCheckbox = styled(Checkbox)<CheckboxProps>(
-  ({ theme }) => ({
-    padding: theme.spacing(0.5),
-    marginRight: theme.spacing(1),
-    color: (theme.vars || theme).palette.primary.main,
-    '&.Mui-checked': {
-      color: (theme.vars || theme).palette.primary.dark,
-    },
-  })
-);
 
 export const IconWrapper = styled('span')(({ theme }) => ({
   display: 'inline-flex',

--- a/src/components/core/MultiSelect/MultiSelect.styles.ts
+++ b/src/components/core/MultiSelect/MultiSelect.styles.ts
@@ -1,0 +1,111 @@
+import { styled } from '@mui/material/styles';
+import Select, { SelectProps } from '@mui/material/Select';
+import MenuItem, { MenuItemProps } from '@mui/material/MenuItem';
+import FormControl, { FormControlProps } from '@mui/material/FormControl';
+import InputLabel, { InputLabelProps } from '@mui/material/InputLabel';
+import FormHelperText, { FormHelperTextProps } from '@mui/material/FormHelperText';
+import Chip, { ChipProps } from '@mui/material/Chip';
+import Box from '@mui/material/Box';
+import Checkbox, { CheckboxProps } from '@mui/material/Checkbox';
+
+export const StyledFormControl = styled(FormControl)<FormControlProps>(
+  ({ theme }) => ({
+    minWidth: 120,
+  })
+);
+
+export const StyledSelect = styled(Select)<SelectProps>(({ theme }) => ({
+  '& .MuiOutlinedInput-notchedOutline': {
+    borderColor: (theme.vars || theme).palette.primary.main,
+  },
+  '&:hover .MuiOutlinedInput-notchedOutline': {
+    borderColor: (theme.vars || theme).palette.primary.light,
+  },
+  '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+    borderColor: (theme.vars || theme).palette.primary.dark,
+  },
+  '&.Mui-error .MuiOutlinedInput-notchedOutline': {
+    borderColor: (theme.vars || theme).palette.error.main,
+  },
+}));
+
+export const StyledMenuItem = styled(MenuItem)<MenuItemProps>(
+  ({ theme }) => ({
+    '&.Mui-selected': {
+      backgroundColor: (theme.vars || theme).palette.primary.main + '20',
+    },
+    '&.Mui-selected:hover': {
+      backgroundColor: (theme.vars || theme).palette.primary.main + '30',
+    },
+    '&:hover': {
+      backgroundColor: (theme.vars || theme).palette.action.hover,
+    },
+    '&.Mui-disabled': {
+      opacity: 0.5,
+    },
+  })
+);
+
+export const StyledInputLabel = styled(InputLabel)<InputLabelProps>(
+  ({ theme }) => ({
+    '&.Mui-focused': {
+      color: (theme.vars || theme).palette.primary.main,
+    },
+    '&.Mui-error': {
+      color: (theme.vars || theme).palette.error.main,
+    },
+  })
+);
+
+export const StyledFormHelperText = styled(
+  FormHelperText
+)<FormHelperTextProps>(({ theme }) => ({
+  '&.Mui-error': {
+    color: (theme.vars || theme).palette.error.main,
+  },
+}));
+
+export const ChipContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 0.5,
+}));
+
+export const StyledChip = styled(Chip)<ChipProps>(({ theme }) => ({
+  margin: theme.spacing(0.25),
+  backgroundColor: (theme.vars || theme).palette.primary.main + '20',
+  '& .MuiChip-deleteIcon': {
+    color: (theme.vars || theme).palette.primary.main,
+    '&:hover': {
+      color: (theme.vars || theme).palette.primary.dark,
+    },
+  },
+}));
+
+export const StyledCheckbox = styled(Checkbox)<CheckboxProps>(
+  ({ theme }) => ({
+    padding: theme.spacing(0.5),
+    marginRight: theme.spacing(1),
+    color: (theme.vars || theme).palette.primary.main,
+    '&.Mui-checked': {
+      color: (theme.vars || theme).palette.primary.dark,
+    },
+  })
+);
+
+export const IconWrapper = styled('span')(({ theme }) => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  marginRight: theme.spacing(1),
+  verticalAlign: 'middle',
+}));
+
+export const GroupHeader = styled('div')(({ theme }) => ({
+  padding: theme.spacing(1, 2),
+  fontWeight: 600,
+  backgroundColor: (theme.vars || theme).palette.background.paper,
+  color: (theme.vars || theme).palette.text.secondary,
+  fontSize: '0.875rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+}));

--- a/src/components/core/MultiSelect/MultiSelect.tsx
+++ b/src/components/core/MultiSelect/MultiSelect.tsx
@@ -30,6 +30,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({
   maxHeight = 300,
   show = 'chips',
   maxChips = 3,
+  'data-testid': dataTestId,
 }) => {
   const handleChange = (event: any) => {
     if (onChange) {
@@ -139,6 +140,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({
             },
           },
         }}
+        data-testid={dataTestId}
       >
         {options.map((option) => {
           const isSelected = value.indexOf(option.value) > -1;

--- a/src/components/core/MultiSelect/MultiSelect.tsx
+++ b/src/components/core/MultiSelect/MultiSelect.tsx
@@ -91,12 +91,12 @@ export const MultiSelect: FC<MultiSelectProps> = ({
 
       case 'count':
         return (
-          <ChipContainer>
-            <StyledChip
-              label={`${selectedArray.length} selected`}
-              size="small"
-            />
-          </ChipContainer>
+          <>
+            <StyledChip label={`${selectedArray.length}`} size="small" />
+            <span style={{ color: 'inherit', opacity: 0.6 }}>
+              {placeholder || 'Select options'}
+            </span>
+          </>
         );
 
       case 'label':

--- a/src/components/core/MultiSelect/MultiSelect.tsx
+++ b/src/components/core/MultiSelect/MultiSelect.tsx
@@ -1,18 +1,16 @@
+import CheckIcon from '@mui/icons-material/Check';
+import ListItemText from '@mui/material/ListItemText';
 import { FC } from 'react';
 import {
-  StyledFormControl,
-  StyledSelect,
-  StyledMenuItem,
-  StyledInputLabel,
-  StyledFormHelperText,
-  StyledChip,
   ChipContainer,
-  StyledCheckbox,
   IconWrapper,
-  GroupHeader,
+  StyledChip,
+  StyledFormControl,
+  StyledFormHelperText,
+  StyledMenuItem,
+  StyledSelect,
 } from './MultiSelect.styles';
-import { MultiSelectProps, MultiSelectOption } from './MultiSelect.types';
-import ListItemText from '@mui/material/ListItemText';
+import { MultiSelectProps } from './MultiSelect.types';
 
 export const MultiSelect: FC<MultiSelectProps> = ({
   options,
@@ -27,16 +25,23 @@ export const MultiSelect: FC<MultiSelectProps> = ({
   helperText,
   label,
   required = false,
+  multiple = true,
   renderValue: customRenderValue,
   maxHeight = 300,
-  showCheckbox = true,
-  showChips = true,
+  show = 'chips',
   maxChips = 3,
 }) => {
   const handleChange = (event: any) => {
     if (onChange) {
-      const selectedValues = event.target.value as string[];
-      onChange(selectedValues);
+      if (multiple === false) {
+        // For single select, wrap the single value in an array
+        const singleValue = event.target.value as string;
+        onChange(singleValue ? [singleValue] : []);
+      } else {
+        // For multi select, pass the array as-is
+        const selectedValues = event.target.value as string[];
+        onChange(selectedValues);
+      }
     }
   };
 
@@ -47,130 +52,112 @@ export const MultiSelect: FC<MultiSelectProps> = ({
   };
 
   const defaultRenderValue = (selected: unknown) => {
-    const selectedArray = selected as string[];
-    if (!selectedArray || selectedArray.length === 0) {
-      return <em>{placeholder}</em>;
-    }
+    const selectedArray = Array.isArray(selected) ? selected : [selected];
 
-    if (showChips) {
+    if (!selectedArray || selectedArray.length === 0) {
       return (
-        <ChipContainer>
-          {selectedArray.slice(0, maxChips).map((val) => {
-            const option = options.find((opt) => opt.value === val);
-            return (
-              <StyledChip
-                key={val}
-                label={option?.label || val}
-                size="small"
-                onDelete={() => handleDelete(val)}
-                onMouseDown={(event) => {
-                  event.stopPropagation();
-                }}
-              />
-            );
-          })}
-          {selectedArray.length > maxChips && (
-            <StyledChip
-              label={`+${selectedArray.length - maxChips} more`}
-              size="small"
-            />
-          )}
-        </ChipContainer>
+        <span style={{ color: 'inherit', opacity: 0.6 }}>
+          {placeholder || 'Select options'}
+        </span>
       );
     }
 
-    const selectedLabels = selectedArray.map((val) => {
-      const option = options.find((opt) => opt.value === val);
-      return option?.label || val;
-    });
-    return selectedLabels.join(', ');
+    switch (show) {
+      case 'chips':
+        return (
+          <ChipContainer>
+            {selectedArray.slice(0, maxChips).map((val) => {
+              const option = options.find((opt) => opt.value === val);
+              return (
+                <StyledChip
+                  key={val}
+                  label={option?.label || val}
+                  size="small"
+                  onDelete={() => handleDelete(val)}
+                  onMouseDown={(event) => {
+                    event.stopPropagation();
+                  }}
+                />
+              );
+            })}
+            {selectedArray.length > maxChips && (
+              <StyledChip
+                label={`+${selectedArray.length - maxChips}`}
+                size="small"
+              />
+            )}
+          </ChipContainer>
+        );
+
+      case 'count':
+        return (
+          <ChipContainer>
+            <StyledChip
+              label={`${selectedArray.length} selected`}
+              size="small"
+            />
+          </ChipContainer>
+        );
+
+      case 'label':
+      default:
+        const selectedLabels = selectedArray.map((val) => {
+          const option = options.find((opt) => opt.value === val);
+          return option?.label || val;
+        });
+        return selectedLabels.join(', ');
+    }
   };
 
   const renderValueFunction = customRenderValue || defaultRenderValue;
 
-  const groupedOptions = options.reduce(
-    (acc, option) => {
-      const group = option.group || '';
-      if (!acc[group]) {
-        acc[group] = [];
-      }
-      acc[group].push(option);
-      return acc;
-    },
-    {} as Record<string, MultiSelectOption[]>,
-  );
-
-  const hasGroups = Object.keys(groupedOptions).some((group) => group !== '');
-
   return (
     <StyledFormControl
       fullWidth={fullWidth}
-      size={size === 'small' ? 'small' : 'medium'}
+      size={size}
       error={error}
       disabled={disabled}
       variant={variant}
       required={required}
     >
-      {label && (
-        <StyledInputLabel id={`${label}-multiselect-label`}>
-          {label}
-        </StyledInputLabel>
-      )}
       <StyledSelect
         labelId={label ? `${label}-multiselect-label` : undefined}
-        multiple
-        value={value}
+        multiple={multiple !== false}
+        value={multiple === false ? value[0] || '' : value}
         onChange={handleChange}
-        label={label}
-        displayEmpty={!!placeholder}
+        displayEmpty={true}
         renderValue={renderValueFunction}
+        size={size}
+        inputProps={{
+          'aria-label': label || placeholder,
+        }}
         MenuProps={{
           PaperProps: {
             style: {
               maxHeight: maxHeight,
+              marginTop: 8,
             },
           },
         }}
       >
-        {placeholder && value.length === 0 && (
-          <StyledMenuItem value="" disabled>
-            <em>{placeholder}</em>
-          </StyledMenuItem>
-        )}
-        {hasGroups
-          ? Object.entries(groupedOptions).map(([group, groupOptions]) => [
-              group && (
-                <GroupHeader key={`group-${group}`}>{group}</GroupHeader>
-              ),
-              ...groupOptions.map((option) => (
-                <StyledMenuItem
-                  key={option.value}
-                  value={option.value}
-                  disabled={option.disabled}
-                >
-                  {showCheckbox && (
-                    <StyledCheckbox
-                      checked={value.indexOf(option.value) > -1}
-                    />
-                  )}
-                  {option.icon && <IconWrapper>{option.icon}</IconWrapper>}
-                  <ListItemText primary={option.label} />
-                </StyledMenuItem>
-              )),
-            ])
-          : options.map((option) => (
-              <StyledMenuItem
-                key={option.value}
-                value={option.value}
-                disabled={option.disabled}
-              >
-                {showCheckbox && (
-                  <StyledCheckbox checked={value.indexOf(option.value) > -1} />
-                )}
-                {option.icon && <IconWrapper>{option.icon}</IconWrapper>}
-                <ListItemText primary={option.label} />
-              </StyledMenuItem>
-            ))}
+        {options.map((option) => {
+          const isSelected = value.indexOf(option.value) > -1;
+          return (
+            <StyledMenuItem key={option.value} value={option.value}>
+              {option.icon && <IconWrapper>{option.icon}</IconWrapper>}
+              <ListItemText primary={option.label} />
+              {isSelected && (
+                <CheckIcon
+                  sx={{
+                    marginLeft: 'auto',
+                    fontSize: '1.2rem',
+                    color: 'primary.main',
+                  }}
+                />
+              )}
+            </StyledMenuItem>
+          );
+        })}
       </StyledSelect>
       {helperText && (
         <StyledFormHelperText error={error}>{helperText}</StyledFormHelperText>

--- a/src/components/core/MultiSelect/MultiSelect.tsx
+++ b/src/components/core/MultiSelect/MultiSelect.tsx
@@ -1,0 +1,180 @@
+import { FC } from 'react';
+import {
+  StyledFormControl,
+  StyledSelect,
+  StyledMenuItem,
+  StyledInputLabel,
+  StyledFormHelperText,
+  StyledChip,
+  ChipContainer,
+  StyledCheckbox,
+  IconWrapper,
+  GroupHeader,
+} from './MultiSelect.styles';
+import { MultiSelectProps, MultiSelectOption } from './MultiSelect.types';
+import ListItemText from '@mui/material/ListItemText';
+
+export const MultiSelect: FC<MultiSelectProps> = ({
+  options,
+  value = [],
+  onChange,
+  placeholder,
+  disabled = false,
+  fullWidth = false,
+  size = 'medium',
+  variant = 'outlined',
+  error = false,
+  helperText,
+  label,
+  required = false,
+  renderValue: customRenderValue,
+  maxHeight = 300,
+  showCheckbox = true,
+  showChips = true,
+  maxChips = 3,
+}) => {
+  const handleChange = (event: any) => {
+    if (onChange) {
+      const selectedValues = event.target.value as string[];
+      onChange(selectedValues);
+    }
+  };
+
+  const handleDelete = (chipValue: string) => {
+    if (onChange) {
+      onChange(value.filter((v) => v !== chipValue));
+    }
+  };
+
+  const defaultRenderValue = (selected: unknown) => {
+    const selectedArray = selected as string[];
+    if (!selectedArray || selectedArray.length === 0) {
+      return <em>{placeholder}</em>;
+    }
+
+    if (showChips) {
+      return (
+        <ChipContainer>
+          {selectedArray.slice(0, maxChips).map((val) => {
+            const option = options.find((opt) => opt.value === val);
+            return (
+              <StyledChip
+                key={val}
+                label={option?.label || val}
+                size="small"
+                onDelete={() => handleDelete(val)}
+                onMouseDown={(event) => {
+                  event.stopPropagation();
+                }}
+              />
+            );
+          })}
+          {selectedArray.length > maxChips && (
+            <StyledChip
+              label={`+${selectedArray.length - maxChips} more`}
+              size="small"
+            />
+          )}
+        </ChipContainer>
+      );
+    }
+
+    const selectedLabels = selectedArray.map((val) => {
+      const option = options.find((opt) => opt.value === val);
+      return option?.label || val;
+    });
+    return selectedLabels.join(', ');
+  };
+
+  const renderValueFunction = customRenderValue || defaultRenderValue;
+
+  const groupedOptions = options.reduce(
+    (acc, option) => {
+      const group = option.group || '';
+      if (!acc[group]) {
+        acc[group] = [];
+      }
+      acc[group].push(option);
+      return acc;
+    },
+    {} as Record<string, MultiSelectOption[]>,
+  );
+
+  const hasGroups = Object.keys(groupedOptions).some((group) => group !== '');
+
+  return (
+    <StyledFormControl
+      fullWidth={fullWidth}
+      size={size === 'small' ? 'small' : 'medium'}
+      error={error}
+      disabled={disabled}
+      variant={variant}
+      required={required}
+    >
+      {label && (
+        <StyledInputLabel id={`${label}-multiselect-label`}>
+          {label}
+        </StyledInputLabel>
+      )}
+      <StyledSelect
+        labelId={label ? `${label}-multiselect-label` : undefined}
+        multiple
+        value={value}
+        onChange={handleChange}
+        label={label}
+        displayEmpty={!!placeholder}
+        renderValue={renderValueFunction}
+        MenuProps={{
+          PaperProps: {
+            style: {
+              maxHeight: maxHeight,
+            },
+          },
+        }}
+      >
+        {placeholder && value.length === 0 && (
+          <StyledMenuItem value="" disabled>
+            <em>{placeholder}</em>
+          </StyledMenuItem>
+        )}
+        {hasGroups
+          ? Object.entries(groupedOptions).map(([group, groupOptions]) => [
+              group && (
+                <GroupHeader key={`group-${group}`}>{group}</GroupHeader>
+              ),
+              ...groupOptions.map((option) => (
+                <StyledMenuItem
+                  key={option.value}
+                  value={option.value}
+                  disabled={option.disabled}
+                >
+                  {showCheckbox && (
+                    <StyledCheckbox
+                      checked={value.indexOf(option.value) > -1}
+                    />
+                  )}
+                  {option.icon && <IconWrapper>{option.icon}</IconWrapper>}
+                  <ListItemText primary={option.label} />
+                </StyledMenuItem>
+              )),
+            ])
+          : options.map((option) => (
+              <StyledMenuItem
+                key={option.value}
+                value={option.value}
+                disabled={option.disabled}
+              >
+                {showCheckbox && (
+                  <StyledCheckbox checked={value.indexOf(option.value) > -1} />
+                )}
+                {option.icon && <IconWrapper>{option.icon}</IconWrapper>}
+                <ListItemText primary={option.label} />
+              </StyledMenuItem>
+            ))}
+      </StyledSelect>
+      {helperText && (
+        <StyledFormHelperText error={error}>{helperText}</StyledFormHelperText>
+      )}
+    </StyledFormControl>
+  );
+};

--- a/src/components/core/MultiSelect/MultiSelect.types.ts
+++ b/src/components/core/MultiSelect/MultiSelect.types.ts
@@ -1,0 +1,28 @@
+export interface MultiSelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+  icon?: React.ReactNode;
+  group?: string;
+}
+
+export interface MultiSelectProps {
+  options: MultiSelectOption[];
+  value?: string[];
+  onChange?: (value: string[]) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  fullWidth?: boolean;
+  size?: 'small' | 'medium' | 'large';
+  variant?: 'outlined' | 'filled' | 'standard';
+  error?: boolean;
+  helperText?: string;
+  label?: string;
+  required?: boolean;
+  multiple?: boolean;
+  renderValue?: (selected: unknown) => React.ReactNode;
+  maxHeight?: number;
+  showCheckbox?: boolean;
+  showChips?: boolean;
+  maxChips?: number;
+}

--- a/src/components/core/MultiSelect/MultiSelect.types.ts
+++ b/src/components/core/MultiSelect/MultiSelect.types.ts
@@ -24,4 +24,5 @@ export interface MultiSelectProps {
   maxHeight?: number;
   show?: MultiSelectDisplayMode;
   maxChips?: number;
+  'data-testid'?: string;
 }

--- a/src/components/core/MultiSelect/MultiSelect.types.ts
+++ b/src/components/core/MultiSelect/MultiSelect.types.ts
@@ -1,10 +1,10 @@
 export interface MultiSelectOption {
   value: string;
   label: string;
-  disabled?: boolean;
   icon?: React.ReactNode;
-  group?: string;
 }
+
+export type MultiSelectDisplayMode = 'chips' | 'label' | 'count';
 
 export interface MultiSelectProps {
   options: MultiSelectOption[];
@@ -13,7 +13,7 @@ export interface MultiSelectProps {
   placeholder?: string;
   disabled?: boolean;
   fullWidth?: boolean;
-  size?: 'small' | 'medium' | 'large';
+  size?: 'small' | 'medium';
   variant?: 'outlined' | 'filled' | 'standard';
   error?: boolean;
   helperText?: string;
@@ -22,7 +22,6 @@ export interface MultiSelectProps {
   multiple?: boolean;
   renderValue?: (selected: unknown) => React.ReactNode;
   maxHeight?: number;
-  showCheckbox?: boolean;
-  showChips?: boolean;
+  show?: MultiSelectDisplayMode;
   maxChips?: number;
 }

--- a/src/components/core/SingleSelect/SingleSelect.stories.tsx
+++ b/src/components/core/SingleSelect/SingleSelect.stories.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { SingleSelect } from './SingleSelect';
+import { SingleSelectOption } from './SingleSelect.types';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+import SettingsIcon from '@mui/icons-material/Settings';
+import HomeIcon from '@mui/icons-material/Home';
+
+const meta = {
+  title: 'Components/Core/SingleSelect',
+  component: SingleSelect,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: { type: 'select' },
+      options: ['small', 'medium', 'large'],
+    },
+    variant: {
+      control: { type: 'select' },
+      options: ['outlined', 'filled', 'standard'],
+    },
+  },
+} satisfies Meta<typeof SingleSelect>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const basicOptions: SingleSelectOption[] = [
+  { value: 'option1', label: 'Option 1' },
+  { value: 'option2', label: 'Option 2' },
+  { value: 'option3', label: 'Option 3' },
+  { value: 'option4', label: 'Option 4', disabled: true },
+];
+
+const optionsWithIcons: SingleSelectOption[] = [
+  { value: 'home', label: 'Home', icon: <HomeIcon /> },
+  { value: 'profile', label: 'Profile', icon: <AccountCircleIcon /> },
+  { value: 'settings', label: 'Settings', icon: <SettingsIcon /> },
+];
+
+export const Default: Story = {
+  args: {
+    options: basicOptions,
+    placeholder: 'Select an option',
+    label: 'Choose Option',
+    fullWidth: false,
+    size: 'medium',
+    variant: 'outlined',
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    options: basicOptions,
+    value: 'option2',
+    label: 'Selected Option',
+    fullWidth: false,
+    size: 'medium',
+    variant: 'outlined',
+  },
+};
+
+export const WithIcons: Story = {
+  args: {
+    options: optionsWithIcons,
+    placeholder: 'Select a page',
+    label: 'Navigation',
+    fullWidth: false,
+    size: 'medium',
+    variant: 'outlined',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    options: basicOptions,
+    value: 'option1',
+    label: 'Disabled Select',
+    disabled: true,
+    fullWidth: false,
+    size: 'medium',
+    variant: 'outlined',
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    options: basicOptions,
+    label: 'Select with Error',
+    error: true,
+    helperText: 'This field is required',
+    fullWidth: false,
+    size: 'medium',
+    variant: 'outlined',
+  },
+};
+
+export const FullWidth: Story = {
+  args: {
+    options: basicOptions,
+    label: 'Full Width Select',
+    fullWidth: true,
+    size: 'medium',
+    variant: 'outlined',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    options: basicOptions,
+    label: 'Small Select',
+    size: 'small',
+    variant: 'outlined',
+  },
+};
+
+export const Filled: Story = {
+  args: {
+    options: basicOptions,
+    label: 'Filled Variant',
+    variant: 'filled',
+    size: 'medium',
+  },
+};
+
+export const Standard: Story = {
+  args: {
+    options: basicOptions,
+    label: 'Standard Variant',
+    variant: 'standard',
+    size: 'medium',
+  },
+};
+
+export const Required: Story = {
+  args: {
+    options: basicOptions,
+    label: 'Required Field',
+    required: true,
+    helperText: 'This field is mandatory',
+    size: 'medium',
+    variant: 'outlined',
+  },
+};

--- a/src/components/core/SingleSelect/SingleSelect.styles.ts
+++ b/src/components/core/SingleSelect/SingleSelect.styles.ts
@@ -1,0 +1,70 @@
+import { styled } from '@mui/material/styles';
+import Select, { SelectProps } from '@mui/material/Select';
+import MenuItem, { MenuItemProps } from '@mui/material/MenuItem';
+import FormControl, { FormControlProps } from '@mui/material/FormControl';
+import InputLabel, { InputLabelProps } from '@mui/material/InputLabel';
+import FormHelperText, { FormHelperTextProps } from '@mui/material/FormHelperText';
+
+export const StyledFormControl = styled(FormControl)<FormControlProps>(
+  ({ theme }) => ({
+    minWidth: 120,
+  })
+);
+
+export const StyledSelect = styled(Select)<SelectProps>(({ theme }) => ({
+  '& .MuiOutlinedInput-notchedOutline': {
+    borderColor: (theme.vars || theme).palette.primary.main,
+  },
+  '&:hover .MuiOutlinedInput-notchedOutline': {
+    borderColor: (theme.vars || theme).palette.primary.light,
+  },
+  '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+    borderColor: (theme.vars || theme).palette.primary.dark,
+  },
+  '&.Mui-error .MuiOutlinedInput-notchedOutline': {
+    borderColor: (theme.vars || theme).palette.error.main,
+  },
+}));
+
+export const StyledMenuItem = styled(MenuItem)<MenuItemProps>(
+  ({ theme }) => ({
+    '&.Mui-selected': {
+      backgroundColor: (theme.vars || theme).palette.primary.main + '20',
+    },
+    '&.Mui-selected:hover': {
+      backgroundColor: (theme.vars || theme).palette.primary.main + '30',
+    },
+    '&:hover': {
+      backgroundColor: (theme.vars || theme).palette.action.hover,
+    },
+    '&.Mui-disabled': {
+      opacity: 0.5,
+    },
+  })
+);
+
+export const StyledInputLabel = styled(InputLabel)<InputLabelProps>(
+  ({ theme }) => ({
+    '&.Mui-focused': {
+      color: (theme.vars || theme).palette.primary.main,
+    },
+    '&.Mui-error': {
+      color: (theme.vars || theme).palette.error.main,
+    },
+  })
+);
+
+export const StyledFormHelperText = styled(
+  FormHelperText
+)<FormHelperTextProps>(({ theme }) => ({
+  '&.Mui-error': {
+    color: (theme.vars || theme).palette.error.main,
+  },
+}));
+
+export const IconWrapper = styled('span')(({ theme }) => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  marginRight: theme.spacing(1),
+  verticalAlign: 'middle',
+}));

--- a/src/components/core/SingleSelect/SingleSelect.styles.ts
+++ b/src/components/core/SingleSelect/SingleSelect.styles.ts
@@ -3,45 +3,73 @@ import Select, { SelectProps } from '@mui/material/Select';
 import MenuItem, { MenuItemProps } from '@mui/material/MenuItem';
 import FormControl, { FormControlProps } from '@mui/material/FormControl';
 import InputLabel, { InputLabelProps } from '@mui/material/InputLabel';
-import FormHelperText, { FormHelperTextProps } from '@mui/material/FormHelperText';
+import FormHelperText, {
+  FormHelperTextProps,
+} from '@mui/material/FormHelperText';
 
 export const StyledFormControl = styled(FormControl)<FormControlProps>(
   ({ theme }) => ({
     minWidth: 120,
-  })
+  }),
 );
 
-export const StyledSelect = styled(Select)<SelectProps>(({ theme }) => ({
-  '& .MuiOutlinedInput-notchedOutline': {
-    borderColor: (theme.vars || theme).palette.primary.main,
-  },
-  '&:hover .MuiOutlinedInput-notchedOutline': {
-    borderColor: (theme.vars || theme).palette.primary.light,
-  },
-  '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-    borderColor: (theme.vars || theme).palette.primary.dark,
-  },
-  '&.Mui-error .MuiOutlinedInput-notchedOutline': {
-    borderColor: (theme.vars || theme).palette.error.main,
-  },
-}));
+const getPillRadius = (size?: 'small' | 'medium') => {
+  return size === 'small' ? 16 : 20;
+};
 
-export const StyledMenuItem = styled(MenuItem)<MenuItemProps>(
-  ({ theme }) => ({
-    '&.Mui-selected': {
-      backgroundColor: (theme.vars || theme).palette.primary.main + '20',
+export const StyledSelect = styled(Select)<SelectProps>(({ theme, size }) => {
+  const pillRadius = getPillRadius(size as 'small' | 'medium');
+
+  return {
+    backgroundColor: (theme.vars || theme).palette.action.hover,
+    borderRadius: pillRadius,
+    '& .MuiSelect-select': {
+      padding: size === 'small' ? '6px 32px 6px 16px' : '8px 32px 8px 24px',
+      minHeight: size === 'small' ? '20px' : '24px',
+      display: 'flex',
+      alignItems: 'center',
     },
-    '&.Mui-selected:hover': {
-      backgroundColor: (theme.vars || theme).palette.primary.main + '30',
+    '& .MuiOutlinedInput-notchedOutline': {
+      border: 'none',
     },
     '&:hover': {
       backgroundColor: (theme.vars || theme).palette.action.hover,
     },
-    '&.Mui-disabled': {
-      opacity: 0.5,
+    '&.Mui-focused': {
+      backgroundColor: (theme.vars || theme).palette.action.hover,
+      '& .MuiOutlinedInput-notchedOutline': {
+        border: `2px solid ${(theme.vars || theme).palette.primary.main}`,
+        borderRadius: pillRadius,
+      },
     },
-  })
-);
+    '&.Mui-error .MuiOutlinedInput-notchedOutline': {
+      border: `2px solid ${(theme.vars || theme).palette.error.main}`,
+      borderRadius: pillRadius,
+    },
+    '& .MuiSelect-icon': {
+      right: size === 'small' ? 8 : 12,
+      color: (theme.vars || theme).palette.text.secondary,
+    },
+  };
+});
+
+export const StyledMenuItem = styled(MenuItem)<MenuItemProps>(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+  '&.Mui-selected': {
+    backgroundColor: (theme.vars || theme).palette.action.selected,
+    '&:hover': {
+      backgroundColor: (theme.vars || theme).palette.action.hover,
+    },
+  },
+  '&:hover': {
+    backgroundColor: (theme.vars || theme).palette.action.hover,
+  },
+  '&.Mui-disabled': {
+    opacity: 0.5,
+  },
+}));
 
 export const StyledInputLabel = styled(InputLabel)<InputLabelProps>(
   ({ theme }) => ({
@@ -51,16 +79,16 @@ export const StyledInputLabel = styled(InputLabel)<InputLabelProps>(
     '&.Mui-error': {
       color: (theme.vars || theme).palette.error.main,
     },
-  })
+  }),
 );
 
-export const StyledFormHelperText = styled(
-  FormHelperText
-)<FormHelperTextProps>(({ theme }) => ({
-  '&.Mui-error': {
-    color: (theme.vars || theme).palette.error.main,
-  },
-}));
+export const StyledFormHelperText = styled(FormHelperText)<FormHelperTextProps>(
+  ({ theme }) => ({
+    '&.Mui-error': {
+      color: (theme.vars || theme).palette.error.main,
+    },
+  }),
+);
 
 export const IconWrapper = styled('span')(({ theme }) => ({
   display: 'inline-flex',

--- a/src/components/core/SingleSelect/SingleSelect.tsx
+++ b/src/components/core/SingleSelect/SingleSelect.tsx
@@ -1,12 +1,5 @@
-import { FC } from 'react';
-import {
-  StyledFormControl,
-  StyledSelect,
-  StyledMenuItem,
-  StyledInputLabel,
-  StyledFormHelperText,
-  IconWrapper,
-} from './SingleSelect.styles';
+import { FC, useCallback, useMemo } from 'react';
+import { MultiSelect } from '../MultiSelect/MultiSelect';
 import { SingleSelectProps } from './SingleSelect.types';
 
 export const SingleSelect: FC<SingleSelectProps> = ({
@@ -23,66 +16,34 @@ export const SingleSelect: FC<SingleSelectProps> = ({
   label,
   required = false,
 }) => {
-  const handleChange = (event: any) => {
-    if (onChange) {
-      onChange(event.target.value as string);
-    }
-  };
+  const arrayValue = useMemo(() => (value ? [value] : []), [value]);
+
+  const handleChange = useCallback(
+    (values: string[]) => {
+      if (onChange) {
+        onChange(values[0] || '');
+      }
+    },
+    [onChange],
+  );
 
   return (
-    <StyledFormControl
-      fullWidth={fullWidth}
-      size={size === 'small' ? 'small' : 'medium'}
-      error={error}
+    <MultiSelect
+      options={options}
+      value={arrayValue}
+      onChange={handleChange}
+      placeholder={placeholder}
       disabled={disabled}
+      fullWidth={fullWidth}
+      size={size}
       variant={variant}
+      error={error}
+      helperText={helperText}
+      label={label}
       required={required}
-    >
-      {label && (
-        <StyledInputLabel id={`${label}-select-label`}>
-          {label}
-        </StyledInputLabel>
-      )}
-      <StyledSelect
-        labelId={label ? `${label}-select-label` : undefined}
-        value={value}
-        onChange={handleChange}
-        label={label}
-        displayEmpty={!!placeholder}
-        renderValue={(selected) => {
-          if (!selected) {
-            return <em>{placeholder}</em>;
-          }
-          const selectedOption = options.find((opt) => opt.value === selected);
-          return (
-            <>
-              {selectedOption?.icon && (
-                <IconWrapper>{selectedOption.icon}</IconWrapper>
-              )}
-              {selectedOption?.label || selected}
-            </>
-          );
-        }}
-      >
-        {placeholder && (
-          <StyledMenuItem value="" disabled>
-            <em>{placeholder}</em>
-          </StyledMenuItem>
-        )}
-        {options.map((option) => (
-          <StyledMenuItem
-            key={option.value}
-            value={option.value}
-            disabled={option.disabled}
-          >
-            {option.icon && <IconWrapper>{option.icon}</IconWrapper>}
-            {option.label}
-          </StyledMenuItem>
-        ))}
-      </StyledSelect>
-      {helperText && (
-        <StyledFormHelperText error={error}>{helperText}</StyledFormHelperText>
-      )}
-    </StyledFormControl>
+      multiple={false}
+      show="label"
+      maxChips={1}
+    />
   );
 };

--- a/src/components/core/SingleSelect/SingleSelect.tsx
+++ b/src/components/core/SingleSelect/SingleSelect.tsx
@@ -1,0 +1,88 @@
+import { FC } from 'react';
+import {
+  StyledFormControl,
+  StyledSelect,
+  StyledMenuItem,
+  StyledInputLabel,
+  StyledFormHelperText,
+  IconWrapper,
+} from './SingleSelect.styles';
+import { SingleSelectProps } from './SingleSelect.types';
+
+export const SingleSelect: FC<SingleSelectProps> = ({
+  options,
+  value = '',
+  onChange,
+  placeholder,
+  disabled = false,
+  fullWidth = false,
+  size = 'medium',
+  variant = 'outlined',
+  error = false,
+  helperText,
+  label,
+  required = false,
+}) => {
+  const handleChange = (event: any) => {
+    if (onChange) {
+      onChange(event.target.value as string);
+    }
+  };
+
+  return (
+    <StyledFormControl
+      fullWidth={fullWidth}
+      size={size === 'small' ? 'small' : 'medium'}
+      error={error}
+      disabled={disabled}
+      variant={variant}
+      required={required}
+    >
+      {label && (
+        <StyledInputLabel id={`${label}-select-label`}>
+          {label}
+        </StyledInputLabel>
+      )}
+      <StyledSelect
+        labelId={label ? `${label}-select-label` : undefined}
+        value={value}
+        onChange={handleChange}
+        label={label}
+        displayEmpty={!!placeholder}
+        renderValue={(selected) => {
+          if (!selected) {
+            return <em>{placeholder}</em>;
+          }
+          const selectedOption = options.find((opt) => opt.value === selected);
+          return (
+            <>
+              {selectedOption?.icon && (
+                <IconWrapper>{selectedOption.icon}</IconWrapper>
+              )}
+              {selectedOption?.label || selected}
+            </>
+          );
+        }}
+      >
+        {placeholder && (
+          <StyledMenuItem value="" disabled>
+            <em>{placeholder}</em>
+          </StyledMenuItem>
+        )}
+        {options.map((option) => (
+          <StyledMenuItem
+            key={option.value}
+            value={option.value}
+            disabled={option.disabled}
+          >
+            {option.icon && <IconWrapper>{option.icon}</IconWrapper>}
+            {option.label}
+          </StyledMenuItem>
+        ))}
+      </StyledSelect>
+      {helperText && (
+        <StyledFormHelperText error={error}>{helperText}</StyledFormHelperText>
+      )}
+    </StyledFormControl>
+  );
+};

--- a/src/components/core/SingleSelect/SingleSelect.tsx
+++ b/src/components/core/SingleSelect/SingleSelect.tsx
@@ -15,6 +15,7 @@ export const SingleSelect: FC<SingleSelectProps> = ({
   helperText,
   label,
   required = false,
+  'data-testid': dataTestId,
 }) => {
   const arrayValue = useMemo(() => (value ? [value] : []), [value]);
 
@@ -44,6 +45,7 @@ export const SingleSelect: FC<SingleSelectProps> = ({
       multiple={false}
       show="label"
       maxChips={1}
+      data-testid={dataTestId}
     />
   );
 };

--- a/src/components/core/SingleSelect/SingleSelect.types.ts
+++ b/src/components/core/SingleSelect/SingleSelect.types.ts
@@ -18,4 +18,5 @@ export interface SingleSelectProps {
   helperText?: string;
   label?: string;
   required?: boolean;
+  'data-testid'?: string;
 }

--- a/src/components/core/SingleSelect/SingleSelect.types.ts
+++ b/src/components/core/SingleSelect/SingleSelect.types.ts
@@ -1,0 +1,21 @@
+export interface SingleSelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+  icon?: React.ReactNode;
+}
+
+export interface SingleSelectProps {
+  options: SingleSelectOption[];
+  value?: string;
+  onChange?: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  fullWidth?: boolean;
+  size?: 'small' | 'medium' | 'large';
+  variant?: 'outlined' | 'filled' | 'standard';
+  error?: boolean;
+  helperText?: string;
+  label?: string;
+  required?: boolean;
+}

--- a/src/components/core/SingleSelect/SingleSelect.types.ts
+++ b/src/components/core/SingleSelect/SingleSelect.types.ts
@@ -12,7 +12,7 @@ export interface SingleSelectProps {
   placeholder?: string;
   disabled?: boolean;
   fullWidth?: boolean;
-  size?: 'small' | 'medium' | 'large';
+  size?: 'small' | 'medium';
   variant?: 'outlined' | 'filled' | 'standard';
   error?: boolean;
   helperText?: string;

--- a/src/components/core/TabSelect/TabSelect.stories.tsx
+++ b/src/components/core/TabSelect/TabSelect.stories.tsx
@@ -1,0 +1,326 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { TabSelect } from './TabSelect';
+import { TabOption } from './TabSelect.types';
+import HomeIcon from '@mui/icons-material/Home';
+import PersonIcon from '@mui/icons-material/Person';
+import SettingsIcon from '@mui/icons-material/Settings';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import StarIcon from '@mui/icons-material/Star';
+import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
+
+const meta = {
+  title: 'Components/Core/TabSelect',
+  component: TabSelect,
+  tags: ['autodocs'],
+  argTypes: {
+    orientation: {
+      control: { type: 'select' },
+      options: ['horizontal', 'vertical'],
+    },
+    variant: {
+      control: { type: 'select' },
+      options: ['standard', 'scrollable', 'fullWidth'],
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['small', 'medium', 'large'],
+    },
+    indicatorColor: {
+      control: { type: 'select' },
+      options: ['primary', 'secondary'],
+    },
+    textColor: {
+      control: { type: 'select' },
+      options: ['primary', 'secondary', 'inherit'],
+    },
+    iconPosition: {
+      control: { type: 'select' },
+      options: ['start', 'end', 'top', 'bottom'],
+    },
+    scrollButtons: {
+      control: { type: 'select' },
+      options: ['auto', true, false],
+    },
+  },
+} satisfies Meta<typeof TabSelect>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const basicOptions: TabOption[] = [
+  { value: 'tab1', label: 'Tab One' },
+  { value: 'tab2', label: 'Tab Two' },
+  { value: 'tab3', label: 'Tab Three' },
+  { value: 'tab4', label: 'Tab Four', disabled: true },
+];
+
+const optionsWithIcons: TabOption[] = [
+  { value: 'home', label: 'Home', icon: <HomeIcon /> },
+  { value: 'profile', label: 'Profile', icon: <PersonIcon /> },
+  { value: 'settings', label: 'Settings', icon: <SettingsIcon /> },
+  { value: 'notifications', label: 'Alerts', icon: <NotificationsIcon /> },
+];
+
+const optionsWithBadges: TabOption[] = [
+  { value: 'messages', label: 'Messages', badge: 5 },
+  { value: 'notifications', label: 'Notifications', badge: 12 },
+  { value: 'updates', label: 'Updates', badge: 'New' },
+  { value: 'alerts', label: 'Alerts' },
+];
+
+const manyOptions: TabOption[] = [
+  { value: 'tab1', label: 'Dashboard', icon: <HomeIcon /> },
+  { value: 'tab2', label: 'Profile', icon: <PersonIcon /> },
+  { value: 'tab3', label: 'Settings', icon: <SettingsIcon /> },
+  {
+    value: 'tab4',
+    label: 'Notifications',
+    icon: <NotificationsIcon />,
+    badge: 3,
+  },
+  { value: 'tab5', label: 'Favorites', icon: <FavoriteIcon /> },
+  { value: 'tab6', label: 'Starred', icon: <StarIcon />, badge: 7 },
+  { value: 'tab7', label: 'Cart', icon: <ShoppingCartIcon />, badge: 2 },
+];
+
+export const Default: Story = {
+  args: {
+    options: basicOptions,
+    value: 'tab1',
+    orientation: 'horizontal',
+    variant: 'standard',
+    size: 'medium',
+    showBorder: false,
+  },
+};
+
+export const WithIcons: Story = {
+  args: {
+    options: optionsWithIcons,
+    value: 'home',
+    orientation: 'horizontal',
+    variant: 'standard',
+    size: 'medium',
+    iconPosition: 'start',
+    showBorder: false,
+  },
+};
+
+export const IconsOnTop: Story = {
+  args: {
+    options: optionsWithIcons,
+    value: 'home',
+    orientation: 'horizontal',
+    variant: 'standard',
+    size: 'medium',
+    iconPosition: 'top',
+    showBorder: false,
+  },
+};
+
+export const WithBadges: Story = {
+  args: {
+    options: optionsWithBadges,
+    value: 'messages',
+    orientation: 'horizontal',
+    variant: 'standard',
+    size: 'medium',
+    showBorder: false,
+  },
+};
+
+export const Scrollable: Story = {
+  args: {
+    options: manyOptions,
+    value: 'tab1',
+    orientation: 'horizontal',
+    variant: 'scrollable',
+    scrollButtons: 'auto',
+    size: 'medium',
+    showBorder: false,
+  },
+};
+
+export const FullWidth: Story = {
+  args: {
+    options: basicOptions.slice(0, 3),
+    value: 'tab1',
+    variant: 'fullWidth',
+    size: 'medium',
+    showBorder: false,
+  },
+};
+
+export const Centered: Story = {
+  args: {
+    options: basicOptions.slice(0, 3),
+    value: 'tab1',
+    centered: true,
+    variant: 'standard',
+    size: 'medium',
+    showBorder: false,
+  },
+};
+
+export const Vertical: Story = {
+  args: {
+    options: optionsWithIcons,
+    value: 'home',
+    orientation: 'vertical',
+    variant: 'standard',
+    size: 'medium',
+    showBorder: true,
+  },
+};
+
+export const WithBorder: Story = {
+  args: {
+    options: basicOptions,
+    value: 'tab1',
+    showBorder: true,
+    size: 'medium',
+    variant: 'standard',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    options: optionsWithIcons,
+    value: 'home',
+    size: 'small',
+    variant: 'standard',
+    iconPosition: 'start',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    options: optionsWithIcons,
+    value: 'home',
+    size: 'large',
+    variant: 'standard',
+    iconPosition: 'start',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    options: basicOptions,
+    value: 'tab1',
+    disabled: true,
+    size: 'medium',
+    variant: 'standard',
+  },
+};
+
+export const SecondaryColor: Story = {
+  args: {
+    options: optionsWithIcons,
+    value: 'home',
+    indicatorColor: 'secondary',
+    textColor: 'secondary',
+    size: 'medium',
+    variant: 'standard',
+  },
+};
+
+export const InteractiveExample: Story = {
+  args: {
+    options: optionsWithIcons,
+    value: 'home',
+    showBorder: true,
+    iconPosition: 'start',
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value as string);
+    const [content, setContent] = useState('Welcome to the Home page!');
+
+    const handleChange = (newValue: string) => {
+      setValue(newValue);
+      const contents: Record<string, string> = {
+        home: 'Welcome to the Home page!',
+        profile: 'This is your Profile section.',
+        settings: 'Manage your Settings here.',
+        notifications: 'Check your latest Notifications.',
+      };
+      setContent(contents[newValue] || '');
+    };
+
+    return (
+      <div style={{ width: '100%' }}>
+        <TabSelect {...args} value={value} onChange={handleChange} />
+        <div
+          style={{
+            padding: '20px',
+            marginTop: '20px',
+            border: '1px solid #e0e0e0',
+            borderRadius: '4px',
+          }}
+        >
+          <h3>Tab Content</h3>
+          <p>{content}</p>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const ComplexExample: Story = {
+  args: {
+    options: manyOptions,
+    value: 'tab1',
+    variant: 'scrollable',
+    scrollButtons: 'auto',
+    showBorder: true,
+    iconPosition: 'start',
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value as string);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
+        <div>
+          <h3>Standard Tabs with Icons and Badges</h3>
+          <TabSelect {...args} value={value} onChange={setValue} />
+        </div>
+
+        <div>
+          <h3>Full Width Tabs</h3>
+          <TabSelect
+            options={manyOptions.slice(0, 3)}
+            value={value}
+            onChange={setValue}
+            variant="fullWidth"
+            showBorder={true}
+          />
+        </div>
+
+        <div style={{ display: 'flex', gap: '24px' }}>
+          <div style={{ width: '200px' }}>
+            <h3>Vertical Tabs</h3>
+            <TabSelect
+              options={manyOptions.slice(0, 4)}
+              value={value}
+              onChange={setValue}
+              orientation="vertical"
+              showBorder={false}
+            />
+          </div>
+          <div
+            style={{
+              flex: 1,
+              padding: '20px',
+              border: '1px solid #e0e0e0',
+              borderRadius: '4px',
+            }}
+          >
+            <h3>Content Area</h3>
+            <p>Selected tab: {value}</p>
+          </div>
+        </div>
+      </div>
+    );
+  },
+};

--- a/src/components/core/TabSelect/TabSelect.styles.ts
+++ b/src/components/core/TabSelect/TabSelect.styles.ts
@@ -17,43 +17,75 @@ const getTabSize = (size?: 'small' | 'medium' | 'large') => {
   switch (size) {
     case 'small':
       return {
-        minHeight: 36,
-        padding: '6px 12px',
+        minHeight: 32,
+        padding: '6px 16px',
         fontSize: '0.875rem',
       };
     case 'large':
       return {
-        minHeight: 56,
-        padding: '12px 24px',
+        minHeight: 48,
+        padding: '12px 32px',
         fontSize: '1.125rem',
       };
     case 'medium':
     default:
       return {
-        minHeight: 48,
-        padding: '8px 16px',
+        minHeight: 40,
+        padding: '8px 24px',
         fontSize: '1rem',
       };
   }
 };
 
+const getPillRadius = (size?: 'small' | 'medium' | 'large') => {
+  switch (size) {
+    case 'small':
+      return 16;
+    case 'large':
+      return 24;
+    case 'medium':
+    default:
+      return 20;
+  }
+};
+
 export const StyledTabs = styled(Tabs, {
   shouldForwardProp: (prop) => prop !== 'showBorder' && prop !== 'size',
-})<StyledTabsProps>(({ theme, showBorder, size }) => ({
-  minHeight: size === 'small' ? 36 : size === 'large' ? 56 : 48,
-  ...(showBorder && {
-    borderBottom: `1px solid ${(theme.vars || theme).palette.divider}`,
-  }),
-  '& .MuiTabs-indicator': {
-    backgroundColor: (theme.vars || theme).palette.primary.main,
-    height: size === 'small' ? 2 : 3,
-  },
-  '& .MuiTabs-scrollButtons': {
-    '&.Mui-disabled': {
-      opacity: 0.3,
+})<StyledTabsProps>(({ theme, showBorder, size }) => {
+  const pillRadius = getPillRadius(size);
+
+  return {
+    minHeight: size === 'small' ? 32 : size === 'large' ? 48 : 40,
+    position: 'relative',
+    backgroundColor: (theme.vars || theme).palette.action.hover,
+    borderRadius: pillRadius,
+    padding: '3px',
+    display: 'inline-flex',
+    ...(showBorder && {
+      border: `1px solid ${(theme.vars || theme).palette.divider}`,
+    }),
+    '& .MuiTabs-indicator': {
+      height: '100%',
+      borderRadius: pillRadius - 3,
+      backgroundColor: (theme.vars || theme).palette.background.paper,
+      boxShadow: '0 2px 8px 0 rgba(0,0,0,0.1)',
+      transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+      zIndex: 1,
+      bottom: 0,
+      border: 'none',
     },
-  },
-}));
+    '& .MuiTabs-flexContainer': {
+      position: 'relative',
+      zIndex: 2,
+      gap: 0,
+    },
+    '& .MuiTabs-scrollButtons': {
+      '&.Mui-disabled': {
+        opacity: 0.3,
+      },
+    },
+  };
+});
 
 export const StyledTab = styled(Tab, {
   shouldForwardProp: (prop) => prop !== 'size',
@@ -61,31 +93,44 @@ export const StyledTab = styled(Tab, {
   textTransform: 'none',
   fontWeight: 500,
   color: (theme.vars || theme).palette.text.secondary,
+  position: 'relative',
+  zIndex: 2,
+  opacity: 0.7,
   ...getTabSize(size),
+  minWidth: 'auto',
+  '&:first-of-type': {
+    borderTopLeftRadius: getPillRadius(size) - 3,
+    borderBottomLeftRadius: getPillRadius(size) - 3,
+  },
+  '&:last-of-type': {
+    borderTopRightRadius: getPillRadius(size) - 3,
+    borderBottomRightRadius: getPillRadius(size) - 3,
+  },
   '&.Mui-selected': {
-    color: (theme.vars || theme).palette.primary.main,
+    color: (theme.vars || theme).palette.text.primary,
     fontWeight: 600,
+    opacity: 1,
   },
   '&.Mui-disabled': {
-    opacity: 0.5,
+    opacity: 0.3,
     cursor: 'not-allowed',
   },
-  '&:hover': {
-    color: (theme.vars || theme).palette.primary.light,
-    backgroundColor: (theme.vars || theme).palette.action.hover,
+  '&:hover:not(.Mui-selected):not(.Mui-disabled)': {
+    opacity: 0.85,
   },
   '& .MuiTab-iconWrapper': {
     marginBottom: size === 'small' ? 2 : 4,
   },
-  transition: theme.transitions.create(['color', 'background-color'], {
+  transition: theme.transitions.create(['color', 'opacity'], {
     duration: theme.transitions.duration.short,
   }),
+  // Disable ripple effect for cleaner pill aesthetic
+  disableRipple: true,
 }));
 
 export const TabContainer = styled(Box)(({ theme }) => ({
-  width: '100%',
-  display: 'flex',
-  flexDirection: 'column',
+  display: 'inline-flex',
+  alignItems: 'center',
 }));
 
 export const StyledBadge = styled(Badge)<BadgeProps>(({ theme }) => ({

--- a/src/components/core/TabSelect/TabSelect.styles.ts
+++ b/src/components/core/TabSelect/TabSelect.styles.ts
@@ -1,0 +1,120 @@
+import { styled } from '@mui/material/styles';
+import Tabs, { TabsProps } from '@mui/material/Tabs';
+import Tab, { TabProps } from '@mui/material/Tab';
+import Box from '@mui/material/Box';
+import Badge, { BadgeProps } from '@mui/material/Badge';
+
+interface StyledTabsProps extends TabsProps {
+  showBorder?: boolean;
+  size?: 'small' | 'medium' | 'large';
+}
+
+interface StyledTabProps extends TabProps {
+  size?: 'small' | 'medium' | 'large';
+}
+
+const getTabSize = (size?: 'small' | 'medium' | 'large') => {
+  switch (size) {
+    case 'small':
+      return {
+        minHeight: 36,
+        padding: '6px 12px',
+        fontSize: '0.875rem',
+      };
+    case 'large':
+      return {
+        minHeight: 56,
+        padding: '12px 24px',
+        fontSize: '1.125rem',
+      };
+    case 'medium':
+    default:
+      return {
+        minHeight: 48,
+        padding: '8px 16px',
+        fontSize: '1rem',
+      };
+  }
+};
+
+export const StyledTabs = styled(Tabs, {
+  shouldForwardProp: (prop) => prop !== 'showBorder' && prop !== 'size',
+})<StyledTabsProps>(({ theme, showBorder, size }) => ({
+  minHeight: size === 'small' ? 36 : size === 'large' ? 56 : 48,
+  ...(showBorder && {
+    borderBottom: `1px solid ${(theme.vars || theme).palette.divider}`,
+  }),
+  '& .MuiTabs-indicator': {
+    backgroundColor: (theme.vars || theme).palette.primary.main,
+    height: size === 'small' ? 2 : 3,
+  },
+  '& .MuiTabs-scrollButtons': {
+    '&.Mui-disabled': {
+      opacity: 0.3,
+    },
+  },
+}));
+
+export const StyledTab = styled(Tab, {
+  shouldForwardProp: (prop) => prop !== 'size',
+})<StyledTabProps>(({ theme, size = 'medium' }) => ({
+  textTransform: 'none',
+  fontWeight: 500,
+  color: (theme.vars || theme).palette.text.secondary,
+  ...getTabSize(size),
+  '&.Mui-selected': {
+    color: (theme.vars || theme).palette.primary.main,
+    fontWeight: 600,
+  },
+  '&.Mui-disabled': {
+    opacity: 0.5,
+    cursor: 'not-allowed',
+  },
+  '&:hover': {
+    color: (theme.vars || theme).palette.primary.light,
+    backgroundColor: (theme.vars || theme).palette.action.hover,
+  },
+  '& .MuiTab-iconWrapper': {
+    marginBottom: size === 'small' ? 2 : 4,
+  },
+  transition: theme.transitions.create(['color', 'background-color'], {
+    duration: theme.transitions.duration.short,
+  }),
+}));
+
+export const TabContainer = styled(Box)(({ theme }) => ({
+  width: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+}));
+
+export const StyledBadge = styled(Badge)<BadgeProps>(({ theme }) => ({
+  '& .MuiBadge-badge': {
+    right: -8,
+    top: 8,
+    border: `2px solid ${(theme.vars || theme).palette.background.paper}`,
+    padding: '0 4px',
+    backgroundColor: (theme.vars || theme).palette.primary.main,
+    color: (theme.vars || theme).palette.primary.contrastText,
+    fontSize: '0.75rem',
+    minWidth: 20,
+    height: 20,
+  },
+}));
+
+export const TabContent = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(2),
+  backgroundColor: (theme.vars || theme).palette.background.paper,
+  borderRadius: theme.shape.borderRadius,
+  marginTop: theme.spacing(1),
+}));
+
+export const IconWrapper = styled('span')(({ theme }) => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  marginRight: theme.spacing(0.5),
+  '& > svg': {
+    fontSize: '1.25rem',
+  },
+}));

--- a/src/components/core/TabSelect/TabSelect.tsx
+++ b/src/components/core/TabSelect/TabSelect.tsx
@@ -1,0 +1,99 @@
+import { FC, SyntheticEvent } from 'react';
+import {
+  StyledTabs,
+  StyledTab,
+  TabContainer,
+  StyledBadge,
+  IconWrapper,
+} from './TabSelect.styles';
+import { TabSelectProps } from './TabSelect.types';
+
+export const TabSelect: FC<TabSelectProps> = ({
+  options,
+  value,
+  onChange,
+  orientation = 'horizontal',
+  variant = 'standard',
+  centered = false,
+  indicatorColor = 'primary',
+  textColor = 'primary',
+  disabled = false,
+  size = 'medium',
+  showBorder = false,
+  scrollButtons = 'auto',
+  allowScrollButtonsMobile = false,
+  iconPosition = 'start',
+  wrapped = false,
+  className,
+  ariaLabel = 'tab selection',
+}) => {
+  const handleChange = (_event: SyntheticEvent, newValue: string) => {
+    if (onChange) {
+      onChange(newValue);
+    }
+  };
+
+  const currentValue = value || (options.length > 0 ? options[0].value : '');
+
+  const renderTabLabel = (option: any) => {
+    const icon = option.icon ? <IconWrapper>{option.icon}</IconWrapper> : null;
+    const label = <span>{option.label}</span>;
+
+    if (!icon) {
+      return option.badge ? (
+        <StyledBadge badgeContent={option.badge}>{label}</StyledBadge>
+      ) : (
+        label
+      );
+    }
+
+    const content = (
+      <>
+        {iconPosition === 'start' || iconPosition === 'top' ? icon : null}
+        {label}
+        {iconPosition === 'end' || iconPosition === 'bottom' ? icon : null}
+      </>
+    );
+
+    return option.badge ? (
+      <StyledBadge badgeContent={option.badge}>{content}</StyledBadge>
+    ) : (
+      content
+    );
+  };
+
+  return (
+    <TabContainer className={className}>
+      <StyledTabs
+        value={currentValue}
+        onChange={handleChange}
+        orientation={orientation}
+        variant={variant}
+        centered={centered && variant !== 'scrollable'}
+        indicatorColor={indicatorColor}
+        textColor={textColor}
+        showBorder={showBorder}
+        size={size}
+        scrollButtons={scrollButtons}
+        allowScrollButtonsMobile={allowScrollButtonsMobile}
+        aria-label={ariaLabel}
+      >
+        {options.map((option) => (
+          <StyledTab
+            key={option.value}
+            value={option.value}
+            label={renderTabLabel(option)}
+            disabled={disabled || option.disabled}
+            wrapped={wrapped}
+            size={size}
+            iconPosition={
+              iconPosition === 'top' || iconPosition === 'bottom'
+                ? iconPosition
+                : undefined
+            }
+          />
+        ))}
+      </StyledTabs>
+    </TabContainer>
+  );
+};

--- a/src/components/core/TabSelect/TabSelect.tsx
+++ b/src/components/core/TabSelect/TabSelect.tsx
@@ -86,6 +86,7 @@ export const TabSelect: FC<TabSelectProps> = ({
             disabled={disabled || option.disabled}
             wrapped={wrapped}
             size={size}
+            disableRipple
             iconPosition={
               iconPosition === 'top' || iconPosition === 'bottom'
                 ? iconPosition

--- a/src/components/core/TabSelect/TabSelect.tsx
+++ b/src/components/core/TabSelect/TabSelect.tsx
@@ -26,6 +26,7 @@ export const TabSelect: FC<TabSelectProps> = ({
   wrapped = false,
   className,
   ariaLabel = 'tab selection',
+  'data-testid': dataTestId,
 }) => {
   const handleChange = (_event: SyntheticEvent, newValue: string) => {
     if (onChange) {
@@ -77,6 +78,7 @@ export const TabSelect: FC<TabSelectProps> = ({
         scrollButtons={scrollButtons}
         allowScrollButtonsMobile={allowScrollButtonsMobile}
         aria-label={ariaLabel}
+        data-testid={dataTestId}
       >
         {options.map((option) => (
           <StyledTab
@@ -86,6 +88,9 @@ export const TabSelect: FC<TabSelectProps> = ({
             disabled={disabled || option.disabled}
             wrapped={wrapped}
             size={size}
+            data-testid={
+              dataTestId ? `${dataTestId}-${option.value}` : undefined
+            }
             disableRipple
             iconPosition={
               iconPosition === 'top' || iconPosition === 'bottom'

--- a/src/components/core/TabSelect/TabSelect.types.ts
+++ b/src/components/core/TabSelect/TabSelect.types.ts
@@ -24,4 +24,5 @@ export interface TabSelectProps {
   wrapped?: boolean;
   className?: string;
   ariaLabel?: string;
+  'data-testid'?: string;
 }

--- a/src/components/core/TabSelect/TabSelect.types.ts
+++ b/src/components/core/TabSelect/TabSelect.types.ts
@@ -1,0 +1,27 @@
+export interface TabOption {
+  value: string;
+  label: string;
+  icon?: React.ReactNode;
+  disabled?: boolean;
+  badge?: string | number;
+}
+
+export interface TabSelectProps {
+  options: TabOption[];
+  value?: string;
+  onChange?: (value: string) => void;
+  orientation?: 'horizontal' | 'vertical';
+  variant?: 'standard' | 'scrollable' | 'fullWidth';
+  centered?: boolean;
+  indicatorColor?: 'primary' | 'secondary';
+  textColor?: 'primary' | 'secondary' | 'inherit';
+  disabled?: boolean;
+  size?: 'small' | 'medium' | 'large';
+  showBorder?: boolean;
+  scrollButtons?: 'auto' | boolean;
+  allowScrollButtonsMobile?: boolean;
+  iconPosition?: 'start' | 'end' | 'top' | 'bottom';
+  wrapped?: boolean;
+  className?: string;
+  ariaLabel?: string;
+}

--- a/src/hooks/earn/useEarnFilterOpportunities.ts
+++ b/src/hooks/earn/useEarnFilterOpportunities.ts
@@ -16,8 +16,6 @@ export type Result = UseQueryResult<
 >;
 
 export const useEarnFilterOpportunities = ({ filter }: Props): Result => {
-  // TODO: LF-14980: Deal with favorites & refetching
-  // TODO: LF-14854: Filtering
   return useQuery({
     queryKey: ['earn-filter-opportunities', filter],
     queryFn: async () => {

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -71,6 +71,10 @@ interface Resources {
       ctaHeadline: 'Join our Discord to learn more';
     };
     earn: {
+      copy: {
+        forYouBasedOnActivity: 'Handpicked markets based on your account activity';
+        forYouDefault: 'Explore curated and comprehensive ways to put your assets to work across {{totalMarkets}}+ markets';
+      };
       sorting: {
         apy: 'APY';
         sortBy: 'Sort By';

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -71,6 +71,11 @@ interface Resources {
       ctaHeadline: 'Join our Discord to learn more';
     };
     earn: {
+      sorting: {
+        apy: 'APY';
+        sortBy: 'Sort By';
+        tvl: 'TVL';
+      };
       top: {
         earnUpTo: 'Your idle <asset/> on <chain/> could earn up to <apy/> a year if placed on <protocol/>';
         makeTheJump: 'Your idle <asset/> on <chain/> could earn up to <apy/> on <protocol/>, make the jump!';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -279,7 +279,7 @@
       "earnUpTo": "Your idle <asset/> on <chain/> could earn up to <apy/> a year if placed on <protocol/>"
     },
     "copy": {
-      "forYouBasedOnActivity": "Handpicked markets based on your account activity",
+      "forYouBasedOnActivity": "Handpicked markets selected across {{totalMarkets}}+ based on your account activity",
       "forYouDefault": "Explore curated and comprehensive ways to put your assets to work across {{totalMarkets}}+ markets"
     },
     "sorting": {

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -277,6 +277,11 @@
       "maximizeYourRevenue": "Maximise your <tag/> revenues by depositing on <protocol/> <token/> Pool",
       "makeTheJump": "Your idle <asset/> on <chain/> could earn up to <apy/> on <protocol/>, make the jump!",
       "earnUpTo": "Your idle <asset/> on <chain/> could earn up to <apy/> a year if placed on <protocol/>"
+    },
+    "sorting": {
+      "sortBy": "Sort By",
+      "apy": "APY",
+      "tvl": "TVL"
     }
   },
   "widget": {

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -278,6 +278,10 @@
       "makeTheJump": "Your idle <asset/> on <chain/> could earn up to <apy/> on <protocol/>, make the jump!",
       "earnUpTo": "Your idle <asset/> on <chain/> could earn up to <apy/> a year if placed on <protocol/>"
     },
+    "copy": {
+      "forYouBasedOnActivity": "Handpicked markets based on your account activity",
+      "forYouDefault": "Explore curated and comprehensive ways to put your assets to work across {{totalMarkets}}+ markets"
+    },
     "sorting": {
       "sortBy": "Sort By",
       "apy": "APY",

--- a/src/types/jumper-backend.ts
+++ b/src/types/jumper-backend.ts
@@ -649,6 +649,8 @@ export interface GeneratePayloadDto {
   params: object;
 }
 
+export type TokenDto = object;
+
 export interface TaskVerificationDto {
   /** Users wallet address */
   address: string;
@@ -964,9 +966,10 @@ export class HttpClient<SecurityDataType = unknown> {
       r.data = null as unknown as T;
       r.error = null as unknown as E;
 
+      const responseToParse = responseFormat ? response.clone() : response;
       const data = !responseFormat
         ? r
-        : await response[responseFormat]()
+        : await responseToParse[responseFormat]()
             .then((data) => {
               if (r.ok) {
                 r.data = data;
@@ -1095,6 +1098,22 @@ export class JumperBackend<
     /**
      * No description
      *
+     * @tags Zaps, Public
+     * @name ZapsControllerGetLpTokensV1
+     * @summary Get all LP tokens
+     * @request GET:/v1/zaps/get-all-lp-tokens
+     */
+    zapsControllerGetLpTokensV1: (params: RequestParams = {}) =>
+      this.request<TokenDto[], any>({
+        path: `/v1/zaps/get-all-lp-tokens`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
      * @tags Earn, Public
      * @name EarnControllerGetTopsV1
      * @summary Get tops for an address
@@ -1144,15 +1163,35 @@ export class JumperBackend<
          */
         featured?: boolean;
         /**
-         * The chain id to filter for
-         * @example 1
+         * The chain ids to filter for
+         * @example [1,10,137]
          */
-        chainId?: number;
+        chains?: number[];
         /**
-         * The protocol to filter for
-         * @example "Aave"
+         * The protocols to filter for
+         * @example ["Aave","Compound","Yearn"]
          */
-        protocol?: string;
+        protocols?: string[];
+        /**
+         * The assets to filter for
+         * @example ["USDC","USDT","DAI"]
+         */
+        assets?: string[];
+        /**
+         * The tags to filter for
+         * @example ["Lending","Staking","Earn"]
+         */
+        tags?: string[];
+        /**
+         * The minimum APY to filter for
+         * @example 5.5
+         */
+        minAPY?: number;
+        /**
+         * The maximum APY to filter for
+         * @example 25
+         */
+        maxAPY?: number;
       },
       params: RequestParams = {},
     ) =>


### PR DESCRIPTION
Closes https://lifi.atlassian.net/browse/LF-15665

Test: the filtering section should be mostly interactive

- For you / Market toggle
- Grid / List toggle
- Changing filters like chain, protocols, etc (except APY) should update state, and trigger a new query to the backend with udpated filters
- Sort won't change ordering yet
- Changing the filters will likely set the component in a loading / error state (filtering is not implement backend side)

<img width="300" src="https://github.com/user-attachments/assets/3d2bde7d-b0d6-4ba8-abd2-5950250d560a" />


