### PR TITLE
feat: add contract link to earn protocol card

### DIFF
--- a/src/components/Cards/ProtocolCard/ProtocolCard.snapshot.spec.tsx
+++ b/src/components/Cards/ProtocolCard/ProtocolCard.snapshot.spec.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { render } from '../../../../vitest.setup';
 
@@ -6,6 +6,40 @@ import { ProtocolCard } from './ProtocolCard';
 import { commonArgs } from './fixtures';
 import { Badge } from 'src/components/Badge/Badge';
 import { BadgeSize, BadgeVariant } from 'src/components/Badge/Badge.styles';
+
+const mockedChains = [
+  {
+    logoURI:
+      'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png',
+    name: 'Ethereum',
+    chainId: 1,
+  },
+  {
+    logoURI:
+      'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png',
+    name: 'Base',
+    chainId: 10,
+  },
+  {
+    logoURI:
+      'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png',
+    name: 'Polygon',
+    chainId: 137,
+  },
+];
+
+vi.mock('src/hooks/useChains', () => ({
+  useChains: () => ({
+    data: {
+      chains: mockedChains,
+    },
+    getChainById: (chainId: number) =>
+      mockedChains.find((chain) => chain.chainId === chainId),
+    isSuccess: true,
+    isLoading: false,
+    error: null,
+  }),
+}));
 
 describe('ProtocolCard snapshot', () => {
   it('protocol card matches snapshot', async () => {

--- a/src/components/Cards/ProtocolCard/ProtocolCard.styles.tsx
+++ b/src/components/Cards/ProtocolCard/ProtocolCard.styles.tsx
@@ -105,15 +105,25 @@ export const ProtocolCardContentContainer = styled(Box)(({ theme }) => ({
 
 export const ProtocolCardContentHeaderContainer = styled(Box)(({ theme }) => ({
   display: 'flex',
+  flexWrap: 'wrap',
   flexDirection: 'column',
   alignItems: 'flex-start',
   justifyContent: 'space-between',
   gap: theme.spacing(1),
   [theme.breakpoints.up('sm')]: {
-    gap: theme.spacing(3),
+    columnGap: theme.spacing(3),
     flexDirection: 'row',
     alignItems: 'center',
   },
+}));
+
+export const ProtocolCardTitleContainer = styled(Stack)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  flexWrap: 'wrap',
+  columnGap: theme.spacing(1.5),
+  rowGap: theme.spacing(1),
 }));
 
 export const ProtocolCardTagsContainer = styled(Stack)(({ theme }) => ({
@@ -156,7 +166,7 @@ export const ProtocolDescriptionModalContentContainer = styled(
   display: 'flex',
   flexDirection: 'column',
   gap: theme.spacing(3),
-  width: 440,
+  width: 488,
   maxWidth: 'calc(100vw - 32px)',
 }));
 

--- a/src/components/Cards/ProtocolCard/ProtocolCard.tsx
+++ b/src/components/Cards/ProtocolCard/ProtocolCard.tsx
@@ -12,12 +12,14 @@ import {
   ProtocolCardProtocolAvatar,
   ProtocolCardProtocolTitle,
   ProtocolCardTagsContainer,
+  ProtocolCardTitleContainer,
 } from './ProtocolCard.styles';
 import { PROTOCOL_CARD_SIZES } from './constants';
 import Typography from '@mui/material/Typography';
 import { Badge } from 'src/components/Badge/Badge';
 import { BadgeSize, BadgeVariant } from 'src/components/Badge/Badge.styles';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import CodeRoundedIcon from '@mui/icons-material/CodeRounded';
 import { useTranslation } from 'react-i18next';
 import { capitalizeString } from 'src/utils/capitalizeString';
 import { ProtocolCardSkeleton } from './ProtocolCardSkeleton';
@@ -25,6 +27,8 @@ import type { EarnOpportunityWithLatestAnalytics } from 'src/types/jumper-backen
 import { useGetContrastTextColor } from 'src/hooks/images/useGetContrastTextColor';
 import { ProtocolCardDescription } from './components/ProtocolCardDescription';
 import { ProtocolCardDescriptionModal } from './components/ProtocolCardDescriptionModal';
+import { useBlockchainExplorerURL } from '@/hooks/useBlockchainExplorerURL';
+import { openInNewTab } from '@/utils/openInNewTab';
 
 interface CommonCardProps {
   fullWidth?: boolean;
@@ -53,10 +57,13 @@ export const ProtocolCard: FC<ProtocolCardProps> = ({
 }) => {
   const [protocolAvatarLoaded, setProtocolAvatarLoaded] = useState(false);
   const [isDescriptionModalOpen, setIsDescriptionModalOpen] = useState(false);
-  const { protocol, tags, description, url, name } = data ?? {};
+  const { protocol, tags, description, url, name, lpToken } = data ?? {};
   const title = name || protocol?.product || protocol?.name;
   const { t } = useTranslation();
-
+  const addressExplorerUrl = useBlockchainExplorerURL(
+    lpToken?.chain.chainId,
+    lpToken?.address,
+  );
   const { contrastTextColor: protocolImageContrastColor } =
     useGetContrastTextColor(protocol?.logo || '');
 
@@ -68,7 +75,18 @@ export const ProtocolCard: FC<ProtocolCardProps> = ({
 
   const headerContent = (
     <ProtocolCardContentHeaderContainer>
-      <Typography variant="titleMedium">{title}</Typography>
+      <ProtocolCardTitleContainer>
+        <Typography variant="titleMedium">{title}</Typography>
+        {addressExplorerUrl && (
+          <Badge
+            variant={BadgeVariant.Alpha}
+            size={BadgeSize.MD}
+            label="Contract"
+            startIcon={<CodeRoundedIcon />}
+            onClick={() => openInNewTab(addressExplorerUrl)}
+          />
+        )}
+      </ProtocolCardTitleContainer>
       <ProtocolCardTagsContainer>
         {tags?.map((tag) => (
           <Badge

--- a/src/components/Cards/ProtocolCard/__snapshots__/ProtocolCard.snapshot.spec.tsx.snap
+++ b/src/components/Cards/ProtocolCard/__snapshots__/ProtocolCard.snapshot.spec.tsx.snap
@@ -30,13 +30,17 @@ exports[`ProtocolCard snapshot > protocol card matches snapshot 1`] = `
       class="MuiBox-root css-pqmg6p"
     >
       <div
-        class="MuiBox-root css-yiuipt"
+        class="MuiBox-root css-15r232g"
       >
-        <span
-          class="MuiTypography-root MuiTypography-titleMedium css-leioi1-MuiTypography-root"
+        <div
+          class="MuiStack-root css-h176g1-MuiStack-root"
         >
-          Moonwell Flagship USDC on base
-        </span>
+          <span
+            class="MuiTypography-root MuiTypography-titleMedium css-leioi1-MuiTypography-root"
+          >
+            Moonwell Flagship USDC on base
+          </span>
+        </div>
         <div
           class="MuiStack-root css-qzuiar-MuiStack-root"
         >
@@ -141,13 +145,17 @@ exports[`ProtocolCard snapshot > protocol card with badge matches snapshot 1`] =
       class="MuiBox-root css-pqmg6p"
     >
       <div
-        class="MuiBox-root css-yiuipt"
+        class="MuiBox-root css-15r232g"
       >
-        <span
-          class="MuiTypography-root MuiTypography-titleMedium css-leioi1-MuiTypography-root"
+        <div
+          class="MuiStack-root css-h176g1-MuiStack-root"
         >
-          Moonwell Flagship USDC on base
-        </span>
+          <span
+            class="MuiTypography-root MuiTypography-titleMedium css-leioi1-MuiTypography-root"
+          >
+            Moonwell Flagship USDC on base
+          </span>
+        </div>
         <div
           class="MuiStack-root css-qzuiar-MuiStack-root"
         >
@@ -271,13 +279,17 @@ exports[`ProtocolCard snapshot > protocol card with long title matches snapshot 
       class="MuiBox-root css-pqmg6p"
     >
       <div
-        class="MuiBox-root css-yiuipt"
+        class="MuiBox-root css-15r232g"
       >
-        <span
-          class="MuiTypography-root MuiTypography-titleMedium css-leioi1-MuiTypography-root"
+        <div
+          class="MuiStack-root css-h176g1-MuiStack-root"
         >
-          Moonwell Flagship USDC on base
-        </span>
+          <span
+            class="MuiTypography-root MuiTypography-titleMedium css-leioi1-MuiTypography-root"
+          >
+            Moonwell Flagship USDC on base
+          </span>
+        </div>
         <div
           class="MuiStack-root css-qzuiar-MuiStack-root"
         >

--- a/src/hooks/useBlockchainExplorerURL.ts
+++ b/src/hooks/useBlockchainExplorerURL.ts
@@ -1,21 +1,23 @@
-import { useChains } from '@/hooks/useChains';
-import { ChainId } from '@lifi/sdk';
+import { useMemo } from 'react';
+import { useChains } from './useChains';
 
-export const useBlockchainExplorerURL = () => {
-  const { isSuccess: chainsLoaded, getChainById } = useChains();
+export const useBlockchainExplorerURL = (
+  chainId?: number,
+  address?: string,
+  prefix: string = 'address',
+) => {
+  const { isSuccess, getChainById } = useChains();
 
-  return (walletAddress?: string, chainId?: number) => {
-    if (!walletAddress || !chainId) {
+  return useMemo(() => {
+    if (!chainId || !address || !isSuccess) {
       return undefined;
     }
-    if (chainId === ChainId.SOL) {
-      return `https://explorer.solana.com/address/${walletAddress}`;
-    }
+
     const chain = getChainById(chainId);
-    if (chainsLoaded && chain?.metamask) {
-      return `${chain.metamask.blockExplorerUrls[0]}address/${walletAddress}`;
-    } else {
-      console.error(`No blockchain explorer found for ${chainId}`);
+    if (!chain) {
+      return undefined;
     }
-  };
+
+    return `${chain.metamask?.blockExplorerUrls?.[0]}${prefix ? prefix : ''}/${address}`;
+  }, [chainId, address, prefix, getChainById, isSuccess]);
 };

--- a/src/hooks/useBlockchainExplorerURL.ts
+++ b/src/hooks/useBlockchainExplorerURL.ts
@@ -18,6 +18,11 @@ export const useBlockchainExplorerURL = (
       return undefined;
     }
 
-    return `${chain.metamask?.blockExplorerUrls?.[0]}${prefix ? prefix : ''}/${address}`;
+    const explorerUrl = chain.metamask?.blockExplorerUrls?.[0];
+    if (!explorerUrl) {
+      return undefined;
+    }
+
+    return `${explorerUrl}${prefix ? prefix : ''}/${address}`;
   }, [chainId, address, prefix, getChainById, isSuccess]);
 };

--- a/src/hooks/useChains.ts
+++ b/src/hooks/useChains.ts
@@ -2,6 +2,7 @@ import type { ChainId, ExtendedChain } from '@lifi/sdk';
 import { ChainType, getChains } from '@lifi/sdk';
 import { useQuery } from '@tanstack/react-query';
 import { getChainById as getChainByIdHelper } from '@/utils/tokenAndChain';
+import { useCallback } from 'react';
 
 export const queryKey = ['chainStats'];
 
@@ -27,9 +28,12 @@ export const useChains = (): ChainProps => {
     refetchInterval: 1000 * 60 * 60,
   });
 
-  const getChainById = (id: ChainId) => {
-    return getChainByIdHelper(data?.chains ?? [], id);
-  };
+  const getChainById = useCallback(
+    (id: ChainId) => {
+      return getChainByIdHelper(data?.chains ?? [], id);
+    },
+    [data?.chains],
+  );
 
   return {
     getChainById,


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-16986

## Testing steps

1. Go the `/earn`
2. Select an opportunity
3. Check the Contract badge next to the protocol card title shows up
4. Check clicking on it opens a new tab on the correct chain explorer and points to the lp token address
5. Switch to a mobile view (as this will most likely truncate the description on the protocol card)
6. Click on the see more
7. Check the open modal contains the Contract badge in the header
8. Clicking on it should open the same new tab as at point 4.
9. Repeat for a few earn opportunities

<img width="468" height="392" alt="Screenshot 2025-12-08 at 11 45 57" src="https://github.com/user-attachments/assets/22fadfb4-41a8-4049-bed9-462c67146691" />
<img width="502" height="386" alt="Screenshot 2025-12-08 at 11 46 06" src="https://github.com/user-attachments/assets/8cf9aa99-67c1-4230-ba2d-a525886d87dc" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a contract explorer badge on protocol cards so users can open the LP token contract in a blockchain explorer.

* **Style**
  * Improved protocol card header layout with wrapping and adjusted spacing.
  * Increased protocol description modal width for better presentation.

* **Tests**
  * Snapshot tests now use mocked chain data for deterministic, reliable test results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->