### PR TITLE
feat: earn page root components - LF-15773

### DIFF
--- a/src/app/lib/getOpportunityAnalytics.ts
+++ b/src/app/lib/getOpportunityAnalytics.ts
@@ -1,0 +1,27 @@
+import {
+  EarnOpportunityHistory,
+  HttpResponse,
+  JumperBackend,
+} from '@/types/jumper-backend';
+import { makeClient } from './client';
+
+export type GetOpportunityAnalyticsResult = HttpResponse<
+  EarnOpportunityHistory,
+  unknown
+>;
+
+export type EarnOpportunityAnalyticsQuery = Parameters<
+  JumperBackend<unknown>['v1']['earnControllerGetAnalyticsV1']
+>[1];
+
+export type AnalyticsValueField = EarnOpportunityAnalyticsQuery['value'];
+export type AnalyticsRangeField = EarnOpportunityAnalyticsQuery['range'];
+
+export async function getOpportunityAnalytics(
+  slug: string,
+  query: EarnOpportunityAnalyticsQuery,
+): Promise<GetOpportunityAnalyticsResult> {
+  const client = makeClient();
+  const analytics = await client.v1.earnControllerGetAnalyticsV1(slug, query);
+  return analytics;
+}

--- a/src/app/lib/getOpportunityRelatedMarket.ts
+++ b/src/app/lib/getOpportunityRelatedMarket.ts
@@ -1,0 +1,23 @@
+import {
+  EarnOpportunityWithLatestAnalytics,
+  HttpResponse,
+} from '@/types/jumper-backend';
+import { makeClient } from './client';
+
+export type GetOpportunityRelatedMarketResult = HttpResponse<
+  EarnOpportunityWithLatestAnalytics[],
+  unknown
+>;
+
+export async function getOpportunityRelatedMarket(
+  slug: string,
+): Promise<GetOpportunityRelatedMarketResult> {
+  try {
+    const client = makeClient();
+    const data = await client.v1.earnControllerGetRelatedItemsV1(slug);
+    // @ts-expect-error: see LF-15589 - we are transforming data in the backend
+    return data.data;
+  } catch (error) {
+    return error as GetOpportunityRelatedMarketResult;
+  }
+}

--- a/src/app/ui/earn/EarnPage.tsx
+++ b/src/app/ui/earn/EarnPage.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation';
 import { FC } from 'react';
 import { getOpportunityBySlug } from 'src/app/lib/getOpportunityBySlug';
 import { getOpportunityRelatedMarket } from 'src/app/lib/getOpportunityRelatedMarket';
+import { EarnDetailsAnalytics } from 'src/components/EarnDetails/EarnDetailsAnalytics';
 
 interface EarnPageProps {
   slug: string;
@@ -26,6 +27,8 @@ export const EarnPage: FC<EarnPageProps> = async ({ slug }) => {
     <div>
       <h1>EarnPage</h1>
       <pre>{JSON.stringify(data, null, 2)}</pre>
+      <h2>Analytics</h2>
+      <EarnDetailsAnalytics slug={slug} />
       <h2>Related Markets</h2>
       <pre>
         {JSON.stringify(

--- a/src/app/ui/earn/EarnPage.tsx
+++ b/src/app/ui/earn/EarnPage.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import { FC } from 'react';
 import { getOpportunityBySlug } from 'src/app/lib/getOpportunityBySlug';
+import { getOpportunityRelatedMarket } from 'src/app/lib/getOpportunityRelatedMarket';
 
 interface EarnPageProps {
   slug: string;
@@ -13,10 +14,26 @@ export const EarnPage: FC<EarnPageProps> = async ({ slug }) => {
     return notFound();
   }
 
+  const relatedMarkets = await getOpportunityRelatedMarket(slug);
+  if (relatedMarkets.error) {
+    console.error(relatedMarkets.error);
+    // pass
+  }
+
+  const related = relatedMarkets.data.slice(0, 3) ?? [];
+
   return (
     <div>
       <h1>EarnPage</h1>
       <pre>{JSON.stringify(data, null, 2)}</pre>
+      <h2>Related Markets</h2>
+      <pre>
+        {JSON.stringify(
+          related.map((x) => x.slug),
+          null,
+          2,
+        )}
+      </pre>
     </div>
   );
 };

--- a/src/components/EarnDetails/EarnDetailsAnalytics.tsx
+++ b/src/components/EarnDetails/EarnDetailsAnalytics.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import {
+  AnalyticsRangeField,
+  AnalyticsValueField,
+  EarnOpportunityAnalyticsQuery,
+} from 'src/app/lib/getOpportunityAnalytics';
+import { useEarnAnalytics } from 'src/hooks/earn/useEarnAnalytics';
+
+type Props = {
+  slug: string;
+};
+
+const useAnalyticsQuery = (slug: string) => {
+  const [query, setQuery] = useState<EarnOpportunityAnalyticsQuery>({
+    value: 'apy',
+    range: 'day',
+  });
+
+  const result = useEarnAnalytics({ slug, query });
+
+  const setValue = useCallback(
+    (value: AnalyticsValueField) => {
+      setQuery((query) => ({ ...query, value }));
+    },
+    [setQuery],
+  );
+
+  const setRange = useCallback(
+    (range: AnalyticsRangeField) => {
+      setQuery((query) => ({ ...query, range }));
+    },
+    [setQuery],
+  );
+
+  return useMemo(
+    () => ({
+      ...result,
+      value: query.value,
+      range: query.range,
+      setValue,
+      setRange,
+    }),
+    [result, query, setValue, setRange],
+  );
+};
+
+export const EarnDetailsAnalytics: React.FC<Props> = ({ slug }) => {
+  const { isLoading, error, data, value, range, setValue, setRange } =
+    useAnalyticsQuery(slug);
+
+  return (
+    <div>
+      <h2>Analytics</h2>
+      <div>
+        <button onClick={() => setValue('apy')} disabled={value === 'apy'}>
+          APY
+        </button>
+        <button onClick={() => setValue('tvl')} disabled={value === 'tvl'}>
+          TVL
+        </button>
+      </div>
+      <div>
+        <button onClick={() => setRange('day')} disabled={range === 'day'}>
+          Day
+        </button>
+        <button onClick={() => setRange('week')} disabled={range === 'week'}>
+          Week
+        </button>
+        <button onClick={() => setRange('month')} disabled={range === 'month'}>
+          Month
+        </button>
+        <button onClick={() => setRange('year')} disabled={range === 'year'}>
+          Year
+        </button>
+      </div>
+      {isLoading && <div>Loading...</div>}
+      {error ? <div>Error: {`${error}`}</div> : null}
+      {data && (
+        <div>
+          {data.points.length} points
+          <pre>{JSON.stringify(data, null, 2)}</pre>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/composite/DepositModal/DepositModal.tsx
+++ b/src/components/composite/DepositModal/DepositModal.tsx
@@ -58,7 +58,7 @@ export const DepositModal: FC<DepositModalProps> = ({
         address: earnOpportunity.address,
         project: earnOpportunity.protocol.name,
         integrator: `zap.${earnOpportunity.protocol.name}`,
-        integratorLink: earnOpportunity.url,
+        integratorLink: earnOpportunity.url ?? 'unset',
         integratorPositionLink: earnOpportunity.positionUrl,
         minFromAmountUSD: earnOpportunity.minFromAmountUSD,
       },

--- a/src/hooks/earn/useEarnAnalytics.ts
+++ b/src/hooks/earn/useEarnAnalytics.ts
@@ -1,0 +1,36 @@
+import {
+  EarnOpportunityFilter,
+  getOpportunitiesFiltered,
+} from '@/app/lib/getOpportunitiesFiltered';
+import {
+  EarnOpportunityHistory,
+  EarnOpportunityWithLatestAnalytics,
+} from '@/types/jumper-backend';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import {
+  EarnOpportunityAnalyticsQuery,
+  getOpportunityAnalytics,
+} from 'src/app/lib/getOpportunityAnalytics';
+import { FIVE_MINUTES_MS } from 'src/const/time';
+
+export interface Props {
+  slug: string;
+  query: EarnOpportunityAnalyticsQuery;
+}
+
+export type Result = UseQueryResult<EarnOpportunityHistory, unknown>;
+
+export const useEarnAnalytics = ({ slug, query }: Props): Result => {
+  return useQuery({
+    queryKey: ['earn-analytics-opportunities', slug, query],
+    queryFn: async () => {
+      const result = await getOpportunityAnalytics(slug, query);
+      if (!result.ok) {
+        throw result.error;
+      }
+      // @ts-expect-error: see LF-15589 - we are transforming data in the backend
+      return result.data.data;
+    },
+    refetchInterval: FIVE_MINUTES_MS,
+  });
+};

--- a/src/hooks/earn/useEarnFilterOpportunities.ts
+++ b/src/hooks/earn/useEarnFilterOpportunities.ts
@@ -4,7 +4,7 @@ import {
 } from '@/app/lib/getOpportunitiesFiltered';
 import { EarnOpportunityWithLatestAnalytics } from '@/types/jumper-backend';
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
-import { FIVE_MINUTES_MS } from 'src/const/time';
+import { ONE_HOUR_MS } from 'src/const/time';
 
 export interface Props {
   filter: EarnOpportunityFilter;
@@ -26,6 +26,6 @@ export const useEarnFilterOpportunities = ({ filter }: Props): Result => {
       // @ts-expect-error: see LF-15589 - we are transforming data in the backend
       return result.data.data;
     },
-    refetchInterval: FIVE_MINUTES_MS,
+    refetchInterval: ONE_HOUR_MS,
   });
 };

--- a/src/types/jumper-backend.ts
+++ b/src/types/jumper-backend.ts
@@ -562,6 +562,7 @@ export interface CreateWalletTransactionDto {
   transactionId?: string;
   transactionLink?: string;
   errorCode?: object;
+  errorCodeKey?: string;
   errorMessage?: string;
   message?: string;
   status?: string;
@@ -719,7 +720,7 @@ export interface EarnOpportunityWithLatestAnalytics {
   name: string;
   asset: Token;
   protocol: Protocol;
-  url: string;
+  url?: string;
   description: string;
   tags: string[];
   rewards: string[];
@@ -739,9 +740,9 @@ export interface UpdateValidityDto {
 }
 
 export type QueryParamsType = Record<string | number, any>;
-export type ResponseFormat = keyof Omit<Body, 'body' | 'bodyUsed'>;
+export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
 
-export interface FullRequestParams extends Omit<RequestInit, 'body'> {
+export interface FullRequestParams extends Omit<RequestInit, "body"> {
   /** set parameter to `true` for call `securityWorker` for this request */
   secure?: boolean;
   /** request path */
@@ -762,12 +763,12 @@ export interface FullRequestParams extends Omit<RequestInit, 'body'> {
 
 export type RequestParams = Omit<
   FullRequestParams,
-  'body' | 'method' | 'query' | 'path'
+  "body" | "method" | "query" | "path"
 >;
 
 export interface ApiConfig<SecurityDataType = unknown> {
   baseUrl?: string;
-  baseApiParams?: Omit<RequestParams, 'baseUrl' | 'cancelToken' | 'signal'>;
+  baseApiParams?: Omit<RequestParams, "baseUrl" | "cancelToken" | "signal">;
   securityWorker?: (
     securityData: SecurityDataType | null,
   ) => Promise<RequestParams | void> | RequestParams | void;
@@ -783,26 +784,26 @@ export interface HttpResponse<D extends unknown, E extends unknown = unknown>
 type CancelToken = Symbol | string | number;
 
 export enum ContentType {
-  Json = 'application/json',
-  JsonApi = 'application/vnd.api+json',
-  FormData = 'multipart/form-data',
-  UrlEncoded = 'application/x-www-form-urlencoded',
-  Text = 'text/plain',
+  Json = "application/json",
+  JsonApi = "application/vnd.api+json",
+  FormData = "multipart/form-data",
+  UrlEncoded = "application/x-www-form-urlencoded",
+  Text = "text/plain",
 }
 
 export class HttpClient<SecurityDataType = unknown> {
-  public baseUrl: string = '';
+  public baseUrl: string = "";
   private securityData: SecurityDataType | null = null;
-  private securityWorker?: ApiConfig<SecurityDataType>['securityWorker'];
+  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
   private abortControllers = new Map<CancelToken, AbortController>();
   private customFetch = (...fetchParams: Parameters<typeof fetch>) =>
     fetch(...fetchParams);
 
   private baseApiParams: RequestParams = {
-    credentials: 'same-origin',
+    credentials: "same-origin",
     headers: {},
-    redirect: 'follow',
-    referrerPolicy: 'no-referrer',
+    redirect: "follow",
+    referrerPolicy: "no-referrer",
   };
 
   constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
@@ -815,7 +816,7 @@ export class HttpClient<SecurityDataType = unknown> {
 
   protected encodeQueryParam(key: string, value: any) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === 'number' ? value : `${value}`)}`;
+    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {
@@ -824,13 +825,13 @@ export class HttpClient<SecurityDataType = unknown> {
 
   protected addArrayQueryParam(query: QueryParamsType, key: string) {
     const value = query[key];
-    return value.map((v: any) => this.encodeQueryParam(key, v)).join('&');
+    return value.map((v: any) => this.encodeQueryParam(key, v)).join("&");
   }
 
   protected toQueryString(rawQuery?: QueryParamsType): string {
     const query = rawQuery || {};
     const keys = Object.keys(query).filter(
-      (key) => 'undefined' !== typeof query[key],
+      (key) => "undefined" !== typeof query[key],
     );
     return keys
       .map((key) =>
@@ -838,25 +839,25 @@ export class HttpClient<SecurityDataType = unknown> {
           ? this.addArrayQueryParam(query, key)
           : this.addQueryParam(query, key),
       )
-      .join('&');
+      .join("&");
   }
 
   protected addQueryParams(rawQuery?: QueryParamsType): string {
     const queryString = this.toQueryString(rawQuery);
-    return queryString ? `?${queryString}` : '';
+    return queryString ? `?${queryString}` : "";
   }
 
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
-      input !== null && (typeof input === 'object' || typeof input === 'string')
+      input !== null && (typeof input === "object" || typeof input === "string")
         ? JSON.stringify(input)
         : input,
     [ContentType.JsonApi]: (input: any) =>
-      input !== null && (typeof input === 'object' || typeof input === 'string')
+      input !== null && (typeof input === "object" || typeof input === "string")
         ? JSON.stringify(input)
         : input,
     [ContentType.Text]: (input: any) =>
-      input !== null && typeof input !== 'string'
+      input !== null && typeof input !== "string"
         ? JSON.stringify(input)
         : input,
     [ContentType.FormData]: (input: any) => {
@@ -870,7 +871,7 @@ export class HttpClient<SecurityDataType = unknown> {
           key,
           property instanceof Blob
             ? property
-            : typeof property === 'object' && property !== null
+            : typeof property === "object" && property !== null
               ? JSON.stringify(property)
               : `${property}`,
         );
@@ -933,7 +934,7 @@ export class HttpClient<SecurityDataType = unknown> {
     ...params
   }: FullRequestParams): Promise<HttpResponse<T, E>> => {
     const secureParams =
-      ((typeof secure === 'boolean' ? secure : this.baseApiParams.secure) &&
+      ((typeof secure === "boolean" ? secure : this.baseApiParams.secure) &&
         this.securityWorker &&
         (await this.securityWorker(this.securityData))) ||
       {};
@@ -943,13 +944,13 @@ export class HttpClient<SecurityDataType = unknown> {
     const responseFormat = format || requestParams.format;
 
     return this.customFetch(
-      `${baseUrl || this.baseUrl || ''}${path}${queryString ? `?${queryString}` : ''}`,
+      `${baseUrl || this.baseUrl || ""}${path}${queryString ? `?${queryString}` : ""}`,
       {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
           ...(type && type !== ContentType.FormData
-            ? { 'Content-Type': type }
+            ? { "Content-Type": type }
             : {}),
         },
         signal:
@@ -957,7 +958,7 @@ export class HttpClient<SecurityDataType = unknown> {
             ? this.createAbortSignal(cancelToken)
             : requestParams.signal) || null,
         body:
-          typeof body === 'undefined' || body === null
+          typeof body === "undefined" || body === null
             ? null
             : payloadFormatter(body),
       },
@@ -1029,9 +1030,9 @@ export class JumperBackend<
     ) =>
       this.request<LeaderboardEntity[], any>({
         path: `/v1/leaderboard`,
-        method: 'GET',
+        method: "GET",
         query: query,
-        format: 'json',
+        format: "json",
         ...params,
       }),
 
@@ -1050,8 +1051,8 @@ export class JumperBackend<
     ) =>
       this.request<LeaderboardEntity, void>({
         path: `/v1/leaderboard/centered-pagination/${position}/${entries}`,
-        method: 'GET',
-        format: 'json',
+        method: "GET",
+        format: "json",
         ...params,
       }),
 
@@ -1069,8 +1070,8 @@ export class JumperBackend<
     ) =>
       this.request<LeaderboardEntity, void>({
         path: `/v1/leaderboard/${address}`,
-        method: 'GET',
-        format: 'json',
+        method: "GET",
+        format: "json",
         ...params,
       }),
 
@@ -1088,10 +1089,10 @@ export class JumperBackend<
     ) =>
       this.request<GeneratePayloadDto, any>({
         path: `/v1/zaps/get-zap-data`,
-        method: 'POST',
+        method: "POST",
         body: data,
         type: ContentType.Json,
-        format: 'json',
+        format: "json",
         ...params,
       }),
 
@@ -1106,8 +1107,8 @@ export class JumperBackend<
     zapsControllerGetLpTokensV1: (params: RequestParams = {}) =>
       this.request<TokenDto[], any>({
         path: `/v1/zaps/get-all-lp-tokens`,
-        method: 'GET',
-        format: 'json',
+        method: "GET",
+        format: "json",
         ...params,
       }),
 
@@ -1131,9 +1132,9 @@ export class JumperBackend<
     ) =>
       this.request<EarnOpportunityWithLatestAnalytics[], any>({
         path: `/v1/earn/tops`,
-        method: 'GET',
+        method: "GET",
         query: query,
-        format: 'json',
+        format: "json",
         ...params,
       }),
 
@@ -1147,6 +1148,16 @@ export class JumperBackend<
      */
     earnControllerFilterV1: (
       query?: {
+        /**
+         * Sort by field.
+         * @example "apy"
+         */
+        sortBy?: "apy" | "tvl" | "slug" | "chain" | "protocol" | "asset";
+        /**
+         * Sort order.
+         * @example "asc"
+         */
+        order?: "asc" | "desc";
         /**
          * The address to filter for
          * @example "0x742d35Cc6634C0532925a3b8D598C2FF000f5E58"
@@ -1197,9 +1208,9 @@ export class JumperBackend<
     ) =>
       this.request<EarnOpportunityWithLatestAnalytics[], any>({
         path: `/v1/earn/filter`,
-        method: 'GET',
+        method: "GET",
         query: query,
-        format: 'json',
+        format: "json",
         ...params,
       }),
 
@@ -1214,8 +1225,27 @@ export class JumperBackend<
     earnControllerGetItemV1: (slug: string, params: RequestParams = {}) =>
       this.request<EarnOpportunityWithLatestAnalytics, any>({
         path: `/v1/earn/items/${slug}`,
-        method: 'GET',
-        format: 'json',
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Earn, Public
+     * @name EarnControllerGetRelatedItemsV1
+     * @summary Get related items to an earn opportunity
+     * @request GET:/v1/earn/items/{slug}/related
+     */
+    earnControllerGetRelatedItemsV1: (
+      slug: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<EarnOpportunityWithLatestAnalytics[], any>({
+        path: `/v1/earn/items/${slug}/related`,
+        method: "GET",
+        format: "json",
         ...params,
       }),
   };

--- a/src/types/jumper-backend.ts
+++ b/src/types/jumper-backend.ts
@@ -652,6 +652,135 @@ export interface GeneratePayloadDto {
 
 export type TokenDto = object;
 
+export interface CheckSweepableTokensDto {
+  /**
+   * Wallet address to check for sweepable tokens
+   * @example "0x1234567890123456789012345678901234567890"
+   */
+  walletAddress: string;
+  /**
+   * Chain ID to check for tokens (optional, defaults to checking all EVM chains)
+   * @example 1
+   */
+  chainId?: number;
+}
+
+export interface SweepableTokenDto {
+  /**
+   * Token address
+   * @example "0x1234567890123456789012345678901234567890"
+   */
+  address: string;
+  /**
+   * Token symbol
+   * @example "USDC"
+   */
+  symbol: string;
+  /**
+   * Token name
+   * @example "USD Coin"
+   */
+  name: string;
+  /**
+   * Token decimals
+   * @example 6
+   */
+  decimals: number;
+  /**
+   * Chain ID where the token is located
+   * @example 1
+   */
+  chainId: number;
+  /**
+   * Token amount available for sweeping
+   * @example "1000.50"
+   */
+  amount: string;
+  /**
+   * Token logo URI
+   * @example "https://example.com/token-logo.png"
+   */
+  logoURI?: string;
+}
+
+export interface CheckSweepableTokensResponseDto {
+  /**
+   * Whether there are tokens available for sweeping
+   * @example true
+   */
+  hasTokensToSweep: boolean;
+  /** List of sweepable tokens */
+  sweepableTokens: SweepableTokenDto[];
+  /**
+   * Smart account address for the given wallet
+   * @example "0x1234567890123456789012345678901234567890"
+   */
+  smartAccountAddress: string;
+  /**
+   * Target chain ID with the most tokens to sweep
+   * @example 1
+   */
+  targetChainId: number;
+}
+
+export interface SweepQuoteDto {
+  /**
+   * Wallet address to get sweep quote for
+   * @example "0x1234567890123456789012345678901234567890"
+   */
+  walletAddress: string;
+  /**
+   * Chain ID to get quote for (optional, defaults to chain with most tokens)
+   * @example 1
+   */
+  chainId?: number;
+  /** List of specific tokens to create sweep instructions for */
+  tokens?: SweepableTokenDto[];
+}
+
+export interface SweepQuoteResponseDto {
+  /**
+   * Whether there are tokens available for sweeping
+   * @example true
+   */
+  hasTokensToSweep: boolean;
+  /** List of sweepable tokens */
+  sweepableTokens: SweepableTokenDto[];
+  /**
+   * Smart account address for the given wallet
+   * @example "0x1234567890123456789012345678901234567890"
+   */
+  smartAccountAddress: string;
+  /**
+   * Target chain ID with the most tokens to sweep
+   * @example 1
+   */
+  targetChainId: number;
+  /**
+   * Generated quote for the frontend to execute
+   * @example {}
+   */
+  quote: object;
+  /**
+   * Transaction raw message for the frontend to execute
+   * @example {}
+   */
+  transactionData: object;
+}
+
+export interface ExecuteSweepQuoteDto {
+  /**
+   * Wallet address to execute sweep quote for
+   * @example "0x1234567890123456789012345678901234567890"
+   */
+  walletAddress: string;
+  /**
+   * Signed message to execute sweep quote for
+   * @example "0x1234567890123456789012345678901234567890"
+   */
+  signedMessage: string;
+}
+
 export interface TaskVerificationDto {
   /** Users wallet address */
   address: string;
@@ -731,6 +860,18 @@ export interface EarnOpportunityWithLatestAnalytics {
   capInDollar?: string;
   forYou: boolean;
   latest: EarnOpportunityHistoryItem;
+}
+
+export interface EarnOpportunityHistoryPoint {
+  /** The timestamp of the data point */
+  t: number;
+  /** The value of the data point */
+  v: number | string;
+}
+
+export interface EarnOpportunityHistory {
+  /** The data points */
+  points: EarnOpportunityHistoryPoint[];
 }
 
 export type WalletVerification = object;
@@ -1115,6 +1256,83 @@ export class JumperBackend<
     /**
      * No description
      *
+     * @tags Zaps, Public
+     * @name ZapsControllerCheckSweepableTokensV1
+     * @summary Check for sweepable tokens for wallet address
+     * @request POST:/v1/zaps/check-sweepable-tokens
+     */
+    zapsControllerCheckSweepableTokensV1: (
+      data: CheckSweepableTokensDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<CheckSweepableTokensResponseDto, any>({
+        path: `/v1/zaps/check-sweepable-tokens`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Zaps, Public
+     * @name ZapsControllerGetSweepQuoteV1
+     * @summary Get sweep quote for wallet address (only if tokens are available)
+     * @request POST:/v1/zaps/sweep-quote
+     */
+    zapsControllerGetSweepQuoteV1: (
+      data: SweepQuoteDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<SweepQuoteResponseDto, any>({
+        path: `/v1/zaps/sweep-quote`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Zaps, Public
+     * @name ZapsControllerExecuteSweepQuoteV1
+     * @summary Execute sweep quote for wallet address
+     * @request POST:/v1/zaps/execute-sweep-quote
+     */
+    zapsControllerExecuteSweepQuoteV1: (
+      data: ExecuteSweepQuoteDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<void, any>({
+        path: `/v1/zaps/execute-sweep-quote`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Zaps, Public
+     * @name ZapsControllerGetSupportedChainsV1
+     * @summary Get supported chains for zaps
+     * @request GET:/v1/zaps/supported-chains
+     */
+    zapsControllerGetSupportedChainsV1: (params: RequestParams = {}) =>
+      this.request<void, any>({
+        path: `/v1/zaps/supported-chains`,
+        method: "GET",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
      * @tags Earn, Public
      * @name EarnControllerGetTopsV1
      * @summary Get tops for an address
@@ -1245,6 +1463,38 @@ export class JumperBackend<
       this.request<EarnOpportunityWithLatestAnalytics[], any>({
         path: `/v1/earn/items/${slug}/related`,
         method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Earn, Public
+     * @name EarnControllerGetAnalyticsV1
+     * @summary Get analytics for an earn opportunity
+     * @request GET:/v1/earn/items/{slug}/analytics
+     */
+    earnControllerGetAnalyticsV1: (
+      slug: string,
+      query: {
+        /**
+         * The value field to filter for
+         * @example "apy"
+         */
+        value: "apy" | "tvl";
+        /**
+         * The range field to filter for
+         * @example "day"
+         */
+        range: "day" | "week" | "month" | "year";
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<EarnOpportunityHistory, any>({
+        path: `/v1/earn/items/${slug}/analytics`,
+        method: "GET",
+        query: query,
         format: "json",
         ...params,
       }),


### PR DESCRIPTION
Contributes to https://lifi.atlassian.net/browse/LF-15773

Create the root components for earn page, with earn analytics and earn related market.
Lay down the structure now that we have the API endpoints.

Test:
- Visit an earn details page, like `/earn/9s-mount-denali-usdc-core-on-mainnet`
- It should display an interactive list of data points (floats for APY and bigint strings for TVL)
- It should display three related earn opportunities

Sister PRs:
https://github.com/jumperexchange/jumper-backend/pull/498
https://github.com/jumperexchange/jumper-backend/pull/491

<img width="300" src="https://github.com/user-attachments/assets/649fbf1a-1c85-4719-a188-2dc8acc95443" />

<img width="300" src="https://github.com/user-attachments/assets/76d32a88-6a36-4daf-8172-1336292d4e02" />



