### PR TITLE
fix: update landing page function to use direct element retrieval

### DIFF
--- a/tests/testData/landingPageFunctions.ts
+++ b/tests/testData/landingPageFunctions.ts
@@ -54,7 +54,7 @@ export async function checkRoutesVisibility(
           .locator('button.MuiIconButton-root.MuiIconButton-sizeSmall:has(svg)')
           .click();
       }
-      const relayLabel = page.getByText(/Relay/);
+      const relayLabel = page.getByText('Relay via LI.FI');
       await expect(relayLabel).toBeVisible();
     }
   } else {

--- a/tests/testData/landingPageFunctions.ts
+++ b/tests/testData/landingPageFunctions.ts
@@ -44,7 +44,7 @@ export async function checkRoutesVisibility(
   const { bestReturnShouldBeVisible, checkRelayRoute } = options;
 
   if (bestReturnShouldBeVisible) {
-    const bestReturnLabel = await getElementByText(page, 'Best Return');
+    const bestReturnLabel = page.getByText('Best Return').first();
     await expect(bestReturnLabel).toBeVisible();
 
     if (checkRelayRoute) {
@@ -54,7 +54,7 @@ export async function checkRoutesVisibility(
           .locator('button.MuiIconButton-root.MuiIconButton-sizeSmall:has(svg)')
           .click();
       }
-      const relayLabel = await getElementByText(page, 'Relay via LI.FI');
+      const relayLabel = page.getByText(/Relay/);
       await expect(relayLabel).toBeVisible();
     }
   } else {

--- a/tests/testData/landingPageFunctions.ts
+++ b/tests/testData/landingPageFunctions.ts
@@ -44,7 +44,7 @@ export async function checkRoutesVisibility(
   const { bestReturnShouldBeVisible, checkRelayRoute } = options;
 
   if (bestReturnShouldBeVisible) {
-    const bestReturnLabel = page.getByText('Best Return').first();
+    const bestReturnLabel = page.getByText('Best Return').first(); //added first() to handle cases where multiple "Best Return" labels exist - LF-16508
     await expect(bestReturnLabel).toBeVisible();
 
     if (checkRelayRoute) {


### PR DESCRIPTION

In scope of this PR I reworked  landingFunctions.spec.ts to verify the .first() best retrun label ( in case if there are more than 1 best return label visible) 

Corresponding JIRA ticket - https://lifi.atlassian.net/browse/LF-16500 