### PR TITLE
chore: remove zap withdrawal tab

### DIFF
--- a/src/components/Zap/ZapWidgetStack.tsx
+++ b/src/components/Zap/ZapWidgetStack.tsx
@@ -6,13 +6,11 @@ import { useTranslation } from 'react-i18next';
 import { ClientOnly } from 'src/components/ClientOnly';
 import { WidgetSkeleton } from 'src/components/Widgets/variants/base/WidgetSkeleton';
 import { ZapDepositBackendWidget } from 'src/components/Widgets/variants/base/ZapWidget/ZapDepositBackendWidget';
-import { ZapWithdrawWidget } from 'src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget';
 import { MISSION_WIDGET_ELEMENT_ID } from 'src/const/quests';
 import { WidgetTrackingProvider } from 'src/providers/WidgetTrackingProvider';
 import { CustomInformation, Quest } from 'src/types/loyaltyPass';
 import { TaskType } from 'src/types/strapi';
 import { DepositPoolCard } from '../ZapWidget/DepositPoolCard/DepositPoolCard';
-import { HorizontalTabs } from 'src/components/HorizontalTabs/HorizontalTabs';
 import { useEnhancedZapData } from 'src/hooks/zaps/useEnhancedZapData';
 import { SweepTokensCard } from '../ZapWidget/SweepTokensCard/SweepTokensCard';
 
@@ -85,32 +83,12 @@ export const ZapWidgetStack: FC<ZapWidgetStackProps> = ({
             },
           }}
         >
-          <HorizontalTabs
-            tabs={tabs}
-            renderContent={(currentTab) => (
-              <ClientOnly>
-                {currentTab === 'deposit' ? (
-                  <ZapDepositBackendWidget
-                    ctx={ctx}
-                    customInformation={customInformation}
-                  />
-                ) : (
-                  <ZapWithdrawWidget
-                    ctx={ctx}
-                    customInformation={customInformation}
-                  />
-                )}
-              </ClientOnly>
-            )}
-            sx={{
-              mb: 3,
-              width: '100%',
-              '&.MuiTabs-root .MuiTab-root': {
-                width: '100%',
-                maxWidth: '100%',
-              },
-            }}
-          />
+          <ClientOnly>
+            <ZapDepositBackendWidget
+              ctx={ctx}
+              customInformation={customInformation}
+            />
+          </ClientOnly>
         </Box>
       </Box>
     </WidgetTrackingProvider>


### PR DESCRIPTION
Removes the tabs from `zap` pages

<img width="429" height="124" alt="Screenshot 2025-10-16 at 20 20 57" src="https://github.com/user-attachments/assets/02d48671-b5aa-4612-b3fc-3d8dc0e3e0d1" />
