### PR TITLE
fix: update border radius for widget theme containers

### DIFF
--- a/src/config/widgetConfig.ts
+++ b/src/config/widgetConfig.ts
@@ -129,7 +129,7 @@ export const getDefaultWidgetThemeV2 = (
         },
         chainSidebarContainer: {
           [copiedTheme.breakpoints.up('sm' as Breakpoint)]: {
-            borderRadius: '12px',
+            borderRadius: '24px',
             maxWidth: 256,
             minWidth: 256,
             maxHeight: WIDGET_HEIGHT,
@@ -138,7 +138,7 @@ export const getDefaultWidgetThemeV2 = (
         },
         routesContainer: {
           [copiedTheme.breakpoints.up('sm' as Breakpoint)]: {
-            borderRadius: '12px',
+            borderRadius: '24px',
             maxWidth: 436,
             minWidth: 436,
             boxShadow: copiedTheme.shadows[1],


### PR DESCRIPTION
### Before

<img width="729" height="716" alt="image" src="https://github.com/user-attachments/assets/5e71765b-b054-4ac2-9c93-56dfda345483" />

### After

<img width="743" height="755" alt="image" src="https://github.com/user-attachments/assets/55bf6377-7da4-45a6-90be-9409ad179c06" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted widget container border radius at smaller breakpoints for a more refined visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->