### PR TITLE
feat: withdraw flow

### DIFF
--- a/src/app/[lng]/(main)/test-withdraw-flow/page.tsx
+++ b/src/app/[lng]/(main)/test-withdraw-flow/page.tsx
@@ -1,0 +1,120 @@
+'use client';
+import { useState } from 'react';
+import Stack from '@mui/material/Stack';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+
+import { WithdrawFlowButton } from 'src/components/composite/WithdrawFlow/WithdrawFlow';
+import { WithdrawFlowModal } from 'src/components/composite/WithdrawFlow/WithdrawFlow';
+import { ConnectButton } from 'src/components/ConnectButton';
+import { useIsDisconnected } from 'src/components/Navbar/hooks';
+import { WalletMenuToggle } from 'src/components/Navbar/components/Buttons/WalletMenuToggle';
+
+import type { EarnOpportunityExtended } from 'src/stores/withdrawFlow/WithdrawFlowStore';
+
+const mockEarnOpportunity: EarnOpportunityExtended = {
+  name: 'morpho',
+  slug: 'morpho',
+  protocol: {
+    name: 'morpho',
+    product: 'morpho',
+    version: '1.0.0',
+    logo: 'logo',
+  },
+  description: 'morpho',
+  tags: ['morpho'],
+  rewards: ['morpho'],
+  featured: true,
+  forYou: true,
+  address: '0xE4248e2105508FcBad3fe95691551d1AF14015f7',
+  url: 'https://morpho.org/',
+  positionUrl:
+    'https://app.morpho.org/katana/vault/0xE4248e2105508FcBad3fe95691551d1AF14015f7/gauntlet-weth',
+  minFromAmountUSD: 0.29,
+  asset: {
+    name: 'Asset',
+    symbol: 'ASSET',
+    decimals: 18,
+    logo: 'logo',
+    address: '0xE4248e2105508FcBad3fe95691551d1AF14015f7',
+    chain: { chainId: 747474, chainKey: 'katana' },
+  },
+  lpToken: {
+    name: 'LP Token',
+    symbol: 'LP',
+    decimals: 18,
+    logo: 'logo',
+    address: '0xE4248e2105508FcBad3fe95691551d1AF14015f7',
+    chain: { chainId: 747474, chainKey: 'katana' },
+  },
+  latest: {
+    date: '2021-01-01',
+    tvlUsd: '1000000',
+    tvlNative: '1000000',
+    apy: {
+      base: 5.5,
+      reward: 0,
+      total: 5.5,
+    },
+  },
+};
+
+export default function TestWithdrawFlowPage() {
+  const isDisconnected = useIsDisconnected();
+  const [showTestInfo] = useState(true);
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" sx={{ mb: 3 }}>
+        WithdrawFlow Test Page
+      </Typography>
+
+      {showTestInfo && (
+        <Box
+          sx={{
+            mb: 3,
+            p: 2,
+            bgcolor: 'info.light',
+            borderRadius: 1,
+            border: '1px solid',
+            borderColor: 'info.main',
+          }}
+        >
+          <Typography variant="body2">
+            This page tests the WithdrawFlow components with mock earn
+            opportunity data from the Storybook story.
+          </Typography>
+        </Box>
+      )}
+
+      <Stack direction="row" spacing={2} sx={{ mb: 3 }}>
+        {isDisconnected ? <ConnectButton /> : <WalletMenuToggle />}
+        <WithdrawFlowButton
+          earnOpportunity={mockEarnOpportunity}
+          refetchCallback={() => console.log('Refetch callback triggered')}
+        />
+      </Stack>
+
+      <WithdrawFlowModal />
+
+      <Box sx={{ mt: 4, p: 2, bgcolor: 'background.paper', borderRadius: 1 }}>
+        <Typography variant="h6" sx={{ mb: 2 }}>
+          Mock Earn Opportunity Data:
+        </Typography>
+        <Box
+          component="pre"
+          sx={{
+            p: 2,
+            bgcolor: 'grey.100',
+            borderRadius: 1,
+            overflow: 'auto',
+            fontSize: '0.875rem',
+          }}
+        >
+          {JSON.stringify(mockEarnOpportunity, null, 2)}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/Cards/SelectCard/SelectCard.styles.ts
+++ b/src/components/Cards/SelectCard/SelectCard.styles.ts
@@ -1,9 +1,13 @@
-import Box, { BoxProps } from '@mui/material/Box';
+import type { BoxProps } from '@mui/material/Box';
+import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
-import InputBase, { InputBaseProps } from '@mui/material/InputBase';
+import type { InputBaseProps } from '@mui/material/InputBase';
+import InputBase from '@mui/material/InputBase';
 import InputLabel from '@mui/material/InputLabel';
+import type { TypographyProps } from '@mui/material/Typography';
 import Typography from '@mui/material/Typography';
-import { styled, Theme } from '@mui/material/styles';
+import type { Theme } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 
 export enum SelectCardMode {
   Display = 'display',
@@ -17,6 +21,7 @@ interface SelectCardContainerProps extends BoxProps {
 export const SelectCardContainer = styled(Card, {
   shouldForwardProp: (prop) => prop !== 'isClickable',
 })<SelectCardContainerProps>(({ theme, isClickable }) => ({
+  width: '100%',
   borderRadius: theme.shape.borderRadius,
   boxShadow: theme.shadows[2],
   background: (theme.vars || theme).palette.surface2.main,
@@ -34,7 +39,7 @@ export const SelectCardContainer = styled(Card, {
 export const SelectCardContentContainer = styled(Box)(({ theme }) => ({
   width: '100%',
   display: 'flex',
-  gap: theme.spacing(1.25),
+  gap: theme.spacing(2),
   alignItems: 'center',
 }));
 
@@ -42,14 +47,26 @@ export const SelectCardValueContainer = styled(Box)(() => ({
   width: '100%',
   display: 'flex',
   flexDirection: 'column',
+  overflow: 'hidden',
 }));
 
 export const SelectCardLabel = styled(InputLabel)(({ theme }) => ({
   ...theme.typography.bodySmallStrong,
 }));
 
-export const SelectCardDescription = styled(Typography)(({ theme }) => ({
-  color: (theme.vars || theme).palette.alpha800.main,
+interface SelectCardDescriptionProps extends TypographyProps {
+  hideOverflow?: boolean;
+}
+
+export const SelectCardDescription = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== 'hideOverflow',
+})<SelectCardDescriptionProps>(({ theme, hideOverflow }) => ({
+  color: (theme.vars || theme).palette.text.secondary,
+  ...(hideOverflow && {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  }),
 }));
 
 export const getPlaceholderTextStyles = (theme: Theme) => ({
@@ -70,6 +87,7 @@ export const SelectCardInputField = styled(InputBase, {
 })<SelectCardInputFieldProps>(({ theme, isAmount }) => ({
   '& input': {
     ...theme.typography.bodyLargeStrong,
+    height: 'auto',
     paddingTop: 0,
     paddingBottom: theme.spacing(0.25),
   },

--- a/src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget.tsx
@@ -32,9 +32,9 @@ export const ZapWithdrawWidget: FC<ZapWithdrawWidgetProps> = ({
     isLoadingDepositTokenData,
     refetchDepositToken,
   } = useGetZapInPoolBalance(
-    account.address as Hex,
-    (projectData.tokenAddress as Hex) || (projectData.address as Hex),
-    projectData.chainId,
+    account?.address as Hex,
+    (projectData?.tokenAddress as Hex) || (projectData?.address as Hex),
+    projectData?.chainId,
   );
 
   const poolName = useMemo(() => {

--- a/src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget.tsx
@@ -1,30 +1,41 @@
-import { FC, useMemo } from 'react';
-import { WidgetProps } from '../Widget.types';
+import type { FC } from 'react';
+import { useMemo } from 'react';
+import type { WidgetProps } from '../Widget.types';
 import { WithdrawWidget } from 'src/components/ZapWidget/WithdrawWidget/WithdrawWidget';
 import { WidgetSkeleton } from '../WidgetSkeleton';
-import { useEnhancedZapData } from 'src/hooks/zaps/useEnhancedZapData';
 import { useZapQuestIdStorage } from 'src/providers/hooks';
+import type { ZapDataResponse } from '@/providers/ZapInitProvider/ModularZaps/zap.jumper-backend';
+import { useAccount } from '@lifi/wallet-management';
+import { useGetZapInPoolBalance } from '@/hooks/zaps/useGetZapInPoolBalance';
+import type { Hex } from 'viem';
 
-interface ZapWithdrawWidgetProps extends Omit<WidgetProps, 'type'> {}
+interface ZapWithdrawWidgetProps extends Omit<WidgetProps, 'type'> {
+  zapData?: ZapDataResponse | null;
+}
 
 export const ZapWithdrawWidget: FC<ZapWithdrawWidgetProps> = ({
+  zapData,
   customInformation,
   ctx,
 }) => {
   useZapQuestIdStorage();
+
+  const { account } = useAccount();
 
   const projectData = useMemo(() => {
     return customInformation?.projectData;
   }, [customInformation?.projectData]);
 
   const {
-    zapData,
-    isSuccess: isZapDataSuccess,
-    isLoadingDepositTokenData,
     depositTokenData,
     depositTokenDecimals,
+    isLoadingDepositTokenData,
     refetchDepositToken,
-  } = useEnhancedZapData(projectData);
+  } = useGetZapInPoolBalance(
+    account.address as Hex,
+    (projectData.tokenAddress as Hex) || (projectData.address as Hex),
+    projectData.chainId,
+  );
 
   const poolName = useMemo(() => {
     return `${zapData?.meta.name} ${zapData?.market?.depositToken?.symbol.toUpperCase()} Pool`;
@@ -32,7 +43,7 @@ export const ZapWithdrawWidget: FC<ZapWithdrawWidgetProps> = ({
 
   const token = useMemo(
     () =>
-      isZapDataSuccess && zapData
+      zapData
         ? {
             chainId: zapData.market?.depositToken.chainId,
             address: zapData.market?.depositToken.address as `0x${string}`,
@@ -48,7 +59,7 @@ export const ZapWithdrawWidget: FC<ZapWithdrawWidgetProps> = ({
             amount: BigInt(0),
           }
         : null,
-    [isZapDataSuccess, zapData],
+    [zapData],
   );
 
   const lpTokenDecimals = Number(depositTokenDecimals ?? 18);
@@ -63,6 +74,7 @@ export const ZapWithdrawWidget: FC<ZapWithdrawWidgetProps> = ({
       projectData={projectData}
       depositTokenData={depositTokenData}
       withdrawAbi={zapData?.abi?.withdraw}
+      sx={ctx?.theme?.container}
     />
   ) : (
     <WidgetSkeleton />

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawForm.tsx
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawForm.tsx
@@ -1,22 +1,17 @@
-import { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import type { FC } from 'react';
+import { useMemo } from 'react';
 import { WithdrawFormContainer } from './WithdrawWidget.style';
-import { AbiParameter, formatUnits, parseUnits } from 'viem';
+import { formatUnits } from 'viem';
 import { Button } from 'src/components/Button/Button';
 import { ConnectButton } from 'src/components/ConnectButton';
-import {
-  useSwitchChain,
-  useWaitForTransactionReceipt,
-  useWriteContract,
-} from 'wagmi';
 import { useAccount } from '@lifi/wallet-management';
-import { useToken } from 'src/hooks/useToken';
 import { WithdrawInput } from './WithdrawInput';
-import BadgeWithChain from '../BadgeWithChain';
-import { useUserTracking } from 'src/hooks/userTracking/useUserTracking';
-import { TrackingCategory } from 'src/const/trackingKeys';
 import WithdrawInputEndAdornment from './WithdrawInputEndAdornment';
-import { WithdrawFormProps } from './WithdrawWidget.types';
-import { Theme } from '@mui/material/styles';
+import type { WithdrawFormProps } from './WithdrawWidget.types';
+import type { Theme } from '@mui/material/styles';
+import { AvatarSize } from '@/components/core/AvatarStack/AvatarStack.types';
+import { EntityChainStack } from '@/components/composite/EntityChainStack/EntityChainStack';
+import { EntityChainStackVariant } from '@/components/composite/EntityChainStack/EntityChainStack.types';
 
 const buttonStyles = (theme: Theme) => ({
   marginTop: theme.spacing(2),
@@ -24,25 +19,30 @@ const buttonStyles = (theme: Theme) => ({
 });
 
 export const WithdrawForm: FC<WithdrawFormProps> = ({
-  sendWithdrawTx,
-  successDataRef,
-  errorMessage,
-  projectData,
   balance,
   lpTokenDecimals,
   token,
-  poolName,
   overrideStyle,
-  refetchPosition,
   isSubmitDisabled,
   isSubmitLoading,
   submitLabel,
+  setWithdrawValue,
+  withdrawValue,
 }) => {
-  const [value, setValue] = useState<string>('');
   const { account } = useAccount();
-  const { trackEvent } = useUserTracking();
-  const { switchChainAsync } = useSwitchChain();
-  const { token: tokenInfo } = useToken(token.chainId, token.address);
+
+  const tokens = useMemo(() => {
+    return [
+      {
+        address: token.address,
+        name: token.name,
+        symbol: token.symbol,
+        decimals: token.decimals,
+        logo: token.logoURI ?? '',
+        chain: { chainId: token.chainId, chainKey: token.coinKey ?? '' },
+      },
+    ];
+  }, [token]);
 
   const maxFormattedAmount = useMemo(() => {
     return parseFloat(formatUnits(BigInt(balance), lpTokenDecimals));
@@ -51,14 +51,6 @@ export const WithdrawForm: FC<WithdrawFormProps> = ({
   const maxAmount = useMemo(() => {
     return BigInt(balance);
   }, [balance]);
-
-  const helperText = useMemo(
-    () => ({
-      left: 'Available balance',
-      right: balance,
-    }),
-    [balance],
-  );
 
   const hintEndAdornment = useMemo(() => {
     return (
@@ -72,101 +64,50 @@ export const WithdrawForm: FC<WithdrawFormProps> = ({
     );
   }, [maxFormattedAmount]);
 
-  const shouldSwitchChain = useMemo(() => {
-    if (!!projectData?.address && account?.chainId !== projectData?.chainId) {
-      return true;
-    }
-    return false;
-  }, [account?.chainId, projectData]);
-
-  const handleSwitchChain = async (chainId: number) => {
-    try {
-      await switchChainAsync({
-        chainId: chainId,
-      });
-    } catch (err) {
-      console.error(err);
-    }
-  };
-
-  const updateSuccessDataRef = useCallback(() => {
-    successDataRef.current = {
-      token,
-      value,
-      tokenPriceUSD: tokenInfo?.priceUSD,
-      callback: () => {
-        setValue('');
-        refetchPosition();
-      },
-    };
-  }, [value, token, tokenInfo, setValue, refetchPosition]);
-
-  const handleSubmit = useCallback(
-    (event: React.FormEvent) => {
-      event.preventDefault();
-      if (!value) {
-        return;
-      }
-      try {
-        updateSuccessDataRef();
-        sendWithdrawTx(value);
-      } catch (e) {
-        console.error(e);
-      }
-    },
-    [sendWithdrawTx, value],
-  );
-
   return (
-    <WithdrawFormContainer as="form" onSubmit={handleSubmit}>
+    <WithdrawFormContainer>
       <WithdrawInput
         name="withdrawValue"
-        placeholder="0"
-        label={`Withdraw from ${poolName || 'Pool'}`}
-        errorMessage={errorMessage}
-        priceUSD={tokenInfo?.priceUSD}
+        label={`Withdraw`}
+        priceUSD={token?.priceUSD}
+        decimals={token?.decimals}
+        symbol={token?.symbol}
         endAdornment={
           !!account.address &&
           !!balance &&
           parseFloat(balance) > 0 && (
             <WithdrawInputEndAdornment
               mainColor={overrideStyle?.mainColor}
-              setValue={setValue}
+              setValue={setWithdrawValue}
               maxAmount={maxAmount}
               decimals={lpTokenDecimals}
             />
           )
         }
-        value={value}
-        onSetValue={setValue}
+        value={withdrawValue}
+        onSetValue={setWithdrawValue}
         maxValue={maxFormattedAmount.toString()}
         startAdornment={
-          token?.logoURI && (
-            <BadgeWithChain
-              chainId={projectData?.chainId}
-              logoURI={token?.logoURI}
-              alt={token?.name}
-            />
-          )
+          <EntityChainStack
+            variant={EntityChainStackVariant.Tokens}
+            tokens={tokens}
+            tokensSize={AvatarSize.XXL}
+            isContentVisible={false}
+          />
         }
         hintEndAdornment={hintEndAdornment}
       />
+
       {!account?.isConnected ? (
         <ConnectButton sx={buttonStyles} />
-      ) : shouldSwitchChain ? (
-        <Button
-          styles={buttonStyles}
-          muiVariant="contained"
-          onClick={() => handleSwitchChain(projectData?.chainId)}
-        >
-          Switch chain
-        </Button>
       ) : (
         <Button
           type="submit"
           loading={isSubmitLoading}
+          loadingPosition="start"
           disabled={balance === '0' || isSubmitDisabled}
           muiVariant="contained"
+          variant="primary"
           styles={buttonStyles}
         >
           {submitLabel}

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawInput.tsx
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawInput.tsx
@@ -1,38 +1,52 @@
-import { formatInputAmount } from '@lifi/widget';
+import {
+  formatInputAmount,
+  formatTokenPrice,
+  priceToTokenAmount,
+} from '@lifi/widget';
 import InputLabel from '@mui/material/InputLabel';
 import Typography from '@mui/material/Typography';
-import { FC, useMemo, ReactNode } from 'react';
+import type { FC, ReactNode } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { SelectCard } from 'src/components/Cards/SelectCard/SelectCard';
 import {
   SelectCardDescription,
   SelectCardMode,
 } from 'src/components/Cards/SelectCard/SelectCard.styles';
-import { WidgetFormHelperText } from './WithdrawWidget.style';
-import { currencyFormatter } from 'src/utils/formatNumbers';
-import Box from '@mui/material/Box';
+import {
+  DescriptionWrapper,
+  HintIcon,
+  HintWrapper,
+  WidgetFormHelperText,
+} from './WithdrawWidget.style';
+import { currencyFormatter, decimalFormatter } from 'src/utils/formatNumbers';
+import { useTranslation } from 'react-i18next';
+import { USD_DECIMALS } from './constants';
 
 interface WithdrawInputProps {
   label?: string;
   value: string;
   onSetValue: (value: string) => void;
   priceUSD?: string;
-  placeholder: string;
+  decimals?: number;
+  symbol?: string;
   name: string;
-  errorMessage?: string;
   maxValue?: string;
   startAdornment?: ReactNode;
   endAdornment?: ReactNode;
   hintEndAdornment?: string;
 }
 
-const NUM_DECIMALS = 1;
+export enum InputMode {
+  Amount = 'amount',
+  Price = 'price',
+}
 
 export const WithdrawInput: FC<WithdrawInputProps> = ({
   label,
   priceUSD,
-  placeholder,
   name,
-  errorMessage,
+  decimals,
+  symbol,
   value,
   onSetValue,
   maxValue,
@@ -40,47 +54,105 @@ export const WithdrawInput: FC<WithdrawInputProps> = ({
   endAdornment,
   hintEndAdornment,
 }) => {
+  const { t } = useTranslation();
+  const [inputMode, setInputMode] = useState<InputMode>(InputMode.Amount);
+  const [formattedPriceInput, setFormattedPriceInput] = useState('');
+  const isEditingRef = useRef(false);
+  const placeholder = useMemo(() => {
+    return inputMode === InputMode.Amount ? '0' : '$0';
+  }, [inputMode]);
   const formattedErrorMessage = useMemo(() => {
     if (maxValue && (parseFloat(value) ?? 0) > parseFloat(maxValue)) {
       return `You have not enough tokens. Current balance: ${maxValue}.`;
     }
 
-    if (errorMessage) {
-      return `An error occurred during the execution: ${errorMessage}. Please check your wallet.`;
-    }
-
     return null;
-  }, [value, maxValue, errorMessage]);
+  }, [value, maxValue]);
 
-  const valueUSD = useMemo(() => {
-    if (!value || !priceUSD) {
-      return '0';
+  const { displayValue, hintValue, hintSymbol } = useMemo(() => {
+    const priceValue = formatTokenPrice(value, priceUSD);
+
+    if (inputMode === InputMode.Price) {
+      let displayVal = '';
+      if (isEditingRef.current) {
+        displayVal = formattedPriceInput;
+      } else {
+        const formattedDisplayValue = decimalFormatter('en-US', {
+          notation: 'standard',
+          useGrouping: false,
+        })(priceValue);
+        displayVal = formattedDisplayValue;
+      }
+
+      const formattedHint = decimalFormatter('en-US', {
+        notation: 'standard',
+        useGrouping: true,
+        minimumFractionDigits: 0,
+        maximumFractionDigits: decimals,
+      })(value);
+
+      return {
+        displayValue: displayVal ? `$${displayVal}` : '',
+        hintValue: formattedHint,
+        hintSymbol: symbol,
+      };
     }
-    return (parseFloat(priceUSD) * parseFloat(value)).toString();
-  }, [priceUSD, value]);
 
-  const hint = useMemo(() => {
-    return valueUSD
-      ? currencyFormatter('en-US', {
-          notation: 'compact',
-          currency: 'USD',
-          useGrouping: true,
-          minimumFractionDigits: 2,
-          maximumFractionDigits: parseFloat(valueUSD) > 2 ? 2 : 4,
-        })(parseFloat(valueUSD))
-      : 'NA';
-  }, [valueUSD]);
+    const formattedHint = currencyFormatter('en-US', {
+      notation: 'compact',
+      currency: 'USD',
+      useGrouping: true,
+      minimumFractionDigits: USD_DECIMALS,
+      maximumFractionDigits: USD_DECIMALS,
+    })(priceValue);
+
+    return {
+      displayValue: value,
+      hintValue: formattedHint,
+      hintSymbol: '',
+    };
+  }, [inputMode, value, priceUSD, decimals, symbol, formattedPriceInput]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const rawValue = e.target.value;
-    const formattedValue = formatInputAmount(rawValue, NUM_DECIMALS, true);
-    onSetValue(formattedValue);
+    isEditingRef.current = true;
+
+    if (inputMode === InputMode.Amount) {
+      const formattedValue = formatInputAmount(rawValue, decimals, true);
+      onSetValue(formattedValue);
+    } else {
+      const cleanInputValue = rawValue.replace('$', '');
+      const formattedValue = formatInputAmount(
+        cleanInputValue,
+        USD_DECIMALS,
+        true,
+      );
+      setFormattedPriceInput(formattedValue);
+      const tokenValue = priceToTokenAmount(formattedValue, priceUSD);
+      onSetValue(tokenValue);
+    }
   };
 
   const handleInputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const rawValue = e.target.value;
-    const formattedValue = formatInputAmount(rawValue, NUM_DECIMALS);
-    onSetValue(formattedValue);
+    isEditingRef.current = false;
+
+    if (inputMode === InputMode.Amount) {
+      const formattedValue = formatInputAmount(rawValue, decimals);
+      onSetValue(formattedValue);
+    } else {
+      const cleanInputValue = rawValue.replace('$', '');
+      const formattedValue = formatInputAmount(cleanInputValue, USD_DECIMALS);
+      const tokenValue = priceToTokenAmount(formattedValue, priceUSD);
+      const formattedAmount = formatInputAmount(tokenValue, decimals);
+      onSetValue(formattedAmount);
+    }
+  };
+
+  const handleSwitch = () => {
+    setInputMode((prev) =>
+      prev === InputMode.Amount ? InputMode.Price : InputMode.Amount,
+    );
   };
 
   return (
@@ -88,10 +160,9 @@ export const WithdrawInput: FC<WithdrawInputProps> = ({
       <InputLabel htmlFor={name} sx={{ marginBottom: 2 }}>
         <Typography
           variant="titleSmall"
-          sx={(theme) => ({
-            color: (theme.vars || theme).palette.text.primary,
+          sx={{
             whiteSpace: 'break-spaces',
-          })}
+          }}
         >
           {label}
         </Typography>
@@ -102,24 +173,28 @@ export const WithdrawInput: FC<WithdrawInputProps> = ({
         isAmount
         mode={SelectCardMode.Input}
         placeholder={placeholder}
-        value={value}
-        label="Amount"
+        value={displayValue}
+        label={t('widget.withdraw.amount')}
         description={
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'row',
-              justifyContent: 'space-between',
-              gap: 1,
-            }}
-          >
-            <SelectCardDescription variant="bodyXSmall">
-              {hint}
-            </SelectCardDescription>
-            <SelectCardDescription variant="bodyXSmall">
+          <DescriptionWrapper>
+            <HintWrapper>
+              <SelectCardDescription variant="bodyXSmall" hideOverflow>
+                {hintValue}
+              </SelectCardDescription>
+              {!!hintSymbol && (
+                <SelectCardDescription
+                  variant="bodyXSmall"
+                  sx={{ flexShrink: 0, marginLeft: 0.25 }}
+                >
+                  {hintSymbol}
+                </SelectCardDescription>
+              )}
+              <HintIcon onClick={handleSwitch} />
+            </HintWrapper>
+            <SelectCardDescription variant="bodyXSmall" sx={{ flexShrink: 0 }}>
               {hintEndAdornment}
             </SelectCardDescription>
-          </Box>
+          </DescriptionWrapper>
         }
         startAdornment={startAdornment}
         endAdornment={endAdornment}

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawStatusSheetController.tsx
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawStatusSheetController.tsx
@@ -1,0 +1,92 @@
+import type { FC } from 'react';
+import { useCallback, useMemo } from 'react';
+import { StatusBottomSheet } from '@/components/composite/StatusBottomSheet/StatusBottomSheet';
+import { WithdrawSuccess } from './WithdrawSuccess';
+import type { Token } from '@lifi/widget';
+import type { Hex } from 'viem';
+import type { WithdrawErrorType } from './WithdrawWidget.types';
+import { useTranslation } from 'react-i18next';
+import { useRouter } from 'next/navigation';
+import { AppPaths } from '@/const/urls';
+import { getErrorStatusContent } from './utils';
+import { ANIMATION_DURATION_SECONDS, WITHDRAW_SHEET_STATES } from './constants';
+
+interface WithdrawStatusSheetControllerProps {
+  sheetState: string;
+  containerId: string;
+  token: Token;
+  txHash?: Hex;
+  value: string;
+  chainId: number;
+  withdrawErrorType: WithdrawErrorType | null;
+  onCloseError: () => void;
+  onCloseSuccess: () => void;
+  onHeightChange: (height: number) => void;
+}
+
+export const WithdrawStatusSheetController: FC<
+  WithdrawStatusSheetControllerProps
+> = ({
+  sheetState,
+  containerId,
+  token,
+  txHash,
+  value,
+  chainId,
+  withdrawErrorType,
+  onCloseError,
+  onCloseSuccess,
+  onHeightChange,
+}) => {
+  const { t } = useTranslation();
+  const router = useRouter();
+
+  const handleNavigateToGas = useCallback(() => {
+    onCloseError();
+    router.push(AppPaths.Gas);
+  }, [onCloseError, router]);
+
+  const errorSheetProps = useMemo(() => {
+    if (!withdrawErrorType || sheetState !== WITHDRAW_SHEET_STATES.ERROR) {
+      return null;
+    }
+
+    return getErrorStatusContent(withdrawErrorType, t, handleNavigateToGas);
+  }, [withdrawErrorType, sheetState, t, handleNavigateToGas]);
+
+  return (
+    <>
+      {errorSheetProps && (
+        <StatusBottomSheet
+          {...errorSheetProps}
+          containerId={containerId}
+          isOpen={sheetState === WITHDRAW_SHEET_STATES.ERROR}
+          onClose={onCloseError}
+          onHeightChange={onHeightChange}
+          transitionDuration={{
+            enter: ANIMATION_DURATION_SECONDS * 1_000,
+          }}
+        />
+      )}
+      <StatusBottomSheet
+        title={t('widget.withdraw.success.title')}
+        status="success"
+        containerId={containerId}
+        isOpen={sheetState === WITHDRAW_SHEET_STATES.SUCCESS}
+        onClose={onCloseSuccess}
+        onHeightChange={onHeightChange}
+        transitionDuration={{
+          enter: ANIMATION_DURATION_SECONDS * 1_000,
+        }}
+      >
+        <WithdrawSuccess
+          token={token}
+          value={value}
+          onClose={onCloseSuccess}
+          chainId={chainId}
+          txHash={txHash}
+        />
+      </StatusBottomSheet>
+    </>
+  );
+};

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawSuccess.tsx
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawSuccess.tsx
@@ -1,0 +1,100 @@
+import { SelectCard } from '@/components/Cards/SelectCard/SelectCard';
+import { SelectCardMode } from '@/components/Cards/SelectCard/SelectCard.styles';
+import { EntityChainStack } from '@/components/composite/EntityChainStack/EntityChainStack';
+import { EntityChainStackVariant } from '@/components/composite/EntityChainStack/EntityChainStack.types';
+import { AvatarSize } from '@/components/core/AvatarStack/AvatarStack.types';
+import { currencyFormatter } from '@/utils/formatNumbers';
+import { formatTokenPrice } from '@lifi/widget';
+import type { FC } from 'react';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ButtonGroupContainer } from './WithdrawWidget.style';
+import { ButtonPrimary, ButtonSecondary } from '@/components/Button';
+import { useChains } from '@/hooks/useChains';
+import { openInNewTab } from '@/utils/openInNewTab';
+import type { WithdrawSuccessProps } from './WithdrawWidget.types';
+import { USD_DECIMALS } from './constants';
+
+export const WithdrawSuccess: FC<WithdrawSuccessProps> = ({
+  token,
+  value,
+  chainId,
+  txHash,
+  onClose,
+}) => {
+  const { t } = useTranslation();
+  const chains = useChains();
+  const chain = useMemo(() => chains.getChainById(chainId), [chains, chainId]);
+  const explorerUrl = useMemo(
+    () => chain?.metamask.blockExplorerUrls?.[0] ?? 'https://etherscan.io/',
+    [chain],
+  );
+
+  const tokens = useMemo(() => {
+    return [
+      {
+        address: token.address,
+        name: token.name,
+        symbol: token.symbol,
+        decimals: token.decimals,
+        logo: token.logoURI ?? '',
+        chain: { chainId: token.chainId, chainKey: token.coinKey ?? '' },
+      },
+    ];
+  }, [token]);
+
+  const hint = useMemo(() => {
+    const priceValue = formatTokenPrice(value, token?.priceUSD);
+    return currencyFormatter('en-US', {
+      notation: 'compact',
+      currency: 'USD',
+      useGrouping: true,
+      minimumFractionDigits: USD_DECIMALS,
+      maximumFractionDigits: USD_DECIMALS,
+    })(priceValue);
+  }, [value, token?.priceUSD]);
+
+  const handleSeeDetails = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    openInNewTab(`${explorerUrl}tx/${txHash}`);
+  };
+
+  return (
+    <>
+      <SelectCard
+        value={value}
+        description={hint}
+        placeholder=""
+        mode={SelectCardMode.Display}
+        label={t('widget.withdraw.received')}
+        startAdornment={
+          <EntityChainStack
+            variant={EntityChainStackVariant.Tokens}
+            tokens={tokens}
+            tokensSize={AvatarSize.XXL}
+            isContentVisible={false}
+          />
+        }
+      />
+      <ButtonGroupContainer>
+        <ButtonSecondary
+          sx={{ padding: 2 }}
+          fullWidth
+          onClick={handleSeeDetails}
+          type="button"
+        >
+          {t('widget.withdraw.success.seeDetails')}
+        </ButtonSecondary>
+        <ButtonPrimary
+          sx={{ padding: 2 }}
+          fullWidth
+          onClick={onClose}
+          type="button"
+        >
+          {t('widget.withdraw.success.done')}
+        </ButtonPrimary>
+      </ButtonGroupContainer>
+    </>
+  );
+};

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawSuccess.tsx
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawSuccess.tsx
@@ -26,7 +26,7 @@ export const WithdrawSuccess: FC<WithdrawSuccessProps> = ({
   const chains = useChains();
   const chain = useMemo(() => chains.getChainById(chainId), [chains, chainId]);
   const explorerUrl = useMemo(
-    () => chain?.metamask.blockExplorerUrls?.[0] ?? 'https://etherscan.io/',
+    () => chain?.metamask?.blockExplorerUrls?.[0] ?? 'https://etherscan.io/',
     [chain],
   );
 

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.style.ts
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.style.ts
@@ -110,10 +110,10 @@ export const DescriptionWrapper = styled(Box)(({ theme }) => ({
   gap: theme.spacing(1),
 }));
 
-export const HintWrapper = styled(Box)(() => ({
+export const HintWrapper = styled(Box)(({ theme }) => ({
   display: 'inline-flex',
   alignItems: 'center',
-  gap: 0.5,
+  gap: theme.spacing(0.5),
   minWidth: 0,
 }));
 

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.style.ts
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.style.ts
@@ -3,11 +3,13 @@ import FormHelperText from '@mui/material/FormHelperText';
 import { styled } from '@mui/material/styles';
 import { cardClasses } from '@mui/material/Card';
 import { ButtonTertiary } from 'src/components/Button';
+import SwapVertRoundedIcon from '@mui/icons-material/SwapVertRounded';
 
 export const WithdrawWidgetBox = styled(Box)(() => ({
   display: 'flex',
   flexGrow: 1,
   flexDirection: 'column',
+  width: '100%',
 }));
 
 export const WithdrawFormContainer = styled(Box)(() => ({
@@ -98,5 +100,36 @@ export const MaxButton = styled(ButtonTertiary)(({ theme }) => ({
       transform: 'scale(0.85) translateY(-10px)',
       transitionDelay: '75ms',
     },
+  },
+}));
+
+export const DescriptionWrapper = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  gap: theme.spacing(1),
+}));
+
+export const HintWrapper = styled(Box)(() => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 0.5,
+  minWidth: 0,
+}));
+
+export const HintIcon = styled(SwapVertRoundedIcon)(({ theme }) => ({
+  fontSize: 16,
+  cursor: 'pointer',
+  flexShrink: 0,
+  color: (theme.vars || theme).palette.text.secondary,
+}));
+
+export const ButtonGroupContainer = styled(Box)(({ theme }) => ({
+  width: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(2),
+  [theme.breakpoints.up('md')]: {
+    flexDirection: 'row',
   },
 }));

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.tsx
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.tsx
@@ -15,7 +15,6 @@ import type { Theme, SxProps } from '@mui/material/styles';
 import { HeightAnimatedContainer } from '@/components/core/HeightAnimatedContainer/HeightAnimatedContainer';
 import { motion } from 'motion/react';
 import { WithdrawStatusSheetController } from './WithdrawStatusSheetController';
-import type { WithdrawErrorType } from './WithdrawWidget.types';
 import { useToken } from '@/hooks/useToken';
 import { getButtonLabel } from './utils';
 import { useTranslation } from 'react-i18next';
@@ -25,7 +24,6 @@ import {
   ANIMATION_DURATION_SECONDS,
   CONTAINER_ID,
   WITHDRAW_SHEET_STATES,
-  WITHDRAW_FLOW_STATES,
 } from './constants';
 
 export interface WithdrawWidgetProps {
@@ -58,7 +56,6 @@ export const WithdrawWidget: React.FC<WithdrawWidgetProps> = ({
     return tokenInfo || token;
   }, [tokenInfo, token]);
 
-  const [withdrawValue, setWithdrawValue] = useState('');
   const [sheetState, setSheetState] = useState<string>(
     WITHDRAW_SHEET_STATES.HIDDEN,
   );
@@ -112,7 +109,7 @@ export const WithdrawWidget: React.FC<WithdrawWidgetProps> = ({
 
   const handleCloseSuccessBottomSheet = useCallback(() => {
     transactionState.resetState();
-    setWithdrawValue('');
+    transactionState.setValue('');
     setSheetState(WITHDRAW_SHEET_STATES.HIDDEN);
   }, [transactionState]);
 
@@ -173,8 +170,8 @@ export const WithdrawWidget: React.FC<WithdrawWidgetProps> = ({
                 poolName={poolName}
                 balance={depositTokenData?.toString() ?? '0'}
                 lpTokenDecimals={lpTokenDecimals}
-                setWithdrawValue={setWithdrawValue}
-                withdrawValue={withdrawValue}
+                setWithdrawValue={transactionState.setValue}
+                withdrawValue={transactionState.value}
               />
             </WithdrawWidgetBox>
             <WithdrawStatusSheetController
@@ -182,7 +179,7 @@ export const WithdrawWidget: React.FC<WithdrawWidgetProps> = ({
               containerId={CONTAINER_ID}
               token={enhancedToken}
               txHash={transactionState.txHash}
-              value={withdrawValue}
+              value={transactionState.value}
               chainId={projectData?.chainId}
               withdrawErrorType={transactionState.withdrawErrorType}
               onCloseError={handleCloseErrorBottomSheet}

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.tsx
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.tsx
@@ -1,14 +1,32 @@
-import { type ContractCall, type TokenAmount } from '@lifi/widget';
+import type { ContractCall, TokenAmount } from '@lifi/widget';
 import { WithdrawWidgetBox } from './WithdrawWidget.style';
 import type { AbiFunction } from 'viem';
-import { ProjectData } from 'src/types/questDetails';
+import type { ProjectData } from 'src/types/questDetails';
 import { WithdrawForm } from './WithdrawForm';
-import { useWithdrawTransaction } from './hooks';
+import {
+  useWithdrawTransactionState,
+  useWithdrawTransactionExecution,
+  useWithdrawTracking,
+} from './hooks';
 import { useAccount } from '@lifi/wallet-management';
-import { useChains } from 'src/hooks/useChains';
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { SectionCardContainer } from 'src/components/Cards/SectionCard/SectionCard.style';
-import { TxBottomSheet } from '../TxBottomSheet/TxBottomSheet';
+import type { Theme, SxProps } from '@mui/material/styles';
+import { HeightAnimatedContainer } from '@/components/core/HeightAnimatedContainer/HeightAnimatedContainer';
+import { motion } from 'motion/react';
+import { WithdrawStatusSheetController } from './WithdrawStatusSheetController';
+import type { WithdrawErrorType } from './WithdrawWidget.types';
+import { useToken } from '@/hooks/useToken';
+import { getButtonLabel } from './utils';
+import { useTranslation } from 'react-i18next';
+import {
+  BOTTOM_SHEET_TOP_OFFSET,
+  MODAL_BOTTOM_SHEET_MIN_HEIGHT,
+  ANIMATION_DURATION_SECONDS,
+  CONTAINER_ID,
+  WITHDRAW_SHEET_STATES,
+  WITHDRAW_FLOW_STATES,
+} from './constants';
 
 export interface WithdrawWidgetProps {
   poolName?: string;
@@ -19,6 +37,7 @@ export interface WithdrawWidgetProps {
   depositTokenData: number | bigint | undefined;
   refetchPosition: () => void;
   withdrawAbi?: AbiFunction;
+  sx?: SxProps<Theme>;
 }
 
 export const WithdrawWidget: React.FC<WithdrawWidgetProps> = ({
@@ -29,70 +48,150 @@ export const WithdrawWidget: React.FC<WithdrawWidgetProps> = ({
   depositTokenData,
   refetchPosition,
   withdrawAbi,
+  sx,
 }) => {
+  const { t } = useTranslation();
   const { account } = useAccount();
-  const chains = useChains();
-  const chain = useMemo(
-    () => chains.getChainById(projectData?.chainId),
-    [projectData?.chainId],
+  const { token: tokenInfo } = useToken(token.chainId, token.address);
+
+  const enhancedToken = useMemo(() => {
+    return tokenInfo || token;
+  }, [tokenInfo, token]);
+
+  const [withdrawValue, setWithdrawValue] = useState('');
+  const [sheetState, setSheetState] = useState<string>(
+    WITHDRAW_SHEET_STATES.HIDDEN,
   );
-  const {
-    sendWithdrawTx,
-    successDataRef,
-    txHash,
-    txError,
-    isTransactionReceiptLoading,
-    isTransactionReceiptSuccess,
-    isWriteContractDataError,
-    isWriteContractDataPending,
-    isWriteContractDataSuccess,
-  } = useWithdrawTransaction({
-    projectData,
-    writeDecimals: lpTokenDecimals,
-    withdrawAbi,
+
+  const transactionState = useWithdrawTransactionState({
     accountAddress: account.address,
+    projectData,
   });
 
-  const containerId = 'withdraw-widget-box';
+  const { sendWithdrawTx } = useWithdrawTransactionExecution({
+    withdrawAbi,
+    projectData,
+    writeDecimals: lpTokenDecimals,
+    accountAddress: account.address,
+    enhancedToken,
+    state: transactionState,
+  });
+
+  useWithdrawTracking({
+    projectData,
+    enhancedToken,
+    withdrawValue: transactionState.value,
+    isTransactionReceiptSuccess: transactionState.isTransactionReceiptSuccess,
+    withdrawStep: transactionState.withdrawStep,
+    refetchPosition,
+  });
+
+  useEffect(() => {
+    if (transactionState.withdrawErrorType) {
+      setSheetState(WITHDRAW_SHEET_STATES.ERROR);
+    }
+  }, [transactionState.withdrawErrorType]);
+
+  useEffect(() => {
+    if (
+      !transactionState.isTransactionReceiptLoading &&
+      transactionState.isTransactionReceiptSuccess &&
+      !!transactionState.txHash
+    ) {
+      setSheetState(WITHDRAW_SHEET_STATES.SUCCESS);
+    }
+  }, [
+    transactionState.isTransactionReceiptLoading,
+    transactionState.isTransactionReceiptSuccess,
+    transactionState.txHash,
+  ]);
+
+  const handleCloseErrorBottomSheet = useCallback(() => {
+    setSheetState(WITHDRAW_SHEET_STATES.HIDDEN);
+  }, []);
+
+  const handleCloseSuccessBottomSheet = useCallback(() => {
+    transactionState.resetState();
+    setWithdrawValue('');
+    setSheetState(WITHDRAW_SHEET_STATES.HIDDEN);
+  }, [transactionState]);
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent) => {
+      event.preventDefault();
+
+      setSheetState(WITHDRAW_SHEET_STATES.HIDDEN);
+
+      const form = event.currentTarget as unknown as HTMLFormElement;
+      const formData = new FormData(form);
+      const values = Object.fromEntries(formData.entries());
+      const value = values['withdrawValue'].toString();
+
+      try {
+        sendWithdrawTx(value);
+      } catch (e) {
+        console.error(e);
+      }
+    },
+    [sendWithdrawTx],
+  );
+
+  const buttonLabel = getButtonLabel(transactionState.withdrawStep, t);
+  const isSheetOpen = sheetState !== WITHDRAW_SHEET_STATES.HIDDEN;
 
   return (
-    <SectionCardContainer
-      id={containerId}
-      sx={{ position: 'relative', overflow: 'hidden' }}
+    <HeightAnimatedContainer
+      isOpen={isSheetOpen}
+      offsetHeight={BOTTOM_SHEET_TOP_OFFSET}
+      minHeight={MODAL_BOTTOM_SHEET_MIN_HEIGHT}
+      animationDuration={ANIMATION_DURATION_SECONDS}
     >
-      <WithdrawWidgetBox>
-        <WithdrawForm
-          submitLabel={'Withdraw'} // This belongs to contractCalls[0].label
-          errorMessage={txError?.name}
-          sendWithdrawTx={sendWithdrawTx}
-          successDataRef={successDataRef}
-          isSubmitDisabled={isWriteContractDataPending}
-          isSubmitLoading={
-            isTransactionReceiptLoading || isWriteContractDataPending
-          }
-          refetchPosition={refetchPosition}
-          projectData={projectData}
-          token={token}
-          poolName={poolName}
-          balance={depositTokenData?.toString() ?? '0'}
-          lpTokenDecimals={lpTokenDecimals}
-        />
-      </WithdrawWidgetBox>
-      <TxBottomSheet
-        title={
-          isTransactionReceiptSuccess
-            ? 'Withdraw successful'
-            : 'Transaction failed'
-        }
-        description="Check transaction on explorer"
-        link={`${chain?.metamask.blockExplorerUrls?.[0] ?? 'https://etherscan.io/'}tx/${txHash}`}
-        containerId={containerId}
-        isOpen={
-          !isTransactionReceiptLoading &&
-          (isTransactionReceiptSuccess ||
-            (!isTransactionReceiptSuccess && !!txHash))
-        }
-      />
-    </SectionCardContainer>
+      {({ motionProps, onHeightChange }) => (
+        <motion.div {...motionProps}>
+          <SectionCardContainer
+            id={CONTAINER_ID}
+            as="form"
+            onSubmit={handleSubmit}
+            sx={{
+              position: 'relative',
+              overflow: 'hidden',
+              display: 'flex',
+              height: '100%',
+              ...sx,
+            }}
+          >
+            <WithdrawWidgetBox>
+              <WithdrawForm
+                submitLabel={buttonLabel}
+                isSubmitDisabled={transactionState.isPending}
+                isSubmitLoading={
+                  transactionState.isTransactionReceiptLoading ||
+                  transactionState.isPending
+                }
+                projectData={projectData}
+                token={enhancedToken}
+                poolName={poolName}
+                balance={depositTokenData?.toString() ?? '0'}
+                lpTokenDecimals={lpTokenDecimals}
+                setWithdrawValue={setWithdrawValue}
+                withdrawValue={withdrawValue}
+              />
+            </WithdrawWidgetBox>
+            <WithdrawStatusSheetController
+              sheetState={sheetState}
+              containerId={CONTAINER_ID}
+              token={enhancedToken}
+              txHash={transactionState.txHash}
+              value={withdrawValue}
+              chainId={projectData?.chainId}
+              withdrawErrorType={transactionState.withdrawErrorType}
+              onCloseError={handleCloseErrorBottomSheet}
+              onCloseSuccess={handleCloseSuccessBottomSheet}
+              onHeightChange={onHeightChange}
+            />
+          </SectionCardContainer>
+        </motion.div>
+      )}
+    </HeightAnimatedContainer>
   );
 };

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.types.ts
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawWidget.types.ts
@@ -1,6 +1,8 @@
-import { ProjectData } from 'src/types/questDetails';
+import type { ProjectData } from 'src/types/questDetails';
+import type { Token } from '@lifi/widget';
 import { type TokenAmount } from '@lifi/widget';
-import { RefObject } from 'react';
+import type { Dispatch, SetStateAction, RefObject } from 'react';
+import type { Hex } from 'viem';
 
 export interface BaseContractCall {
   label: string;
@@ -19,27 +21,42 @@ export interface SendContractCall extends BaseContractCall {
 
 export type ContractCall = SignContractCall | SendContractCall;
 
-export interface SuccessDataRef {
-  token?: TokenAmount;
-  tokenPriceUSD?: string;
-  value?: string;
-  callback?: () => void;
-}
-
 export interface WithdrawFormProps {
   errorMessage?: string;
   projectData: ProjectData;
   balance: string;
-  token: TokenAmount;
+  token: Token;
   poolName?: string;
   overrideStyle?: {
     mainColor?: string;
   };
-  refetchPosition: () => void;
-  sendWithdrawTx: (value: string) => void;
-  successDataRef: RefObject<SuccessDataRef>;
   isSubmitDisabled?: boolean;
   isSubmitLoading?: boolean;
   submitLabel?: string;
   lpTokenDecimals: number;
+  setWithdrawValue: Dispatch<SetStateAction<string>>;
+  withdrawValue: string;
+}
+
+export interface WithdrawStatusSheetContent {
+  title: string;
+  description: string;
+  callToAction: string;
+  callToActionType: 'submit' | 'button';
+  onClick?: () => void;
+}
+
+export enum WithdrawErrorType {
+  ChainSwitchFailed = 'chainSwitchFailed',
+  SignatureFailed = 'signatureFailed',
+  InsufficientGas = 'insufficientGas',
+  TransactionFailed = 'transactionFailed',
+}
+
+export interface WithdrawSuccessProps {
+  token: Token;
+  value: string;
+  chainId: number;
+  txHash?: Hex;
+  onClose: () => void;
 }

--- a/src/components/ZapWidget/WithdrawWidget/constants.ts
+++ b/src/components/ZapWidget/WithdrawWidget/constants.ts
@@ -1,0 +1,20 @@
+export const WITHDRAW_FLOW_STATES = {
+  IDLE: 'idle',
+  SWITCHING_CHAIN: 'switching_chain',
+  WAITING_FOR_TRANSACTION: 'waiting_for_transaction',
+  SUCCESS: 'success',
+  ERROR: 'error',
+} as const;
+
+export const WITHDRAW_SHEET_STATES = {
+  HIDDEN: 'hidden',
+  ERROR: 'error',
+  SUCCESS: 'success',
+} as const;
+
+export const BOTTOM_SHEET_TOP_OFFSET = 16;
+export const MODAL_BOTTOM_SHEET_MIN_HEIGHT = 424;
+export const ANIMATION_DURATION_SECONDS = 0.3;
+export const CONTAINER_ID = 'withdraw-widget-box';
+
+export const USD_DECIMALS = 2;

--- a/src/components/ZapWidget/WithdrawWidget/hooks.ts
+++ b/src/components/ZapWidget/WithdrawWidget/hooks.ts
@@ -159,7 +159,7 @@ export const useWithdrawTransactionExecution = ({
         const data = encodeFunctionData({
           abi: [abi],
           functionName: (abi.name || 'redeem') as 'redeem',
-          args: dynamicArgs as unknown as readonly [bigint],
+          args: dynamicArgs,
         });
 
         const hash = await walletClient.sendTransaction({

--- a/src/components/ZapWidget/WithdrawWidget/hooks.ts
+++ b/src/components/ZapWidget/WithdrawWidget/hooks.ts
@@ -1,11 +1,23 @@
-import { TokenAmount } from '@lifi/sdk';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { TrackingCategory } from 'src/const/trackingKeys';
 import { useUserTracking } from 'src/hooks/userTracking';
-import { ProjectData } from 'src/types/questDetails';
-import { AbiFunction, AbiParameter, parseUnits } from 'viem';
-import { useWaitForTransactionReceipt, useWriteContract } from 'wagmi';
-import { SuccessDataRef } from './WithdrawWidget.types';
+import type { ProjectData } from 'src/types/questDetails';
+import type { AbiFunction, Hex } from 'viem';
+import { encodeFunctionData } from 'viem';
+import {
+  useWaitForTransactionReceipt,
+  useSwitchChain,
+  useWalletClient,
+} from 'wagmi';
+import { useAccount } from '@lifi/wallet-management';
+import { WithdrawErrorType } from './WithdrawWidget.types';
+import type { Token } from '@lifi/widget';
+import {
+  buildWithdrawAbiArgs,
+  classifyWithdrawError,
+  buildTrackingData,
+} from './utils';
+import { WITHDRAW_FLOW_STATES } from './constants';
 
 const defaultAbi: AbiFunction = {
   inputs: [{ name: 'amount', type: 'uint256' }],
@@ -15,23 +27,24 @@ const defaultAbi: AbiFunction = {
   type: 'function',
 };
 
-interface UseWithdrawSubmitProps {
-  withdrawAbi?: AbiFunction;
-  projectData: ProjectData;
-  writeDecimals: number;
+interface UseWithdrawTransactionStateProps {
   accountAddress?: string;
+  projectData: ProjectData;
 }
 
-export const useWithdrawTransaction = ({
-  withdrawAbi,
+export const useWithdrawTransactionState = ({
   accountAddress,
   projectData,
-  writeDecimals,
-}: UseWithdrawSubmitProps) => {
-  const successDataRef = useRef<SuccessDataRef>({} as SuccessDataRef);
-
-  const { writeContract, data, isPending, isError, error, isSuccess } =
-    useWriteContract();
+}: UseWithdrawTransactionStateProps) => {
+  const [value, setValue] = useState<string>('');
+  const [txHash, setTxHash] = useState<Hex | undefined>(undefined);
+  const [txError, setTxError] = useState<Error | null>(null);
+  const [withdrawStep, setWithdrawStep] = useState<string>(
+    WITHDRAW_FLOW_STATES.IDLE,
+  );
+  const [withdrawErrorType, setWithdrawErrorType] =
+    useState<WithdrawErrorType | null>(null);
+  const [isPending, setIsPending] = useState(false);
 
   const {
     data: transactionReceiptData,
@@ -39,64 +52,186 @@ export const useWithdrawTransaction = ({
     isSuccess: isTransactionReceiptSuccess,
   } = useWaitForTransactionReceipt({
     chainId: projectData?.chainId,
-    hash: data,
+    hash: txHash,
     confirmations: 5,
     pollingInterval: 1_000,
     query: {
-      enabled: !!projectData?.chainId && !!data,
+      enabled: !!projectData?.chainId && !!txHash,
     },
   });
 
-  const sendWithdrawTx = useCallback((value: string) => {
-    // Generate dynamic args based on ABI inputs
-    const abi = withdrawAbi || defaultAbi;
-
-    const dynamicArgs = abi.inputs?.map((input: AbiParameter) => {
-      if (input.type === 'uint256') {
-        return parseUnits(value, writeDecimals);
-      } else if (input.type === 'address') {
-        // Use the user's account address
-        return accountAddress as `0x${string}`;
-      }
-    }) || [parseUnits(value, writeDecimals)];
-
-    writeContract({
-      address: (projectData?.withdrawAddress ||
-        projectData?.address) as `0x${string}`,
-      chainId: projectData?.chainId,
-      functionName: (withdrawAbi?.name || 'redeem') as 'redeem',
-      abi: withdrawAbi
-        ? [withdrawAbi]
-        : [
-            {
-              inputs: [{ name: 'amount', type: 'uint256' }],
-              name: 'redeem',
-              outputs: [{ name: '', type: 'uint256' }],
-              stateMutability: 'nonpayable',
-              type: 'function',
-            },
-          ],
-      args: dynamicArgs as unknown as readonly [bigint],
-    });
+  const resetState = useCallback(() => {
+    setIsPending(false);
+    setTxError(null);
+    setTxHash(undefined);
+    setWithdrawErrorType(null);
+    setWithdrawStep(WITHDRAW_FLOW_STATES.IDLE);
   }, []);
 
+  return {
+    value,
+    setValue,
+    txHash,
+    setTxHash,
+    txError,
+    setTxError,
+    withdrawStep,
+    setWithdrawStep,
+    withdrawErrorType,
+    setWithdrawErrorType,
+    isPending,
+    setIsPending,
+    transactionReceiptData,
+    isTransactionReceiptLoading,
+    isTransactionReceiptSuccess,
+    resetState,
+  };
+};
+
+interface UseWithdrawTransactionExecutionProps {
+  withdrawAbi?: AbiFunction;
+  projectData: ProjectData;
+  writeDecimals: number;
+  accountAddress?: string;
+  enhancedToken: Token;
+  state: ReturnType<typeof useWithdrawTransactionState>;
+}
+
+export const useWithdrawTransactionExecution = ({
+  withdrawAbi,
+  projectData,
+  writeDecimals,
+  accountAddress,
+  enhancedToken,
+  state,
+}: UseWithdrawTransactionExecutionProps) => {
+  const { account } = useAccount();
+  const { switchChainAsync } = useSwitchChain();
+  const { data: walletClient } = useWalletClient({
+    account: accountAddress as Hex,
+    chainId: projectData?.chainId,
+    query: {
+      enabled: !!accountAddress && !!projectData?.chainId,
+    },
+  });
+
+  const sendWithdrawTx = useCallback(
+    async (withdrawValue: string) => {
+      state.resetState();
+      state.setIsPending(true);
+
+      try {
+        if (!walletClient || !accountAddress) {
+          throw new Error('Wallet not connected');
+        }
+
+        if (!withdrawValue) {
+          throw new Error('Amount is required');
+        }
+
+        const targetChainId = projectData?.chainId;
+        const currentChainId = account?.chainId;
+
+        if (targetChainId && targetChainId !== currentChainId) {
+          state.setWithdrawStep(WITHDRAW_FLOW_STATES.SWITCHING_CHAIN);
+          try {
+            await switchChainAsync({ chainId: targetChainId });
+          } catch (switchError) {
+            const error = new Error('Failed to switch chain for withdrawal');
+            state.setTxError(error);
+            state.setWithdrawErrorType(WithdrawErrorType.ChainSwitchFailed);
+            state.setWithdrawStep(WITHDRAW_FLOW_STATES.ERROR);
+            state.setIsPending(false);
+            return;
+          }
+        }
+
+        state.setWithdrawStep(WITHDRAW_FLOW_STATES.WAITING_FOR_TRANSACTION);
+
+        const abi = withdrawAbi || defaultAbi;
+        const dynamicArgs = buildWithdrawAbiArgs(
+          abi.inputs,
+          withdrawValue,
+          writeDecimals,
+          accountAddress as Hex,
+        );
+
+        const data = encodeFunctionData({
+          abi: [abi],
+          functionName: (abi.name || 'redeem') as 'redeem',
+          args: dynamicArgs as unknown as readonly [bigint],
+        });
+
+        const hash = await walletClient.sendTransaction({
+          account: accountAddress as Hex,
+          to: (projectData?.withdrawAddress || projectData?.address) as Hex,
+          chainId: targetChainId,
+          data,
+        });
+
+        state.setTxHash(hash);
+        state.setWithdrawStep(WITHDRAW_FLOW_STATES.SUCCESS);
+      } catch (error) {
+        const err =
+          error instanceof Error ? error : new Error('Withdrawal failed');
+
+        const errorType = classifyWithdrawError(err);
+
+        state.setTxError(err);
+        state.setWithdrawErrorType(errorType);
+        state.setWithdrawStep(WITHDRAW_FLOW_STATES.ERROR);
+      } finally {
+        state.setIsPending(false);
+      }
+    },
+    [
+      walletClient,
+      accountAddress,
+      projectData,
+      account?.chainId,
+      switchChainAsync,
+      withdrawAbi,
+      writeDecimals,
+      state,
+    ],
+  );
+
+  return { sendWithdrawTx };
+};
+
+interface UseWithdrawTrackingProps {
+  projectData: ProjectData;
+  enhancedToken: Token;
+  withdrawValue: string;
+  isTransactionReceiptSuccess: boolean;
+  withdrawStep: string;
+  refetchPosition: () => void;
+}
+
+export const useWithdrawTracking = ({
+  projectData,
+  enhancedToken,
+  withdrawValue,
+  isTransactionReceiptSuccess,
+  withdrawStep,
+  refetchPosition,
+}: UseWithdrawTrackingProps) => {
   const { trackEvent } = useUserTracking();
 
   useEffect(() => {
-    if (!isSuccess) {
+    if (
+      !isTransactionReceiptSuccess ||
+      withdrawStep !== WITHDRAW_FLOW_STATES.SUCCESS
+    ) {
       return;
     }
-    successDataRef.current?.callback?.();
-    const trackingData = {
-      protocol_name: projectData.integrator,
-      chain_id: successDataRef.current?.token?.chainId ?? '',
-      withdrawn_token: successDataRef.current?.token?.address ?? '',
-      amount_withdrawn: successDataRef.current?.value ?? 'NA',
-      amount_withdrawn_usd:
-        parseFloat(successDataRef.current?.value ?? '0') *
-        parseFloat(successDataRef.current?.tokenPriceUSD ?? '0'),
-      timestamp: new Date().toISOString(),
-    };
+
+    refetchPosition();
+    const trackingData = buildTrackingData(
+      projectData.integrator,
+      enhancedToken,
+      withdrawValue,
+    );
 
     trackEvent({
       category: TrackingCategory.WidgetEvent,
@@ -105,18 +240,13 @@ export const useWithdrawTransaction = ({
       data: trackingData,
       isConversion: true,
     });
-  }, [transactionReceiptData]);
-
-  return {
-    txHash: data,
-    txError: error,
-    isWriteContractDataPending: isPending,
-    isWriteContractDataError: isError,
-    isWriteContractDataSuccess: isSuccess,
-    transactionReceiptData,
-    isTransactionReceiptLoading,
+  }, [
+    trackEvent,
+    projectData,
     isTransactionReceiptSuccess,
-    successDataRef,
-    sendWithdrawTx,
-  };
+    withdrawStep,
+    refetchPosition,
+    enhancedToken,
+    withdrawValue,
+  ]);
 };

--- a/src/components/ZapWidget/WithdrawWidget/utils.ts
+++ b/src/components/ZapWidget/WithdrawWidget/utils.ts
@@ -79,7 +79,7 @@ export const buildWithdrawAbiArgs = (
   value: string,
   writeDecimals: number,
   accountAddress: Hex,
-): unknown[] => {
+) => {
   if (!abiInputs || abiInputs.length === 0) {
     return [parseUnits(value, writeDecimals)];
   }

--- a/src/components/ZapWidget/WithdrawWidget/utils.ts
+++ b/src/components/ZapWidget/WithdrawWidget/utils.ts
@@ -1,0 +1,109 @@
+import type { AbiParameter, Hex } from 'viem';
+import { parseUnits } from 'viem';
+import type { WithdrawStatusSheetContent } from './WithdrawWidget.types';
+import { WithdrawErrorType } from './WithdrawWidget.types';
+import type { Token } from '@lifi/widget';
+import type { TFunction } from 'i18next';
+
+export const getErrorStatusContent = (
+  errorType: WithdrawErrorType,
+  t: TFunction,
+  handleNavigateToGas: () => void,
+): WithdrawStatusSheetContent => {
+  switch (errorType) {
+    case WithdrawErrorType.ChainSwitchFailed:
+      return {
+        title: t('widget.withdraw.error.chainSwitchFailed.title'),
+        description: t('widget.withdraw.error.chainSwitchFailed.description'),
+        callToAction: t('widget.withdraw.error.chainSwitchFailed.tryAgain'),
+        callToActionType: 'submit' as const,
+      };
+    case WithdrawErrorType.SignatureFailed:
+      return {
+        title: t('widget.withdraw.error.signatureFailed.title'),
+        description: t('widget.withdraw.error.signatureFailed.description'),
+        callToAction: t('widget.withdraw.error.signatureFailed.tryAgain'),
+        callToActionType: 'submit' as const,
+      };
+    case WithdrawErrorType.InsufficientGas:
+      return {
+        title: t('widget.withdraw.error.insufficientGas.title'),
+        description: t('widget.withdraw.error.insufficientGas.description'),
+        callToAction: t('widget.withdraw.error.insufficientGas.increaseGas'),
+        callToActionType: 'button' as const,
+        onClick: handleNavigateToGas,
+      };
+    default:
+      return {
+        title: t('widget.withdraw.error.transactionFailed.title'),
+        description: t('widget.withdraw.error.transactionFailed.description'),
+        callToAction: t('widget.withdraw.error.transactionFailed.tryAgain'),
+        callToActionType: 'submit' as const,
+      };
+  }
+};
+
+export const getButtonLabel = (step: string, t: TFunction): string => {
+  switch (step) {
+    case 'switching_chain':
+      return t('widget.withdraw.switchChain');
+    case 'waiting_for_transaction':
+      return t('widget.withdraw.waitingForTransaction');
+    default:
+      return t('widget.withdraw.withdraw');
+  }
+};
+
+export const classifyWithdrawError = (error: Error): WithdrawErrorType => {
+  const errorMessage = error.message.toLowerCase();
+
+  if (
+    ['signature', 'sign', 'rejected', 'denied'].some((keyword) =>
+      errorMessage.includes(keyword),
+    )
+  ) {
+    return WithdrawErrorType.SignatureFailed;
+  }
+
+  if (
+    ['gas', 'insufficient'].some((keyword) => errorMessage.includes(keyword))
+  ) {
+    return WithdrawErrorType.InsufficientGas;
+  }
+
+  return WithdrawErrorType.TransactionFailed;
+};
+
+export const buildWithdrawAbiArgs = (
+  abiInputs: readonly AbiParameter[] | undefined,
+  value: string,
+  writeDecimals: number,
+  accountAddress: Hex,
+): unknown[] => {
+  if (!abiInputs || abiInputs.length === 0) {
+    return [parseUnits(value, writeDecimals)];
+  }
+
+  return Array.from(abiInputs).map((input: AbiParameter) => {
+    if (input.type === 'uint256') {
+      return parseUnits(value, writeDecimals);
+    } else if (input.type === 'address') {
+      return accountAddress;
+    }
+    return null;
+  });
+};
+
+export const buildTrackingData = (
+  integrator: string,
+  token: Token,
+  amount: string,
+) => ({
+  protocol_name: integrator,
+  chain_id: token.chainId ?? '',
+  withdrawn_token: token.address ?? '',
+  amount_withdrawn: amount ?? 'NA',
+  amount_withdrawn_usd:
+    parseFloat(amount ?? '0') * parseFloat(token.priceUSD ?? '0'),
+  timestamp: new Date().toISOString(),
+});

--- a/src/components/composite/StatusBottomSheet/StatusBottomSheet.styles.ts
+++ b/src/components/composite/StatusBottomSheet/StatusBottomSheet.styles.ts
@@ -6,8 +6,13 @@ export const StyledTitleContainer = styled(Box)(() => ({
   textAlign: 'center',
 }));
 
-export const ErrorIconCircle = styled(Box)(({ theme }) => ({
-  backgroundColor: (theme.vars || theme).palette.statusErrorBg,
+export interface StatusIconCircleProps {
+  status?: 'error' | 'success';
+}
+
+export const StatusIconCircle = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'status',
+})<StatusIconCircleProps>(({ theme, status = 'error' }) => ({
   borderRadius: '50%',
   width: 96,
   height: 96,
@@ -15,9 +20,28 @@ export const ErrorIconCircle = styled(Box)(({ theme }) => ({
   position: 'relative',
   placeItems: 'center',
   '& > svg': {
-    color: (theme.vars || theme).palette.statusErrorFg,
     fontSize: 48,
   },
+  variants: [
+    {
+      props: { status: 'error' },
+      style: {
+        backgroundColor: (theme.vars || theme).palette.statusErrorBg,
+        '& > svg': {
+          color: (theme.vars || theme).palette.statusErrorFg,
+        },
+      },
+    },
+    {
+      props: { status: 'success' },
+      style: {
+        backgroundColor: (theme.vars || theme).palette.statusSuccessBg,
+        '& > svg': {
+          color: (theme.vars || theme).palette.statusSuccessFg,
+        },
+      },
+    },
+  ],
 }));
 
 export const StyledModalContentContainer = styled(Box)(({ theme }) => ({

--- a/src/components/composite/StatusBottomSheet/StatusBottomSheet.tsx
+++ b/src/components/composite/StatusBottomSheet/StatusBottomSheet.tsx
@@ -1,6 +1,7 @@
-import type { FC } from 'react';
+import type { FC, PropsWithChildren } from 'react';
 import { useEffect, useRef } from 'react';
 import ErrorRounded from '@mui/icons-material/ErrorRounded';
+import Check from '@mui/icons-material/Check';
 import Typography from '@mui/material/Typography';
 import type {
   BottomSheetBase,
@@ -9,16 +10,17 @@ import type {
 import { BottomSheet } from 'src/components/core/BottomSheet/BottomSheet';
 import { Button } from 'src/components/Button/Button';
 import {
-  ErrorIconCircle,
+  StatusIconCircle,
   StyledModalContentContainer,
   StyledTitleContainer,
 } from './StatusBottomSheet.styles';
 
-interface StatusBottomSheetProps {
+interface StatusBottomSheetProps extends PropsWithChildren {
   title: string;
-  description: string;
-  callToAction: string;
-  callToActionType: 'submit' | 'button';
+  description?: string;
+  callToAction?: string;
+  callToActionType?: 'submit' | 'button';
+  status?: 'error' | 'success';
   containerId: string;
   isOpen: boolean;
   onClick?: () => void;
@@ -29,9 +31,11 @@ interface StatusBottomSheetProps {
 
 export const StatusBottomSheet: FC<StatusBottomSheetProps> = ({
   title,
+  children,
   description,
   callToAction,
-  callToActionType,
+  callToActionType = 'submit',
+  status = 'error',
   containerId,
   isOpen,
   onClick,
@@ -103,25 +107,33 @@ export const StatusBottomSheet: FC<StatusBottomSheetProps> = ({
           padding: theme.spacing(3),
         })}
       >
-        <ErrorIconCircle>
-          <ErrorRounded />
-        </ErrorIconCircle>
+        <StatusIconCircle status={status}>
+          {status === 'error' ? <ErrorRounded /> : <Check />}
+        </StatusIconCircle>
 
         <StyledTitleContainer>
           <Typography variant="titleXSmall">{title}</Typography>
         </StyledTitleContainer>
 
-        <Typography variant="bodyMedium">{description}</Typography>
+        {children ? (
+          children
+        ) : (
+          <>
+            {description && (
+              <Typography variant="bodyMedium">{description}</Typography>
+            )}
 
-        {callToAction && (
-          <Button
-            fullWidth
-            variant="primary"
-            type={callToActionType}
-            onClick={onClick}
-          >
-            {callToAction}
-          </Button>
+            {callToAction && (
+              <Button
+                fullWidth
+                variant="primary"
+                type={callToActionType}
+                onClick={onClick}
+              >
+                {callToAction}
+              </Button>
+            )}
+          </>
         )}
       </StyledModalContentContainer>
     </BottomSheet>

--- a/src/components/composite/WithdrawButton/WithdrawButton.styles.ts
+++ b/src/components/composite/WithdrawButton/WithdrawButton.styles.ts
@@ -1,0 +1,95 @@
+import type { BoxProps } from '@mui/material/Box';
+import Box from '@mui/material/Box';
+import { styled } from '@mui/material/styles';
+import type { ButtonProps } from 'src/components/Button';
+import { ButtonTransparent } from 'src/components/Button';
+
+export const WithdrawButtonContentWrapper = styled(Box)(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  flexDirection: 'row',
+}));
+
+interface WithdrawButtonLabelWrapperProps extends BoxProps {
+  size: ButtonProps['size'];
+}
+
+export const WithdrawButtonLabelWrapper = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'size',
+})<WithdrawButtonLabelWrapperProps>(({ theme }) => ({
+  variants: [
+    {
+      props: ({ size }) => size === 'small',
+      style: {
+        padding: theme.spacing(0.25, 0.5),
+        fontSize: theme.typography.bodyXSmallStrong.fontSize,
+        lineHeight: theme.typography.bodyXSmallStrong.lineHeight,
+      },
+    },
+    {
+      props: ({ size }) => size === 'medium',
+      style: {
+        padding: theme.spacing(0.5, 1),
+        fontSize: theme.typography.bodySmallStrong.fontSize,
+        lineHeight: theme.typography.bodySmallStrong.lineHeight,
+      },
+    },
+    {
+      props: ({ size }) => size === 'large',
+      style: {
+        padding: theme.spacing(0.5, 1.5),
+        fontSize: theme.typography.bodyMediumStrong.fontSize,
+        lineHeight: theme.typography.bodyMediumStrong.lineHeight,
+      },
+    },
+  ],
+}));
+
+export const WithdrawButtonPrimary = styled(ButtonTransparent)(({ theme }) => ({
+  minWidth: 'auto',
+  height: 'fit-content',
+  flexShrink: 0,
+  borderRadius: theme.shape.buttonBorderRadius,
+  '&:disabled': {
+    backgroundColor: (theme.vars || theme).palette.buttonDisabledBg,
+    color: (theme.vars || theme).palette.buttonDisabledAction,
+  },
+  color: (theme.vars || theme).palette.buttonAlphaDarkAction,
+  backgroundColor: (theme.vars || theme).palette.buttonAlphaDarkBg,
+  ...theme.applyStyles('light', {
+    backgroundColor: (theme.vars || theme).palette.buttonAlphaLightAction,
+    color: (theme.vars || theme).palette.buttonAlphaLightBg,
+  }),
+  variants: [
+    {
+      props: ({ size }) => size === 'small',
+      style: {
+        padding: theme.spacing(0.5),
+        '& > .MuiBox-root': {
+          padding: theme.spacing(0.25, 0),
+          height: 24,
+        },
+      },
+    },
+    {
+      props: ({ size }) => size === 'medium',
+      style: {
+        padding: theme.spacing(0.75),
+        '& > .MuiBox-root': {
+          padding: theme.spacing(0.125, 0.25),
+          height: 28,
+        },
+      },
+    },
+    {
+      props: ({ size }) => size === 'large',
+      style: {
+        padding: theme.spacing(1),
+        '& > .MuiBox-root': {
+          padding: theme.spacing(0.25),
+          height: 32,
+        },
+      },
+    },
+  ],
+}));

--- a/src/components/composite/WithdrawButton/WithdrawButton.tsx
+++ b/src/components/composite/WithdrawButton/WithdrawButton.tsx
@@ -1,0 +1,29 @@
+import type { FC } from 'react';
+import {
+  WithdrawButtonContentWrapper,
+  WithdrawButtonLabelWrapper,
+  WithdrawButtonPrimary,
+} from './WithdrawButton.styles';
+import type { WithdrawButtonProps } from './WithdrawButton.types';
+
+export const WithdrawButton: FC<WithdrawButtonProps> = ({
+  size = 'medium',
+  label,
+  onClick,
+  ...props
+}) => {
+  return (
+    <WithdrawButtonPrimary
+      {...props}
+      sx={props.sx}
+      size={size}
+      onClick={onClick}
+    >
+      <WithdrawButtonContentWrapper>
+        <WithdrawButtonLabelWrapper size={size}>
+          {label}
+        </WithdrawButtonLabelWrapper>
+      </WithdrawButtonContentWrapper>
+    </WithdrawButtonPrimary>
+  );
+};

--- a/src/components/composite/WithdrawButton/WithdrawButton.types.ts
+++ b/src/components/composite/WithdrawButton/WithdrawButton.types.ts
@@ -1,0 +1,6 @@
+import type { ButtonProps } from '@mui/material/Button';
+
+export interface WithdrawButtonProps extends ButtonProps {
+  onClick: () => void;
+  label?: string;
+}

--- a/src/components/composite/WithdrawFlow/WithdrawFlow.tsx
+++ b/src/components/composite/WithdrawFlow/WithdrawFlow.tsx
@@ -1,0 +1,46 @@
+'use client';
+import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { EarnOpportunityExtended } from 'src/stores/withdrawFlow/WithdrawFlowStore';
+import { useWithdrawFlowStore } from 'src/stores/withdrawFlow/WithdrawFlowStore';
+import { WithdrawButton } from '../WithdrawButton/WithdrawButton';
+import type { WithdrawButtonProps } from '../WithdrawButton/WithdrawButton.types';
+import { WithdrawModal } from '../WithdrawModal/WithdrawModal';
+
+export const WithdrawFlowModal = () => {
+  const { selectedEarnOpportunity, isModalOpen, closeModal } =
+    useWithdrawFlowStore((state) => state);
+
+  if (!selectedEarnOpportunity) {
+    return null;
+  }
+
+  return (
+    <WithdrawModal
+      isOpen={isModalOpen}
+      onClose={closeModal}
+      earnOpportunity={selectedEarnOpportunity!}
+    />
+  );
+};
+
+interface WithdrawFlowButtonProps extends Omit<WithdrawButtonProps, 'onClick'> {
+  earnOpportunity: EarnOpportunityExtended;
+  refetchCallback?: () => void;
+}
+export const WithdrawFlowButton: FC<WithdrawFlowButtonProps> = ({
+  earnOpportunity,
+  refetchCallback,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  const openModal = useWithdrawFlowStore((state) => state.openModal);
+  return (
+    <WithdrawButton
+      onClick={() => openModal(earnOpportunity, refetchCallback)}
+      label={t('buttons.withdrawButtonLabel')}
+      {...props}
+    />
+  );
+};

--- a/src/components/composite/WithdrawModal/WithdrawModal.stories.tsx
+++ b/src/components/composite/WithdrawModal/WithdrawModal.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useState } from 'react';
+
+import { WithdrawModal } from './WithdrawModal';
+import { fn } from '@storybook/test';
+import { ConnectButton } from 'src/components/ConnectButton';
+import { useIsDisconnected } from 'src/components/Navbar/hooks';
+import { WalletMenuToggle } from 'src/components/Navbar/components/Buttons/WalletMenuToggle';
+import { WithdrawButton } from '../WithdrawButton/WithdrawButton';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+
+const meta = {
+  component: WithdrawModal,
+  title: 'Composite/Withdraw Modal',
+  args: {
+    onClose: fn(),
+  },
+} satisfies Meta<typeof WithdrawModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    isOpen: true,
+    earnOpportunity: {
+      name: 'morpho',
+      slug: 'morpho',
+      protocol: {
+        name: 'morpho',
+        product: 'morpho',
+        version: '1.0.0',
+        logo: 'logo',
+      },
+      address: '0xE4248e2105508FcBad3fe95691551d1AF14015f7',
+      url: 'https://morpho.org/',
+      positionUrl:
+        'https://app.morpho.org/katana/vault/0xE4248e2105508FcBad3fe95691551d1AF14015f7/gauntlet-weth',
+      minFromAmountUSD: 0.29,
+      asset: {
+        name: 'Asset',
+        symbol: 'ASSET',
+        decimals: 18,
+        logo: 'logo',
+        address: '0xE4248e2105508FcBad3fe95691551d1AF14015f7',
+        chain: { chainId: 747474, chainKey: 'katana' },
+      },
+      lpToken: {
+        name: 'LP Token',
+        symbol: 'LP',
+        decimals: 18,
+        logo: 'logo',
+        address: '0xE4248e2105508FcBad3fe95691551d1AF14015f7',
+        chain: { chainId: 747474, chainKey: 'katana' },
+      },
+      latest: {
+        date: '2021-01-01',
+        tvlUsd: '1000000',
+        tvlNative: '1000000',
+        apy: {
+          base: 5.5,
+          reward: 0,
+          total: 5.5,
+        },
+      },
+    },
+  },
+};
+
+export const WithToggleAndConnectButton: Story = {
+  render: (args) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const isDisconnected = useIsDisconnected();
+
+    return (
+      <Box sx={{ p: 2 }}>
+        <Stack direction="row" spacing={2}>
+          {isDisconnected ? <ConnectButton /> : <WalletMenuToggle />}
+          <WithdrawButton onClick={() => setIsOpen(!isOpen)} label="Withdraw" />
+        </Stack>
+
+        <WithdrawModal
+          {...args}
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+        />
+      </Box>
+    );
+  },
+  args: {
+    isOpen: false,
+    earnOpportunity: {
+      slug: 'morpho',
+      name: 'morpho',
+      protocol: {
+        name: 'morpho',
+        product: 'morpho',
+        version: '1.0.0',
+        logo: 'logo',
+      },
+      address: '0xE4248e2105508FcBad3fe95691551d1AF14015f7',
+      url: 'https://morpho.org/',
+      positionUrl:
+        'https://app.morpho.org/katana/vault/0xE4248e2105508FcBad3fe95691551d1AF14015f7/gauntlet-weth',
+      minFromAmountUSD: 0.29,
+      asset: {
+        name: 'Asset',
+        symbol: 'ASSET',
+        decimals: 18,
+        logo: 'logo',
+        address: '0xE4248e2105508FcBad3fe95691551d1AF14015f7',
+        chain: { chainId: 747474, chainKey: 'katana' },
+      },
+      lpToken: {
+        name: 'LP Token',
+        symbol: 'LP',
+        decimals: 18,
+        logo: 'logo',
+        address: '0xE4248e2105508FcBad3fe95691551d1AF14015f7',
+        chain: { chainId: 747474, chainKey: 'katana' },
+      },
+      latest: {
+        date: '2021-01-01',
+        tvlUsd: '1000000',
+        tvlNative: '1000000',
+        apy: {
+          base: 5.5,
+          reward: 0,
+          total: 5.5,
+        },
+      },
+    },
+  },
+};

--- a/src/components/composite/WithdrawModal/WithdrawModal.tsx
+++ b/src/components/composite/WithdrawModal/WithdrawModal.tsx
@@ -1,0 +1,59 @@
+import type { FC } from 'react';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { ClientOnly } from 'src/components/ClientOnly';
+import { ZapWithdrawWidget } from 'src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget';
+import { WidgetTrackingProvider } from 'src/providers/WidgetTrackingProvider';
+import type { EarnOpportunityWithLatestAnalytics } from 'src/types/jumper-backend';
+import { TaskType } from 'src/types/strapi';
+import type { ModalContainerProps } from 'src/components/core/modals/ModalContainer/ModalContainer';
+import { ModalContainer } from 'src/components/core/modals/ModalContainer/ModalContainer';
+import { useProjectLikeDataFromEarnOpportunity } from 'src/hooks/earn/useProjectLikeDataFromEarnOpportunity';
+import { useZapEarnOpportunitySlugStorage } from 'src/providers/hooks';
+import { useDepositFlowStore } from 'src/stores/depositFlow/DepositFlowStore';
+import { useTheme } from '@mui/material/styles';
+interface WithdrawModalProps extends ModalContainerProps {
+  earnOpportunity: Pick<
+    EarnOpportunityWithLatestAnalytics,
+    'name' | 'asset' | 'protocol' | 'url' | 'lpToken' | 'latest' | 'slug'
+  > & {
+    minFromAmountUSD: number;
+    positionUrl: string;
+    address: string;
+  };
+}
+
+export const WithdrawModal: FC<WithdrawModalProps> = ({
+  onClose,
+  isOpen,
+  earnOpportunity,
+}) => {
+  const theme = useTheme();
+  const { projectData, zapData } =
+    useProjectLikeDataFromEarnOpportunity(earnOpportunity);
+
+  //   const refetchCallback = useDepositFlowStore((state) => state.refetchCallback);
+
+  return (
+    <WidgetTrackingProvider>
+      <ModalContainer isOpen={isOpen} onClose={onClose}>
+        <ZapWithdrawWidget
+          customInformation={{ projectData }}
+          zapData={zapData}
+          ctx={{
+            theme: {
+              container: {
+                maxHeight: 'calc(100vh - 6rem)',
+                minWidth: '100%',
+                maxWidth: 400,
+                borderRadius: '24px',
+                [theme.breakpoints.up('sm')]: {
+                  minWidth: 400,
+                },
+              },
+            },
+          }}
+        />
+      </ModalContainer>
+    </WidgetTrackingProvider>
+  );
+};

--- a/src/components/core/HeightAnimatedContainer/HeightAnimatedContainer.tsx
+++ b/src/components/core/HeightAnimatedContainer/HeightAnimatedContainer.tsx
@@ -10,6 +10,7 @@ export interface HeightAnimatedContainerRenderProps {
 export interface HeightAnimatedContainerProps {
   isOpen: boolean;
   offsetHeight?: number;
+  minHeight?: number;
   animationDuration?: number;
   animationEase?:
     | 'easeInOut'
@@ -29,6 +30,7 @@ export interface HeightAnimatedContainerProps {
 export const HeightAnimatedContainer: FC<HeightAnimatedContainerProps> = ({
   isOpen,
   offsetHeight = 0,
+  minHeight = 0,
   animationDuration = 0.3,
   animationEase = 'easeInOut',
   children,
@@ -42,7 +44,7 @@ export const HeightAnimatedContainer: FC<HeightAnimatedContainerProps> = ({
   const motionProps: MotionProps = {
     initial: { height: 'auto' },
     animate: {
-      height: isOpen ? height + offsetHeight : 'auto',
+      height: isOpen ? Math.max(height + offsetHeight, minHeight) : 'auto',
     },
     transition: {
       duration: animationDuration,

--- a/src/hooks/earn/useProjectLikeDataFromEarnOpportunity.ts
+++ b/src/hooks/earn/useProjectLikeDataFromEarnOpportunity.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
-import { EarnOpportunityWithLatestAnalytics } from 'src/types/jumper-backend';
-import { ZapDataResponse } from 'src/providers/ZapInitProvider/ModularZaps/zap.jumper-backend';
+import type { EarnOpportunityWithLatestAnalytics } from 'src/types/jumper-backend';
+import type { ZapDataResponse } from 'src/providers/ZapInitProvider/ModularZaps/zap.jumper-backend';
 
 export const useProjectLikeDataFromEarnOpportunity = (
   earnOpportunity: Pick<
@@ -47,6 +47,32 @@ export const useProjectLikeDataFromEarnOpportunity = (
         approve: {} as any, // Not needed for DepositModal
         deposit: {} as any, // Not needed for DepositModal
         transfer: {} as any, // Not needed for DepositModal
+        withdraw: {
+          inputs: [
+            {
+              name: 'shares',
+              type: 'uint256',
+            },
+            {
+              name: 'receiver',
+              type: 'address',
+            },
+            {
+              name: 'owner',
+              type: 'address',
+            },
+          ],
+          name: 'redeem',
+          outputs: [
+            {
+              name: 'assets',
+              type: 'uint256',
+            },
+          ],
+          payable: false,
+          stateMutability: 'nonpayable',
+          type: 'function',
+        },
       },
     };
 

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -38,6 +38,7 @@ interface Resources {
     };
     buttons: {
       depositButtonLabel: 'Quick deposit';
+      withdrawButtonLabel: 'Withdraw';
       managePositionsButtonLabel: 'Manage Positions';
     };
     campaign: {
@@ -516,6 +517,41 @@ interface Resources {
           description: 'Your funds have been returned and are now available to use in your wallet.';
           title: 'Funds successfully returned';
         };
+      };
+      withdraw: {
+        amount: 'Amount';
+        error: {
+          chainSwitchFailed: {
+            description: 'Failed to switch to the required network. Please try again.';
+            title: 'Chain switch failed';
+            tryAgain: 'Try again';
+          };
+          insufficientGas: {
+            description: 'You have insufficient gas to complete this transaction. Please top up and try again.';
+            increaseGas: 'Get gas';
+            title: 'Insufficient gas';
+          };
+          signatureFailed: {
+            description: 'You need to sign the transaction to confirm ownership of the wallet address.';
+            title: 'Signature required';
+            tryAgain: 'Try again';
+          };
+          transactionFailed: {
+            description: 'Something went wrong with the transaction. No funds were lost or moved. Please try again.';
+            title: 'Transaction failed';
+            tryAgain: 'Try again';
+          };
+        };
+        received: 'Received';
+        success: {
+          done: 'Done';
+          seeDetails: 'See details';
+          title: 'Withdraw successful';
+        };
+        switchChain: 'Switching chain...';
+        title: 'Withdraw';
+        waitingForTransaction: 'Waiting for transaction...';
+        withdraw: 'Withdraw';
       };
       zap: {
         depositSuccess: 'You will be able to see your position in a few seconds or alternatively by clicking on <bold>Manage your position</bold> that redirects to {{partnerName}} UI';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -463,6 +463,41 @@
     },
     "earn": {
       "depositSuccess": "You will be able to see and manage your position in a few seconds by clicking on <bold>Manage your positions</bold>"
+    },
+    "withdraw": {
+      "title": "Withdraw",
+      "amount": "Amount",
+      "received": "Received",
+      "switchChain": "Switching chain...",
+      "waitingForTransaction": "Waiting for transaction...",
+      "withdraw": "Withdraw",
+      "success": {
+        "title": "Withdraw successful",
+        "seeDetails": "See details",
+        "done": "Done"
+      },
+      "error": {
+        "chainSwitchFailed": {
+          "title": "Chain switch failed",
+          "description": "Failed to switch to the required network. Please try again.",
+          "tryAgain": "Try again"
+        },
+        "signatureFailed": {
+          "title": "Signature required",
+          "description": "You need to sign the transaction to confirm ownership of the wallet address.",
+          "tryAgain": "Try again"
+        },
+        "insufficientGas": {
+          "title": "Insufficient gas",
+          "description": "You have insufficient gas to complete this transaction. Please top up and try again.",
+          "increaseGas": "Get gas"
+        },
+        "transactionFailed": {
+          "title": "Transaction failed",
+          "description": "Something went wrong with the transaction. No funds were lost or moved. Please try again.",
+          "tryAgain": "Try again"
+        }
+      }
     }
   },
   "links": {
@@ -470,6 +505,7 @@
   },
   "buttons": {
     "depositButtonLabel": "Quick deposit",
+    "withdrawButtonLabel": "Withdraw",
     "managePositionsButtonLabel": "Manage Positions"
   },
   "modal": {

--- a/src/stores/withdrawFlow/WithdrawFlowStore.ts
+++ b/src/stores/withdrawFlow/WithdrawFlowStore.ts
@@ -1,0 +1,49 @@
+import { createWithEqualityFn } from 'zustand/traditional';
+import { shallow } from 'zustand/shallow';
+import type { EarnOpportunityWithLatestAnalytics } from 'src/types/jumper-backend';
+
+export interface EarnOpportunityExtended
+  extends EarnOpportunityWithLatestAnalytics {
+  minFromAmountUSD: number;
+  positionUrl: string;
+  address: string;
+}
+
+interface WithdrawFlowState {
+  isModalOpen: boolean;
+  selectedEarnOpportunity: EarnOpportunityExtended | null;
+  refetchCallback?: () => void;
+
+  openModal: (
+    earnOpportunity: EarnOpportunityExtended,
+    refetchCallback?: () => void,
+  ) => void;
+  closeModal: () => void;
+}
+
+export const useWithdrawFlowStore = createWithEqualityFn<WithdrawFlowState>(
+  (set) => ({
+    isModalOpen: false,
+    selectedEarnOpportunity: null,
+    refetchCallback: undefined,
+
+    openModal: (
+      earnOpportunity: EarnOpportunityExtended,
+      refetchCallback?: () => void,
+    ) => {
+      set({
+        isModalOpen: true,
+        selectedEarnOpportunity: earnOpportunity,
+        refetchCallback,
+      });
+    },
+
+    closeModal: () => {
+      set({
+        isModalOpen: false,
+        refetchCallback: undefined,
+      });
+    },
+  }),
+  shallow,
+);


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-16667

## Testing steps
1. Go to `/test-withdraw-flow`
2. Click on `Withdraw`
3. Insert a value but do not sign the tx
4. Check the proper error message is shown
5. Click `Try again` but do not sign the tx
6. The same message should be shown
7. Now click on the backdrop and trigger again the tx signing
8. Sign the tx
9. Check the success screen is shown
10. Check `See details` open the proper explorer
11. Check `Done` closes the bottom sheet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added complete withdrawal flow with dedicated UI components and modal interface
  * Introduced multi-mode withdrawal input allowing users to enter amounts or prices
  * Added error handling with user-friendly error messages for withdrawal failures
  * Enhanced bottom sheet status displays with error and success states

* **Improvements**
  * Updated card styling with improved text overflow handling
  * Enhanced state management for withdrawal processes
  * Refined button and modal components for better UX
  * Added responsive height animations for modal content

* **Localization**
  * Added comprehensive translation support for withdrawal flow, including error messages and success confirmations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->