### PR TITLE
fix: earn containers and components spacing on mobile

### DIFF
--- a/src/app/ui/earn/EarnOpportunitiesAll/EarnOpportunitiesAll.tsx
+++ b/src/app/ui/earn/EarnOpportunitiesAll/EarnOpportunitiesAll.tsx
@@ -30,8 +30,22 @@ const EarnOpportunitiesAllInner = () => {
 
   return (
     <>
-      <SectionCardContainer ref={sectionRef}>
-        <Stack direction="column" gap={3}>
+      <SectionCardContainer
+        ref={sectionRef}
+        sx={(theme) => ({
+          padding: theme.spacing(2),
+          [theme.breakpoints.up('md')]: {
+            padding: theme.spacing(3),
+          },
+        })}
+      >
+        <Stack
+          direction="column"
+          gap={{
+            xs: 2,
+            md: 3,
+          }}
+        >
           <EarnFilterBar
             isLoading={isAllDataLoading}
             variant={variant}

--- a/src/app/ui/earn/EarnOpportunitiesCards.tsx
+++ b/src/app/ui/earn/EarnOpportunitiesCards.tsx
@@ -24,7 +24,7 @@ export const EarnOpportunitiesCards = ({
     <GridContainer
       gridTemplateColumns={
         isCompact
-          ? 'repeat(auto-fill, minmax(328px, 1fr))'
+          ? 'repeat(auto-fill, minmax(min(328px, 100%), 1fr))'
           : 'repeat(auto-fit, 100%)'
       }
       gap={3}

--- a/src/app/ui/earn/EarnTopOpportunities.tsx
+++ b/src/app/ui/earn/EarnTopOpportunities.tsx
@@ -21,12 +21,14 @@ export const EarnTopOpportunities = () => {
     <Grid container spacing={2}>
       {items?.map((item, index) => {
         const isMain = index === 0;
+
         return (
           <Grid
             key={index}
             size={{
               xs: 12,
-              sm: isSingleItem ? 12 : index === 0 ? 7 : 5,
+              sm: 6,
+              md: isSingleItem ? 12 : index === 0 ? 7 : 5,
             }}
             sx={{ display: 'flex' }}
           >
@@ -50,12 +52,11 @@ export const EarnTopOpportunities = () => {
                       address: item.lpToken.address,
                     }}
                     displayMode={
-                      isMain
+                      isMain && !isMobile
                         ? DepositButtonDisplayMode.IconAndLabel
                         : DepositButtonDisplayMode.IconOnly
                     }
                     size="large"
-                    fullWidth={isMain && isMobile}
                     disabled
                   />
                 }

--- a/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
+++ b/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
@@ -64,7 +64,7 @@ exports[`EarnCard snapshot > compact card matches snapshot 1`] = `
         </div>
       </div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary css-181aqyq-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary css-zben4u-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         type="button"
       >
@@ -94,7 +94,7 @@ exports[`EarnCard snapshot > compact card matches snapshot 1`] = `
       class="MuiStack-root css-4e6rn7-MuiStack-root"
     >
       <div
-        class="MuiBox-root css-h1oaii"
+        class="MuiBox-root css-u70uxf"
         data-testid="protocol-morpho"
       >
         <div
@@ -402,7 +402,7 @@ exports[`EarnCard snapshot > compact card with href matches snapshot 1`] = `
         class="MuiStack-root css-4e6rn7-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-h1oaii"
+          class="MuiBox-root css-u70uxf"
           data-testid="protocol-morpho"
         >
           <div
@@ -665,7 +665,7 @@ exports[`EarnCard snapshot > compact card with loading matches snapshot 1`] = `
       class="MuiStack-root css-4e6rn7-MuiStack-root"
     >
       <div
-        class="MuiBox-root css-cmx6on"
+        class="MuiBox-root css-1lr3mj0"
       >
         <span
           class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-lvnl87-MuiSkeleton-root"
@@ -725,7 +725,7 @@ exports[`EarnCard snapshot > compact card with no recommendation matches snapsho
         </div>
       </div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary css-181aqyq-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary css-zben4u-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         type="button"
       >
@@ -755,7 +755,7 @@ exports[`EarnCard snapshot > compact card with no recommendation matches snapsho
       class="MuiStack-root css-4e6rn7-MuiStack-root"
     >
       <div
-        class="MuiBox-root css-h1oaii"
+        class="MuiBox-root css-u70uxf"
         data-testid="protocol-morpho"
       >
         <div
@@ -1055,7 +1055,7 @@ exports[`EarnCard snapshot > compact card with single asset matches snapshot 1`]
         </div>
       </div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary css-181aqyq-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary css-zben4u-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         type="button"
       >
@@ -1085,7 +1085,7 @@ exports[`EarnCard snapshot > compact card with single asset matches snapshot 1`]
       class="MuiStack-root css-4e6rn7-MuiStack-root"
     >
       <div
-        class="MuiBox-root css-h1oaii"
+        class="MuiBox-root css-u70uxf"
         data-testid="protocol-morpho"
       >
         <div
@@ -1330,7 +1330,7 @@ exports[`EarnCard snapshot > list item card matches snapshot 1`] = `
       class="MuiStack-root css-qvm35a-MuiStack-root"
     >
       <div
-        class="MuiBox-root css-h1oaii"
+        class="MuiBox-root css-u70uxf"
         data-testid="protocol-morpho"
       >
         <div
@@ -1506,7 +1506,7 @@ exports[`EarnCard snapshot > list item card matches snapshot 1`] = `
           </p>
         </div>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-o57fdb-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-rvb98k-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1550,7 +1550,7 @@ exports[`EarnCard snapshot > list item card with href matches snapshot 1`] = `
         class="MuiStack-root css-qvm35a-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-h1oaii"
+          class="MuiBox-root css-u70uxf"
           data-testid="protocol-morpho"
         >
           <div
@@ -1741,7 +1741,7 @@ exports[`EarnCard snapshot > list item card with loading matches snapshot 1`] = 
       class="MuiStack-root css-qvm35a-MuiStack-root"
     >
       <div
-        class="MuiBox-root css-cmx6on"
+        class="MuiBox-root css-1lr3mj0"
       >
         <span
           class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-f9555f-MuiSkeleton-root"
@@ -1799,7 +1799,7 @@ exports[`EarnCard snapshot > list item card with no recommendation matches snaps
       class="MuiStack-root css-qvm35a-MuiStack-root"
     >
       <div
-        class="MuiBox-root css-h1oaii"
+        class="MuiBox-root css-u70uxf"
         data-testid="protocol-morpho"
       >
         <div
@@ -1944,7 +1944,7 @@ exports[`EarnCard snapshot > list item card with no recommendation matches snaps
           </p>
         </div>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-o57fdb-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-rvb98k-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1984,7 +1984,7 @@ exports[`EarnCard snapshot > list item card with single asset matches snapshot 1
       class="MuiStack-root css-qvm35a-MuiStack-root"
     >
       <div
-        class="MuiBox-root css-h1oaii"
+        class="MuiBox-root css-u70uxf"
         data-testid="protocol-morpho"
       >
         <div

--- a/src/components/Cards/HeroEarnCard/HeroEarnCard.styles.ts
+++ b/src/components/Cards/HeroEarnCard/HeroEarnCard.styles.ts
@@ -22,12 +22,15 @@ export const HeroEarnCardContainer = styled(Box, {
   ...theme.applyStyles('dark', {
     backgroundColor: (theme.vars || theme).palette.surface2.main,
   }),
-  padding: theme.spacing(3),
+  padding: theme.spacing(4),
   gap: theme.spacing(0.5),
   minHeight: 312,
   height: '-webkit-fill-available',
   display: 'flex',
   flexDirection: 'column',
+  [theme.breakpoints.up('md')]: {
+    padding: theme.spacing(3),
+  },
 }));
 
 export const HeroEarnCardHeaderContainer = styled(Stack)(({ theme }) => ({
@@ -60,7 +63,7 @@ export const HeroEarnCardFooterContentContainer = styled(Stack)(
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    flexWrap: 'wrap',
+    flexWrap: 'nowrap',
     gap: theme.spacing(2),
   }),
 );

--- a/src/components/Cards/HeroEarnCard/HeroEarnCard.tsx
+++ b/src/components/Cards/HeroEarnCard/HeroEarnCard.tsx
@@ -18,6 +18,7 @@ import { HeroHighlight } from './HeroHighlight';
 import { AvatarSize } from 'src/components/core/AvatarStack/AvatarStack.types';
 import { EarnOpportunityWithLatestAnalytics } from 'src/types/jumper-backend';
 import { ConditionalLink } from 'src/components/Link/ConditionalLink';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 export enum EarnHeroCardCopyKey {
   USE_YOUR_SPARE = 'earn.top.useYourSpare',
@@ -57,6 +58,7 @@ export const HeroEarnCard: FC<HeroEarnCardProps> = ({
   isMain = false,
   href,
 }) => {
+  const isMobile = useMediaQuery((theme) => theme.breakpoints.down('md'));
   // Note: later we might want to keep rendering the card if it's loading but already has data (on ttl for examples).
   const isEmpty = data === null || isLoading;
 
@@ -77,7 +79,7 @@ export const HeroEarnCard: FC<HeroEarnCardProps> = ({
   const formattedApy = `${(latest.apy.total * 100).toLocaleString()}%`;
 
   return (
-    <ConditionalLink href={href}>
+    <ConditionalLink href={href} sx={{ width: '100%' }}>
       <HeroEarnCardContainer hasLink={!!href}>
         <HeroEarnCardHeaderContainer direction="row">
           {forYou && (
@@ -128,6 +130,9 @@ export const HeroEarnCard: FC<HeroEarnCardProps> = ({
               chains={chains}
               protocolSize={AvatarSize.XXL}
               chainsSize={AvatarSize.SM}
+              content={{
+                titleVariant: isMobile ? 'bodyLargeStrong' : 'titleXSmall',
+              }}
             />
             {primaryAction}
           </HeroEarnCardFooterContentContainer>

--- a/src/components/Cards/HeroEarnCard/__snapshots__/HeroEarnCard.snapshot.spec.tsx.snap
+++ b/src/components/Cards/HeroEarnCard/__snapshots__/HeroEarnCard.snapshot.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`HeroEarnCard snapshot > hero card matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-vs3jgl"
+    class="MuiBox-root css-1y44ltr"
   >
     <div
       class="MuiStack-root css-imab1l-MuiStack-root"
@@ -67,10 +67,10 @@ exports[`HeroEarnCard snapshot > hero card matches snapshot 1`] = `
       class="MuiStack-root css-185w891-MuiStack-root"
     >
       <div
-        class="MuiStack-root css-69zndg-MuiStack-root"
+        class="MuiStack-root css-4n2h5n-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-h1oaii"
+          class="MuiBox-root css-u70uxf"
           data-testid="protocol-morpho"
         >
           <div
@@ -139,11 +139,11 @@ exports[`HeroEarnCard snapshot > hero card matches snapshot 1`] = `
 exports[`HeroEarnCard snapshot > hero card with link matches snapshot 1`] = `
 <div>
   <a
-    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-fvpjsp-MuiTypography-root-MuiLink-root"
+    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1u8xbgg-MuiTypography-root-MuiLink-root"
     href="/earn/moonwell-flagship-usdc-on-base"
   >
     <div
-      class="MuiBox-root css-1t5s2yj"
+      class="MuiBox-root css-yyhbh8"
     >
       <div
         class="MuiStack-root css-imab1l-MuiStack-root"
@@ -207,10 +207,10 @@ exports[`HeroEarnCard snapshot > hero card with link matches snapshot 1`] = `
         class="MuiStack-root css-185w891-MuiStack-root"
       >
         <div
-          class="MuiStack-root css-69zndg-MuiStack-root"
+          class="MuiStack-root css-4n2h5n-MuiStack-root"
         >
           <div
-            class="MuiBox-root css-h1oaii"
+            class="MuiBox-root css-u70uxf"
             data-testid="protocol-morpho"
           >
             <div
@@ -280,7 +280,7 @@ exports[`HeroEarnCard snapshot > hero card with link matches snapshot 1`] = `
 exports[`HeroEarnCard snapshot > hero card with loading matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1ug8t68"
+    class="MuiBox-root css-gpbse"
   >
     <div
       class="MuiStack-root css-imab1l-MuiStack-root"
@@ -302,10 +302,10 @@ exports[`HeroEarnCard snapshot > hero card with loading matches snapshot 1`] = `
       class="MuiStack-root css-185w891-MuiStack-root"
     >
       <div
-        class="MuiStack-root css-69zndg-MuiStack-root"
+        class="MuiStack-root css-4n2h5n-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-cmx6on"
+          class="MuiBox-root css-1lr3mj0"
         >
           <span
             class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-f9555f-MuiSkeleton-root"
@@ -323,7 +323,7 @@ exports[`HeroEarnCard snapshot > hero card with loading matches snapshot 1`] = `
 exports[`HeroEarnCard snapshot > hero card with single asset matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-vs3jgl"
+    class="MuiBox-root css-1y44ltr"
   >
     <div
       class="MuiStack-root css-imab1l-MuiStack-root"
@@ -387,10 +387,10 @@ exports[`HeroEarnCard snapshot > hero card with single asset matches snapshot 1`
       class="MuiStack-root css-185w891-MuiStack-root"
     >
       <div
-        class="MuiStack-root css-69zndg-MuiStack-root"
+        class="MuiStack-root css-4n2h5n-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-h1oaii"
+          class="MuiBox-root css-u70uxf"
           data-testid="protocol-morpho"
         >
           <div
@@ -451,7 +451,7 @@ exports[`HeroEarnCard snapshot > hero card with single asset matches snapshot 1`
           </div>
         </div>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary css-181aqyq-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary css-zben4u-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >

--- a/src/components/Containers/PageContainer.tsx
+++ b/src/components/Containers/PageContainer.tsx
@@ -7,7 +7,7 @@ export const PageContainer: FC<PropsWithChildren> = ({ children }) => {
       sx={{
         px: { xs: 2, md: 4 },
         mt: 6,
-        mb: { xs: 12, md: 5.5 },
+        pb: { xs: 12, md: 5.5 },
         // We need to cover a width of 1080px + paddingX
         maxWidth: '1144px !important',
         position: 'relative',

--- a/src/components/EarnFilterBar/EarnFilterBar.styles.ts
+++ b/src/components/EarnFilterBar/EarnFilterBar.styles.ts
@@ -9,12 +9,15 @@ export const EarnFilterBarContainer = styled(Box)(({ theme }) => ({
   borderRadius: theme.shape.cardBorderRadius,
   boxShadow: theme.shadows[2],
   backgroundColor: (theme.vars || theme).palette.surface1.main,
-  padding: theme.spacing(3),
+  padding: theme.spacing(2),
   gap: theme.spacing(2),
   overflow: 'hidden',
   ...theme.applyStyles('dark', {
     backgroundColor: (theme.vars || theme).palette.surface2.main,
   }),
+  [theme.breakpoints.up('md')]: {
+    padding: theme.spacing(3),
+  },
 }));
 
 export const EarnFilterBarHeaderContainer = styled(Box)(({ theme }) => ({

--- a/src/components/EarnFilterBar/EarnFilterBar.tsx
+++ b/src/components/EarnFilterBar/EarnFilterBar.tsx
@@ -73,6 +73,9 @@ export const EarnFilterBar: React.FC<EarnFilterBarProps> = ({
           sx={(theme) => ({
             flex: '0 0 auto',
             backgroundColor: `${(theme.vars || theme).palette.alpha100.main} !important`,
+            '.MuiTabs-list': {
+              gap: theme.spacing(0.5),
+            },
           })}
         />
         {/* TODO: add latest update in backend and render here */}

--- a/src/components/composite/DepositButton/DepositButton.styles.tsx
+++ b/src/components/composite/DepositButton/DepositButton.styles.tsx
@@ -85,6 +85,7 @@ export const DepositButtonLabelWrapper = styled(Box, {
 export const DepositButtonPrimary = styled(ButtonPrimary)(({ theme }) => ({
   minWidth: 'auto',
   height: 'fit-content',
+  flexShrink: 0,
   borderRadius: theme.shape.buttonBorderRadius,
   '&:disabled': {
     backgroundColor: (theme.vars || theme).palette.buttonDisabledBg,

--- a/src/components/composite/DepositButton/__snapshots__/DepositButton.snapshot.spec.tsx.snap
+++ b/src/components/composite/DepositButton/__snapshots__/DepositButton.snapshot.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`DepositButton snapshot > disabled state matches snapshot 1`] = `
 <div>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-o57fdb-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-rvb98k-MuiButtonBase-root-MuiButton-root"
     disabled=""
     tabindex="-1"
     type="button"
@@ -40,7 +40,7 @@ exports[`DepositButton snapshot > disabled state matches snapshot 1`] = `
 exports[`DepositButton snapshot > icon and label matches snapshot 1`] = `
 <div>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-o57fdb-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-rvb98k-MuiButtonBase-root-MuiButton-root"
     tabindex="0"
     type="button"
   >
@@ -76,7 +76,7 @@ exports[`DepositButton snapshot > icon and label matches snapshot 1`] = `
 exports[`DepositButton snapshot > icon and label with large size matches snapshot 1`] = `
 <div>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary css-181aqyq-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary css-zben4u-MuiButtonBase-root-MuiButton-root"
     tabindex="0"
     type="button"
   >
@@ -112,7 +112,7 @@ exports[`DepositButton snapshot > icon and label with large size matches snapsho
 exports[`DepositButton snapshot > icon and label with small size matches snapshot 1`] = `
 <div>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-1l19amm-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-e6v5za-MuiButtonBase-root-MuiButton-root"
     tabindex="0"
     type="button"
   >
@@ -148,7 +148,7 @@ exports[`DepositButton snapshot > icon and label with small size matches snapsho
 exports[`DepositButton snapshot > icon only mode matches snapshot 1`] = `
 <div>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-o57fdb-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-rvb98k-MuiButtonBase-root-MuiButton-root"
     tabindex="0"
     type="button"
   >
@@ -179,7 +179,7 @@ exports[`DepositButton snapshot > icon only mode matches snapshot 1`] = `
 exports[`DepositButton snapshot > icon only with large size matches snapshot 1`] = `
 <div>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary css-181aqyq-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary css-zben4u-MuiButtonBase-root-MuiButton-root"
     tabindex="0"
     type="button"
   >
@@ -210,7 +210,7 @@ exports[`DepositButton snapshot > icon only with large size matches snapshot 1`]
 exports[`DepositButton snapshot > icon only with small size matches snapshot 1`] = `
 <div>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-1l19amm-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-e6v5za-MuiButtonBase-root-MuiButton-root"
     tabindex="0"
     type="button"
   >
@@ -241,7 +241,7 @@ exports[`DepositButton snapshot > icon only with small size matches snapshot 1`]
 exports[`DepositButton snapshot > label only mode matches snapshot 1`] = `
 <div>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-o57fdb-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-rvb98k-MuiButtonBase-root-MuiButton-root"
     tabindex="0"
     type="button"
   >
@@ -261,7 +261,7 @@ exports[`DepositButton snapshot > label only mode matches snapshot 1`] = `
 exports[`DepositButton snapshot > label only with large size matches snapshot 1`] = `
 <div>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary css-181aqyq-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary css-zben4u-MuiButtonBase-root-MuiButton-root"
     tabindex="0"
     type="button"
   >
@@ -281,7 +281,7 @@ exports[`DepositButton snapshot > label only with large size matches snapshot 1`
 exports[`DepositButton snapshot > label only with small size matches snapshot 1`] = `
 <div>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-1l19amm-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-e6v5za-MuiButtonBase-root-MuiButton-root"
     tabindex="0"
     type="button"
   >

--- a/src/components/composite/EntityChainStack/EntityChainStack.styles.ts
+++ b/src/components/composite/EntityChainStack/EntityChainStack.styles.ts
@@ -1,11 +1,21 @@
 import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 
-export const EntityChainContainer = styled(Box)(({}) => ({
+interface EntityChainContainerProps {
+  isContentVisible?: boolean;
+}
+
+export const EntityChainContainer = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'isContentVisible',
+})<EntityChainContainerProps>(({ theme, isContentVisible }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
   gap: 16,
+  ...(isContentVisible && {
+    minWidth: 0,
+    overflow: 'hidden',
+  }),
 }));
 
 export const EntityChainStackWrapper = styled(Box)(({}) => ({

--- a/src/components/composite/EntityChainStack/variants/BaseChainStack.tsx
+++ b/src/components/composite/EntityChainStack/variants/BaseChainStack.tsx
@@ -81,7 +81,11 @@ export const BaseChainStack: FC<BaseChainStackProps> = ({
   );
 
   return (
-    <EntityChainContainer gap={spacing.containerGap} data-testid={dataTestId}>
+    <EntityChainContainer
+      gap={spacing.containerGap}
+      data-testid={dataTestId}
+      isContentVisible={isContentVisible}
+    >
       <EntityChainStackWrapper>
         {mainStack}
         {chainsPlacement === EntityChainStackChainsPlacement.Overlay && (

--- a/src/components/core/form/Select/__snapshots__/Select.snapshot.spec.tsx.snap
+++ b/src/components/core/form/Select/__snapshots__/Select.snapshot.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`Select snapshot > matches snapshot 1`] = `
           class="MuiBox-root css-1a18fce"
         >
           <div
-            class="MuiBox-root css-1ht30bk"
+            class="MuiBox-root css-466uax"
           >
             <p
               class="MuiTypography-root MuiTypography-bodySmallStrong css-19wdc5t-MuiTypography-root"
@@ -71,7 +71,7 @@ exports[`Select snapshot > matches snapshot with filter 1`] = `
           class="MuiBox-root css-1a18fce"
         >
           <div
-            class="MuiBox-root css-1ht30bk"
+            class="MuiBox-root css-466uax"
           >
             <p
               class="MuiTypography-root MuiTypography-bodySmallStrong css-19wdc5t-MuiTypography-root"
@@ -123,7 +123,7 @@ exports[`Select snapshot > matches snapshot with icons 1`] = `
           class="MuiBox-root css-1a18fce"
         >
           <div
-            class="MuiBox-root css-1ht30bk"
+            class="MuiBox-root css-466uax"
           >
             <p
               class="MuiTypography-root MuiTypography-bodySmallStrong css-19wdc5t-MuiTypography-root"
@@ -175,7 +175,7 @@ exports[`Select snapshot > matches snapshot with selected value 1`] = `
           class="MuiBox-root css-1a18fce"
         >
           <div
-            class="MuiBox-root css-1ht30bk"
+            class="MuiBox-root css-466uax"
           >
             <p
               class="MuiTypography-root MuiTypography-bodySmallStrong css-19wdc5t-MuiTypography-root"
@@ -236,7 +236,7 @@ exports[`Select snapshot > matches snapshot with single select 1`] = `
           class="MuiBox-root css-1a18fce"
         >
           <div
-            class="MuiBox-root css-1ht30bk"
+            class="MuiBox-root css-466uax"
           >
             <p
               class="MuiTypography-root MuiTypography-bodySmallStrong css-19wdc5t-MuiTypography-root"
@@ -288,7 +288,7 @@ exports[`Select snapshot > matches snapshot with slider select 1`] = `
           class="MuiBox-root css-1a18fce"
         >
           <div
-            class="MuiBox-root css-1ht30bk"
+            class="MuiBox-root css-466uax"
           >
             <p
               class="MuiTypography-root MuiTypography-bodySmallStrong css-19wdc5t-MuiTypography-root"


### PR DESCRIPTION
Contributes to https://lifi.atlassian.net/browse/LF-16343

The purpose of this PR is to handle earn cards and sections styling on mobile

## Testing steps
1. Go to `/earn`
2. Ensure the earn cars and sections containers are styled as per [Figma](https://www.figma.com/design/JUaT4CQ9YSCQ4IWsQQSRIK/Earn--Webpage-?node-id=3507-75580&t=RBo17PxPmmEYKf0U-11)