### PR TITLE
feat: add earn analytics chart section to earn details page

### DIFF
--- a/src/app/[lng]/earn/[slug]/page.tsx
+++ b/src/app/[lng]/earn/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { EarnPage, EarnsPageSkeleton } from '@/app/ui/earn';
+import { EarnPage, EarnPageSkeleton } from '@/app/ui/earn';
 import { notFound } from 'next/navigation';
 import { Metadata } from 'next/types';
 import { Suspense } from 'react';
@@ -33,7 +33,7 @@ export default async function Page({ params }: { params: Params }) {
   }
 
   return (
-    <Suspense fallback={<EarnsPageSkeleton />}>
+    <Suspense fallback={<EarnPageSkeleton />}>
       <EarnPage slug={slug} />
     </Suspense>
   );

--- a/src/app/ui/earn/EarnPage.tsx
+++ b/src/app/ui/earn/EarnPage.tsx
@@ -3,6 +3,7 @@ import { FC } from 'react';
 import { getOpportunityBySlug } from 'src/app/lib/getOpportunityBySlug';
 import { getOpportunityRelatedMarket } from 'src/app/lib/getOpportunityRelatedMarket';
 import { EarnDetailsAnalytics } from 'src/components/EarnDetails/EarnDetailsAnalytics';
+import { EarnDetailsSection } from 'src/components/EarnDetails/EarnDetailsSection';
 
 interface EarnPageProps {
   slug: string;
@@ -24,19 +25,23 @@ export const EarnPage: FC<EarnPageProps> = async ({ slug }) => {
   const related = relatedMarkets.data.slice(0, 3) ?? [];
 
   return (
-    <div>
-      <h1>EarnPage</h1>
-      <pre>{JSON.stringify(data, null, 2)}</pre>
-      <h2>Analytics</h2>
-      <EarnDetailsAnalytics slug={slug} />
-      <h2>Related Markets</h2>
-      <pre>
-        {JSON.stringify(
-          related.map((x) => x.slug),
-          null,
-          2,
-        )}
-      </pre>
-    </div>
+    <>
+      <EarnDetailsSection>
+        <h1>EarnPage</h1>
+        <pre>{JSON.stringify(data, null, 2)}</pre>
+        <h2>Analytics</h2>
+        <EarnDetailsAnalytics slug={slug} />
+      </EarnDetailsSection>
+      <EarnDetailsSection>
+        <h2>Related Markets</h2>
+        <pre>
+          {JSON.stringify(
+            related.map((x) => x.slug),
+            null,
+            2,
+          )}
+        </pre>
+      </EarnDetailsSection>
+    </>
   );
 };

--- a/src/app/ui/earn/EarnPageSkeleton.tsx
+++ b/src/app/ui/earn/EarnPageSkeleton.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { EarnDetailsAnalyticsSkeleton } from 'src/components/EarnDetails/EarnDetailsAnalyticsSkeleton';
 import { EarnDetailsSection } from 'src/components/EarnDetails/EarnDetailsSection';
 

--- a/src/app/ui/earn/EarnPageSkeleton.tsx
+++ b/src/app/ui/earn/EarnPageSkeleton.tsx
@@ -1,3 +1,15 @@
+'use client';
+
+import { EarnDetailsAnalyticsSkeleton } from 'src/components/EarnDetails/EarnDetailsAnalyticsSkeleton';
+import { EarnDetailsSection } from 'src/components/EarnDetails/EarnDetailsSection';
+
 export const EarnPageSkeleton = () => {
-  return <div>EarnPageSkeleton</div>;
+  return (
+    <>
+      <EarnDetailsSection>
+        <EarnDetailsAnalyticsSkeleton />
+      </EarnDetailsSection>
+      <EarnDetailsSection>Related Markets</EarnDetailsSection>
+    </>
+  );
 };

--- a/src/components/EarnDetails/EarnDetails.styles.ts
+++ b/src/components/EarnDetails/EarnDetails.styles.ts
@@ -1,0 +1,82 @@
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import { styled } from '@mui/material/styles';
+import { ButtonPrimary, ButtonProps } from '../Button';
+import Skeleton from '@mui/material/Skeleton';
+
+export const EarnDetailsAnalyticsContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(3),
+  padding: theme.spacing(3),
+  borderRadius: theme.shape.cardBorderRadius,
+  boxShadow: `0px 4px 24px 0px rgba(0, 0, 0, 0.08)`,
+  backgroundColor: (theme.vars || theme).palette.surface1.main,
+  ...theme.applyStyles('dark', {
+    backgroundColor: (theme.vars || theme).palette.surface2.main,
+  }),
+}));
+
+export const EarnDetailsAnalyticsHeaderContainer = styled(Stack)(
+  ({ theme }) => ({
+    gap: theme.spacing(2),
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    flexWrap: 'wrap',
+  }),
+);
+
+export const EarnDetailsAnalyticsButtonsContainer = styled(Stack)(
+  ({ theme }) => ({
+    gap: theme.spacing(1),
+    flexWrap: 'wrap',
+  }),
+);
+
+interface EarnDetailsAnalyticsButtonProps extends Omit<ButtonProps, 'variant'> {
+  isActive: boolean;
+}
+
+export const EarnDetailsAnalyticsButton = styled(ButtonPrimary, {
+  shouldForwardProp: (prop) => prop !== 'isActive',
+})<EarnDetailsAnalyticsButtonProps>(({ theme }) => ({
+  ...theme.typography.bodyXSmallStrong,
+  padding: theme.spacing(1),
+  width: 'fit-content',
+  minWidth: 'fit-content',
+  variants: [
+    {
+      props: { isActive: false },
+      style: {
+        backgroundColor: (theme.vars || theme).palette.buttonLightBg,
+        color: (theme.vars || theme).palette.buttonLightAction,
+        '&:hover': {
+          backgroundColor: (theme.vars || theme).palette.buttonPrimaryBg,
+          color: (theme.vars || theme).palette.buttonPrimaryAction,
+        },
+      },
+    },
+    {
+      props: { isActive: true },
+      style: {
+        cursor: 'default',
+        pointerEvents: 'none',
+      },
+    },
+  ],
+}));
+
+export const EarnDetailsAnalyticsLineChartContainer = styled(Box)(
+  ({ theme }) => ({
+    height: 234,
+  }),
+);
+
+export const BaseSkeletonBox = styled(Skeleton)(({ theme }) => ({
+  backgroundColor: (theme.vars || theme).palette.surface2.main,
+  borderRadius: theme.shape.buttonBorderRadius,
+  transform: 'none',
+  ...theme.applyStyles('dark', {
+    backgroundColor: (theme.vars || theme).palette.surface1.main,
+  }),
+}));

--- a/src/components/EarnDetails/EarnDetailsAnalytics.tsx
+++ b/src/components/EarnDetails/EarnDetailsAnalytics.tsx
@@ -29,15 +29,6 @@ export const EarnDetailsAnalytics: React.FC<EarnDetailsAnalyticsProps> = ({
     dateFormat: chartDateFormat,
   } = useAnalyticsChartData(data, range);
 
-  const transformedData = useMemo(() => {
-    return (
-      data?.points.map((point) => ({
-        date: new Date(point.t).toISOString(),
-        value: point.v,
-      })) ?? []
-    );
-  }, [data]);
-
   return (
     <EarnDetailsAnalyticsContainer>
       <EarnDetailsAnalyticsHeaderContainer direction="row">

--- a/src/components/EarnDetails/EarnDetailsAnalytics.tsx
+++ b/src/components/EarnDetails/EarnDetailsAnalytics.tsx
@@ -1,88 +1,79 @@
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import {
-  AnalyticsRangeField,
-  AnalyticsValueField,
-  EarnOpportunityAnalyticsQuery,
-} from 'src/app/lib/getOpportunityAnalytics';
-import { useEarnAnalytics } from 'src/hooks/earn/useEarnAnalytics';
+  EarnDetailsAnalyticsButton,
+  EarnDetailsAnalyticsButtonsContainer,
+  EarnDetailsAnalyticsContainer,
+  EarnDetailsAnalyticsHeaderContainer,
+  EarnDetailsAnalyticsLineChartContainer,
+} from './EarnDetails.styles';
+import { LineChart } from '../core/charts/LineChart/LineChart';
+import { useAnalyticsChartData, useAnalyticsQuery } from './hooks';
+import { AnalyticsRangeFieldEnum, AnalyticsValueFieldEnum } from './types';
+import { capitalizeString } from 'src/utils/capitalizeString';
 
-type Props = {
+interface EarnDetailsAnalyticsProps {
   slug: string;
-};
+}
 
-const useAnalyticsQuery = (slug: string) => {
-  const [query, setQuery] = useState<EarnOpportunityAnalyticsQuery>({
-    value: 'apy',
-    range: 'day',
-  });
-
-  const result = useEarnAnalytics({ slug, query });
-
-  const setValue = useCallback(
-    (value: AnalyticsValueField) => {
-      setQuery((query) => ({ ...query, value }));
-    },
-    [setQuery],
-  );
-
-  const setRange = useCallback(
-    (range: AnalyticsRangeField) => {
-      setQuery((query) => ({ ...query, range }));
-    },
-    [setQuery],
-  );
-
-  return useMemo(
-    () => ({
-      ...result,
-      value: query.value,
-      range: query.range,
-      setValue,
-      setRange,
-    }),
-    [result, query, setValue, setRange],
-  );
-};
-
-export const EarnDetailsAnalytics: React.FC<Props> = ({ slug }) => {
+export const EarnDetailsAnalytics: React.FC<EarnDetailsAnalyticsProps> = ({
+  slug,
+}) => {
   const { isLoading, error, data, value, range, setValue, setRange } =
     useAnalyticsQuery(slug);
 
+  const {
+    data: chartData,
+    theme: chartTheme,
+    dateFormat: chartDateFormat,
+  } = useAnalyticsChartData(data, range);
+
+  const transformedData = useMemo(() => {
+    return (
+      data?.points.map((point) => ({
+        date: new Date(point.t).toISOString(),
+        value: point.v,
+      })) ?? []
+    );
+  }, [data]);
+
   return (
-    <div>
-      <h2>Analytics</h2>
-      <div>
-        <button onClick={() => setValue('apy')} disabled={value === 'apy'}>
-          APY
-        </button>
-        <button onClick={() => setValue('tvl')} disabled={value === 'tvl'}>
-          TVL
-        </button>
-      </div>
-      <div>
-        <button onClick={() => setRange('day')} disabled={range === 'day'}>
-          Day
-        </button>
-        <button onClick={() => setRange('week')} disabled={range === 'week'}>
-          Week
-        </button>
-        <button onClick={() => setRange('month')} disabled={range === 'month'}>
-          Month
-        </button>
-        <button onClick={() => setRange('year')} disabled={range === 'year'}>
-          Year
-        </button>
-      </div>
-      {isLoading && <div>Loading...</div>}
-      {error ? <div>Error: {`${error}`}</div> : null}
-      {data && (
-        <div>
-          {data.points.length} points
-          <pre>{JSON.stringify(data, null, 2)}</pre>
-        </div>
-      )}
-    </div>
+    <EarnDetailsAnalyticsContainer>
+      <EarnDetailsAnalyticsHeaderContainer direction="row">
+        <EarnDetailsAnalyticsButtonsContainer direction="row">
+          {Object.values(AnalyticsRangeFieldEnum).map((rangeItem) => (
+            <EarnDetailsAnalyticsButton
+              key={rangeItem}
+              isActive={rangeItem === range}
+              onClick={() => setRange(rangeItem as AnalyticsRangeFieldEnum)}
+              size="small"
+            >
+              {capitalizeString(rangeItem)}
+            </EarnDetailsAnalyticsButton>
+          ))}
+        </EarnDetailsAnalyticsButtonsContainer>
+        <EarnDetailsAnalyticsButtonsContainer direction="row">
+          {Object.values(AnalyticsValueFieldEnum).map((valueItem) => (
+            <EarnDetailsAnalyticsButton
+              key={valueItem}
+              isActive={valueItem === value}
+              onClick={() => setValue(valueItem as AnalyticsValueFieldEnum)}
+              size="small"
+            >
+              {valueItem.toUpperCase()}
+            </EarnDetailsAnalyticsButton>
+          ))}
+        </EarnDetailsAnalyticsButtonsContainer>
+      </EarnDetailsAnalyticsHeaderContainer>
+      <EarnDetailsAnalyticsLineChartContainer>
+        <LineChart
+          isLoading={isLoading}
+          data={chartData}
+          dateFormat={chartDateFormat}
+          theme={chartTheme}
+        />
+      </EarnDetailsAnalyticsLineChartContainer>
+    </EarnDetailsAnalyticsContainer>
   );
 };

--- a/src/components/EarnDetails/EarnDetailsAnalyticsSkeleton.tsx
+++ b/src/components/EarnDetails/EarnDetailsAnalyticsSkeleton.tsx
@@ -1,0 +1,40 @@
+import { LineChartSkeleton } from '../core/charts/LineChart/LineChartSkeleton';
+import {
+  EarnDetailsAnalyticsContainer,
+  EarnDetailsAnalyticsHeaderContainer,
+  EarnDetailsAnalyticsButtonsContainer,
+  EarnDetailsAnalyticsLineChartContainer,
+  BaseSkeletonBox,
+} from './EarnDetails.styles';
+
+export const EarnDetailsAnalyticsSkeleton = () => {
+  return (
+    <EarnDetailsAnalyticsContainer>
+      <EarnDetailsAnalyticsHeaderContainer direction="row">
+        <EarnDetailsAnalyticsButtonsContainer direction="row">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <BaseSkeletonBox
+              key={index}
+              variant="rounded"
+              width={56}
+              height={32}
+            />
+          ))}
+        </EarnDetailsAnalyticsButtonsContainer>
+        <EarnDetailsAnalyticsButtonsContainer direction="row">
+          {Array.from({ length: 2 }).map((_, index) => (
+            <BaseSkeletonBox
+              key={index}
+              variant="rounded"
+              width={56}
+              height={32}
+            />
+          ))}
+        </EarnDetailsAnalyticsButtonsContainer>
+      </EarnDetailsAnalyticsHeaderContainer>
+      <EarnDetailsAnalyticsLineChartContainer>
+        <LineChartSkeleton />
+      </EarnDetailsAnalyticsLineChartContainer>
+    </EarnDetailsAnalyticsContainer>
+  );
+};

--- a/src/components/EarnDetails/EarnDetailsAnalyticsSkeleton.tsx
+++ b/src/components/EarnDetails/EarnDetailsAnalyticsSkeleton.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { LineChartSkeleton } from '../core/charts/LineChart/LineChartSkeleton';
 import {
   EarnDetailsAnalyticsContainer,

--- a/src/components/EarnDetails/EarnDetailsSection.tsx
+++ b/src/components/EarnDetails/EarnDetailsSection.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { PropsWithChildren } from 'react';
+import { SectionCardContainer } from '../Cards/SectionCard/SectionCard.style';
+
+export const EarnDetailsSection = ({ children }: PropsWithChildren) => {
+  return <SectionCardContainer>{children}</SectionCardContainer>;
+};

--- a/src/components/EarnDetails/hooks.ts
+++ b/src/components/EarnDetails/hooks.ts
@@ -1,0 +1,81 @@
+import { useColorScheme, useTheme } from '@mui/material/styles';
+import { useState, useCallback, useMemo } from 'react';
+import { EarnOpportunityAnalyticsQuery } from 'src/app/lib/getOpportunityAnalytics';
+import { useEarnAnalytics } from 'src/hooks/earn/useEarnAnalytics';
+import { EarnOpportunityHistory } from 'src/types/jumper-backend';
+import { AnalyticsRangeFieldEnum, AnalyticsValueFieldEnum } from './types';
+
+export const useAnalyticsQuery = (slug: string) => {
+  const [query, setQuery] = useState<EarnOpportunityAnalyticsQuery>({
+    value: AnalyticsValueFieldEnum.APY,
+    range: AnalyticsRangeFieldEnum.DAY,
+  });
+
+  const result = useEarnAnalytics({ slug, query });
+
+  const setValue = useCallback(
+    (value: AnalyticsValueFieldEnum) => {
+      setQuery((query) => ({ ...query, value }));
+    },
+    [setQuery],
+  );
+
+  const setRange = useCallback(
+    (range: AnalyticsRangeFieldEnum) => {
+      setQuery((query) => ({ ...query, range }));
+    },
+    [setQuery],
+  );
+
+  return useMemo(
+    () => ({
+      ...result,
+      value: query.value as AnalyticsValueFieldEnum,
+      range: query.range as AnalyticsRangeFieldEnum,
+      setValue,
+      setRange,
+    }),
+    [result, query, setValue, setRange],
+  );
+};
+
+export const useAnalyticsChartData = (
+  rawData: EarnOpportunityHistory | undefined,
+  range: AnalyticsRangeFieldEnum,
+) => {
+  const theme = useTheme();
+  const { mode } = useColorScheme();
+  const isLightTheme = mode === 'light';
+  const data = useMemo(() => {
+    return (
+      rawData?.points.map((point) => ({
+        date: new Date(point.t).toISOString(),
+        value: point.v,
+      })) ?? []
+    );
+  }, [rawData]);
+
+  return useMemo(() => {
+    return {
+      data,
+      dateFormat:
+        range === AnalyticsRangeFieldEnum.DAY
+          ? 'dd MMM yyyy'
+          : range === AnalyticsRangeFieldEnum.WEEK
+            ? 'ww MMM'
+            : range === AnalyticsRangeFieldEnum.MONTH
+              ? 'MMM yyyy'
+              : 'yyyy',
+      theme: {
+        areaTopColor: isLightTheme
+          ? `#F2D9F6`
+          : (theme.vars || theme).palette.accent2Alt,
+        areaBottomColor: isLightTheme
+          ? (theme.vars || theme).palette.white.main
+          : (theme.vars || theme).palette.bg.main,
+        pointColor: (theme.vars || theme).palette.accent1.main,
+        lineColor: (theme.vars || theme).palette.accent2.main,
+      },
+    };
+  }, [data, theme, isLightTheme, range]);
+};

--- a/src/components/EarnDetails/hooks.ts
+++ b/src/components/EarnDetails/hooks.ts
@@ -30,8 +30,8 @@ export const useAnalyticsQuery = (slug: string) => {
   return useMemo(
     () => ({
       ...result,
-      value: query.value as AnalyticsValueFieldEnum,
-      range: query.range as AnalyticsRangeFieldEnum,
+      value: query.value,
+      range: query.range,
       setValue,
       setRange,
     }),
@@ -41,7 +41,7 @@ export const useAnalyticsQuery = (slug: string) => {
 
 export const useAnalyticsChartData = (
   rawData: EarnOpportunityHistory | undefined,
-  range: AnalyticsRangeFieldEnum,
+  range: EarnOpportunityAnalyticsQuery['range'],
 ) => {
   const theme = useTheme();
   const { mode } = useColorScheme();

--- a/src/components/EarnDetails/types.ts
+++ b/src/components/EarnDetails/types.ts
@@ -1,0 +1,11 @@
+export enum AnalyticsValueFieldEnum {
+  APY = 'apy',
+  TVL = 'tvl',
+}
+
+export enum AnalyticsRangeFieldEnum {
+  DAY = 'day',
+  WEEK = 'week',
+  MONTH = 'month',
+  YEAR = 'year',
+}

--- a/src/components/core/charts/LineChart/LineChart.tsx
+++ b/src/components/core/charts/LineChart/LineChart.tsx
@@ -12,7 +12,7 @@ import { CustomTooltip } from './CustomTooltip';
 import { toCompactValue } from 'src/utils/formatNumbers';
 import { LineChartSkeleton } from './LineChartSkeleton';
 import { calculateTooltipPosition, calculateVisibleYRange } from './utils';
-import { useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { format } from 'date-fns';
 import { AREA_CONFIG } from './constants';
 
@@ -55,6 +55,12 @@ export const LineChart = <V, T extends ChartDataPoint<V>>({
   const chartContainerRef = useRef<HTMLDivElement>(null);
 
   const { minValue, maxValue } = calculateVisibleYRange(data);
+
+  const tickValues = useMemo(() => {
+    const range = maxValue - minValue;
+    const step = range / 4; // for 5 ticks, there are 4 steps
+    return Array.from({ length: 5 }, (_, i) => minValue + step * i);
+  }, [minValue, maxValue]);
 
   if (isLoading) {
     return <LineChartSkeleton />;
@@ -107,7 +113,7 @@ export const LineChart = <V, T extends ChartDataPoint<V>>({
           <YAxis
             axisLine={false}
             tickLine={false}
-            tickCount={6} // 5+1 as we do not start from 0
+            ticks={tickValues}
             width={40}
             tickMargin={8}
             domain={[minValue, maxValue]}

--- a/src/components/core/charts/LineChart/LineChartSkeleton.tsx
+++ b/src/components/core/charts/LineChart/LineChartSkeleton.tsx
@@ -23,8 +23,8 @@ export const LineChartSkeleton = () => {
     { time: '2025-01-13', value: 55 },
   ];
   return (
-    <Box sx={{ position: 'relative' }}>
-      <ResponsiveContainer width="100%" height={300}>
+    <Box sx={{ position: 'relative', height: '100%' }}>
+      <ResponsiveContainer width="100%" height="100%">
         <AreaChart data={mockData}>
           <defs>
             <mask id="areaMask">
@@ -56,6 +56,7 @@ export const LineChartSkeleton = () => {
           height="100%"
           animation="wave"
           sx={{
+            transform: 'none',
             borderRadius: 0,
             backgroundColor: (muiTheme.vars || muiTheme).palette.surface2.main,
           }}

--- a/src/components/core/charts/LineChart/__snapshots__/LineChart.snapshot.spec.tsx.snap
+++ b/src/components/core/charts/LineChart/__snapshots__/LineChart.snapshot.spec.tsx.snap
@@ -29,11 +29,11 @@ exports[`LineChart snapshot > default matches snapshot 1`] = `
 exports[`LineChart snapshot > skeleton matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-79elbk"
+    class="MuiBox-root css-1vx1dtt"
   >
     <div
       class="recharts-responsive-container"
-      style="width: 100%; height: 300px; min-width: 0;"
+      style="width: 100%; height: 100%; min-width: 0;"
     >
       <div
         style="width: 0px; height: 0px; overflow: visible;"
@@ -43,7 +43,7 @@ exports[`LineChart snapshot > skeleton matches snapshot 1`] = `
       class="MuiBox-root css-16xxfrc"
     >
       <span
-        class="MuiSkeleton-root MuiSkeleton-rectangular MuiSkeleton-wave css-ezoe2y-MuiSkeleton-root"
+        class="MuiSkeleton-root MuiSkeleton-rectangular MuiSkeleton-wave css-11jdrzx-MuiSkeleton-root"
         style="width: 100%; height: 100%;"
       />
     </div>


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-15994

> [!NOTE]
> Will treat the links from the earn cards to the earn details page on a separate PR once the other ones get merged to avoid too many merging conflicts 🏳️ 

## Testing steps

1. Please go to `/earn/aave-v3-prime-usdc-on-mainnet` or `/earn/clearstar-openeden-usdc-on-base`
2. Check the analytics chart section matches [Figma](https://www.figma.com/design/JUaT4CQ9YSCQ4IWsQQSRIK/Earn?node-id=361-41241&m=dev)