### PR TITLE
fix: earn card layout for only 2 items

### DIFF
--- a/src/components/Cards/EarnCard/EarnCard.snapshot.spec.tsx
+++ b/src/components/Cards/EarnCard/EarnCard.snapshot.spec.tsx
@@ -145,6 +145,30 @@ describe('EarnCard snapshot', () => {
     );
     expect(container).toMatchSnapshot();
   });
+  it('compact card with two items matches snapshot', async () => {
+    const { container } = render(
+      <EarnCard
+        {...commonArgs}
+        data={{
+          ...commonArgs.data,
+          lockupMonths: undefined,
+          latest: {
+            date: '2021-01-01',
+            tvlUsd: '',
+            tvlNative: '',
+            apy: {
+              base: 0.0558,
+              reward: 0,
+              total: 0.0558,
+            },
+          },
+        }}
+        variant="compact"
+        primaryAction={compactPrimaryAction}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
   it('list item card matches snapshot', async () => {
     const { container } = render(
       <EarnCard

--- a/src/components/Cards/EarnCard/EarnCard.stories.tsx
+++ b/src/components/Cards/EarnCard/EarnCard.stories.tsx
@@ -65,6 +65,29 @@ export const CompactWithHref: Story = {
     href: `${AppPaths.Earn}/${commonArgs.data.slug}`,
   },
 };
+
+export const CompactWithTwoItems: Story = {
+  args: {
+    ...commonArgs,
+    data: {
+      ...commonArgs.data,
+      lockupMonths: undefined,
+      latest: {
+        date: '2021-01-01',
+        tvlUsd: '',
+        tvlNative: '',
+        apy: {
+          base: 0.0558,
+          reward: 0,
+          total: 0.0558,
+        },
+      },
+    },
+    variant: 'compact',
+    primaryAction: compactPrimaryAction,
+  },
+};
+
 export const ListItem: Story = {
   args: {
     ...commonArgs,

--- a/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
+++ b/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
@@ -1325,6 +1325,265 @@ exports[`EarnCard snapshot > compact card with single asset matches snapshot 1`]
 </div>
 `;
 
+exports[`EarnCard snapshot > compact card with two items matches snapshot 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-aiq5q4"
+  >
+    <div
+      class="MuiStack-root css-10yhf5k-MuiStack-root"
+    >
+      <div
+        class="MuiStack-root css-101nimo-MuiStack-root"
+      >
+        <div
+          class="badge-container MuiBox-root css-1wzsofa"
+        >
+          <svg
+            fill="none"
+            height="12"
+            viewBox="0 0 20 20"
+            width="12"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              clip-path="url(#a)"
+            >
+              <path
+                d="M18.016 14.167c.573 0 1.057.166 1.45.5.393.333.587.722.58 1.166l-8.03 2.5-7-1.666v-7.5h1.95l7.27 2.241c.52.173.78.484.78.934 0 .26-.113.489-.34.683-.227.194-.513.297-.86.308h-2.8l-1.75-.558-.33.783 2.08.609h7Zm-4-11.475c.707-.684 1.607-1.025 2.7-1.025.907 0 1.673.277 2.3.833.627.556.96 1.194 1 1.917 0 .572-.333 1.255-1 2.05-.667.794-1.323 1.458-1.97 1.991-.647.534-1.657 1.325-3.03 2.375a116.845 116.845 0 0 1-3.06-2.375c-.653-.533-1.31-1.197-1.97-1.991-.66-.795-.983-1.478-.97-2.05 0-.756.323-1.395.97-1.917s1.427-.8 2.34-.833c1.067 0 1.963.341 2.69 1.025ZM-1 9.167h4.016v9.166H-1V9.167Z"
+                fill="currentColor"
+                fill-opacity="0.92"
+              />
+            </g>
+            <defs>
+              <clippath
+                id="a"
+              >
+                <path
+                  d="M0 0h20v20H0z"
+                  fill="#fff"
+                />
+              </clippath>
+            </defs>
+          </svg>
+        </div>
+        <div
+          class="badge-container MuiBox-root css-1wzsofa"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="earn-card-tag-staking"
+          >
+            Staking
+          </p>
+        </div>
+        <div
+          class="badge-container MuiBox-root css-1wzsofa"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="earn-card-tag-earn"
+          >
+            Earn
+          </p>
+        </div>
+      </div>
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary css-zben4u-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="MuiBox-root css-wxfvax"
+        >
+          <div
+            class="MuiBox-root css-11hplq4"
+          >
+            <svg
+              fill="none"
+              height="28"
+              viewBox="0 0 28 28"
+              width="28"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M15.535 1.766a1.167 1.167 0 0 1 1.338 1.458l-.007.021-2.24 7.024a.624.624 0 0 1-.009.026.584.584 0 0 0 .548.788h8.168a1.751 1.751 0 0 1 1.742 1.956 1.75 1.75 0 0 1-.413.935l-11.55 11.9h-.001a1.165 1.165 0 0 1-1.984-1.097l.007-.023 2.24-7.024a.584.584 0 0 0-.268-.748.584.584 0 0 0-.27-.065h-8.17a1.751 1.751 0 0 1-1.362-2.853l.034-.039 11.55-11.9c.171-.187.398-.313.647-.359Z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+        </div>
+      </button>
+    </div>
+    <div
+      class="MuiStack-root css-4e6rn7-MuiStack-root"
+    >
+      <div
+        class="MuiBox-root css-u70uxf"
+        data-testid="protocol-morpho"
+      >
+        <div
+          class="MuiBox-root css-wioyy2"
+        >
+          <div
+            class="MuiStack-root css-5s31b2-MuiStack-root"
+          >
+            <div
+              class="MuiStack-root css-k0vgmj-MuiStack-root"
+            >
+              <div
+                class="MuiAvatar-root MuiAvatar-circular css-1we4ia9-MuiAvatar-root"
+              >
+                <img
+                  alt="morpho"
+                  class="MuiAvatar-img css-i4dfdj-MuiAvatar-img"
+                  loading="lazy"
+                  src="https://strapi.jumper.exchange/uploads/morpho_eef0686ee3_2e4b8e06a6.png"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-k8f1u5"
+          >
+            <div
+              class="MuiStack-root css-1g44ov9-MuiStack-root"
+            >
+              <div
+                class="MuiStack-root css-1x5pyaa-MuiStack-root"
+              >
+                <div
+                  class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-5ylplk-MuiAvatar-root"
+                >
+                  <span
+                    class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-1dpscep-MuiSkeleton-root"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-fxacz8"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-titleXSmall css-10j8ruw-MuiTypography-root"
+            data-testid="entity-chain-stack-title"
+          >
+            Moonwell Flagship USDC on base
+          </span>
+          <p
+            class="MuiTypography-root MuiTypography-bodyXSmall css-1gwx9ao-MuiTypography-root"
+            data-testid="entity-chain-stack-chain-name"
+          >
+            Base
+          </p>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-1gk85zv-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-12 css-xvszvy-MuiGrid-root"
+          data-testid="apy-0.0558"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.apy
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.apy"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
+            >
+              5.58%
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-1gk85zv-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-12 css-xvszvy-MuiGrid-root"
+          data-testid="assets-USDC"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.assets
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.assets"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <div
+              class="MuiBox-root css-1xdhyk6"
+            >
+              <div
+                class="MuiStack-root css-5s31b2-MuiStack-root"
+              >
+                <div
+                  class="MuiStack-root css-k0vgmj-MuiStack-root"
+                >
+                  <div
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+                  >
+                    <span
+                      class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-lvnl87-MuiSkeleton-root"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
+            >
+              USDC
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EarnCard snapshot > list item card matches snapshot 1`] = `
 <div>
   <div

--- a/src/components/Cards/EarnCard/variants/CompactEarnCard.tsx
+++ b/src/components/Cards/EarnCard/variants/CompactEarnCard.tsx
@@ -37,7 +37,9 @@ export const CompactEarnCard: FC<Omit<EarnCardProps, 'variant'>> = ({
 
   const items = overviewItems.map((item, index) => {
     const shouldExpand =
-      index === overviewItems.length - 1 && overviewItems.length % 2 !== 0;
+      overviewItems.length === 2 ||
+      (index === overviewItems.length - 1 && overviewItems.length % 2 !== 0);
+
     return (
       <CompactEarnCardItem
         key={item.key}
@@ -88,7 +90,7 @@ export const CompactEarnCard: FC<Omit<EarnCardProps, 'variant'>> = ({
               title,
             }}
           />
-          {chunk(items, 2).map((itemsChunk, index) => (
+          {chunk(items, items.length > 2 ? 2 : 1).map((itemsChunk, index) => (
             <Grid
               container
               rowSpacing={2}


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-16952

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout of compact earn cards when displaying two items—they now stack vertically for better visual presentation rather than using a side-by-side arrangement.

* **Tests**
  * Added snapshot test for compact card variant with two-item display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->