### PR TITLE
fix: add for you flag for earn opportunities

### DIFF
--- a/src/app/ui/earn/EarnFilteringContext.tsx
+++ b/src/app/ui/earn/EarnFilteringContext.tsx
@@ -12,6 +12,13 @@ import { useAccountAddress } from 'src/hooks/earn/useAccountAddress';
 import { useEarnFilterOpportunities } from 'src/hooks/earn/useEarnFilterOpportunities';
 import type { EarnOpportunityWithLatestAnalytics } from 'src/types/jumper-backend';
 import type { Hex } from 'viem';
+import {
+  enrichDataWithFlag,
+  extractFilteringParams,
+  removeNullValuesFromFilter,
+  sanitizeFilter,
+  searchParamsParsers,
+} from './utils';
 import { EMPTY_FILTERING_PARAMS } from './constants';
 import type {
   EarnFilteringParams,
@@ -20,12 +27,6 @@ import type {
   SortByEnum,
 } from './types';
 import { SortByOptions } from './types';
-import {
-  extractFilteringParams,
-  removeNullValuesFromFilter,
-  sanitizeFilter,
-  searchParamsParsers,
-} from './utils';
 
 export interface EarnFilteringContextType extends EarnFilteringParams {
   sortBy: SortByEnum;
@@ -167,6 +168,15 @@ export const EarnFilteringProvider = ({
     [setSortBy, setSearchParamsState],
   );
 
+  const data = useMemo(() => {
+    const sourceData = showForYou ? forYou.data?.data : all.data?.data;
+    const forYouSlugsSet = new Set(
+      (forYou.data?.data ?? []).map((item) => item.slug),
+    );
+
+    return enrichDataWithFlag(sourceData, 'forYou', forYouSlugsSet);
+  }, [showForYou, forYou.data, all.data]);
+
   const context: EarnFilteringContextType = {
     sortBy,
     setSortBy: updateSortBy,
@@ -176,7 +186,7 @@ export const EarnFilteringProvider = ({
     usedYourAddress,
     toggleForYou,
     totalMarkets,
-    data: showForYou ? forYouData : allData,
+    data,
     updatedAt: showForYou ? forYouUpdatedAt : undefined,
     isLoading: showForYou ? forYou.isLoading || !address : all.isLoading,
     error: (showForYou ? forYou.error : all.error) ?? null,

--- a/src/app/ui/earn/utils.ts
+++ b/src/app/ui/earn/utils.ts
@@ -1,11 +1,11 @@
 import { map, uniqBy, uniq, sortBy, fromPairs } from 'lodash';
-import { EarnOpportunityWithLatestAnalytics } from 'src/types/jumper-backend';
-import {
+import type { EarnOpportunityWithLatestAnalytics } from 'src/types/jumper-backend';
+import type {
   EarnFilteringParams,
   EarnOpportunityFilterWithoutSortByAndOrder,
-  OrderOptions,
-  SortByOptions,
 } from './types';
+import { OrderOptions, SortByOptions } from './types';
+import type { Nullable } from 'nuqs';
 import {
   parseAsStringEnum,
   parseAsBoolean,
@@ -13,7 +13,6 @@ import {
   parseAsInteger,
   parseAsString,
   parseAsFloat,
-  Nullable,
 } from 'nuqs';
 
 export const searchParamsParsers = {
@@ -111,4 +110,19 @@ export const sanitizeFilter = (
         ? Math.max(Math.min(filter.maxAPY, apyMax), apyMin)
         : null,
   };
+};
+
+export const enrichDataWithFlag = <
+  T extends { slug: string },
+  K extends { [P in keyof T]: T[P] extends boolean ? P : never }[keyof T] &
+    string,
+>(
+  data: T[] | undefined,
+  flagName: K,
+  matchingSlugs: Set<string>,
+): T[] => {
+  return (data ?? []).map((item) => ({
+    ...item,
+    [flagName]: matchingSlugs.has(item.slug),
+  })) as T[];
 };


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-16767

## Testing steps
1. Go to earn, check the icon (a hand with a heart) is showing up on all opportunities in the for you tab
2. Switch to the all markets tab, recommended opportunities, should still show up in the all markets tab with that icon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Earn list now marks and preserves "For You" items so they’re clearly identifiable when viewing filtered or combined lists.

* **Performance**
  * Improved memoization and data handling to make filtering and toggling between views faster and more efficient.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->