### PR TITLE
fix: recreate maps in PortfolioStore for proper change detection

### DIFF
--- a/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
+++ b/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
@@ -86,7 +86,7 @@ export const WalletBalanceCard: FC<WalletBalanceCardProps> = ({
       />
       <Stack>
         {!isSuccess &&
-          data.length == 0 &&
+          tokens.length == 0 &&
           Array.from({ length: 8 }).map(() => (
             <TokenListCardSkeleton key={generateKey('token')} />
           ))}

--- a/src/stores/portfolio/PortfolioStore.tsx
+++ b/src/stores/portfolio/PortfolioStore.tsx
@@ -1,4 +1,3 @@
-import type { StateCreator } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { shallow } from 'zustand/shallow';
 import { createWithEqualityFn } from 'zustand/traditional';
@@ -9,6 +8,12 @@ import type {
 } from '@/utils/getTokens';
 import { createJSONStorage } from 'zustand/middleware';
 import type { Account } from '@lifi/wallet-management';
+
+export function getOrCreateMap<T>(
+  data: Map<string, T> | { [key: string]: T },
+): Map<string, T> {
+  return new Map(data instanceof Map ? data : Object.entries(data));
+}
 
 function cacheTokenPartialize({
   address,
@@ -54,8 +59,8 @@ export const usePortfolioStore = createWithEqualityFn(
       ...defaultSettings,
 
       setLast(address: string, value: number, date: number) {
-        const lastTotalValue = get().lastTotalValue;
-        const lastDate = get().lastDate;
+        const lastTotalValue = getOrCreateMap(get().lastTotalValue);
+        const lastDate = getOrCreateMap(get().lastDate);
         lastTotalValue.set(address, value);
         lastDate.set(address, date);
         set({
@@ -72,7 +77,7 @@ export const usePortfolioStore = createWithEqualityFn(
         };
       },
       setForceRefresh(address: string, state: boolean) {
-        const forceRefresh = get().forceRefresh;
+        const forceRefresh = getOrCreateMap(get().forceRefresh);
         if (state) {
           forceRefresh.set(address, true);
         } else {
@@ -83,10 +88,10 @@ export const usePortfolioStore = createWithEqualityFn(
         });
       },
       deleteCacheTokenAddress(address: string) {
-        const cacheTokens = get().cacheTokens;
-        const lastTotalValue = get().lastTotalValue;
-        const lastDate = get().lastDate;
-        const forceRefresh = get().forceRefresh;
+        const cacheTokens = getOrCreateMap(get().cacheTokens);
+        const lastTotalValue = getOrCreateMap(get().lastTotalValue);
+        const lastDate = getOrCreateMap(get().lastDate);
+        const forceRefresh = getOrCreateMap(get().forceRefresh);
 
         cacheTokens.delete(address);
         lastTotalValue.delete(address);
@@ -129,7 +134,7 @@ export const usePortfolioStore = createWithEqualityFn(
         };
       },
       setCacheTokens(account: string, tokens: ExtendedTokenAmount[]) {
-        const cacheTokens = get().cacheTokens;
+        const cacheTokens = getOrCreateMap(get().cacheTokens);
         cacheTokens.set(account, tokens.map(cacheTokenPartialize));
 
         set({


### PR DESCRIPTION
Contributes to https://lifi.atlassian.net/browse/LF-16194

## Testing steps
1. Open dev tools
2. Go to Application
3. Delete the `jumper-portfolio` - just to ease the testing

<img width="657" height="688" alt="Screenshot 2025-11-07 at 19 47 57" src="https://github.com/user-attachments/assets/67540367-e3f8-4c7a-b6ea-1195602e55a1" />


4. Now connect a wallet
5. Open the wallet sheet
6. Check that once total balance shows up, also a list of tokens is shown
7. While the balance changes, more tokens should be added to the list
8. Disconnect and connect another wallet
9. Repeat steps `5.-7.`