### PR TITLE
feat: update portfolio price on the frontend

### DIFF
--- a/src/hooks/portfolio/usePortfolioDeFiPositions.ts
+++ b/src/hooks/portfolio/usePortfolioDeFiPositions.ts
@@ -1,11 +1,13 @@
 import type { PortfolioPositionsQuery } from '@/app/lib/getPositionsForAddress';
 import { getPositionsForAddress } from '@/app/lib/getPositionsForAddress';
 import type { DefiPosition, WalletPositions } from '@/types/jumper-backend';
+import type { GetTokenUSDPrice } from '@/utils/positions/update-price';
 import { updateWalletPositionsPrice } from '@/utils/positions/update-price';
 import { useQueries } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { ONE_HOUR_MS } from 'src/const/time';
 import type { Hex } from 'viem';
+import { useTokens } from '../useTokens';
 
 export interface Props {
   addresses: Hex[];
@@ -20,18 +22,33 @@ export interface Result {
   refetch: () => void;
 }
 
-const getTokenUSDPrice = async (token: {
-  chainId: number;
-  address: string;
-}): Promise<number> => {
-  // TODO: this data is probably somewhere in the codebase already
-  return Promise.resolve(4.2);
-};
-
 export const usePortfolioDeFiPositions = ({
   addresses,
   filter,
 }: Props): Result => {
+  const { getTokenByAddressAndChain } = useTokens();
+
+  const getTokenUSDPrice: GetTokenUSDPrice = useCallback(
+    (token: { chainId: number; address: string }) => {
+      try {
+        const tokenFound = getTokenByAddressAndChain(
+          token.address,
+          token.chainId,
+        );
+
+        if (!tokenFound) {
+          return undefined;
+        }
+
+        return parseFloat(tokenFound.priceUSD);
+      } catch (error) {
+        console.warn('Could not get token USD price', token, error);
+        return undefined;
+      }
+    },
+    [getTokenByAddressAndChain],
+  );
+
   const queries = useQueries({
     queries: addresses.map((address) => ({
       queryKey: ['portfolio-defi-positions', address, filter],

--- a/src/hooks/portfolio/usePortfolioDeFiPositions.ts
+++ b/src/hooks/portfolio/usePortfolioDeFiPositions.ts
@@ -26,7 +26,11 @@ export const usePortfolioDeFiPositions = ({
   addresses,
   filter,
 }: Props): Result => {
-  const { getTokenByAddressAndChain, updatedAt } = useTokens();
+  const {
+    getTokenByAddressAndChain,
+    isLoading: isLoadingTokens,
+    updatedAt,
+  } = useTokens();
 
   const getTokenUSDPrice: GetTokenUSDPrice = useCallback(
     (token: { chainId: number; address: string }) => {
@@ -72,12 +76,12 @@ export const usePortfolioDeFiPositions = ({
 
         return updateWalletPositionsPrice(positions, getTokenUSDPrice);
       },
-      enabled: !!address,
+      enabled: !!address && !isLoadingTokens,
       refetchInterval: ONE_HOUR_MS,
     })),
   });
 
-  const isLoading = queries.some((query) => query.isLoading);
+  const isLoading = isLoadingTokens || queries.some((query) => query.isLoading);
   const isSuccess = queries.every((query) => query.isSuccess);
   const error = queries.find((query) => query.error)?.error ?? null;
 

--- a/src/hooks/portfolio/usePortfolioDeFiPositions.ts
+++ b/src/hooks/portfolio/usePortfolioDeFiPositions.ts
@@ -42,7 +42,15 @@ export const usePortfolioDeFiPositions = ({
           );
         }
 
-        return parseFloat(tokenFound.priceUSD);
+        const priceUSD = parseFloat(tokenFound.priceUSD);
+
+        if (isNaN(priceUSD)) {
+          throw new Error(
+            `Price USD is NaN for token ${token.address} on chain ${token.chainId}`,
+          );
+        }
+
+        return priceUSD;
       } catch (error) {
         console.warn('Could not get token USD price', token, error);
         return undefined;

--- a/src/hooks/portfolio/usePortfolioDeFiPositions.ts
+++ b/src/hooks/portfolio/usePortfolioDeFiPositions.ts
@@ -26,7 +26,7 @@ export const usePortfolioDeFiPositions = ({
   addresses,
   filter,
 }: Props): Result => {
-  const { getTokenByAddressAndChain } = useTokens();
+  const { getTokenByAddressAndChain, updatedAt } = useTokens();
 
   const getTokenUSDPrice: GetTokenUSDPrice = useCallback(
     (token: { chainId: number; address: string }) => {
@@ -53,7 +53,7 @@ export const usePortfolioDeFiPositions = ({
 
   const queries = useQueries({
     queries: addresses.map((address) => ({
-      queryKey: ['portfolio-defi-positions', address, filter],
+      queryKey: ['portfolio-defi-positions', address, filter, updatedAt],
       queryFn: async () => {
         const result = await getPositionsForAddress({
           evm: address,

--- a/src/hooks/portfolio/usePortfolioDeFiPositions.ts
+++ b/src/hooks/portfolio/usePortfolioDeFiPositions.ts
@@ -37,7 +37,9 @@ export const usePortfolioDeFiPositions = ({
         );
 
         if (!tokenFound) {
-          return undefined;
+          throw new Error(
+            `Token not found for address ${token.address} on chain ${token.chainId}`,
+          );
         }
 
         return parseFloat(tokenFound.priceUSD);

--- a/src/hooks/portfolio/usePortfolioDeFiPositions.ts
+++ b/src/hooks/portfolio/usePortfolioDeFiPositions.ts
@@ -1,10 +1,11 @@
-import { useQueries } from '@tanstack/react-query';
 import type { PortfolioPositionsQuery } from '@/app/lib/getPositionsForAddress';
 import { getPositionsForAddress } from '@/app/lib/getPositionsForAddress';
+import type { DefiPosition, WalletPositions } from '@/types/jumper-backend';
+import { updateWalletPositionsPrice } from '@/utils/positions/update-price';
+import { useQueries } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { ONE_HOUR_MS } from 'src/const/time';
 import type { Hex } from 'viem';
-import type { WalletPositions, DefiPosition } from '@/types/jumper-backend';
-import { useMemo } from 'react';
 
 export interface Props {
   addresses: Hex[];
@@ -19,6 +20,14 @@ export interface Result {
   refetch: () => void;
 }
 
+const getTokenUSDPrice = async (token: {
+  chainId: number;
+  address: string;
+}): Promise<number> => {
+  // TODO: this data is probably somewhere in the codebase already
+  return Promise.resolve(4.2);
+};
+
 export const usePortfolioDeFiPositions = ({
   addresses,
   filter,
@@ -32,7 +41,9 @@ export const usePortfolioDeFiPositions = ({
           ...filter,
         });
         // @ts-expect-error: see LF-15589 - we are transforming data in the backend
-        return result.data.data as WalletPositions;
+        const positions = result.data.data as WalletPositions;
+
+        return updateWalletPositionsPrice(positions, getTokenUSDPrice);
       },
       enabled: !!address,
       refetchInterval: ONE_HOUR_MS,

--- a/src/hooks/useTokens.ts
+++ b/src/hooks/useTokens.ts
@@ -30,8 +30,8 @@ export const useTokens = () => {
     refetchInterval: 1000 * 60 * 60,
   });
 
-  const tokens = useMemo(
-    () => data?.tokens ?? ({} as TokensResponse),
+  const tokens = useMemo<TokensResponse['tokens']>(
+    () => data?.tokens ?? {},
     [data?.tokens],
   );
 

--- a/src/hooks/useTokens.ts
+++ b/src/hooks/useTokens.ts
@@ -15,10 +15,6 @@ export const getTokensQuery = async () => {
   const tokens = await getTokens({
     chainTypes: [ChainType.EVM, ChainType.SVM, ChainType.UTXO, ChainType.MVM],
   });
-  console.log(
-    'tokens',
-    tokens.tokens[1].filter((token) => token.address.startsWith('0x00')),
-  );
   return tokens;
 };
 

--- a/src/hooks/useTokens.ts
+++ b/src/hooks/useTokens.ts
@@ -15,11 +15,15 @@ export const getTokensQuery = async () => {
   const tokens = await getTokens({
     chainTypes: [ChainType.EVM, ChainType.SVM, ChainType.UTXO, ChainType.MVM],
   });
+  console.log(
+    'tokens',
+    tokens.tokens[1].filter((token) => token.address.startsWith('0x00')),
+  );
   return tokens;
 };
 
 export const useTokens = () => {
-  const { data, isSuccess, isLoading } = useQuery({
+  const { data, isSuccess, isLoading, dataUpdatedAt } = useQuery({
     queryKey,
     queryFn: getTokensQuery,
     enabled: true,
@@ -67,5 +71,6 @@ export const useTokens = () => {
     tokens,
     isSuccess,
     isLoading,
+    updatedAt: dataUpdatedAt,
   };
 };

--- a/src/hooks/useTokens.ts
+++ b/src/hooks/useTokens.ts
@@ -1,12 +1,13 @@
-import { ChainType, getTokens } from '@lifi/sdk';
-import type { TokensResponse } from '@lifi/sdk';
-import { useQuery } from '@tanstack/react-query';
 import {
-  getTokenBySymbol as getTokenBySymbolHelper,
-  getTokenByName as getTokenByNameHelper,
-  getTokenByAddressOnSpecificChain as getTokenByAddressOnSpecificChainHelper,
   getNativeTokenForChain as getNativeTokenForChainHelper,
+  getTokenByAddressOnSpecificChain as getTokenByAddressOnSpecificChainHelper,
+  getTokenByName as getTokenByNameHelper,
+  getTokenBySymbol as getTokenBySymbolHelper,
 } from '@/utils/tokenAndChain';
+import type { TokensResponse } from '@lifi/sdk';
+import { ChainType, getTokens } from '@lifi/sdk';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
 
 export const queryKey = ['tokenStats'];
 
@@ -18,50 +19,53 @@ export const getTokensQuery = async () => {
 };
 
 export const useTokens = () => {
-  const { data, isSuccess } = useQuery({
+  const { data, isSuccess, isLoading } = useQuery({
     queryKey,
     queryFn: getTokensQuery,
     enabled: true,
     refetchInterval: 1000 * 60 * 60,
   });
 
-  const getTokenBySymbol = (symbol: string) => {
-    if (!data?.tokens) {
-      return;
-    }
-    return getTokenBySymbolHelper(data?.tokens, symbol);
-  };
+  const tokens = useMemo(
+    () => data?.tokens ?? ({} as TokensResponse),
+    [data?.tokens],
+  );
 
-  const getTokenByName = (name: string) => {
-    if (!data?.tokens) {
-      return;
-    }
-    return getTokenByNameHelper(data?.tokens, name);
-  };
+  const getTokenBySymbol = useCallback(
+    (symbol: string) => {
+      return getTokenBySymbolHelper(tokens, symbol);
+    },
+    [tokens],
+  );
 
-  const getTokenByAddressAndChain = (address: string, chainId: number) => {
-    if (!data?.tokens) {
-      return;
-    }
-    return getTokenByAddressOnSpecificChainHelper(
-      data?.tokens,
-      chainId,
-      address,
-    );
-  };
-  const getNativeTokenForChain = (chainId: number) => {
-    if (!data?.tokens) {
-      return;
-    }
-    return getNativeTokenForChainHelper(data?.tokens, chainId);
-  };
+  const getTokenByName = useCallback(
+    (name: string) => {
+      return getTokenByNameHelper(tokens, name);
+    },
+    [tokens],
+  );
+
+  const getTokenByAddressAndChain = useCallback(
+    (address: string, chainId: number) => {
+      return getTokenByAddressOnSpecificChainHelper(tokens, chainId, address);
+    },
+    [tokens],
+  );
+
+  const getNativeTokenForChain = useCallback(
+    (chainId: number) => {
+      return getNativeTokenForChainHelper(tokens, chainId);
+    },
+    [tokens],
+  );
 
   return {
     getTokenBySymbol,
     getTokenByName,
     getTokenByAddressAndChain,
     getNativeTokenForChain,
-    tokens: data || ({} as TokensResponse),
+    tokens,
     isSuccess,
+    isLoading,
   };
 };

--- a/src/utils/positions/update-price.spec.ts
+++ b/src/utils/positions/update-price.spec.ts
@@ -1,0 +1,97 @@
+import type { DefiPosition } from '@/types/jumper-backend';
+import { describe, expect, it, vi } from 'vitest';
+import { updatePositionPrice } from './update-price';
+
+// Generated from http://localhost:3001/v1/portfolio/positions?evm=0xb29601eB52a052042FB6c68C69a442BD0AE90082 on 2025-12-10
+const ASSET_FIXTURE: DefiPosition = {
+  name: 'Aave V3',
+  assetUsd: 0.115107514249528,
+  debtUsd: 0,
+  netUsd: 0.115107514249528,
+  address: '0x794a61358d6845594f94dc1db02a252b5b4814ad',
+  chain: {
+    chainId: 43114,
+    chainKey: 'avax',
+  },
+  type: 'Lending',
+  protocol: {
+    name: 'Aave V3',
+    logo: 'https://static.debank.com/image/project/logo_url/aave3/54df7839ab09493ba7540ab832590255.png',
+    url: 'https://app.aave.com',
+  },
+  supplyTokens: [
+    {
+      chainType: 'EVM',
+      amount: '114628',
+      amountUSD: 0.114628,
+      name: 'USD Coin',
+      symbol: 'USDC',
+      decimals: 6,
+      logo: 'https://static.debank.com/image/eth_token/logo_url/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/fffcd27b9efff5a86ab942084c05924d.png',
+      address: '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e',
+      chain: {
+        chainId: 43114,
+        chainKey: 'avax',
+      },
+      priceUSD: 1,
+    },
+  ],
+  borrowTokens: [],
+  assetTokens: [],
+  collateralTokens: [],
+  rewardTokens: [
+    {
+      chainType: 'EVM',
+      amount: '14353125728879',
+      amountUSD: 0.00020395791660737,
+      name: 'Wrapped AVAX',
+      symbol: 'WAVAX',
+      decimals: 18,
+      logo: 'https://static.debank.com/image/avax_token/logo_url/0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7/753d82f0137617110f8dec56309b4065.png',
+      address: '0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7',
+      chain: {
+        chainId: 43114,
+        chainKey: 'avax',
+      },
+      priceUSD: 14.21,
+    },
+    {
+      chainType: 'EVM',
+      amount: '19391719417341',
+      amountUSD: 0.000275556332920414,
+      name: 'AVAX',
+      symbol: 'AVAX',
+      decimals: 18,
+      logo: 'https://static.debank.com/image/project/logo_url/avax_wavax/e195cdd89f44bf3d0c65d38ce2c6c662.png',
+      address: 'avax',
+      chain: {
+        chainId: 43114,
+        chainKey: 'avax',
+      },
+      priceUSD: 14.21,
+    },
+  ],
+};
+
+describe('updatePrice', () => {
+  it('should update the priceUSD and netUSD price of the position when a token price changes', async () => {
+    const getTokenPrice = vi.fn().mockImplementation((token) => {
+      if (
+        token.address === '0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7' ||
+        token.address === 'avax'
+      ) {
+        return Promise.resolve(14.21 * 2.0);
+      }
+
+      return Promise.resolve(2);
+    });
+
+    const updated = await updatePositionPrice(ASSET_FIXTURE, getTokenPrice);
+
+    expect(updated.supplyTokens[0].priceUSD).toBeCloseTo(1 * 2.0);
+    expect(updated.rewardTokens[0].priceUSD).toBeCloseTo(14.21 * 2.0);
+    expect(updated.rewardTokens[1].priceUSD).toBeCloseTo(14.21 * 2.0);
+    expect(updated.netUsd).toBeCloseTo(0.115107514249528 * 2.0);
+    expect(updated.assetUsd).toBeCloseTo(0.115107514249528 * 2.0);
+  });
+});

--- a/src/utils/positions/update-price.ts
+++ b/src/utils/positions/update-price.ts
@@ -1,0 +1,106 @@
+import type {
+  DefiPosition,
+  DefiToken,
+  WalletPositions,
+} from '@/types/jumper-backend';
+import { sumBy } from 'lodash';
+
+type GetTokenUSDPrice = (token: {
+  chainId: number;
+  address: string;
+}) => Promise<number>;
+
+const amountToUSD = (
+  amount: bigint,
+  decimals: number | string | bigint,
+  usdPricePerOne: number,
+): number => {
+  const base = 10n ** BigInt(decimals);
+  const whole = amount / base;
+  const remainder = amount % base;
+
+  const wholeUSD = Number(whole) * usdPricePerOne;
+  const remainderUSD = (Number(remainder) / Number(base)) * usdPricePerOne;
+
+  return wholeUSD + remainderUSD;
+};
+
+const updateTokenPrice = async (
+  token: DefiToken,
+  getTokenUSDPrice: GetTokenUSDPrice,
+): Promise<DefiToken> => {
+  const priceUSD = await getTokenUSDPrice({
+    chainId: token.chain.chainId,
+    address: token.address,
+  });
+
+  const amountUSD = amountToUSD(BigInt(token.amount), token.decimals, priceUSD);
+
+  return {
+    ...token,
+    amountUSD,
+    priceUSD,
+  };
+};
+
+const updateTokensPrice = async (
+  tokens: DefiToken[],
+  getTokenUSDPrice: GetTokenUSDPrice,
+): Promise<DefiToken[]> => {
+  return Promise.all(
+    tokens.map(async (token) => updateTokenPrice(token, getTokenUSDPrice)),
+  );
+};
+
+export const updatePositionPrice = async (
+  position: DefiPosition,
+  getTokenUSDPrice: GetTokenUSDPrice,
+): Promise<DefiPosition> => {
+  const [
+    supplyTokens,
+    borrowTokens,
+    assetTokens,
+    collateralTokens,
+    rewardTokens,
+  ] = await Promise.all([
+    updateTokensPrice(position.supplyTokens, getTokenUSDPrice),
+    updateTokensPrice(position.borrowTokens, getTokenUSDPrice),
+    updateTokensPrice(position.assetTokens, getTokenUSDPrice),
+    updateTokensPrice(position.collateralTokens, getTokenUSDPrice),
+    updateTokensPrice(position.rewardTokens, getTokenUSDPrice),
+  ]);
+
+  const assetUsd =
+    sumBy(supplyTokens, 'amountUSD') +
+    sumBy(assetTokens, 'amountUSD') +
+    sumBy(rewardTokens, 'amountUSD') +
+    sumBy(collateralTokens, 'amountUSD');
+  const debtUsd = sumBy(borrowTokens, 'amountUSD');
+  const netUsd = assetUsd - debtUsd;
+
+  return {
+    ...position,
+    supplyTokens,
+    borrowTokens,
+    assetTokens,
+    collateralTokens,
+    rewardTokens,
+    assetUsd,
+    debtUsd,
+    netUsd,
+  };
+};
+
+export const updateWalletPositionsPrice = async (
+  wallet: WalletPositions,
+  getTokenUSDPrice: GetTokenUSDPrice,
+): Promise<WalletPositions> => {
+  return {
+    ...wallet,
+    positions: await Promise.all(
+      wallet.positions.map((position) =>
+        updatePositionPrice(position, getTokenUSDPrice),
+      ),
+    ),
+  };
+};

--- a/src/utils/positions/update-price.ts
+++ b/src/utils/positions/update-price.ts
@@ -5,10 +5,10 @@ import type {
 } from '@/types/jumper-backend';
 import { sumBy } from 'lodash';
 
-type GetTokenUSDPrice = (token: {
+export type GetTokenUSDPrice = (token: {
   chainId: number;
   address: string;
-}) => Promise<number>;
+}) => undefined | number | Promise<number | undefined>;
 
 // TODO: this function is probably somewhere in the codebase already
 const amountToUSD = (
@@ -34,6 +34,10 @@ const updateTokenPrice = async (
     chainId: token.chain.chainId,
     address: token.address,
   });
+
+  if (!priceUSD) {
+    return token;
+  }
 
   const amountUSD = amountToUSD(BigInt(token.amount), token.decimals, priceUSD);
 

--- a/src/utils/positions/update-price.ts
+++ b/src/utils/positions/update-price.ts
@@ -10,6 +10,7 @@ type GetTokenUSDPrice = (token: {
   address: string;
 }) => Promise<number>;
 
+// TODO: this function is probably somewhere in the codebase already
 const amountToUSD = (
   amount: bigint,
   decimals: number | string | bigint,

--- a/src/utils/positions/update-price.ts
+++ b/src/utils/positions/update-price.ts
@@ -3,28 +3,13 @@ import type {
   DefiToken,
   WalletPositions,
 } from '@/types/jumper-backend';
+import { formatTokenPrice } from '@lifi/widget';
 import { sumBy } from 'lodash';
 
 export type GetTokenUSDPrice = (token: {
   chainId: number;
   address: string;
 }) => undefined | number | Promise<number | undefined>;
-
-// TODO: this function is probably somewhere in the codebase already
-const amountToUSD = (
-  amount: bigint,
-  decimals: number | string | bigint,
-  usdPricePerOne: number,
-): number => {
-  const base = 10n ** BigInt(decimals);
-  const whole = amount / base;
-  const remainder = amount % base;
-
-  const wholeUSD = Number(whole) * usdPricePerOne;
-  const remainderUSD = (Number(remainder) / Number(base)) * usdPricePerOne;
-
-  return wholeUSD + remainderUSD;
-};
 
 const updateTokenPrice = async (
   token: DefiToken,
@@ -39,7 +24,11 @@ const updateTokenPrice = async (
     return token;
   }
 
-  const amountUSD = amountToUSD(BigInt(token.amount), token.decimals, priceUSD);
+  const amountUSD = formatTokenPrice(
+    BigInt(token.amount),
+    `${priceUSD}`,
+    token.decimals,
+  );
 
   return {
     ...token,

--- a/src/utils/tokenAndChain.ts
+++ b/src/utils/tokenAndChain.ts
@@ -29,21 +29,11 @@ export const getTokenBySymbolOnSpecificChain = (
   chainId: number,
   symbol: string,
 ) => {
-  const chainTokens = tokens[chainId];
-  if (!chainTokens) {
-    return;
-  }
-
+  const chainTokens = tokens[chainId] ?? [];
   const filteredToken = chainTokens.find(
     (el) => el.symbol.toLowerCase() === symbol.toLowerCase(),
   );
-  if (filteredToken) {
-    return filteredToken;
-  } else {
-    console.error(
-      `Token symbol ${symbol} is not available on chain ${chainId}`,
-    );
-  }
+  return filteredToken;
 };
 
 export const getTokenBySymbol = (
@@ -73,21 +63,11 @@ export const getTokenByAddressOnSpecificChain = (
   chainId: number,
   address: string,
 ) => {
-  const chainTokens = tokens[chainId];
-  if (!chainTokens) {
-    return;
-  }
-
+  const chainTokens = tokens[chainId] ?? [];
   const filteredToken = chainTokens.find(
     (el) => el.address.toLowerCase() === address.toLowerCase(),
   );
-  if (filteredToken) {
-    return filteredToken;
-  } else {
-    console.error(
-      `Token address ${address} is not available on chain ${chainId}`,
-    );
-  }
+  return filteredToken;
 };
 
 // @Note: this works only for EVM chains
@@ -95,9 +75,6 @@ export const getNativeTokenForChain = (
   tokens: TokensResponse['tokens'],
   chainId: number,
 ) => {
-  const chainTokens = tokens[chainId];
-  if (!chainTokens) {
-    return;
-  }
+  const chainTokens = tokens[chainId] ?? [];
   return chainTokens.find((token) => token.address === zeroAddress);
 };


### PR DESCRIPTION
Closes https://lifi.atlassian.net/browse/LF-17026

- [x] Implement a method to update defi position based on recent token prices
- [x] Use in portfolio
- [x] figure out which getToken function we can use
- [x] figure out if we have a `caculateAmountUSD` somewhere else

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DeFi positions now include per-token USD prices and aggregated USD valuations.

* **Enhancements**
  * Portfolio view enriches positions with pricing, combines token-loading into overall loading state, supports overall and per-position refetch, and token hook now returns memoized tokens with updated timestamp.

* **Bug Fixes**
  * Quieter, safer token lookup when tokens are missing.

* **Tests**
  * Added unit tests verifying price propagation and updated USD metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->