### PR TITLE
feat: enable overall partner bg if no chain flag is set

### DIFF
--- a/src/hooks/theme/useThemeConditionsMet.ts
+++ b/src/hooks/theme/useThemeConditionsMet.ts
@@ -17,9 +17,13 @@ export const useThemeConditionsMet = () => {
     const showForFromChain = configTheme?.showForFromChain;
     const showForToChain = configTheme?.showForToChain;
 
+    if (!showForFromChain && !showForToChain) {
+      setShouldShowForChain(true);
+      return;
+    }
+
     setShouldShowForChain(
-      (!!showForFromChain && fromChainId === showForFromChain) ||
-        (!!showForToChain && toChainId === showForToChain),
+      fromChainId === showForFromChain || toChainId === showForToChain,
     );
   }, [
     fromChainId,


### PR DESCRIPTION
This PR aims to enable the partner bg for all chains if the `showForFromChain`/`showForToChain` are set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved chain validation logic for enhanced performance and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->