### PR TITLE
feat: enable intercom support for earn and portfolio + refactor

### DIFF
--- a/src/app/ui/earn/EarnOpportunitiesAll/EarnOpportunitiesAll.tsx
+++ b/src/app/ui/earn/EarnOpportunitiesAll/EarnOpportunitiesAll.tsx
@@ -15,8 +15,10 @@ import { EarnOpportunitiesCards } from '../EarnOpportunitiesCards';
 import { DepositFlowModal } from 'src/components/composite/DepositFlow/DepositFlow';
 import { WithdrawFlowModal } from '@/components/composite/WithdrawFlow/WithdrawFlow';
 import { EarnViewAllMarketsButton } from '../EarnViewAllMarketsButton';
+import { useContactSupportEvent } from '@/components/Widgets/events/hooks/useContactSupportEvent';
 
 const EarnOpportunitiesAllInner = () => {
+  useContactSupportEvent();
   const { data, isLoading, isAllDataLoading, showForYou, toggleForYou } =
     useEarnFiltering();
 

--- a/src/app/ui/earn/EarnPage.tsx
+++ b/src/app/ui/earn/EarnPage.tsx
@@ -10,6 +10,7 @@ import { EarnDetailsIntro } from 'src/components/EarnDetails/EarnDetailsIntro';
 import { EarnRelatedMarkets } from 'src/components/EarnRelatedMarkets/EarnRelatedMarkets';
 import { DepositFlowModal } from 'src/components/composite/DepositFlow/DepositFlow';
 import { WithdrawFlowModal } from '@/components/composite/WithdrawFlow/WithdrawFlow';
+import { ContactSupportEventProvider } from '@/components/Widgets/events/ContactSupportEventProvider';
 
 interface EarnPageProps {
   slug: string;
@@ -46,6 +47,7 @@ export const EarnPage: FC<EarnPageProps> = async ({ slug }) => {
       </EarnDetailsSection>
       <DepositFlowModal />
       <WithdrawFlowModal />
+      <ContactSupportEventProvider />
     </>
   );
 };

--- a/src/app/ui/portfolio/PortfolioDeFiProtocolsList.tsx
+++ b/src/app/ui/portfolio/PortfolioDeFiProtocolsList.tsx
@@ -11,6 +11,7 @@ import {
 import { WithdrawFlowModal } from '@/components/composite/WithdrawFlow/WithdrawFlow';
 import { DeFiPositionCardSkeleton } from '@/components/composite/DeFiPositionCard/DeFiPositionCardSkeleton';
 import { motion, AnimatePresence } from 'motion/react';
+import { useContactSupportEvent } from '@/components/Widgets/events/hooks/useContactSupportEvent';
 
 const AnimatedAssetItem = ({ children }: PropsWithChildren) => (
   <motion.div
@@ -25,6 +26,7 @@ const AnimatedAssetItem = ({ children }: PropsWithChildren) => (
 );
 
 export const PortfolioDeFiProtocolsList = () => {
+  useContactSupportEvent();
   const { data, isAllDataEmpty, isLoading, clearFilters, sortBy, order } =
     usePortfolioDeFiPositionsFiltering();
 

--- a/src/components/Widgets/WidgetEvents.tsx
+++ b/src/components/Widgets/WidgetEvents.tsx
@@ -5,14 +5,12 @@ import { MultisigConnectedAlert } from '@/components/MultisigConnectedAlert';
 import { useMultisig } from '@/hooks/useMultisig';
 import { useActiveTabStore } from '@/stores/activeTab';
 import { useChainTokenSelectionStore } from '@/stores/chainTokenSelection';
-import { useMenuStore } from '@/stores/menu';
 import { useMultisigStore } from '@/stores/multisig';
 import { usePortfolioStore } from '@/stores/portfolio';
 import type { RouteExtended } from '@lifi/sdk';
 import { useAccount } from '@lifi/wallet-management';
 import type {
   ChainTokenSelected,
-  ContactSupport,
   FormFieldChanged,
   RouteExecutionUpdate,
 } from '@lifi/widget';
@@ -25,16 +23,15 @@ import { getRouteStatus } from 'src/utils/routes';
 import type { WidgetEventsConfig } from './WidgetEventsManager';
 import { setupWidgetEvents, teardownWidgetEvents } from './WidgetEventsManager';
 import { useWidgetCacheStore } from 'src/stores/widgetCache/WidgetCacheStore';
+import { useContactSupportEvent } from './events/hooks/useContactSupportEvent';
 
 export function WidgetEvents() {
+  useContactSupportEvent();
   const { activeTab } = useActiveTabStore();
   const { setDestinationChainToken, setSourceChainToken } =
     useChainTokenSelectionStore();
   const { setFromChainId, setFromToken, setToChainId, setToToken } =
     useWidgetCacheStore((state) => state);
-  const [setSupportModalState] = useMenuStore((state) => [
-    state.setSupportModalState,
-  ]);
   const widgetEvents = useWidgetEvents();
   const { isMultisigSigner, shouldOpenMultisigSignatureModal } = useMultisig();
   const [setDestinationChain] = useMultisigStore((state) => [
@@ -129,10 +126,6 @@ export function WidgetEvents() {
       }
     };
 
-    const contactSupport = (supportId: ContactSupport) => {
-      setSupportModalState(true);
-    };
-
     const sourceChainTokenSelected = async (
       sourceChainData: ChainTokenSelected,
     ) => {
@@ -186,7 +179,6 @@ export function WidgetEvents() {
     const config: WidgetEventsConfig = {
       routeExecutionUpdated,
       routeExecutionCompleted,
-      contactSupport,
       sourceChainTokenSelected,
       destinationChainTokenSelected,
       pageEntered,
@@ -204,7 +196,6 @@ export function WidgetEvents() {
     setDestinationChain,
     setDestinationChainToken,
     setSourceChainToken,
-    setSupportModalState,
     shouldOpenMultisigSignatureModal,
     setCompletedRoute,
     setContributed,

--- a/src/components/Widgets/events/ContactSupportEventProvider.tsx
+++ b/src/components/Widgets/events/ContactSupportEventProvider.tsx
@@ -1,0 +1,7 @@
+'use client';
+import { useContactSupportEvent } from './hooks/useContactSupportEvent';
+
+export const ContactSupportEventProvider = () => {
+  useContactSupportEvent();
+  return null;
+};

--- a/src/components/Widgets/events/hooks/useContactSupportEvent.ts
+++ b/src/components/Widgets/events/hooks/useContactSupportEvent.ts
@@ -1,0 +1,26 @@
+'use client';
+import { useMenuStore } from '@/stores/menu';
+import { useWidgetEvents } from '@lifi/widget';
+import { useEffect } from 'react';
+import type { WidgetEventsConfig } from '../../WidgetEventsManager';
+import {
+  setupWidgetEvents,
+  teardownWidgetEvents,
+} from '../../WidgetEventsManager';
+
+export const useContactSupportEvent = () => {
+  const widgetEvents = useWidgetEvents();
+  const setSupportModalState = useMenuStore(
+    (state) => state.setSupportModalState,
+  );
+
+  useEffect(() => {
+    const contactSupport = () => {
+      setSupportModalState(true);
+    };
+    const config: WidgetEventsConfig = { contactSupport };
+
+    setupWidgetEvents(config, widgetEvents);
+    return () => teardownWidgetEvents(config, widgetEvents);
+  }, [widgetEvents, setSupportModalState]);
+};


### PR DESCRIPTION
## Testing steps

1. Go to `/earn`, `/earn/[slug]` or portfolio
2. Perform a deposit or withdrawal
3. Once the tx is settled, click on `See details`
4. Click on contact support
5. This should open up the intercom modal
6. Regression testing: try performing a deposit on the main widget page `/` and check clicking on the `Contact support` opens up the intercom modal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced contact support functionality now available across earn opportunities and portfolio DeFi protocols sections.

* **Refactor**
  * Restructured support event management system for improved integration and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->