### PR TITLE
fix: viewport issues on main widget pages

### DIFF
--- a/src/app/ui/app/App.tsx
+++ b/src/app/ui/app/App.tsx
@@ -73,7 +73,11 @@ const App = ({ children }: { children: React.ReactNode }) => {
     <Box
       onClick={handleWelcomeScreenEnter}
       sx={{
-        height: { xs: `calc(100dvh - ${HeaderHeight.XS}px)`, sm: 'auto' },
+        height: {
+          xs: `calc(100dvh - ${HeaderHeight.XS}px)`,
+          sm: `calc(100dvh - ${HeaderHeight.SM}px)`,
+          md: `calc(100dvh - ${HeaderHeight.MD}px)`,
+        },
       }}
     >
       <Slide

--- a/src/app/ui/app/App.tsx
+++ b/src/app/ui/app/App.tsx
@@ -8,6 +8,7 @@ import { Box, Slide, Stack } from '@mui/material';
 import { VerticalTabs } from 'src/components/Menus/VerticalMenu';
 import React, { useEffect, useRef, useState } from 'react';
 import { AnnouncementBanner } from 'src/components/AnnouncementBanner/AnnouncementBanner';
+import { HeaderHeight } from 'src/const/headerHeight';
 
 export interface AppProps {
   children: React.ReactNode;
@@ -69,7 +70,12 @@ const App = ({ children }: { children: React.ReactNode }) => {
   }, []);
 
   return (
-    <Box onClick={handleWelcomeScreenEnter}>
+    <Box
+      onClick={handleWelcomeScreenEnter}
+      sx={{
+        height: { xs: `calc(100dvh - ${HeaderHeight.XS}px)`, sm: 'auto' },
+      }}
+    >
       <Slide
         direction="up"
         in={enabled && !welcomeScreenClosed}
@@ -97,6 +103,17 @@ const App = ({ children }: { children: React.ReactNode }) => {
         justifyContent="center"
         alignItems="start"
         paddingTop={3.5}
+        sx={{
+          height: welcomeScreenClosed ? '100%' : 'auto',
+          overflow: {
+            xs: welcomeScreenClosed ? 'scroll' : 'hidden',
+            sm: 'inherit',
+          },
+          paddingTop: 3.5,
+          paddingBottom: { xs: 11, md: 0 },
+          WebkitOverflowScrolling: 'touch',
+          overscrollBehavior: 'none',
+        }}
       >
         {welcomeScreenClosed && (
           <Box

--- a/src/components/Containers/MainWidgetContainer.tsx
+++ b/src/components/Containers/MainWidgetContainer.tsx
@@ -10,7 +10,7 @@ export const MainWidgetContainer: FC<MainWidgetContainerProps> = ({
     <Box
       sx={{
         paddingX: { xs: 2, sm: 0 },
-        marginBottom: { xs: 12, md: 0 },
+        height: '100%',
       }}
     >
       {children}

--- a/src/components/Containers/MainWidgetContainer.tsx
+++ b/src/components/Containers/MainWidgetContainer.tsx
@@ -10,7 +10,7 @@ export const MainWidgetContainer: FC<MainWidgetContainerProps> = ({
     <Box
       sx={{
         paddingX: { xs: 2, sm: 0 },
-        height: '100%',
+        flex: '1',
       }}
     >
       {children}

--- a/src/components/WelcomeScreen/WelcomeScreen.style.ts
+++ b/src/components/WelcomeScreen/WelcomeScreen.style.ts
@@ -5,12 +5,14 @@ import { ButtonPrimary } from '../Button';
 
 /**
  * more welcome-screen styles to be found in Widget.style.tsx + Widgets.style.tsx
+ * Using dvh (dynamic viewport height) for mobile to handle iOS Safari keyboard/URL bar
+ * Using vh for desktop where viewport is stable
  */
 
 export const DEFAULT_WELCOME_SCREEN_HEIGHT = '55vh';
 export const DEFAULT_WELCOME_SCREEN_HEIGHTS = {
-  xs: '55vh',
-  md: '50vh',
+  xs: '55dvh', // Dynamic viewport height for mobile (iOS Safari fix)
+  md: '50vh', // Standard viewport for desktop
 };
 
 export interface ContentWrapperProps extends BoxProps {

--- a/src/components/Widgets/Widget.style.ts
+++ b/src/components/Widgets/Widget.style.ts
@@ -98,6 +98,7 @@ export const WidgetWrapper = styled(Box, {
       },
       '& [id^="widget-app-expanded-container-"], & [id^="widget-scrollable-container-"]':
         {
+          height: '100% !important',
           maxHeight: '100% !important',
         },
     },

--- a/src/components/Widgets/Widget.style.ts
+++ b/src/components/Widgets/Widget.style.ts
@@ -27,9 +27,7 @@ export const WidgetWrapper = styled(Box, {
     prop !== 'contributionDisplayed',
 })<WidgetWrapperProps>(({ theme, autoHeight, contributionDisplayed }) => {
   // autoHeight is used to adapt widget-height automatically instead of default 686px
-  const widgetHeight: 'auto' | number = autoHeight
-    ? 'auto'
-    : DEFAULT_WIDGET_HEIGHT;
+  const widgetHeight: 'auto' | '100%' = autoHeight ? 'auto' : '100%';
 
   return {
     width: '100%',
@@ -37,6 +35,7 @@ export const WidgetWrapper = styled(Box, {
     margin: theme.spacing(0, 'auto'),
     zIndex: 2,
     height: 'auto',
+    display: 'contents',
     '& > div:not(.alert)': {
       position: 'relative',
       transitionProperty: 'margin-top',
@@ -93,6 +92,15 @@ export const WidgetWrapper = styled(Box, {
         height: '600px',
       },
     }),
+    [theme.breakpoints.down('sm')]: {
+      '& [id^="widget-relative-container-"]': {
+        maxHeight: '100% !important',
+      },
+      '& [id^="widget-app-expanded-container-"], & [id^="widget-scrollable-container-"]':
+        {
+          maxHeight: '100% !important',
+        },
+    },
     variants: [
       {
         props: ({ welcomeScreenClosed }) => !welcomeScreenClosed,

--- a/src/config/widgetConfig.ts
+++ b/src/config/widgetConfig.ts
@@ -119,13 +119,11 @@ export const getDefaultWidgetThemeV2 = (
         container: {
           borderRadius: '24px',
           maxWidth: '100%',
-          height: '100%',
           [copiedTheme.breakpoints.up('sm' as Breakpoint)]: {
             borderRadius: '24px',
             maxWidth: WIDGET_WIDTH,
             minWidth: WIDGET_WIDTH,
             maxHeight: WIDGET_HEIGHT,
-            height: 'auto',
             boxShadow: copiedTheme.shadows[1],
           },
         },
@@ -134,6 +132,7 @@ export const getDefaultWidgetThemeV2 = (
             borderRadius: '12px',
             maxWidth: 256,
             minWidth: 256,
+            maxHeight: WIDGET_HEIGHT,
             boxShadow: copiedTheme.shadows[1],
           },
         },

--- a/src/config/widgetConfig.ts
+++ b/src/config/widgetConfig.ts
@@ -10,6 +10,7 @@ import {
 import { themeCustomized } from 'src/theme/theme';
 
 export const WIDGET_WIDTH = 416;
+export const WIDGET_HEIGHT = 720;
 
 // INFO: Do NOT use theme.vars here, it will break the widget
 export const getDefaultWidgetTheme = (
@@ -29,10 +30,13 @@ export const getDefaultWidgetTheme = (
         container: {
           borderRadius: '12px',
           maxWidth: '100%',
+          height: '100%',
           [theme.breakpoints.up('sm' as Breakpoint)]: {
             borderRadius: '12px',
             maxWidth: WIDGET_WIDTH,
             minWidth: WIDGET_WIDTH,
+            maxHeight: WIDGET_HEIGHT,
+            height: 'auto',
             boxShadow: theme.shadows[1],
           },
         },
@@ -115,11 +119,13 @@ export const getDefaultWidgetThemeV2 = (
         container: {
           borderRadius: '24px',
           maxWidth: '100%',
-          maxHeight: 720,
+          height: '100%',
           [copiedTheme.breakpoints.up('sm' as Breakpoint)]: {
             borderRadius: '24px',
-            maxWidth: 416,
-            minWidth: 416,
+            maxWidth: WIDGET_WIDTH,
+            minWidth: WIDGET_WIDTH,
+            maxHeight: WIDGET_HEIGHT,
+            height: 'auto',
             boxShadow: copiedTheme.shadows[1],
           },
         },

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -536,7 +536,15 @@ export const themeCustomized: Omit<Theme, 'applyStyles'> & CssVarsTheme =
       MuiCssBaseline: {
         styleOverrides: {
           '@supports': { fontVariationSettings: 'normal' },
-          body: { scrollBehavior: 'smooth' },
+          html: {
+            margin: 0,
+            padding: 0,
+          },
+          body: {
+            scrollBehavior: 'smooth',
+            margin: 0,
+            padding: 0,
+          },
         },
       },
       MuiButton: {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -537,10 +537,12 @@ export const themeCustomized: Omit<Theme, 'applyStyles'> & CssVarsTheme =
         styleOverrides: {
           '@supports': { fontVariationSettings: 'normal' },
           html: {
+            height: '100%',
             margin: 0,
             padding: 0,
           },
           body: {
+            height: '100%',
             scrollBehavior: 'smooth',
             margin: 0,
             padding: 0,


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-16315

Actually this seems to be the most stable approach to remove extra scrollbars.
Based this over the announcement banner changes as it will impact the layout on the main page

> [!NOTE]
> Ideally you try testing this with a real `iPhone 16 (Pro)`
> Otherwise xcode simulator might come handy as the browser responsive view is not enough to try reproducing the bug

## Testing steps
1.  Go to `/`
2. Try opening different views of the widget and ensure the bottom navigation is not shown on top of the widget screens