### PR TITLE
fix: update visibility checks in connectWallet and mainMenu tests

### DIFF
--- a/tests/connectWallet.spec.ts
+++ b/tests/connectWallet.spec.ts
@@ -58,7 +58,7 @@ test.describe('Connect/disconnect Metamask with Jumper app and open /profile pag
       );
       await clickOnJumperLogo(page);
       await transactionHistoryButton.click();
-      await expect(noRecentTransactions).toBeVisible();
+      await expect(noRecentTransactions).not.toBeVisible();
     });
 
     await test.step('Disconnect wallet from the Jumper app ', async () => {

--- a/tests/mainMenu.spec.ts
+++ b/tests/mainMenu.spec.ts
@@ -31,7 +31,7 @@ test.describe('Main Menu flows', () => {
     qase(12, 'Should be able to open menu and close it'),
     async ({ page }) => {
       await openOrCloseMainMenu(page);
-      await checkTheNumberOfMenuItems(page, 6);
+      await checkTheNumberOfMenuItems(page, 5);
       await page.locator('body').click();
       await expect(page.getByRole('menu')).not.toBeVisible();
     },

--- a/tests/mainMenu.spec.ts
+++ b/tests/mainMenu.spec.ts
@@ -30,8 +30,8 @@ test.describe('Main Menu flows', () => {
   test(
     qase(12, 'Should be able to open menu and close it'),
     async ({ page }) => {
-      openOrCloseMainMenu(page);
-      await checkTheNumberOfMenuItems(page, 5);
+      await openOrCloseMainMenu(page);
+      await checkTheNumberOfMenuItems(page, 6);
       await page.locator('body').click();
       await expect(page.getByRole('menu')).not.toBeVisible();
     },

--- a/tests/testData/connectWalletFunctions.ts
+++ b/tests/testData/connectWalletFunctions.ts
@@ -1,25 +1,6 @@
 import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 
-export const getRankValue = async (page: Page) => {
-  const rankSelector = 'xpath=(//div[@class="MuiBox-root mui-19kp780"]//p)[1]';
-  return await page.locator(rankSelector).textContent();
-};
-
-export const verifyRankValueVisibility = async (page, rankValue) => {
-  const rankElements = page.locator(`text=${rankValue}`);
-  await expect(rankElements).toHaveCount(2);
-  for (const element of await rankElements.all()) {
-    await expect(element).toBeVisible();
-  }
-};
-
-export const verifyPageParameter = async (page) => {
-  const currentUrl = page.url();
-  await expect(currentUrl).toContain('page=');
-  await expect(currentUrl.split('page=')[1]).not.toBe('undefined');
-};
-
 export const connectedWalletButton = async (page: Page) => {
   await page.locator('#wallet-digest-button').click();
 };

--- a/tests/testData/earnPageFunctions.ts
+++ b/tests/testData/earnPageFunctions.ts
@@ -6,17 +6,17 @@ export async function selectAllMarketsTab(page: Page) {
 }
 
 export async function verifyAnalyticsButtonsAreVisible(page: Page) {
-	const chartButtons = [
-		"analytics-range-week",
-		"analytics-range-month",
-		"analytics-range-year",
-		"analytics-value-apy",
-		"analytics-value-tvl",
-	];
-	for (const chartButton of chartButtons) {
-		await page.waitForLoadState("networkidle");
-		await expect(page.getByTestId(chartButton)).toBeVisible();
-	}
+  const chartButtons = [
+    'analytics-range-week',
+    'analytics-range-month',
+    'analytics-range-year',
+    'analytics-value-apy',
+    'analytics-value-tvl',
+  ];
+  for (const chartButton of chartButtons) {
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId(chartButton)).toBeVisible();
+  }
 }
 export async function verifyNoSelectedChainsAreVisible(
   page: Page,
@@ -53,36 +53,6 @@ export async function verifyNoSelectedProtocolsAreVisible(
   protocol1: string,
 ) {
   await verifyNoSelectedItemsAreVisible(page, [protocol1]);
-}
-
-export async function verifyNoSelectedAssetsAreVisible(
-  page: Page,
-  asset1: string,
-) {
-  await verifyNoSelectedItemsAreVisible(page, [asset1]);
-}
-
-export async function getAllAssetsFromDropdown(page: Page): Promise<string[]> {
-  // Wait for the dropdown to be visible and options to load
-  await page.waitForLoadState('networkidle');
-
-  const options = page.locator('[role="option"]');
-
-  // Wait for at least one option to be available
-  await options.first().waitFor({ state: 'visible', timeout: 10000 });
-
-  // Get the actual count of available options
-  const optionCount = await options.count();
-  console.debug(`Found ${optionCount} options in the dropdown`);
-
-  const assets: string[] = [];
-  for (let i = 0; i < optionCount; i++) {
-    const optionText = await options.nth(i).textContent();
-    if (optionText?.trim()) {
-      assets.push(optionText.trim());
-    }
-  }
-  return assets;
 }
 
 export async function verifyOnlySelectedAssetIsVisible(
@@ -141,7 +111,9 @@ async function verifyNoSelectedItemsAreVisible(page: Page, items: string[]) {
   const childElements = earnOpportunitiesContainer.locator('*');
   const childCount = await childElements.count();
 
-  console.debug(`Checking ${childCount} elements for items: ${items.join(', ')}`);
+  console.debug(
+    `Checking ${childCount} elements for items: ${items.join(', ')}`,
+  );
 
   const patterns = items.map(
     (item) => new RegExp(`\\b${item.toLowerCase()}\\b`),
@@ -157,7 +129,9 @@ async function verifyNoSelectedItemsAreVisible(page: Page, items: string[]) {
       for (let j = 0; j < patterns.length; j++) {
         const pattern = patterns[j];
         if (lowerText.match(pattern)) {
-          console.debug(`Found matching text in element ${i}: "${textContent}"`);
+          console.debug(
+            `Found matching text in element ${i}: "${textContent}"`,
+          );
         }
         expect(lowerText).not.toMatch(pattern);
       }

--- a/tests/testData/landingPageFunctions.ts
+++ b/tests/testData/landingPageFunctions.ts
@@ -6,10 +6,6 @@ export const LANDING_PAGE = {
   GET_STARTED_BUTTON: '#get-started-button',
 };
 
-export async function findTheBestRoute(page) {
-  await page.getByRole('heading', { name: 'Find the best route' });
-}
-
 export async function closeWelcomeScreen(page: Page) {
   return page.locator(LANDING_PAGE.GET_STARTED_BUTTON).click();
 }
@@ -19,15 +15,6 @@ export async function itemInMenu(page, option: string) {
 
 export async function itemInNavigation(page, option: string) {
   await page.getByRole('link', { name: option }).click();
-}
-
-export async function tabInHeader(page, tabname1: string, tabname2: string) {
-  const gasTab = await page.locator('#tab-key-1');
-  const exchangeTab = await page.locator('#tab-key-0');
-  await gasTab.click();
-  await expect(page.locator(`xpath=//p[text()="${tabname1}"]`)).toBeVisible();
-  await exchangeTab.click();
-  await expect(page.locator(`xpath=//p[text()=${tabname2}]`)).toBeVisible();
 }
 
 export async function clickOnJumperLogo(page: Page) {


### PR DESCRIPTION
Corresponding JIRA ticket : 
https://lifi.atlassian.net/browse/LF-16903 


### **Test fixes**

1. connectWallet.spec.ts: Fixed assertion — changed expect(noRecentTransactions).toBeVisible() to .not.toBeVisible() (if transactions exist, the "no recent transactions" message should not be visible).
2. mainMenu.spec.ts:
3. Added missing await to openOrCloseMainMenu(page) call
4. Updated expected menu items count from 5 to 6

### **Code cleanup — removed unused functions**

1. connectWalletFunctions.ts: Removed 3 unused functions:
2. getRankValue
3. verifyRankValueVisibility
4. verifyPageParameter
5. earnPageFunctions.ts: Removed 2 unused functions:
6. verifyNoSelectedAssetsAreVisible
7. getAllAssetsFromDropdown
8. landingPageFunctions.ts: Removed 2 unused functions:
9. findTheBestRoute
10. tabInHeader

### **Code formatting**

1. earnPageFunctions.ts: Formatting fixes:
2. Converted tabs to spaces in verifyAnalyticsButtonsAreVisible
3. Changed double quotes to single quotes
4. Improved console.debug formatting for better readability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Adjusted a transaction-history assertion to expect a different visibility outcome.
  * Improved test flow by awaiting an asynchronous menu action.
  * Removed several unused test helper utilities to streamline the test suite.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->