### PR TITLE
fix: mission verify wallet status message animation

### DIFF
--- a/src/app/ui/mission/MissionWidget/MissionVerifyWallet.tsx
+++ b/src/app/ui/mission/MissionWidget/MissionVerifyWallet.tsx
@@ -2,17 +2,21 @@ import { useAccount, useWalletMenu } from '@lifi/wallet-management';
 import { FC, useEffect, useState } from 'react';
 import CheckIcon from '@mui/icons-material/Check';
 import { Trans, useTranslation } from 'react-i18next';
+import { motion } from 'framer-motion';
 import { Badge } from 'src/components/Badge/Badge';
 import { BadgeSize, BadgeVariant } from 'src/components/Badge/Badge.styles';
 import { Button } from 'src/components/Button';
 import { SectionCardContainer } from 'src/components/Cards/SectionCard/SectionCard.style';
 import { StatusBottomSheet } from 'src/components/composite/StatusBottomSheet/StatusBottomSheet';
+import { HeightAnimatedContainer } from 'src/components/core/HeightAnimatedContainer/HeightAnimatedContainer';
 import { SignMessageErrorType, useSignMessage } from 'src/hooks/useSignMessage';
 import { useVerifyTaskWithSharedState } from 'src/hooks/tasksVerification/useVerifyTaskWithSharedState';
 import { useMissionStore } from 'src/stores/mission/MissionStore';
 import { walletDigest } from 'src/utils/walletDigest';
 import { useVerifyWalletStatusSheetContent } from '../hooks';
 import {
+  ANIMATION_DURATION_SECONDS,
+  BOTTOM_SHEET_TOP_OFFSET,
   VERIFY_WALLET_CONTAINER_ID,
   VERIFY_WALLET_MESSAGE,
 } from '../constants';
@@ -26,7 +30,6 @@ import {
 import { Link } from 'src/components/Link';
 import { DISCORD_URL } from 'src/const/urls';
 import { ParseKeys } from 'i18next';
-import { motion } from 'framer-motion';
 
 interface MissionVerifyWalletProps {
   isComplete: boolean;
@@ -45,7 +48,6 @@ export const MissionVerifyWallet: FC<MissionVerifyWalletProps> = ({
     SignMessageErrorType.Unknown,
   );
   const [showError, setShowError] = useState(false);
-  const [statusBottomSheetHeight, setStatusBottomSheetHeight] = useState(0);
 
   const {
     signMessageAsync,
@@ -198,43 +200,41 @@ export const MissionVerifyWallet: FC<MissionVerifyWalletProps> = ({
   };
 
   return (
-    <motion.div
-      initial={{ height: 'auto' }}
-      animate={{
-        height: showError ? statusBottomSheetHeight + 24 : 'auto',
-      }}
-      transition={{ duration: 0.3, ease: 'easeInOut' }}
-      style={{
-        overflow: 'hidden',
-        display: 'flex',
-        flexDirection: 'column',
-      }}
+    <HeightAnimatedContainer
+      isOpen={showError}
+      offsetHeight={BOTTOM_SHEET_TOP_OFFSET}
+      animationDuration={ANIMATION_DURATION_SECONDS}
     >
-      <SectionCardContainer
-        as="form"
-        onSubmit={handleSubmit}
-        id={VERIFY_WALLET_CONTAINER_ID}
-        sx={{
-          position: 'relative',
-          overflow: 'hidden',
-          display: 'flex',
-          height: '100%',
-        }}
-      >
-        <MissionWidgetContainer
-          sx={{ height: 'auto', justifyContent: 'space-between' }}
-        >
-          {renderContent()}
+      {({ motionProps, onHeightChange }) => (
+        <motion.div {...motionProps}>
+          <SectionCardContainer
+            as="form"
+            onSubmit={handleSubmit}
+            id={VERIFY_WALLET_CONTAINER_ID}
+            sx={{
+              position: 'relative',
+              overflow: 'hidden',
+              display: 'flex',
+              height: '100%',
+            }}
+          >
+            <MissionWidgetContainer sx={{ justifyContent: 'space-between' }}>
+              {renderContent()}
 
-          <StatusBottomSheet
-            {...errorSheetProps}
-            containerId={VERIFY_WALLET_CONTAINER_ID}
-            isOpen={showError}
-            onClose={handleCloseErrorBottomSheet}
-            onHeightChange={setStatusBottomSheetHeight}
-          />
-        </MissionWidgetContainer>
-      </SectionCardContainer>
-    </motion.div>
+              <StatusBottomSheet
+                {...errorSheetProps}
+                containerId={VERIFY_WALLET_CONTAINER_ID}
+                isOpen={showError}
+                onClose={handleCloseErrorBottomSheet}
+                onHeightChange={onHeightChange}
+                transitionDuration={{
+                  enter: ANIMATION_DURATION_SECONDS * 1_000,
+                }}
+              />
+            </MissionWidgetContainer>
+          </SectionCardContainer>
+        </motion.div>
+      )}
+    </HeightAnimatedContainer>
   );
 };

--- a/src/app/ui/mission/MissionWidget/MissionVerifyWallet.tsx
+++ b/src/app/ui/mission/MissionWidget/MissionVerifyWallet.tsx
@@ -26,6 +26,7 @@ import {
 import { Link } from 'src/components/Link';
 import { DISCORD_URL } from 'src/const/urls';
 import { ParseKeys } from 'i18next';
+import { motion } from 'framer-motion';
 
 interface MissionVerifyWalletProps {
   isComplete: boolean;
@@ -197,30 +198,43 @@ export const MissionVerifyWallet: FC<MissionVerifyWalletProps> = ({
   };
 
   return (
-    <SectionCardContainer
-      as="form"
-      onSubmit={handleSubmit}
-      id={VERIFY_WALLET_CONTAINER_ID}
-      sx={{
-        position: 'relative',
+    <motion.div
+      initial={{ height: 'auto' }}
+      animate={{
+        height: showError ? statusBottomSheetHeight + 24 : 'auto',
+      }}
+      transition={{ duration: 0.3, ease: 'easeInOut' }}
+      style={{
         overflow: 'hidden',
         display: 'flex',
-        minHeight: showError ? statusBottomSheetHeight + 24 : 'auto',
+        flexDirection: 'column',
       }}
     >
-      <MissionWidgetContainer
-        sx={{ height: 'auto', justifyContent: 'space-between' }}
+      <SectionCardContainer
+        as="form"
+        onSubmit={handleSubmit}
+        id={VERIFY_WALLET_CONTAINER_ID}
+        sx={{
+          position: 'relative',
+          overflow: 'hidden',
+          display: 'flex',
+          height: '100%',
+        }}
       >
-        {renderContent()}
+        <MissionWidgetContainer
+          sx={{ height: 'auto', justifyContent: 'space-between' }}
+        >
+          {renderContent()}
 
-        <StatusBottomSheet
-          {...errorSheetProps}
-          containerId={VERIFY_WALLET_CONTAINER_ID}
-          isOpen={showError}
-          onClose={handleCloseErrorBottomSheet}
-          onHeightChange={setStatusBottomSheetHeight}
-        />
-      </MissionWidgetContainer>
-    </SectionCardContainer>
+          <StatusBottomSheet
+            {...errorSheetProps}
+            containerId={VERIFY_WALLET_CONTAINER_ID}
+            isOpen={showError}
+            onClose={handleCloseErrorBottomSheet}
+            onHeightChange={setStatusBottomSheetHeight}
+          />
+        </MissionWidgetContainer>
+      </SectionCardContainer>
+    </motion.div>
   );
 };

--- a/src/app/ui/mission/constants.ts
+++ b/src/app/ui/mission/constants.ts
@@ -1,3 +1,7 @@
 export const VERIFY_WALLET_MESSAGE = 'Verify ownership for Jumper mission';
 
-export const VERIFY_WALLET_CONTAINER_ID = 'VERIFY_WALLET_CONTAINER_ID';
+export const VERIFY_WALLET_CONTAINER_ID = 'verify-wallet-container';
+
+export const BOTTOM_SHEET_TOP_OFFSET = 24;
+
+export const ANIMATION_DURATION_SECONDS = 0.3;

--- a/src/components/composite/StatusBottomSheet/StatusBottomSheet.tsx
+++ b/src/components/composite/StatusBottomSheet/StatusBottomSheet.tsx
@@ -4,6 +4,7 @@ import Typography from '@mui/material/Typography';
 import {
   BottomSheet,
   BottomSheetBase,
+  BottomSheetProps,
 } from 'src/components/core/BottomSheet/BottomSheet';
 import { Button } from 'src/components/Button/Button';
 import {
@@ -22,6 +23,7 @@ interface StatusBottomSheetProps {
   onClick?: () => void;
   onClose?: () => void;
   onHeightChange?: (height: number) => void;
+  transitionDuration?: BottomSheetProps['transitionDuration'];
 }
 
 export const StatusBottomSheet: FC<StatusBottomSheetProps> = ({
@@ -34,6 +36,7 @@ export const StatusBottomSheet: FC<StatusBottomSheetProps> = ({
   onClick,
   onClose,
   onHeightChange,
+  transitionDuration,
 }) => {
   const bottomSheetRef = useRef<BottomSheetBase>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -95,6 +98,7 @@ export const StatusBottomSheet: FC<StatusBottomSheetProps> = ({
       ref={bottomSheetRef}
       backdropFilter="blur(16px)"
       onClose={onClose}
+      transitionDuration={transitionDuration}
     >
       <StyledModalContentContainer
         ref={containerRef}

--- a/src/components/core/BottomSheet/BottomSheet.tsx
+++ b/src/components/core/BottomSheet/BottomSheet.tsx
@@ -1,6 +1,5 @@
-import Drawer from '@mui/material/Drawer';
+import Drawer, { DrawerProps } from '@mui/material/Drawer';
 import {
-  FC,
   PropsWithChildren,
   forwardRef,
   startTransition,
@@ -19,12 +18,13 @@ export interface BottomSheetBase {
   close(): void;
 }
 
-interface BottomSheetProps extends PropsWithChildren {
+export interface BottomSheetProps extends PropsWithChildren {
   open?: boolean;
   onClose?: () => void;
   containerId: string;
   elementRef?: RefObject<HTMLDivElement>;
   backdropFilter?: string;
+  transitionDuration?: DrawerProps['transitionDuration'];
 }
 
 export const BottomSheet = forwardRef<BottomSheetBase, BottomSheetProps>(
@@ -36,6 +36,7 @@ export const BottomSheet = forwardRef<BottomSheetBase, BottomSheetProps>(
       open = false,
       onClose,
       backdropFilter,
+      transitionDuration,
     },
     ref,
   ) => {
@@ -102,9 +103,7 @@ export const BottomSheet = forwardRef<BottomSheetBase, BottomSheetProps>(
           container: container,
           style: { position: 'absolute' },
         }}
-        transitionDuration={{
-          enter: 300,
-        }}
+        transitionDuration={transitionDuration}
         slotProps={{
           transition: {
             direction: 'up',

--- a/src/components/core/BottomSheet/BottomSheet.tsx
+++ b/src/components/core/BottomSheet/BottomSheet.tsx
@@ -102,6 +102,9 @@ export const BottomSheet = forwardRef<BottomSheetBase, BottomSheetProps>(
           container: container,
           style: { position: 'absolute' },
         }}
+        transitionDuration={{
+          enter: 300,
+        }}
         slotProps={{
           transition: {
             direction: 'up',

--- a/src/components/core/HeightAnimatedContainer/HeightAnimatedContainer.tsx
+++ b/src/components/core/HeightAnimatedContainer/HeightAnimatedContainer.tsx
@@ -1,0 +1,62 @@
+import { FC, ReactNode, useState, useCallback } from 'react';
+import { MotionProps } from 'framer-motion';
+
+export interface HeightAnimatedContainerRenderProps {
+  height: number;
+  onHeightChange: (height: number) => void;
+  motionProps: MotionProps;
+}
+
+export interface HeightAnimatedContainerProps {
+  isOpen: boolean;
+  offsetHeight?: number;
+  animationDuration?: number;
+  animationEase?:
+    | 'easeInOut'
+    | 'easeIn'
+    | 'easeOut'
+    | 'linear'
+    | 'circIn'
+    | 'circOut'
+    | 'circInOut'
+    | 'backIn'
+    | 'backOut'
+    | 'backInOut'
+    | 'anticipate';
+  children: (renderProps: HeightAnimatedContainerRenderProps) => ReactNode;
+}
+
+export const HeightAnimatedContainer: FC<HeightAnimatedContainerProps> = ({
+  isOpen,
+  offsetHeight = 0,
+  animationDuration = 0.3,
+  animationEase = 'easeInOut',
+  children,
+}) => {
+  const [height, setHeight] = useState(0);
+
+  const handleHeightChange = useCallback((newHeight: number) => {
+    setHeight(newHeight);
+  }, []);
+
+  const motionProps: MotionProps = {
+    initial: { height: 'auto' },
+    animate: {
+      height: isOpen ? height + offsetHeight : 'auto',
+    },
+    transition: {
+      duration: animationDuration,
+      ease: animationEase,
+    },
+  };
+
+  return (
+    <>
+      {children({
+        height,
+        onHeightChange: handleHeightChange,
+        motionProps,
+      })}
+    </>
+  );
+};


### PR DESCRIPTION
Tackles the animation shown for the status bottom sheet on the verify wallet ownership mission widget. 
Added `HeightAnimatedContainer` so we can reuse it for the withdraw modal widget as discussed w/ design