### PR TITLE
chore: add bottom sheet for withdraw widget

### DIFF
--- a/src/components/ZapWidget/TxBottomSheet/TxBottomSheet.tsx
+++ b/src/components/ZapWidget/TxBottomSheet/TxBottomSheet.tsx
@@ -1,0 +1,98 @@
+import { FC, useEffect, useRef } from 'react';
+import { ButtonPrimary } from 'src/components/Button/Button.style';
+import {
+  BottomSheet,
+  BottomSheetBase,
+} from 'src/components/core/BottomSheet/BottomSheet';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { Link } from 'src/components/Link';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+
+interface TxBottomSheetProps {
+  title: string;
+  description: string;
+  link: string;
+  containerId: string;
+  isOpen: boolean;
+}
+
+export const TxBottomSheet: FC<TxBottomSheetProps> = ({
+  title,
+  description,
+  link,
+  containerId,
+  isOpen,
+}) => {
+  const bottomSheetRef = useRef<BottomSheetBase>(null);
+
+  useEffect(() => {
+    if (isOpen && !bottomSheetRef.current?.isOpen()) {
+      bottomSheetRef.current?.open();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    return () => {
+      bottomSheetRef.current?.close();
+    };
+  }, []);
+
+  return (
+    <BottomSheet containerId={containerId} ref={bottomSheetRef}>
+      <Box
+        sx={{
+          padding: 3,
+          textAlign: 'center',
+        }}
+      >
+        <Typography variant="titleXSmall" sx={{ py: 1 }}>
+          {title}
+        </Typography>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            flexDirection: 'row',
+            justifyContent: 'center',
+            py: 1,
+            mb: 2,
+          }}
+        >
+          <Typography variant="bodyMedium" sx={{ fontWeight: 400 }}>
+            {description}
+          </Typography>
+          <Link
+            href={link}
+            target="_blank"
+            rel="noreferrer"
+            sx={{
+              textDecoration: 'none',
+              color: 'inherit',
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            <OpenInNewIcon
+              sx={{
+                margin: 0.5,
+                width: '16px',
+                height: '16px',
+              }}
+            />
+          </Link>
+        </Box>
+
+        <ButtonPrimary
+          fullWidth
+          onClick={() => bottomSheetRef.current?.close()}
+          variant="contained"
+          style={{ boxShadow: 'none' }}
+        >
+          Close
+        </ButtonPrimary>
+      </Box>
+    </BottomSheet>
+  );
+};

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.tsx
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.tsx
@@ -1,5 +1,4 @@
 import { type ContractCall, type TokenAmount } from '@lifi/widget';
-import { formatUnits } from 'viem';
 import { WithdrawWidgetBox } from './WithdrawWidget.style';
 import type { AbiFunction } from 'viem';
 import { ProjectData } from 'src/types/questDetails';
@@ -8,8 +7,8 @@ import { useWithdrawTransaction } from './hooks';
 import { useAccount } from '@lifi/wallet-management';
 import { useChains } from 'src/hooks/useChains';
 import { useMemo } from 'react';
-import { TxConfirmation } from '../TxConfirmation/TxConfirmation';
 import { SectionCardContainer } from 'src/components/Cards/SectionCard/SectionCard.style';
+import { TxBottomSheet } from '../TxBottomSheet/TxBottomSheet';
 
 export interface WithdrawWidgetProps {
   poolName?: string;
@@ -54,11 +53,16 @@ export const WithdrawWidget: React.FC<WithdrawWidgetProps> = ({
     accountAddress: account.address,
   });
 
+  const containerId = 'withdraw-widget-box';
+
   return (
-    <SectionCardContainer>
+    <SectionCardContainer
+      id={containerId}
+      sx={{ position: 'relative', overflow: 'hidden' }}
+    >
       <WithdrawWidgetBox>
         <WithdrawForm
-          submitLabel={'Redeem'} // This belongs to contractCalls[0].label
+          submitLabel={'Withdraw'} // This belongs to contractCalls[0].label
           errorMessage={txError?.name}
           sendWithdrawTx={sendWithdrawTx}
           successDataRef={successDataRef}
@@ -73,25 +77,22 @@ export const WithdrawWidget: React.FC<WithdrawWidgetProps> = ({
           balance={depositTokenData?.toString() ?? '0'}
           lpTokenDecimals={lpTokenDecimals}
         />
-
-        {isTransactionReceiptSuccess && (
-          <TxConfirmation
-            description={'Withdraw successful'}
-            link={`${chain?.metamask.blockExplorerUrls?.[0] ?? 'https://etherscan.io/'}tx/${txHash}`}
-            success={
-              !!isWriteContractDataSuccess && !isWriteContractDataPending
-            }
-          />
-        )}
-
-        {!isTransactionReceiptSuccess && txHash && (
-          <TxConfirmation
-            description={'Check on explorer'}
-            link={`${chain?.metamask.blockExplorerUrls?.[0] ?? 'https://etherscan.io/'}tx/${txHash}`}
-            success={false}
-          />
-        )}
       </WithdrawWidgetBox>
+      <TxBottomSheet
+        title={
+          isTransactionReceiptSuccess
+            ? 'Withdraw successful'
+            : 'Transaction failed'
+        }
+        description="Check transaction on explorer"
+        link={`${chain?.metamask.blockExplorerUrls?.[0] ?? 'https://etherscan.io/'}tx/${txHash}`}
+        containerId={containerId}
+        isOpen={
+          !isTransactionReceiptLoading &&
+          (isTransactionReceiptSuccess ||
+            (!isTransactionReceiptSuccess && !!txHash))
+        }
+      />
     </SectionCardContainer>
   );
 };

--- a/src/components/core/BottomSheet/BottomSheet.tsx
+++ b/src/components/core/BottomSheet/BottomSheet.tsx
@@ -1,0 +1,123 @@
+import Drawer from '@mui/material/Drawer';
+import {
+  FC,
+  PropsWithChildren,
+  forwardRef,
+  startTransition,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+  useState,
+  RefObject,
+  useEffect,
+  useLayoutEffect,
+} from 'react';
+
+export interface BottomSheetBase {
+  isOpen(): void;
+  open(): void;
+  close(): void;
+}
+
+interface BottomSheetProps extends PropsWithChildren {
+  open?: boolean;
+  onClose?: () => void;
+  containerId: string;
+  elementRef?: RefObject<HTMLDivElement>;
+}
+
+export const BottomSheet = forwardRef<any, BottomSheetProps>(
+  ({ containerId, elementRef, children, open = false, onClose }, ref) => {
+    const [drawerOpen, setDrawerOpen] = useState(open);
+    const openRef = useRef(open);
+    const [isInert, setIsInert] = useState(!open);
+
+    let container = document.getElementById(containerId);
+
+    useLayoutEffect(() => {
+      container = document.getElementById(containerId);
+    }, [containerId]);
+
+    useEffect(() => {
+      if (container && open) {
+        setIsInert(false);
+        setDrawerOpen(true);
+        openRef.current = true;
+      } else if (!open) {
+        setIsInert(true);
+        setDrawerOpen(false);
+        openRef.current = false;
+      }
+    }, [open, container]);
+
+    const close = useCallback(() => {
+      setIsInert(true);
+      startTransition(() => {
+        setDrawerOpen(false);
+        openRef.current = false;
+        onClose?.();
+      });
+    }, [onClose]);
+
+    const openDrawer = useCallback(() => {
+      if (container) {
+        setIsInert(false);
+        setDrawerOpen(true);
+        openRef.current = true;
+      }
+    }, [container]);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        isOpen: () => openRef.current,
+        open: openDrawer,
+        close,
+      }),
+      [openDrawer, close],
+    );
+
+    return (
+      <Drawer
+        container={container}
+        ref={elementRef}
+        anchor="bottom"
+        open={drawerOpen}
+        onClose={close}
+        disableAutoFocus
+        inert={isInert}
+        ModalProps={{
+          container: container,
+          style: { position: 'absolute' },
+        }}
+        slotProps={{
+          transition: {
+            direction: 'up',
+            appear: true,
+          },
+          paper: {
+            sx: (theme) => ({
+              position: 'absolute',
+              bottom: 0,
+              left: 0,
+              right: 0,
+              backgroundImage: 'none',
+              backgroundColor: (theme.vars || theme).palette.background.default,
+              borderTopLeftRadius: (theme.vars || theme).shape.borderRadius,
+              borderTopRightRadius: (theme.vars || theme).shape.borderRadius,
+            }),
+          },
+          backdrop: {
+            sx: {
+              position: 'absolute',
+              backgroundColor: 'rgb(0 0 0 / 32%)',
+              backdropFilter: 'blur(3px)',
+            },
+          },
+        }}
+      >
+        {children}
+      </Drawer>
+    );
+  },
+);


### PR DESCRIPTION
Issue: https://www.notion.so/lifi/Withdrawal-successful-message-should-be-moved-a-bit-below-276f0ff14ac780c1b447c38fa768fe73

Used the same bottom sheet as for the main widget to have a similar UX