### PR TITLE
fix: use evm wallet address for earn filtering

### DIFF
--- a/src/hooks/earn/useAccountAddress.ts
+++ b/src/hooks/earn/useAccountAddress.ts
@@ -1,10 +1,17 @@
+import { ChainType } from '@lifi/sdk';
 import { useAccount } from '@lifi/wallet-management';
 import { Hex, isHex } from 'viem';
 
 export const useAccountAddress = (): Hex | undefined => {
-  const { account } = useAccount();
+  const { accounts } = useAccount();
 
-  if (account.address && isHex(account.address, { strict: true })) {
+  const evmAccounts = accounts?.filter(
+    (account) => account.chainType === ChainType.EVM,
+  );
+
+  const account = evmAccounts?.[0];
+
+  if (account?.address && isHex(account.address, { strict: true })) {
     return account.address;
   }
 


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-16225

> [!NOTE]
> Endpoints to check `/v1/earn/tops` and `/v1/earn/filter`

<img width="885" height="456" alt="Screenshot 2025-10-20 at 22 50 37" src="https://github.com/user-attachments/assets/039de926-3a34-41f9-856b-ff25afcc0a0b" />
<img width="882" height="417" alt="Screenshot 2025-10-20 at 22 50 47" src="https://github.com/user-attachments/assets/56250805-c096-4d49-97ad-957fc39032d4" />


## Testing steps
1. Go to `/earn`
2. Connect an EVM wallet
3. Connect a Solana/Sui/etc. wallet
4. Ensure the request to backend `/earn` endpoints use the EVM wallet address
5. Now disconnect your EVM wallet
6. Check the request to the `/earn` endpoints do not include the `address` (normally these should not have been made if the cache did not expire and there is still data for no address)
7. You can connect another EVM wallet and check this one is used for fresh new requests to the `/earn` endpoints