### PR TITLE
fix: viewport issues on main widget pages

### DIFF
--- a/src/app/ui/app/App.tsx
+++ b/src/app/ui/app/App.tsx
@@ -82,8 +82,11 @@ const App = ({ children }: { children: React.ReactNode }) => {
         justifyContent="center"
         alignItems="start"
         sx={{
-          height: '100%',
-          overflow: { xs: 'scroll', sm: 'inherit' },
+          height: welcomeScreenClosed ? '100%' : 'auto',
+          overflow: {
+            xs: welcomeScreenClosed ? 'scroll' : 'inherit',
+            sm: 'inherit',
+          },
           paddingTop: 3.5,
           paddingBottom: { xs: 11, md: 0 },
         }}

--- a/src/app/ui/app/App.tsx
+++ b/src/app/ui/app/App.tsx
@@ -51,6 +51,8 @@ const App = ({ children }: { children: React.ReactNode }) => {
         height: { xs: 'calc(100dvh - 64px)', sm: 'auto' },
         position: 'relative',
         zIndex: 1,
+        WebkitOverflowScrolling: 'touch',
+        overscrollBehavior: 'none',
       }}
     >
       <Slide

--- a/src/app/ui/app/App.tsx
+++ b/src/app/ui/app/App.tsx
@@ -13,7 +13,6 @@ export interface AppProps {
 }
 
 const App = ({ children }: { children: React.ReactNode }) => {
-
   const { trackEvent } = useUserTracking();
 
   const { welcomeScreenClosed, setWelcomeScreenClosed, enabled } =
@@ -46,7 +45,14 @@ const App = ({ children }: { children: React.ReactNode }) => {
   }, [setWelcomeScreenClosed]);
 
   return (
-    <Box onClick={handleWelcomeScreenEnter}>
+    <Box
+      onClick={handleWelcomeScreenEnter}
+      sx={{
+        height: { xs: 'calc(100dvh - 64px)', sm: 'auto' },
+        position: 'relative',
+        zIndex: 1,
+      }}
+    >
       <Slide
         direction="up"
         in={enabled && !welcomeScreenClosed}
@@ -73,7 +79,12 @@ const App = ({ children }: { children: React.ReactNode }) => {
         direction="row"
         justifyContent="center"
         alignItems="start"
-        paddingTop={3.5}
+        sx={{
+          height: '100%',
+          overflow: { xs: 'scroll', sm: 'inherit' },
+          paddingTop: 3.5,
+          paddingBottom: { xs: 11, md: 0 },
+        }}
       >
         {welcomeScreenClosed && <VerticalTabs />}
         <WidgetContainer

--- a/src/app/ui/app/App.tsx
+++ b/src/app/ui/app/App.tsx
@@ -7,6 +7,7 @@ import { useUserTracking } from '@/hooks/userTracking';
 import { Box, Slide, Stack } from '@mui/material';
 import { VerticalTabs } from 'src/components/Menus/VerticalMenu';
 import React, { useEffect } from 'react';
+import { HeaderHeight } from 'src/const/headerHeight';
 
 export interface AppProps {
   children: React.ReactNode;
@@ -48,7 +49,7 @@ const App = ({ children }: { children: React.ReactNode }) => {
     <Box
       onClick={handleWelcomeScreenEnter}
       sx={{
-        height: { xs: 'calc(100dvh - 64px)', sm: 'auto' },
+        height: { xs: `calc(100dvh - ${HeaderHeight.XS}px)`, sm: 'auto' },
       }}
     >
       <Slide

--- a/src/app/ui/app/App.tsx
+++ b/src/app/ui/app/App.tsx
@@ -49,10 +49,6 @@ const App = ({ children }: { children: React.ReactNode }) => {
       onClick={handleWelcomeScreenEnter}
       sx={{
         height: { xs: 'calc(100dvh - 64px)', sm: 'auto' },
-        position: 'relative',
-        zIndex: 1,
-        WebkitOverflowScrolling: 'touch',
-        overscrollBehavior: 'none',
       }}
     >
       <Slide
@@ -81,6 +77,7 @@ const App = ({ children }: { children: React.ReactNode }) => {
         direction="row"
         justifyContent="center"
         alignItems="start"
+        gap={3}
         sx={{
           height: welcomeScreenClosed ? '100%' : 'auto',
           overflow: {
@@ -89,6 +86,8 @@ const App = ({ children }: { children: React.ReactNode }) => {
           },
           paddingTop: 3.5,
           paddingBottom: { xs: 11, md: 0 },
+          WebkitOverflowScrolling: 'touch',
+          overscrollBehavior: 'none',
         }}
       >
         {welcomeScreenClosed && <VerticalTabs />}

--- a/src/components/Containers/MainWidgetContainer.tsx
+++ b/src/components/Containers/MainWidgetContainer.tsx
@@ -11,6 +11,7 @@ export const MainWidgetContainer: FC<MainWidgetContainerProps> = ({
       id="main-widget-container"
       sx={{
         paddingX: { xs: 2, sm: 0 },
+        height: '100%',
       }}
     >
       {children}

--- a/src/components/Containers/MainWidgetContainer.tsx
+++ b/src/components/Containers/MainWidgetContainer.tsx
@@ -8,9 +8,9 @@ export const MainWidgetContainer: FC<MainWidgetContainerProps> = ({
 }) => {
   return (
     <Box
+      id="main-widget-container"
       sx={{
         paddingX: { xs: 2, sm: 0 },
-        marginBottom: { xs: 12, md: 0 },
       }}
     >
       {children}

--- a/src/components/Navbar/layout/Layout.styles.tsx
+++ b/src/components/Navbar/layout/Layout.styles.tsx
@@ -4,6 +4,7 @@ import { styled } from '@mui/material/styles';
 export const FloatingMainLinksContainer = styled(Stack)(({ theme }) => ({
   left: 0,
   right: 0,
+  transform: 'translate3d(0, 0, 0)',
   position: 'fixed',
   zIndex: theme.zIndex.appBar,
   bottom: theme.spacing(1.25),

--- a/src/components/WelcomeScreen/WelcomeScreen.style.ts
+++ b/src/components/WelcomeScreen/WelcomeScreen.style.ts
@@ -5,12 +5,14 @@ import { ButtonPrimary } from '../Button';
 
 /**
  * more welcome-screen styles to be found in Widget.style.tsx + Widgets.style.tsx
+ * Using dvh (dynamic viewport height) for mobile to handle iOS Safari keyboard/URL bar
+ * Using vh for desktop where viewport is stable
  */
 
 export const DEFAULT_WELCOME_SCREEN_HEIGHT = '55vh';
 export const DEFAULT_WELCOME_SCREEN_HEIGHTS = {
-  xs: '55vh',
-  md: '50vh',
+  xs: '55dvh', // Dynamic viewport height for mobile (iOS Safari fix)
+  md: '50vh', // Standard viewport for desktop
 };
 
 export interface ContentWrapperProps extends BoxProps {

--- a/src/components/Widgets/Widget.style.ts
+++ b/src/components/Widgets/Widget.style.ts
@@ -96,17 +96,16 @@ export const WidgetWrapper = styled(Box, {
       },
     }),
 
-    [`@media screen and (max-width: ${theme.breakpoints.values.sm - 1}px) and (min-height: 700px)`]:
-      {
-        '& [id^="widget-relative-container-"]': {
+    [theme.breakpoints.down('sm')]: {
+      '& [id^="widget-relative-container-"]': {
+        maxHeight: '100% !important',
+      },
+      '& [id^="widget-app-expanded-container-"], & [id^="widget-scrollable-container-"]':
+        {
+          height: '100%',
           maxHeight: '100% !important',
         },
-        '& [id^="widget-app-expanded-container-"], & [id^="widget-scrollable-container-"]':
-          {
-            height: '100%',
-            maxHeight: '100% !important',
-          },
-      },
+    },
     variants: [
       {
         props: ({ welcomeScreenClosed }) => !welcomeScreenClosed,

--- a/src/components/Widgets/Widget.style.ts
+++ b/src/components/Widgets/Widget.style.ts
@@ -26,10 +26,8 @@ export const WidgetWrapper = styled(Box, {
     prop !== 'autoHeight' &&
     prop !== 'contributionDisplayed',
 })<WidgetWrapperProps>(({ theme, autoHeight, contributionDisplayed }) => {
-  // autoHeight is used to adapt widget-height automatically instead of default 686px
-  const widgetHeight: 'auto' | number = autoHeight
-    ? 'auto'
-    : DEFAULT_WIDGET_HEIGHT;
+  // autoHeight is used to adapt widget-height automatically
+  const widgetHeight: 'auto' | '100%' = autoHeight ? 'auto' : '100%';
 
   return {
     width: '100%',
@@ -97,6 +95,22 @@ export const WidgetWrapper = styled(Box, {
         height: '600px',
       },
     }),
+
+    '& [id^="widget-relative-container-"]': {
+      maxHeight: '100%',
+    },
+    '& [id^="widget-app-expanded-container-"], & [id^="widget-scrollable-container-"]':
+      {
+        height: '100%',
+        maxHeight: '100%',
+      },
+    [theme.breakpoints.up('sm' as Breakpoint)]: {
+      '& [id^="widget-app-expanded-container-"], & [id^="widget-relative-container-"], & [id^="widget-scrollable-container-"]':
+        {
+          height: 'initial',
+          maxHeight: 'initial',
+        },
+    },
     variants: [
       {
         props: ({ welcomeScreenClosed }) => !welcomeScreenClosed,

--- a/src/components/Widgets/Widget.style.ts
+++ b/src/components/Widgets/Widget.style.ts
@@ -96,21 +96,17 @@ export const WidgetWrapper = styled(Box, {
       },
     }),
 
-    '& [id^="widget-relative-container-"]': {
-      maxHeight: '100%',
-    },
-    '& [id^="widget-app-expanded-container-"], & [id^="widget-scrollable-container-"]':
+    [`@media screen and (max-width: ${theme.breakpoints.values.sm - 1}px) and (min-height: 700px)`]:
       {
-        height: '100%',
-        maxHeight: '100%',
-      },
-    [theme.breakpoints.up('sm' as Breakpoint)]: {
-      '& [id^="widget-app-expanded-container-"], & [id^="widget-relative-container-"], & [id^="widget-scrollable-container-"]':
-        {
-          height: 'initial',
-          maxHeight: 'initial',
+        '& [id^="widget-relative-container-"]': {
+          maxHeight: '100% !important',
         },
-    },
+        '& [id^="widget-app-expanded-container-"], & [id^="widget-scrollable-container-"]':
+          {
+            height: '100%',
+            maxHeight: '100% !important',
+          },
+      },
     variants: [
       {
         props: ({ welcomeScreenClosed }) => !welcomeScreenClosed,

--- a/src/components/Widgets/Widget.style.ts
+++ b/src/components/Widgets/Widget.style.ts
@@ -37,6 +37,7 @@ export const WidgetWrapper = styled(Box, {
     margin: theme.spacing(0, 'auto'),
     zIndex: 2,
     height: 'auto',
+    display: 'contents',
     '& > div:not(.alert)': {
       position: 'relative',
       transitionProperty: 'margin-top',

--- a/src/components/Widgets/Widget.style.ts
+++ b/src/components/Widgets/Widget.style.ts
@@ -43,10 +43,13 @@ export const WidgetWrapper = styled(Box, {
       transitionDuration: '.3s',
       transitionTimingFunction: 'ease-in-out',
       marginTop: 0,
-      maxHeight: '50vh',
+      // Use dvh on mobile for dynamic viewport (iOS Safari keyboard fix)
+      maxHeight: '50dvh',
       [theme.breakpoints.up('sm' as Breakpoint)]: {
         height: 'auto',
         marginTop: 0,
+        // Use standard vh on larger screens
+        maxHeight: '50vh',
         [`@media screen and (min-height: 700px)`]: {
           // set default widget height
           height: '50vh',

--- a/src/components/Widgets/Widgets.style.tsx
+++ b/src/components/Widgets/Widgets.style.tsx
@@ -23,13 +23,15 @@ export const WidgetContainer = styled(Box, {
   return {
     display: 'flex',
     flexDirection: 'column',
-    overflow: 'inherit',
+    height: '100%',
     width: '100%',
+    overflow: 'inherit',
     transitionProperty: 'max-height',
     transitionDuration: '.3s',
     transitionTimingFunction: 'ease-in-out',
     [theme.breakpoints.up('sm' as Breakpoint)]: {
       width: 'auto',
+      // height: 'auto',
     },
     [theme.breakpoints.up('lg' as Breakpoint)]: {
       margin: theme.spacing(0, 4),
@@ -64,9 +66,9 @@ export const WidgetContainer = styled(Box, {
         top: GLOW_EFFECT_TOP_POSITIONS.md,
       },
       [theme.breakpoints.up('lg' as Breakpoint)]: {
-        // using vh here as well to make it a circle-ish glow
-        maxWidth: '90vh',
-        maxHeight: '90vh',
+        // using viewport units to make it a circle-ish glow
+        maxWidth: '90dvh',
+        maxHeight: '90dvh',
       },
       ...theme.applyStyles('light', {
         background:

--- a/src/components/Widgets/Widgets.style.tsx
+++ b/src/components/Widgets/Widgets.style.tsx
@@ -21,10 +21,7 @@ export const WidgetContainer = styled(Box, {
   shouldForwardProp: (prop) => prop !== 'welcomeScreenClosed',
 })<WidgetContainerProps>(({ theme, welcomeScreenClosed }) => {
   return {
-    display: 'flex',
-    flexDirection: 'column',
-    height: '100%',
-    width: '100%',
+    display: 'contents',
     overflow: 'inherit',
     transitionProperty: 'max-height',
     transitionDuration: '.3s',

--- a/src/config/widgetConfig.ts
+++ b/src/config/widgetConfig.ts
@@ -113,11 +113,11 @@ export const getDefaultWidgetThemeV2 = (
         container: {
           borderRadius: '24px',
           maxWidth: '100%',
-          maxHeight: 720,
           [copiedTheme.breakpoints.up('sm' as Breakpoint)]: {
             borderRadius: '24px',
             maxWidth: 416,
             minWidth: 416,
+            maxHeight: 720,
             boxShadow: copiedTheme.shadows[1],
           },
         },

--- a/src/config/widgetConfig.ts
+++ b/src/config/widgetConfig.ts
@@ -27,10 +27,13 @@ export const getDefaultWidgetTheme = (
         container: {
           borderRadius: '12px',
           maxWidth: '100%',
+          height: '100%',
           [theme.breakpoints.up('sm' as Breakpoint)]: {
             borderRadius: '12px',
             maxWidth: 416,
             minWidth: 416,
+            maxHeight: 720,
+            height: 'auto',
             boxShadow: theme.shadows[1],
           },
         },

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -536,7 +536,17 @@ export const themeCustomized: Omit<Theme, 'applyStyles'> & CssVarsTheme =
       MuiCssBaseline: {
         styleOverrides: {
           '@supports': { fontVariationSettings: 'normal' },
-          body: { scrollBehavior: 'smooth' },
+          html: {
+            margin: 0,
+            padding: 0,
+          },
+          body: {
+            scrollBehavior: 'smooth',
+            margin: 0,
+            padding: 0,
+            WebkitOverflowScrolling: 'touch',
+            overscrollBehavior: 'none',
+          },
         },
       },
       MuiButton: {
@@ -624,6 +634,7 @@ export const themeCustomized: Omit<Theme, 'applyStyles'> & CssVarsTheme =
       Background: {
         styleOverrides: {
           root: ({ theme }: { theme: Theme }) => ({
+            transform: 'translate3d(0, 0, 0)',
             position: 'fixed',
             left: 0,
             bottom: 0,

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -544,8 +544,6 @@ export const themeCustomized: Omit<Theme, 'applyStyles'> & CssVarsTheme =
             scrollBehavior: 'smooth',
             margin: 0,
             padding: 0,
-            WebkitOverflowScrolling: 'touch',
-            overscrollBehavior: 'none',
           },
         },
       },


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-16315

> [!NOTE]
> Ideally you try testing this with a real `iPhone 16 (Pro)`
> Otherwise xcode simulator might come handy as the browser responsive view is not enough to try reproducing the bug

## Testing steps
1.  Go to `/`
2. Try opening different views of the widget and ensure the bottom navigation is not shown on top of the widget screens