### PR TITLE
chore: update available routes tracking event

### DIFF
--- a/src/providers/WidgetTrackingProvider.tsx
+++ b/src/providers/WidgetTrackingProvider.tsx
@@ -99,6 +99,8 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
   const destinationChainToken = useRef<ChainTokenSelected | null>(null);
   const isRoutesForCurrentSourceTokenTracked = useRef(false);
   const isRoutesForCurrentDestinationTokenTracked = useRef(false);
+  const isRoutesForCurrentFromAmountTracked = useRef(false);
+  const currentFromAmount = useRef<string | null>(null);
   const posthogTracker = useMemo(() => {
     return makePosthogTracker({ trackTransaction, trackEvent });
   }, [trackTransaction, trackEvent]);
@@ -129,9 +131,15 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
 
   const availableRoutes = useCallback(
     (availableRoutes: Route[]) => {
+      if (currentFromAmount.current !== availableRoutes[0]?.fromAmount) {
+        currentFromAmount.current = availableRoutes[0]?.fromAmount;
+        isRoutesForCurrentFromAmountTracked.current = false;
+      }
+
       if (
         isRoutesForCurrentSourceTokenTracked.current &&
-        isRoutesForCurrentDestinationTokenTracked.current
+        isRoutesForCurrentDestinationTokenTracked.current &&
+        isRoutesForCurrentFromAmountTracked.current
       ) {
         return;
       }
@@ -188,6 +196,7 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
 
       isRoutesForCurrentSourceTokenTracked.current = true;
       isRoutesForCurrentDestinationTokenTracked.current = true;
+      isRoutesForCurrentFromAmountTracked.current = true;
     },
     [trackEvent, trackingActionKeys.availableRoutes],
   );

--- a/src/providers/WidgetTrackingProvider.tsx
+++ b/src/providers/WidgetTrackingProvider.tsx
@@ -145,6 +145,8 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
             [TrackingEventParameter.Steps]: {
               tools: routeData[TrackingEventParameter.Steps],
             },
+            [TrackingEventParameter.ToAmount]:
+              routeData[TrackingEventParameter.ToAmount] || '',
             [TrackingEventParameter.ToAmountUSD]:
               Number(routeData[TrackingEventParameter.ToAmountUSD]) || 0,
             [TrackingEventParameter.GasCostUSD]:
@@ -178,6 +180,7 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
           [TrackingEventParameter.FromAmountUSD]: Number(
             availableRoutes?.[0]?.fromAmountUSD,
           ),
+          [TrackingEventParameter.FromAmount]: availableRoutes?.[0]?.fromAmount,
           [TrackingEventParameter.NbOfSteps]: availableRoutes.length,
           [TrackingEventParameter.Routes]: transformedRoutes,
         },

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -67,6 +67,7 @@ export interface DataItem {
 export interface TransformedRoute {
   [TrackingEventParameter.NbOfSteps]: number;
   [TrackingEventParameter.Steps]: object;
+  [TrackingEventParameter.ToAmount]: string;
   [TrackingEventParameter.ToAmountUSD]: number;
   [TrackingEventParameter.GasCostUSD]: number | null;
   [TrackingEventParameter.Time]: number;

--- a/src/utils/routes/routeAmounts.ts
+++ b/src/utils/routes/routeAmounts.ts
@@ -15,15 +15,18 @@ export const getToAmountData = (route: Route | RouteExtended) => {
   const toAmount = lastStepExecutionOrRoute?.toAmount || route.toAmount;
   const toTokenDecimals =
     lastStepExecutionOrRoute?.toToken?.decimals || route.toToken.decimals;
-  const formattedToAmount = formatUnits(BigInt(toAmount), toTokenDecimals);
+  const toAmountFormatted = formatUnits(BigInt(toAmount), toTokenDecimals);
   const priceUsd =
     lastStepExecutionOrRoute?.toToken?.priceUSD || route.toToken.priceUSD;
-  const toAmountUSD = Number(formattedToAmount) * Number(priceUsd);
+  const toAmountUSD =
+    toAmountFormatted && priceUsd
+      ? Number(toAmountFormatted) * Number(priceUsd)
+      : Number(route?.toAmountUSD || 0);
 
   return {
     toAmount,
     toAmountUSD,
-    toAmountFormatted: formattedToAmount,
+    toAmountFormatted,
   };
 };
 


### PR DESCRIPTION
Issue: https://lifi.atlassian.net/browse/LF-15709

## Testing steps
1. Go to `/`
2. Select a source and destination token
3. Enter an amount
4. Check the `available_routes` event is triggered
5. Check the `data` includes `param_from_amount` at top level and each `param_routes` includes the `param_to_amount`
<img width="612" height="785" alt="Screenshot 2025-09-25 at 18 53 17" src="https://github.com/user-attachments/assets/e2c7acad-7f87-4f2b-85a9-1dcca8d42b9a" />

6. Change the from amount to a different value
7. Check the tracking event is re-triggered
8. Wait for the routes to expire
9. Check the event is not re-triggered
