### PR TITLE
fix: update main widget config to use internal scan path

### DIFF
--- a/src/components/Widgets/variants/widgetConfig/useMainWidgetConfig.ts
+++ b/src/components/Widgets/variants/widgetConfig/useMainWidgetConfig.ts
@@ -6,6 +6,7 @@ import { useMemelist } from 'src/hooks/useMemelist';
 import { tokens } from 'src/config/tokens';
 import { generateRouteLabel } from './utils';
 import { themeAllowChains } from '../../Widget.types';
+import { getSiteUrl, AppPaths } from 'src/const/urls';
 
 /**
  * Configuration hook for the main widget variant
@@ -35,6 +36,9 @@ export function useMainWidgetConfig(
     }
 
     const config: Partial<WidgetConfig> = {
+      explorerUrls: {
+        internal: [`${getSiteUrl()}${AppPaths.Scan}`],
+      },
       keyPrefix: `jumper-${context.starterVariant}`,
       // Variant configuration
       variant: context.starterVariant === 'refuel' ? 'compact' : 'wide',


### PR DESCRIPTION
As we currently are not pointing to our own `/scan` page, this PR should fix it

Issue: https://lifi.atlassian.net/browse/LF-15762