### PR TITLE
feat: add partner theme to menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-i18next": "^16.3.2",
     "recharts": "^3.4.1",
     "sharp": "^0.34.5",
+    "superjson": "^2.2.6",
     "swiper": "12.0.3",
     "universal-cookie": "^8.0.1",
     "uuid": "^13.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
+      superjson:
+        specifier: ^2.2.6
+        version: 2.2.6
       swiper:
         specifier: 12.0.3
         version: 12.0.3
@@ -4703,7 +4706,6 @@ packages:
 
   '@walletconnect/ethereum-provider@2.21.7':
     resolution: {integrity: sha512-T+cBFCw095tDpR35WqwsTFod2ZsizmLfieSbTqpQDpNjhQyFwYf9d+tn2kcBFmxzENXAsWA8BIZK1tjRrXKtog==}
-    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
 
   '@walletconnect/events@1.0.1':
     resolution: {integrity: sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==}
@@ -5491,6 +5493,10 @@ packages:
 
   cookie@1.0.2:
     resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
+
+  copy-anything@4.0.5:
+    resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
 
   core-js-compat@3.46.0:
@@ -6928,6 +6934,10 @@ packages:
   is-weakset@2.0.4:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
+
+  is-what@5.5.0:
+    resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
+    engines: {node: '>=18'}
 
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -8850,6 +8860,10 @@ packages:
 
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
+
+  superjson@2.2.6:
+    resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
+    engines: {node: '>=16'}
 
   superstruct@1.0.4:
     resolution: {integrity: sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==}
@@ -17711,6 +17725,10 @@ snapshots:
 
   cookie@1.0.2: {}
 
+  copy-anything@4.0.5:
+    dependencies:
+      is-what: 5.5.0
+
   core-js-compat@3.46.0:
     dependencies:
       browserslist: 4.28.0
@@ -19379,6 +19397,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  is-what@5.5.0: {}
 
   is-wsl@2.2.0:
     dependencies:
@@ -21708,6 +21728,10 @@ snapshots:
   stylis@4.3.2: {}
 
   stylis@4.3.6: {}
+
+  superjson@2.2.6:
+    dependencies:
+      copy-anything: 4.0.5
 
   superstruct@1.0.4: {}
 

--- a/src/components/Menus/MainMenu/hooks.tsx
+++ b/src/components/Menus/MainMenu/hooks.tsx
@@ -341,7 +341,8 @@ export const useMenuItems = () => {
   const isMobile = useMediaQuery((theme) => theme.breakpoints.down('md'));
   const theme = useTheme();
   const [configTheme] = useThemeStore((state) => [state.configTheme]);
-  const { selectedThemeIcon, selectedThemeMode } = useThemeModesMenuContent();
+  const { selectedThemeIcon, selectedThemeMode, selectedPartnerTheme } =
+    useThemeModesMenuContent();
   const isEarnEnabled = isEarnFeatureEnabled();
   const isPortfolioEnabled = isPortfolioFeatureEnabled();
   const { supportModalUnreadCount } = useMenuStore((state) => state);
@@ -366,11 +367,11 @@ export const useMenuItems = () => {
 
     return (
       <Badge
-        label={t(`navbar.themes.${selectedThemeMode}`)}
+        label={selectedPartnerTheme ?? t(`navbar.themes.${selectedThemeMode}`)}
         variant={BadgeVariant.Secondary}
       />
     );
-  }, [t, selectedThemeMode, isMobile]);
+  }, [t, selectedThemeMode, selectedPartnerTheme, isMobile]);
 
   const languageSuffixIcon = useMemo(() => {
     if (!isMobile) {

--- a/src/components/Menus/ThemeModesSubMenu/useThemeModesMenuContent.tsx
+++ b/src/components/Menus/ThemeModesSubMenu/useThemeModesMenuContent.tsx
@@ -16,7 +16,6 @@ import {
   TrackingEventParameter,
 } from '@/const/trackingKeys';
 import { isDarkOrLightThemeMode } from '@/utils/formatTheme';
-import { useThemeConditionsMet } from '@/hooks/theme/useThemeConditionsMet';
 import Avatar from '@mui/material/Avatar';
 
 interface SubmenuItem {
@@ -49,7 +48,6 @@ export const useThemeModesMenuContent = () => {
   const { t } = useTranslation();
   const { trackEvent } = useUserTracking();
   const { isMainPaths } = useMainPaths();
-  const { shouldShowForChain, shouldShowForPath } = useThemeConditionsMet();
 
   const [setConfigThemeState, configThemeStates, getAvailablePartnerThemes] =
     useThemeStore((state) => [
@@ -114,16 +112,9 @@ export const useThemeModesMenuContent = () => {
         prefixIcon: MODE_OPTIONS[themeMode].icon,
         checkIcon: !activeConfigThemeUid && mode === themeMode,
         onClick: () => handleSwitchMode(themeMode),
-        disabled: shouldShowForChain && shouldShowForPath,
+        disabled: false,
       })),
-    [
-      t,
-      activeConfigThemeUid,
-      mode,
-      handleSwitchMode,
-      shouldShowForChain,
-      shouldShowForPath,
-    ],
+    [t, activeConfigThemeUid, mode, handleSwitchMode],
   );
 
   const displayablePartnerThemes = useMemo(() => {
@@ -143,7 +134,11 @@ export const useThemeModesMenuContent = () => {
             <Avatar
               src={themeModeIcon}
               alt={theme.PartnerName}
-              sx={{ height: 24, width: 24, filter: 'grayscale(100%)' }}
+              sx={{
+                height: 24,
+                width: 24,
+                filter: 'grayscale(100%)',
+              }}
             />
           ) : (
             <FlareRoundedIcon />

--- a/src/components/Menus/ThemeModesSubMenu/useThemeModesMenuContent.tsx
+++ b/src/components/Menus/ThemeModesSubMenu/useThemeModesMenuContent.tsx
@@ -97,12 +97,16 @@ export const useThemeModesMenuContent = () => {
         },
       });
 
+      if (activeConfigThemeUid && activeConfigThemeUid !== theme.uid) {
+        setConfigThemeState(activeConfigThemeUid, { isSelected: false });
+      }
+
       setConfigThemeState(theme.uid, { isSelected: true });
 
       const themeMode = isDarkOrLightThemeMode(theme);
       setMode(themeMode);
     },
-    [trackEvent, setConfigThemeState, setMode],
+    [trackEvent, setConfigThemeState, setMode, activeConfigThemeUid],
   );
 
   const standardModeItems = useMemo<SubmenuItem[]>(

--- a/src/components/Menus/ThemeModesSubMenu/useThemeModesMenuContent.tsx
+++ b/src/components/Menus/ThemeModesSubMenu/useThemeModesMenuContent.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/const/trackingKeys';
 import { isDarkOrLightThemeMode } from '@/utils/formatTheme';
 import Avatar from '@mui/material/Avatar';
+import { selectAvailablePartnerThemes } from '@/stores/theme/createThemeStore';
 
 interface SubmenuItem {
   label: string;
@@ -49,12 +50,11 @@ export const useThemeModesMenuContent = () => {
   const { trackEvent } = useUserTracking();
   const { isMainPaths } = useMainPaths();
 
-  const [setConfigThemeState, configThemeStates, getAvailablePartnerThemes] =
-    useThemeStore((state) => [
-      state.setConfigThemeState,
-      state.configThemeStates,
-      state.getAvailablePartnerThemes,
-    ]);
+  const [setConfigThemeState, configThemeStates] = useThemeStore((state) => [
+    state.setConfigThemeState,
+    state.configThemeStates,
+  ]);
+  const availablePartnerThemes = useThemeStore(selectAvailablePartnerThemes);
 
   const defaultMode = isMainPaths ? 'system' : 'light';
   const selectedThemeMode = mode ?? defaultMode;
@@ -122,10 +122,10 @@ export const useThemeModesMenuContent = () => {
   );
 
   const displayablePartnerThemes = useMemo(() => {
-    return getAvailablePartnerThemes().filter(
+    return availablePartnerThemes.filter(
       (theme) => theme.SelectableInMenu && theme.PartnerName,
     );
-  }, [getAvailablePartnerThemes]);
+  }, [availablePartnerThemes]);
 
   const partnerThemeItems = useMemo<SubmenuItem[]>(
     () =>

--- a/src/components/Menus/ThemeModesSubMenu/useThemeModesMenuContent.tsx
+++ b/src/components/Menus/ThemeModesSubMenu/useThemeModesMenuContent.tsx
@@ -3,6 +3,10 @@ import { useTranslation } from 'react-i18next';
 import WbSunnyOutlinedIcon from '@mui/icons-material/WbSunnyOutlined';
 import NightlightIcon from '@mui/icons-material/Nightlight';
 import BrightnessAutoIcon from '@mui/icons-material/BrightnessAuto';
+import FlareRoundedIcon from '@mui/icons-material/FlareRounded';
+import { useMemo, useCallback } from 'react';
+import type { Appearance } from '@lifi/widget';
+import type { PartnerThemesData } from '@/types/strapi';
 import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
 import { useMainPaths } from '@/hooks/useMainPaths';
 import { useThemeStore } from '@/stores/theme';
@@ -11,85 +15,162 @@ import {
   TrackingCategory,
   TrackingEventParameter,
 } from '@/const/trackingKeys';
-import type { Appearance } from '@lifi/widget';
-import { useThemeConditionsMet } from 'src/hooks/theme/useThemeConditionsMet';
-import { useEffect, useRef } from 'react';
+import { isDarkOrLightThemeMode } from '@/utils/formatTheme';
+import { useThemeConditionsMet } from '@/hooks/theme/useThemeConditionsMet';
+import Avatar from '@mui/material/Avatar';
+
+interface SubmenuItem {
+  label: string;
+  prefixIcon: React.JSX.Element;
+  checkIcon: boolean;
+  onClick: () => void;
+  disabled: boolean;
+}
+
+const MODE_OPTIONS = {
+  light: {
+    icon: <WbSunnyOutlinedIcon />,
+    translationKey: 'navbar.themes.light',
+  },
+  dark: {
+    icon: <NightlightIcon />,
+    translationKey: 'navbar.themes.dark',
+  },
+  system: {
+    icon: <BrightnessAutoIcon />,
+    translationKey: 'navbar.themes.system',
+  },
+} as const;
+
+const STANDARD_MODES: Appearance[] = ['light', 'dark', 'system'];
 
 export const useThemeModesMenuContent = () => {
   const { mode, setMode } = useColorScheme();
   const { t } = useTranslation();
   const { trackEvent } = useUserTracking();
   const { isMainPaths } = useMainPaths();
-  const [configTheme] = useThemeStore((state) => [state.configTheme]);
-  const defaultThemeMode = configTheme?.defaultThemeMode;
-  const isThemeConditionsMet = useThemeConditionsMet();
+  const { shouldShowForChain, shouldShowForPath } = useThemeConditionsMet();
+
+  const [setConfigThemeState, configThemeStates, getAvailablePartnerThemes] =
+    useThemeStore((state) => [
+      state.setConfigThemeState,
+      state.configThemeStates,
+      state.getAvailablePartnerThemes,
+    ]);
+
   const defaultMode = isMainPaths ? 'system' : 'light';
   const selectedThemeMode = mode ?? defaultMode;
-  const selectedThemeModeRef = useRef<Appearance | undefined>(undefined);
 
-  useEffect(() => {
-    if (
-      isThemeConditionsMet &&
-      defaultThemeMode &&
-      selectedThemeMode !== defaultThemeMode
-    ) {
-      setMode(defaultThemeMode);
-      selectedThemeModeRef.current = selectedThemeMode;
-    } else if (
-      !isThemeConditionsMet &&
-      selectedThemeModeRef.current &&
-      selectedThemeModeRef.current !== selectedThemeMode
-    ) {
-      setMode(selectedThemeModeRef.current);
-      selectedThemeModeRef.current = undefined;
-    }
-  }, [isThemeConditionsMet, defaultThemeMode, selectedThemeMode, setMode]);
+  const activeConfigThemeUid = useMemo(() => {
+    const entry = Object.entries(configThemeStates).find(
+      ([_, state]) => state.isSelected,
+    );
+    return entry?.[0];
+  }, [configThemeStates]);
 
-  const handleSwitchMode = (newMode: Appearance) => {
-    trackEvent({
-      category: TrackingCategory.ThemeSection,
-      action: TrackingAction.SwitchTheme,
-      label: `theme_${newMode}`,
-      data: {
-        [TrackingEventParameter.SwitchedTheme]: newMode,
-      },
-    });
-    setMode(newMode ?? 'system');
-  };
+  const handleSwitchMode = useCallback(
+    (newMode: Appearance) => {
+      trackEvent({
+        category: TrackingCategory.ThemeSection,
+        action: TrackingAction.SwitchTheme,
+        label: `theme_${newMode}`,
+        data: {
+          [TrackingEventParameter.SwitchedTheme]: newMode,
+        },
+      });
 
-  const isModeAvailable = (theme: Appearance) =>
-    isMainPaths ||
-    !configTheme?.availableThemeModes ||
-    configTheme.availableThemeModes.includes(theme);
+      setMode(newMode ?? 'system');
 
-  const modeOptions = {
-    light: {
-      label: t('navbar.themes.light'),
-      prefixIcon: <WbSunnyOutlinedIcon />,
+      if (activeConfigThemeUid) {
+        setConfigThemeState(activeConfigThemeUid, { isSelected: false });
+      }
     },
-    dark: {
-      label: t('navbar.themes.dark'),
-      prefixIcon: <NightlightIcon />,
-    },
-    system: {
-      label: t('navbar.themes.system'),
-      prefixIcon: <BrightnessAutoIcon />,
-    },
-  } as const;
+    [trackEvent, setMode, activeConfigThemeUid, setConfigThemeState],
+  );
 
-  const submenuItems = (['light', 'dark', 'system'] as Appearance[]).map(
-    (theme) => ({
-      label: modeOptions[theme].label,
-      prefixIcon: modeOptions[theme].prefixIcon,
-      checkIcon: mode === theme,
-      onClick: () => handleSwitchMode(theme),
-      disabled: isThemeConditionsMet || !isModeAvailable(theme),
-    }),
+  const handleSwitchTheme = useCallback(
+    (theme: PartnerThemesData) => {
+      trackEvent({
+        category: TrackingCategory.ThemeSection,
+        action: TrackingAction.SwitchThemeTemplate,
+        label: `theme_${theme.uid}`,
+        data: {
+          [TrackingEventParameter.SwitchedTemplate]: theme.uid,
+        },
+      });
+
+      setConfigThemeState(theme.uid, { isSelected: true });
+
+      const themeMode = isDarkOrLightThemeMode(theme);
+      setMode(themeMode);
+    },
+    [trackEvent, setConfigThemeState, setMode],
+  );
+
+  const standardModeItems = useMemo<SubmenuItem[]>(
+    () =>
+      STANDARD_MODES.map((themeMode) => ({
+        label: t(MODE_OPTIONS[themeMode].translationKey),
+        prefixIcon: MODE_OPTIONS[themeMode].icon,
+        checkIcon: !activeConfigThemeUid && mode === themeMode,
+        onClick: () => handleSwitchMode(themeMode),
+        disabled: shouldShowForChain && shouldShowForPath,
+      })),
+    [
+      t,
+      activeConfigThemeUid,
+      mode,
+      handleSwitchMode,
+      shouldShowForChain,
+      shouldShowForPath,
+    ],
+  );
+
+  const displayablePartnerThemes = useMemo(() => {
+    return getAvailablePartnerThemes().filter(
+      (theme) => theme.SelectableInMenu && theme.PartnerName,
+    );
+  }, [getAvailablePartnerThemes]);
+
+  const partnerThemeItems = useMemo<SubmenuItem[]>(
+    () =>
+      displayablePartnerThemes.map((theme) => {
+        const themeModeIcon = (theme.lightConfig || theme.darkConfig)
+          ?.customization?.themeModeIcon;
+        return {
+          label: theme.PartnerName,
+          prefixIcon: themeModeIcon ? (
+            <Avatar
+              src={themeModeIcon}
+              alt={theme.PartnerName}
+              sx={{ height: 24, width: 24, filter: 'grayscale(100%)' }}
+            />
+          ) : (
+            <FlareRoundedIcon />
+          ),
+          checkIcon: activeConfigThemeUid === theme.uid,
+          onClick: () => handleSwitchTheme(theme),
+          disabled: false,
+        };
+      }),
+    [displayablePartnerThemes, activeConfigThemeUid, handleSwitchTheme],
+  );
+
+  // Note: using partnerThemeItems as we might change the label or prefix icon
+  const selectedPartnerTheme = useMemo(() => {
+    return partnerThemeItems.find((theme) => theme.checkIcon);
+  }, [partnerThemeItems]);
+
+  const submenuItems = useMemo(
+    () => [...standardModeItems, ...partnerThemeItems],
+    [standardModeItems, partnerThemeItems],
   );
 
   return {
-    selectedThemeMode,
-    selectedThemeIcon: modeOptions[selectedThemeMode].prefixIcon,
+    selectedThemeMode: selectedThemeMode,
+    selectedPartnerTheme: selectedPartnerTheme?.label,
+    selectedThemeIcon:
+      selectedPartnerTheme?.prefixIcon ?? MODE_OPTIONS[selectedThemeMode].icon,
     submenuItems,
   };
 };

--- a/src/components/Menus/ThemeModesSubMenu/useThemeModesMenuContent.tsx
+++ b/src/components/Menus/ThemeModesSubMenu/useThemeModesMenuContent.tsx
@@ -141,7 +141,7 @@ export const useThemeModesMenuContent = () => {
               sx={{
                 height: 24,
                 width: 24,
-                filter: 'grayscale(100%)',
+                filter: 'grayscale(100%) contrast(2)',
               }}
             />
           ) : (

--- a/src/hooks/theme/useGetPartnerThemeImage.ts
+++ b/src/hooks/theme/useGetPartnerThemeImage.ts
@@ -3,11 +3,10 @@ import { useThemeConditionsMet } from './useThemeConditionsMet';
 
 export const useGetPartnerThemeImage = () => {
   const configTheme = useThemeStore((state) => state.configTheme);
-  const { shouldShowForTheme, shouldShowForChain, shouldShowForPath } =
-    useThemeConditionsMet();
+  const { shouldShowForTheme, shouldShowForPath } = useThemeConditionsMet();
 
   const imageUrl =
-    shouldShowForPath && (shouldShowForTheme || shouldShowForChain)
+    shouldShowForPath && shouldShowForTheme
       ? configTheme?.backgroundImageUrl?.href
       : null;
 

--- a/src/hooks/theme/useGetPartnerThemeImage.ts
+++ b/src/hooks/theme/useGetPartnerThemeImage.ts
@@ -3,11 +3,13 @@ import { useThemeConditionsMet } from './useThemeConditionsMet';
 
 export const useGetPartnerThemeImage = () => {
   const configTheme = useThemeStore((state) => state.configTheme);
-  const isThemeConditionsMet = useThemeConditionsMet();
+  const { shouldShowForTheme, shouldShowForChain, shouldShowForPath } =
+    useThemeConditionsMet();
 
-  const imageUrl = isThemeConditionsMet
-    ? configTheme?.backgroundImageUrl?.href
-    : null;
+  const imageUrl =
+    shouldShowForPath && (shouldShowForTheme || shouldShowForChain)
+      ? configTheme?.backgroundImageUrl?.href
+      : null;
 
   return imageUrl;
 };

--- a/src/hooks/theme/useThemeConditionsMet.ts
+++ b/src/hooks/theme/useThemeConditionsMet.ts
@@ -1,39 +1,57 @@
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
+import { isBefore } from 'date-fns';
 import { AppPaths } from 'src/const/urls';
 import { useThemeStore } from 'src/stores/theme';
 import { useWidgetCacheStore } from 'src/stores/widgetCache';
 import { usePathnameWithoutLocale } from '../routing/usePathnameWithoutLocale';
 
+const ALLOWED_PATHS = [AppPaths.Main, AppPaths.Gas];
+
 export const useThemeConditionsMet = () => {
-  const [shouldShowForChain, setShouldShowForChain] = useState<boolean>(false);
   const pathname = usePathnameWithoutLocale();
-  const configTheme = useThemeStore((state) => state.configTheme);
+  const [configTheme, configThemeStates] = useThemeStore((state) => [
+    state.configTheme,
+    state.configThemeStates,
+  ]);
   const [fromChainId, toChainId] = useWidgetCacheStore((state) => [
     state.fromChainId,
     state.toChainId,
   ]);
 
-  useEffect(() => {
-    const showForFromChain = configTheme?.showForFromChain;
-    const showForToChain = configTheme?.showForToChain;
+  const activeConfigThemeState = useMemo(() => {
+    const entry = Object.entries(configThemeStates).find(
+      ([uid]) => uid === configTheme?.uid,
+    );
+    return entry?.[1];
+  }, [configThemeStates, configTheme]);
 
-    if (!showForFromChain && !showForToChain) {
-      setShouldShowForChain(true);
-      return;
+  const shouldShowForTheme = useMemo(() => {
+    if (!activeConfigThemeState?.isSelected) {
+      return false;
     }
 
-    setShouldShowForChain(
-      fromChainId === showForFromChain || toChainId === showForToChain,
-    );
-  }, [
-    fromChainId,
-    toChainId,
-    configTheme.showForFromChain,
-    configTheme.showForToChain,
-  ]);
+    if (!activeConfigThemeState.expirationDate) {
+      return false;
+    }
 
-  const shouldShowForPath = [AppPaths.Main, AppPaths.Gas].includes(
-    pathname as AppPaths,
-  );
-  return shouldShowForChain && shouldShowForPath;
+    return isBefore(new Date(), activeConfigThemeState.expirationDate);
+  }, [activeConfigThemeState]);
+
+  const shouldShowForChain = useMemo(() => {
+    const { showForFromChain, showForToChain } = configTheme || {};
+
+    if (!showForFromChain && !showForToChain) {
+      return true;
+    }
+
+    return fromChainId === showForFromChain || toChainId === showForToChain;
+  }, [fromChainId, toChainId, configTheme]);
+
+  const shouldShowForPath = ALLOWED_PATHS.includes(pathname as AppPaths);
+
+  return {
+    shouldShowForTheme,
+    shouldShowForChain,
+    shouldShowForPath,
+  };
 };

--- a/src/hooks/theme/useThemeConditionsMet.ts
+++ b/src/hooks/theme/useThemeConditionsMet.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 import { isBefore } from 'date-fns';
 import { AppPaths } from 'src/const/urls';
 import { useThemeStore } from 'src/stores/theme';
-import { useWidgetCacheStore } from 'src/stores/widgetCache';
 import { usePathnameWithoutLocale } from '../routing/usePathnameWithoutLocale';
 
 const ALLOWED_PATHS = [AppPaths.Main, AppPaths.Gas];
@@ -12,10 +11,6 @@ export const useThemeConditionsMet = () => {
   const [configTheme, configThemeStates] = useThemeStore((state) => [
     state.configTheme,
     state.configThemeStates,
-  ]);
-  const [fromChainId, toChainId] = useWidgetCacheStore((state) => [
-    state.fromChainId,
-    state.toChainId,
   ]);
 
   const activeConfigThemeState = useMemo(() => {
@@ -37,21 +32,10 @@ export const useThemeConditionsMet = () => {
     return isBefore(new Date(), activeConfigThemeState.expirationDate);
   }, [activeConfigThemeState]);
 
-  const shouldShowForChain = useMemo(() => {
-    const { showForFromChain, showForToChain } = configTheme || {};
-
-    if (!showForFromChain && !showForToChain) {
-      return true;
-    }
-
-    return fromChainId === showForFromChain || toChainId === showForToChain;
-  }, [fromChainId, toChainId, configTheme]);
-
   const shouldShowForPath = ALLOWED_PATHS.includes(pathname as AppPaths);
 
   return {
     shouldShowForTheme,
-    shouldShowForChain,
     shouldShowForPath,
   };
 };

--- a/src/providers/ThemeProvider/DefaultThemeProvider.tsx
+++ b/src/providers/ThemeProvider/DefaultThemeProvider.tsx
@@ -28,6 +28,7 @@ export function DefaultThemeProvider({ children, themes }: ThemeProviderProps) {
       configTheme: formatConfig(partnerThemeConfig),
       partnerThemes: themes!,
       widgetTheme: widgetTheme,
+      configThemeStates: {},
     };
   }, [mode, themes, partnerThemeConfig, prefersDarkMode]);
 

--- a/src/stores/theme/createThemeStore.tsx
+++ b/src/stores/theme/createThemeStore.tsx
@@ -190,22 +190,21 @@ export const createThemeStore = (props: ThemeProps) =>
           widgetTheme: state.widgetTheme,
           configThemeStates: state.configThemeStates,
         }),
-        onRehydrateStorage: () => {
-          return (state) => {
-            if (!state) {
-              return;
-            }
+        merge: (persistedState, currentState) => {
+          const persisted = (persistedState || {}) as PersistedThemeState;
 
-            state.configTheme = state.configTheme;
+          const mergedConfigThemeStates = {
+            ...(persisted.configThemeStates ?? {}),
+            ...currentState.configThemeStates,
+          };
 
-            const mergedStates = initializeConfigThemeStates(
-              state.configTheme,
-              state.configThemeStates,
-            );
-
-            if (!isEqual(mergedStates, state.configThemeStates)) {
-              state.configThemeStates = mergedStates;
-            }
+          return {
+            ...persisted,
+            ...currentState,
+            configThemeStates: initializeConfigThemeStates(
+              currentState.configTheme,
+              mergedConfigThemeStates,
+            ),
           };
         },
       },

--- a/src/stores/theme/createThemeStore.tsx
+++ b/src/stores/theme/createThemeStore.tsx
@@ -230,8 +230,6 @@ export const createThemeStore = (props: ThemeProps) =>
             }
           });
 
-          newStore.configTheme = newStore.configTheme;
-
           return newStore;
         },
         partialize: (state: ThemeState): PersistedThemeState => ({

--- a/src/stores/theme/createThemeStore.tsx
+++ b/src/stores/theme/createThemeStore.tsx
@@ -10,73 +10,10 @@ import type {
 import type { WidgetConfig } from '@lifi/widget';
 import { addDays, isBefore } from 'date-fns';
 import { isEqual } from 'lodash';
+import superjson from 'superjson';
 import Cookies from 'universal-cookie';
-import { createJSONStorage, persist } from 'zustand/middleware';
+import { persist } from 'zustand/middleware';
 import { createWithEqualityFn } from 'zustand/traditional';
-
-interface TaggedValue<T extends string = string> {
-  __type: T;
-  value: string;
-}
-
-const isTaggedValue = (val: unknown): val is TaggedValue =>
-  val !== null && typeof val === 'object' && '__type' in val && 'value' in val;
-
-const serializers = {
-  URL: {
-    test: (val: unknown): val is URL => val instanceof URL,
-    serialize: (val: URL): TaggedValue<'URL'> => ({
-      __type: 'URL',
-      value: val.href,
-    }),
-    deserialize: (val: string) => new URL(val),
-  },
-  Date: {
-    test: (val: unknown): val is Date => val instanceof Date,
-    serialize: (val: Date): TaggedValue<'Date'> => ({
-      __type: 'Date',
-      value: val.toISOString(),
-    }),
-    deserialize: (val: string) => new Date(val),
-  },
-} as const;
-
-type SerializerKey = keyof typeof serializers;
-
-const serialize = (_key: string, value: unknown): unknown => {
-  for (const [, handler] of Object.entries(serializers)) {
-    if (handler.test(value)) {
-      return handler.serialize(value as never);
-    }
-  }
-  if (Array.isArray(value)) {
-    return value.map((item, index) => serialize(String(index), item));
-  }
-  if (value !== null && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value).map(([k, v]) => [k, serialize(k, v)]),
-    );
-  }
-  return value;
-};
-
-const deserialize = (_key: string, value: unknown): unknown => {
-  if (value instanceof Date || value instanceof URL) {
-    return value;
-  }
-  if (isTaggedValue(value) && value.__type in serializers) {
-    return serializers[value.__type as SerializerKey].deserialize(value.value);
-  }
-  if (Array.isArray(value)) {
-    return value.map((item, index) => deserialize(String(index), item));
-  }
-  if (value !== null && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value).map(([k, v]) => [k, deserialize(k, v)]),
-    );
-  }
-  return value;
-};
 
 export const selectAvailablePartnerThemes = (
   state: ThemeState,
@@ -180,10 +117,21 @@ export const createThemeStore = (props: ThemeProps) =>
       {
         name: 'jumper-theme-store',
         version: 2,
-        storage: createJSONStorage(() => localStorage, {
-          reviver: deserialize,
-          replacer: serialize,
-        }),
+        storage: {
+          getItem: (name) => {
+            const str = localStorage.getItem(name);
+            if (!str) {
+              return null;
+            }
+            return superjson.parse(str);
+          },
+          setItem: (name, value) => {
+            localStorage.setItem(name, superjson.stringify(value));
+          },
+          removeItem: (name) => {
+            localStorage.removeItem(name);
+          },
+        },
         migrate: (
           persistedState: unknown,
           version: number,

--- a/src/stores/theme/createThemeStore.tsx
+++ b/src/stores/theme/createThemeStore.tsx
@@ -61,6 +61,9 @@ const serialize = (_key: string, value: unknown): unknown => {
 };
 
 const deserialize = (_key: string, value: unknown): unknown => {
+  if (value instanceof Date || value instanceof URL) {
+    return value;
+  }
   if (isTaggedValue(value) && value.__type in serializers) {
     return serializers[value.__type as SerializerKey].deserialize(value.value);
   }

--- a/src/stores/theme/createThemeStore.tsx
+++ b/src/stores/theme/createThemeStore.tsx
@@ -33,6 +33,9 @@ export const selectAvailablePartnerThemes = (
 
 const CONFIG_THEME_EXPIRATION_DAYS = 7;
 
+const getLocalStorage = () =>
+  typeof window === 'undefined' ? undefined : localStorage;
+
 const defaultConfigThemeState: ConfigThemeState = {
   expirationDate: undefined,
   isSelected: false,
@@ -119,17 +122,14 @@ export const createThemeStore = (props: ThemeProps) =>
         version: 2,
         storage: {
           getItem: (name) => {
-            const str = localStorage.getItem(name);
-            if (!str) {
-              return null;
-            }
-            return superjson.parse(str);
+            const str = getLocalStorage()?.getItem(name);
+            return str ? superjson.parse(str) : null;
           },
           setItem: (name, value) => {
-            localStorage.setItem(name, superjson.stringify(value));
+            getLocalStorage()?.setItem(name, superjson.stringify(value));
           },
           removeItem: (name) => {
-            localStorage.removeItem(name);
+            getLocalStorage()?.removeItem(name);
           },
         },
         migrate: (

--- a/src/stores/theme/createThemeStore.tsx
+++ b/src/stores/theme/createThemeStore.tsx
@@ -75,6 +75,22 @@ const deserialize = (_key: string, value: unknown): unknown => {
   return value;
 };
 
+export const selectAvailablePartnerThemes = (
+  state: ThemeState,
+): PartnerThemesData[] => {
+  const availableUids = Object.entries(state.configThemeStates)
+    .filter(
+      ([_, themeState]) =>
+        themeState.expirationDate &&
+        isBefore(new Date(), themeState.expirationDate),
+    )
+    .map(([uid]) => uid);
+
+  return state.partnerThemes.filter((theme) =>
+    availableUids.some((uid) => uid === theme.uid),
+  );
+};
+
 const CONFIG_THEME_EXPIRATION_DAYS = 7;
 
 const defaultConfigThemeState: ConfigThemeState = {
@@ -156,20 +172,6 @@ export const createThemeStore = (props: ThemeProps) =>
         },
         getConfigThemeState: (uid: string): ConfigThemeState => {
           return getOrCreateConfigThemeState(get().configThemeStates, uid);
-        },
-        getAvailablePartnerThemes: (): PartnerThemesData[] => {
-          const currentStates = get().configThemeStates;
-          const availableUids = Object.entries(currentStates)
-            .filter(
-              ([_, state]) =>
-                state.expirationDate &&
-                isBefore(new Date(), state.expirationDate),
-            )
-            .map(([uid]) => uid);
-
-          return get().partnerThemes.filter((theme) =>
-            availableUids.some((uid) => uid === theme.uid),
-          );
         },
       }),
       {

--- a/src/stores/theme/createThemeStore.tsx
+++ b/src/stores/theme/createThemeStore.tsx
@@ -1,67 +1,263 @@
 import type { PartnerThemeConfig } from '@/types/PartnerThemeConfig';
-import type { ThemeProps, ThemeState } from '@/types/theme';
+import type { PartnerThemesData } from '@/types/strapi';
+import type {
+  ConfigThemeState,
+  ConfigThemeStates,
+  PersistedThemeState,
+  ThemeProps,
+  ThemeState,
+} from '@/types/theme';
 import type { WidgetConfig } from '@lifi/widget';
-import type { StateCreator } from 'zustand';
-import { persist } from 'zustand/middleware';
-import { createWithEqualityFn } from 'zustand/traditional';
+import { addDays, isBefore } from 'date-fns';
+import { isEqual } from 'lodash';
 import Cookies from 'universal-cookie';
-import { cookieName } from 'src/i18n';
+import { createJSONStorage, persist } from 'zustand/middleware';
+import { createWithEqualityFn } from 'zustand/traditional';
+
+interface TaggedValue<T extends string = string> {
+  __type: T;
+  value: string;
+}
+
+const isTaggedValue = (val: unknown): val is TaggedValue =>
+  val !== null && typeof val === 'object' && '__type' in val && 'value' in val;
+
+const serializers = {
+  URL: {
+    test: (val: unknown): val is URL => val instanceof URL,
+    serialize: (val: URL): TaggedValue<'URL'> => ({
+      __type: 'URL',
+      value: val.href,
+    }),
+    deserialize: (val: string) => new URL(val),
+  },
+  Date: {
+    test: (val: unknown): val is Date => val instanceof Date,
+    serialize: (val: Date): TaggedValue<'Date'> => ({
+      __type: 'Date',
+      value: val.toISOString(),
+    }),
+    deserialize: (val: string) => new Date(val),
+  },
+} as const;
+
+type SerializerKey = keyof typeof serializers;
+
+const serialize = (_key: string, value: unknown): unknown => {
+  for (const [, handler] of Object.entries(serializers)) {
+    if (handler.test(value)) {
+      return handler.serialize(value as never);
+    }
+  }
+  if (Array.isArray(value)) {
+    return value.map((item, index) => serialize(String(index), item));
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([k, v]) => [k, serialize(k, v)]),
+    );
+  }
+  return value;
+};
+
+const deserialize = (_key: string, value: unknown): unknown => {
+  if (isTaggedValue(value) && value.__type in serializers) {
+    return serializers[value.__type as SerializerKey].deserialize(value.value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item, index) => deserialize(String(index), item));
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([k, v]) => [k, deserialize(k, v)]),
+    );
+  }
+  return value;
+};
+
+const CONFIG_THEME_EXPIRATION_DAYS = 7;
+
+const defaultConfigThemeState: ConfigThemeState = {
+  expirationDate: undefined,
+  isSelected: false,
+};
+
+const calculateExpirationDate = (publishedAt?: string): Date => {
+  const baseDate = publishedAt ? new Date(publishedAt) : new Date();
+  return addDays(baseDate, CONFIG_THEME_EXPIRATION_DAYS);
+};
+
+const getOrCreateConfigThemeState = (
+  states: ConfigThemeStates,
+  uid: string,
+): ConfigThemeState => {
+  return states[uid] ?? { ...defaultConfigThemeState };
+};
+
+const initializeConfigThemeStates = (
+  configTheme: Partial<PartnerThemeConfig>,
+  persistedStates: ConfigThemeStates = {},
+): ConfigThemeStates => {
+  if (!configTheme.uid) {
+    return persistedStates;
+  }
+
+  const currentThemeUid = configTheme.uid;
+  const expirationDate = calculateExpirationDate(configTheme.publishedAt);
+
+  const existingState = persistedStates[currentThemeUid];
+  const existingExpirationDate = existingState?.expirationDate
+    ? new Date(existingState.expirationDate)
+    : undefined;
+
+  if (
+    existingState &&
+    (!configTheme.publishedAt ||
+      isEqual(existingExpirationDate, expirationDate))
+  ) {
+    return persistedStates;
+  }
+
+  return {
+    ...persistedStates,
+    [currentThemeUid]: {
+      expirationDate,
+      isSelected: true,
+    },
+  };
+};
 
 export const createThemeStore = (props: ThemeProps) =>
-  createWithEqualityFn<ThemeState>(
-    persist(
+  createWithEqualityFn(
+    persist<ThemeState, [], [], PersistedThemeState>(
       (set, get) => ({
         ...props,
         setConfigTheme: (configTheme: Partial<PartnerThemeConfig>) => {
-          set({
-            configTheme,
-          });
+          set({ configTheme });
         },
         setWidgetTheme: (widgetTheme: { config: Partial<WidgetConfig> }) => {
+          set({ widgetTheme });
+        },
+        setConfigThemeState: (
+          uid: string,
+          state: Partial<ConfigThemeState>,
+        ) => {
+          const currentStates = get().configThemeStates;
+          const currentState = getOrCreateConfigThemeState(currentStates, uid);
           set({
-            widgetTheme,
+            configThemeStates: {
+              ...currentStates,
+              [uid]: {
+                ...currentState,
+                ...state,
+              },
+            },
           });
+        },
+        getConfigThemeState: (uid: string): ConfigThemeState => {
+          return getOrCreateConfigThemeState(get().configThemeStates, uid);
+        },
+        getAvailablePartnerThemes: (): PartnerThemesData[] => {
+          const currentStates = get().configThemeStates;
+          const availableUids = Object.entries(currentStates)
+            .filter(
+              ([_, state]) =>
+                state.expirationDate &&
+                isBefore(new Date(), state.expirationDate),
+            )
+            .map(([uid]) => uid);
+
+          return get().partnerThemes.filter((theme) =>
+            availableUids.some((uid) => uid === theme.uid),
+          );
         },
       }),
       {
         name: 'jumper-theme-store',
-        version: 1,
-        migrate: (persistedState: any, version: number) => {
+        version: 2,
+        storage: createJSONStorage(() => localStorage, {
+          reviver: deserialize,
+          replacer: serialize,
+        }),
+        migrate: (
+          persistedState: unknown,
+          version: number,
+        ): PersistedThemeState => {
+          const state = persistedState as Partial<PersistedThemeState> & {
+            configThemeState?: ConfigThemeState & { uid?: string };
+          };
+          const newStore: PersistedThemeState = {
+            configTheme: state.configTheme ?? {},
+            widgetTheme: state.widgetTheme ?? { config: {} },
+            configThemeStates: state.configThemeStates ?? {},
+          };
+
           if (version === 0) {
             const cookies = new Cookies();
-            const theme = cookies.get('theme')
-            const themeMode = cookies.get('themeMode')
-            const newStore = { ...persistedState };
+            const theme = cookies.get('theme');
+            const themeMode = cookies.get('themeMode');
 
             if (theme) {
-              newStore.activeTheme = theme;
-              cookies.remove('theme', { path: '/', sameSite: true })
+              cookies.remove('theme', { path: '/', sameSite: true });
             }
 
             if (themeMode) {
-              newStore.themeMode = themeMode;
-              cookies.remove('themeMode', { path: '/', sameSite: true })
+              cookies.remove('themeMode', { path: '/', sameSite: true });
             }
 
             console.debug('theme/themeMode cookies migrated');
-
-            return newStore;
           }
-          return persistedState;
+
+          if (version === 1 && state.configThemeState?.uid) {
+            const migratedState = state.configThemeState;
+            const uid = state.configThemeState.uid;
+            if (typeof migratedState.expirationDate === 'string') {
+              migratedState.expirationDate = new Date(
+                migratedState.expirationDate,
+              );
+            }
+            newStore.configThemeStates = {
+              [uid]: {
+                expirationDate: migratedState.expirationDate,
+                isSelected: migratedState.isSelected,
+              },
+            };
+          }
+
+          Object.values(newStore.configThemeStates).forEach((themeState) => {
+            if (typeof themeState.expirationDate === 'string') {
+              themeState.expirationDate = new Date(themeState.expirationDate);
+            }
+          });
+
+          newStore.configTheme = newStore.configTheme;
+
+          return newStore;
         },
-        partialize: (state) => {
-          return {
-            configTheme: state.configTheme,
-            widgetTheme: state.widgetTheme,
-          };
-        },
-        merge: (persistedState, currentState) => {
-          return {
-            ...(persistedState as ThemeState),
-            ...currentState,
+        partialize: (state: ThemeState): PersistedThemeState => ({
+          configTheme: state.configTheme,
+          widgetTheme: state.widgetTheme,
+          configThemeStates: state.configThemeStates,
+        }),
+        onRehydrateStorage: () => {
+          return (state) => {
+            if (!state) {
+              return;
+            }
+
+            state.configTheme = state.configTheme;
+
+            const mergedStates = initializeConfigThemeStates(
+              state.configTheme,
+              state.configThemeStates,
+            );
+
+            if (!isEqual(mergedStates, state.configThemeStates)) {
+              state.configThemeStates = mergedStates;
+            }
           };
         },
       },
-    ) as StateCreator<ThemeState, [], [], ThemeState>,
+    ),
     Object.is,
   );

--- a/src/types/PartnerThemeConfig.ts
+++ b/src/types/PartnerThemeConfig.ts
@@ -6,6 +6,7 @@ import type {
 } from '@lifi/widget';
 
 export interface PartnerThemeConfig {
+  themeModeIcon?: string;
   defaultThemeMode: 'light' | 'dark';
   availableThemeModes: string[];
   backgroundColor: string | null;
@@ -23,6 +24,7 @@ export interface PartnerThemeConfig {
   partnerUrl: URL | undefined;
   selectableInMenu: boolean;
   createdAt: string;
+  publishedAt?: string;
   uid: string;
   integrator?: string;
   fromChain?: ChainId;

--- a/src/types/PartnerThemeConfig.ts
+++ b/src/types/PartnerThemeConfig.ts
@@ -39,6 +39,4 @@ export interface PartnerThemeConfig {
   hasBlurredNavigation: boolean;
   allowedBridges: string[];
   allowedExchanges: string[];
-  showForFromChain: number;
-  showForToChain: number;
 }

--- a/src/types/strapi.ts
+++ b/src/types/strapi.ts
@@ -247,8 +247,6 @@ export interface Customization {
   typography?: string;
   hasBackgroundGradient?: boolean;
   hasBlurredNavigation?: boolean;
-  showForFromChain?: number;
-  showForToChain?: number;
   hasThemeModeSwitch?: boolean;
   themeModeIcon?: string;
 }

--- a/src/types/strapi.ts
+++ b/src/types/strapi.ts
@@ -250,6 +250,7 @@ export interface Customization {
   showForFromChain?: number;
   showForToChain?: number;
   hasThemeModeSwitch?: boolean;
+  themeModeIcon?: string;
 }
 
 type WidgetConfigProps = Omit<WidgetConfig, 'integrator'> &

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -25,7 +25,6 @@ export interface ThemeActions {
   setWidgetTheme: (widgetTheme: { config: Partial<WidgetConfig> }) => void;
   setConfigThemeState: (uid: string, state: Partial<ConfigThemeState>) => void;
   getConfigThemeState: (uid: string) => ConfigThemeState;
-  getAvailablePartnerThemes: () => PartnerThemesData[];
 }
 
 export type ThemeState = ThemeProps & ThemeActions;

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -6,17 +6,33 @@ import type { UseBoundStoreWithEqualityFn } from 'zustand/traditional';
 
 export type ActiveTheme = 'default' | string;
 
+export interface ConfigThemeState {
+  expirationDate: Date | undefined;
+  isSelected: boolean;
+}
+
+export type ConfigThemeStates = Record<string, ConfigThemeState>;
+
 export interface ThemeProps {
   partnerThemes: PartnerThemesData[];
   widgetTheme: { config: Partial<WidgetConfig> };
   configTheme: Partial<PartnerThemeConfig>;
+  configThemeStates: ConfigThemeStates;
 }
 
 export interface ThemeActions {
   setConfigTheme: (configTheme: Partial<PartnerThemeConfig>) => void;
   setWidgetTheme: (widgetTheme: { config: Partial<WidgetConfig> }) => void;
+  setConfigThemeState: (uid: string, state: Partial<ConfigThemeState>) => void;
+  getConfigThemeState: (uid: string) => ConfigThemeState;
+  getAvailablePartnerThemes: () => PartnerThemesData[];
 }
 
 export type ThemeState = ThemeProps & ThemeActions;
+
+export type PersistedThemeState = Pick<
+  ThemeState,
+  'configTheme' | 'widgetTheme' | 'configThemeStates'
+>;
 
 export type ThemeStore = UseBoundStoreWithEqualityFn<StoreApi<ThemeState>>;

--- a/src/utils/formatTheme.ts
+++ b/src/utils/formatTheme.ts
@@ -97,12 +97,6 @@ export function formatConfig(
     hasBackgroundGradient:
       (theme.lightConfig || theme.darkConfig)?.customization
         ?.hasBackgroundGradient ?? false,
-    showForFromChain:
-      (theme.lightConfig || theme.darkConfig)?.customization
-        ?.showForFromChain ?? undefined,
-    showForToChain:
-      (theme.lightConfig || theme.darkConfig)?.customization?.showForToChain ??
-      undefined,
     integrator:
       (theme.lightConfig || theme.darkConfig)?.config?.integrator ?? undefined,
     fromChain:

--- a/src/utils/formatTheme.ts
+++ b/src/utils/formatTheme.ts
@@ -37,7 +37,7 @@ export function getAvailableThemeModes(
   return result;
 }
 
-function getLogoData(theme: PartnerThemesAttributes) {
+export function getLogoData(theme: PartnerThemesAttributes) {
   const baseStrapiUrl = getStrapiUrl(STRAPI_PARTNER_THEMES);
   const logo = theme.LogoDark || theme.LogoLight || null;
 
@@ -82,7 +82,10 @@ export function formatConfig(
     partnerUrl: theme.PartnerURL,
     selectableInMenu: theme.SelectableInMenu || false,
     createdAt: theme.createdAt,
+    publishedAt: theme.publishedAt,
     uid: theme.uid,
+    themeModeIcon: (theme.lightConfig || theme.darkConfig)?.customization
+      ?.themeModeIcon,
     defaultThemeMode: (theme.lightConfig || theme.darkConfig)?.config
       ?.appearance as 'light' | 'dark',
     hasThemeModeSwitch:


### PR DESCRIPTION
- [x] Need to validate whether we keep the chain selection for showing up a theme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partner themes added to the theme selector with avatar/icon display and mobile badge fallback.
  * Partner-theme selection tracking and clearer submenu presentation.

* **Improvements**
  * Partner-theme images now show only when both theme and page conditions are met.
  * Per-theme visibility with expiration-aware logic and page filtering.
  * Persistent per-theme state with migrations and recovery for reliable theme availability and faster menu updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->