### PR TITLE
feat: toggle between lockup period and cap in dollars

### DIFF
--- a/src/components/Cards/EarnCard/EarnCard.snapshot.spec.tsx
+++ b/src/components/Cards/EarnCard/EarnCard.snapshot.spec.tsx
@@ -152,6 +152,7 @@ describe('EarnCard snapshot', () => {
         data={{
           ...commonArgs.data,
           lockupMonths: undefined,
+          capInDollar: undefined,
           latest: {
             date: '2021-01-01',
             tvlUsd: '',

--- a/src/components/Cards/EarnCard/EarnCard.snapshot.spec.tsx
+++ b/src/components/Cards/EarnCard/EarnCard.snapshot.spec.tsx
@@ -169,6 +169,36 @@ describe('EarnCard snapshot', () => {
     );
     expect(container).toMatchSnapshot();
   });
+  it('compact card with cap in dollar matches snapshot', async () => {
+    const { container } = render(
+      <EarnCard
+        {...commonArgs}
+        variant="compact"
+        data={{ ...commonArgs.data, capInDollar: '1000000' }}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+  it('compact card with lockup months matches snapshot', async () => {
+    const { container } = render(
+      <EarnCard
+        {...commonArgs}
+        variant="compact"
+        data={{ ...commonArgs.data, lockupMonths: 2 }}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+  it('compact card with lockup months and cap in dollar matches snapshot', async () => {
+    const { container } = render(
+      <EarnCard
+        {...commonArgs}
+        variant="compact"
+        data={{ ...commonArgs.data, lockupMonths: 2, capInDollar: '1000000' }}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
   it('list item card matches snapshot', async () => {
     const { container } = render(
       <EarnCard
@@ -217,6 +247,36 @@ describe('EarnCard snapshot', () => {
     );
     expect(container).toMatchSnapshot();
   });
+  it('list item card with cap in dollar matches snapshot', async () => {
+    const { container } = render(
+      <EarnCard
+        {...commonArgs}
+        variant="list-item"
+        data={{ ...commonArgs.data, capInDollar: '1000000' }}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+  it('list item card with lockup months matches snapshot', async () => {
+    const { container } = render(
+      <EarnCard
+        {...commonArgs}
+        variant="list-item"
+        data={{ ...commonArgs.data, lockupMonths: 2 }}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+  it('list item card with lockup months and cap in dollar matches snapshot', async () => {
+    const { container } = render(
+      <EarnCard
+        {...commonArgs}
+        variant="list-item"
+        data={{ ...commonArgs.data, lockupMonths: 2, capInDollar: '1000000' }}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
   it('overview card matches snapshot', async () => {
     const { container } = render(
       <EarnCard {...commonArgs} variant="overview" />,
@@ -240,6 +300,43 @@ describe('EarnCard snapshot', () => {
             Badge
           </Badge>
         }
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('overview card with cap in dollar matches snapshot', async () => {
+    const { container } = render(
+      <EarnCard
+        {...commonArgs}
+        variant="overview"
+        data={{
+          ...commonArgs.data,
+          lockupMonths: undefined,
+          capInDollar: '1000000',
+        }}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('overview card with lockup months matches snapshot', async () => {
+    const { container } = render(
+      <EarnCard
+        {...commonArgs}
+        variant="overview"
+        data={{ ...commonArgs.data, lockupMonths: 2 }}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('overview card with lockup months and cap in dollar matches snapshot', async () => {
+    const { container } = render(
+      <EarnCard
+        {...commonArgs}
+        variant="overview"
+        data={{ ...commonArgs.data, lockupMonths: 2, capInDollar: '1000000' }}
       />,
     );
     expect(container).toMatchSnapshot();

--- a/src/components/Cards/EarnCard/EarnCard.stories.tsx
+++ b/src/components/Cards/EarnCard/EarnCard.stories.tsx
@@ -72,6 +72,7 @@ export const CompactWithTwoItems: Story = {
     data: {
       ...commonArgs.data,
       lockupMonths: undefined,
+      capInDollar: undefined,
       latest: {
         date: '2021-01-01',
         tvlUsd: '',

--- a/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
+++ b/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
@@ -2399,7 +2399,7 @@ exports[`EarnCard snapshot > compact card with two items matches snapshot 1`] = 
         class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-1gk85zv-MuiGrid-root"
       >
         <div
-          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-12 css-xvszvy-MuiGrid-root"
           data-testid="apy-0.0558"
         >
           <div
@@ -2431,42 +2431,6 @@ exports[`EarnCard snapshot > compact card with two items matches snapshot 1`] = 
               class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
             >
               5.58%
-            </p>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
-          data-testid="capInDollar-1000000000000000000"
-        >
-          <div
-            class="MuiBox-root css-5ul7dk"
-          >
-            <p
-              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
-            >
-              labels.capInDollar
-            </p>
-            <svg
-              aria-hidden="true"
-              aria-label="tooltips.capInDollar"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
-              data-mui-internal-clone-element="true"
-              data-testid="InfoIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
-              />
-            </svg>
-          </div>
-          <div
-            class="MuiBox-root css-nqls9x"
-          >
-            <p
-              class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
-            >
-              $1,000,000T
             </p>
           </div>
         </div>

--- a/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
+++ b/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
@@ -331,6 +331,311 @@ exports[`EarnCard snapshot > compact card matches snapshot 1`] = `
 </div>
 `;
 
+exports[`EarnCard snapshot > compact card with cap in dollar matches snapshot 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-aiq5q4"
+  >
+    <div
+      class="MuiStack-root css-10yhf5k-MuiStack-root"
+    >
+      <div
+        class="MuiStack-root css-101nimo-MuiStack-root"
+      >
+        <div
+          class="badge-container MuiBox-root css-1wzsofa"
+        >
+          <svg
+            fill="none"
+            height="12"
+            viewBox="0 0 20 20"
+            width="12"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              clip-path="url(#a)"
+            >
+              <path
+                d="M18.016 14.167c.573 0 1.057.166 1.45.5.393.333.587.722.58 1.166l-8.03 2.5-7-1.666v-7.5h1.95l7.27 2.241c.52.173.78.484.78.934 0 .26-.113.489-.34.683-.227.194-.513.297-.86.308h-2.8l-1.75-.558-.33.783 2.08.609h7Zm-4-11.475c.707-.684 1.607-1.025 2.7-1.025.907 0 1.673.277 2.3.833.627.556.96 1.194 1 1.917 0 .572-.333 1.255-1 2.05-.667.794-1.323 1.458-1.97 1.991-.647.534-1.657 1.325-3.03 2.375a116.845 116.845 0 0 1-3.06-2.375c-.653-.533-1.31-1.197-1.97-1.991-.66-.795-.983-1.478-.97-2.05 0-.756.323-1.395.97-1.917s1.427-.8 2.34-.833c1.067 0 1.963.341 2.69 1.025ZM-1 9.167h4.016v9.166H-1V9.167Z"
+                fill="currentColor"
+                fill-opacity="0.92"
+              />
+            </g>
+            <defs>
+              <clippath
+                id="a"
+              >
+                <path
+                  d="M0 0h20v20H0z"
+                  fill="#fff"
+                />
+              </clippath>
+            </defs>
+          </svg>
+        </div>
+        <div
+          class="badge-container MuiBox-root css-1wzsofa"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="earn-card-tag-staking"
+          >
+            Staking
+          </p>
+        </div>
+        <div
+          class="badge-container MuiBox-root css-1wzsofa"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="earn-card-tag-earn"
+          >
+            Earn
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiStack-root css-4e6rn7-MuiStack-root"
+    >
+      <div
+        class="MuiBox-root css-u70uxf"
+        data-testid="protocol-morpho"
+      >
+        <div
+          class="MuiBox-root css-wioyy2"
+        >
+          <div
+            class="MuiStack-root css-5s31b2-MuiStack-root"
+          >
+            <div
+              class="MuiStack-root css-k0vgmj-MuiStack-root"
+            >
+              <div
+                class="MuiAvatar-root MuiAvatar-circular css-1we4ia9-MuiAvatar-root"
+              >
+                <img
+                  alt="morpho"
+                  class="MuiAvatar-img css-i4dfdj-MuiAvatar-img"
+                  loading="lazy"
+                  src="https://strapi.jumper.exchange/uploads/morpho_eef0686ee3_2e4b8e06a6.png"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-k8f1u5"
+          >
+            <div
+              class="MuiStack-root css-1g44ov9-MuiStack-root"
+            >
+              <div
+                class="MuiStack-root css-1x5pyaa-MuiStack-root"
+              >
+                <div
+                  class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-5ylplk-MuiAvatar-root"
+                >
+                  <span
+                    class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-1dpscep-MuiSkeleton-root"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-fxacz8"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-titleXSmall css-10j8ruw-MuiTypography-root"
+            data-testid="entity-chain-stack-title"
+          >
+            Moonwell Flagship USDC on base
+          </span>
+          <p
+            class="MuiTypography-root MuiTypography-bodyXSmall css-1gwx9ao-MuiTypography-root"
+            data-testid="entity-chain-stack-chain-name"
+          >
+            Base
+          </p>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-1gk85zv-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="apy-0.07150000000000001"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.apy
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.apy"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
+            >
+              7.15%
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="lockupPeriod-2"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.lockupPeriod
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.lockupPeriod"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
+            >
+              2 months
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-1gk85zv-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="tvl-62572415"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.tvl
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.tvl"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
+            >
+              $62.57M
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="assets-USDC"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.assets
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.assets"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <div
+              class="MuiBox-root css-1xdhyk6"
+            >
+              <div
+                class="MuiStack-root css-5s31b2-MuiStack-root"
+              >
+                <div
+                  class="MuiStack-root css-k0vgmj-MuiStack-root"
+                >
+                  <div
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+                  >
+                    <span
+                      class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-lvnl87-MuiSkeleton-root"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
+            >
+              USDC
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EarnCard snapshot > compact card with href matches snapshot 1`] = `
 <div>
   <a
@@ -689,6 +994,616 @@ exports[`EarnCard snapshot > compact card with loading matches snapshot 1`] = `
       <span
         class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse css-1letoxv-MuiSkeleton-root"
       />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EarnCard snapshot > compact card with lockup months and cap in dollar matches snapshot 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-aiq5q4"
+  >
+    <div
+      class="MuiStack-root css-10yhf5k-MuiStack-root"
+    >
+      <div
+        class="MuiStack-root css-101nimo-MuiStack-root"
+      >
+        <div
+          class="badge-container MuiBox-root css-1wzsofa"
+        >
+          <svg
+            fill="none"
+            height="12"
+            viewBox="0 0 20 20"
+            width="12"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              clip-path="url(#a)"
+            >
+              <path
+                d="M18.016 14.167c.573 0 1.057.166 1.45.5.393.333.587.722.58 1.166l-8.03 2.5-7-1.666v-7.5h1.95l7.27 2.241c.52.173.78.484.78.934 0 .26-.113.489-.34.683-.227.194-.513.297-.86.308h-2.8l-1.75-.558-.33.783 2.08.609h7Zm-4-11.475c.707-.684 1.607-1.025 2.7-1.025.907 0 1.673.277 2.3.833.627.556.96 1.194 1 1.917 0 .572-.333 1.255-1 2.05-.667.794-1.323 1.458-1.97 1.991-.647.534-1.657 1.325-3.03 2.375a116.845 116.845 0 0 1-3.06-2.375c-.653-.533-1.31-1.197-1.97-1.991-.66-.795-.983-1.478-.97-2.05 0-.756.323-1.395.97-1.917s1.427-.8 2.34-.833c1.067 0 1.963.341 2.69 1.025ZM-1 9.167h4.016v9.166H-1V9.167Z"
+                fill="currentColor"
+                fill-opacity="0.92"
+              />
+            </g>
+            <defs>
+              <clippath
+                id="a"
+              >
+                <path
+                  d="M0 0h20v20H0z"
+                  fill="#fff"
+                />
+              </clippath>
+            </defs>
+          </svg>
+        </div>
+        <div
+          class="badge-container MuiBox-root css-1wzsofa"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="earn-card-tag-staking"
+          >
+            Staking
+          </p>
+        </div>
+        <div
+          class="badge-container MuiBox-root css-1wzsofa"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="earn-card-tag-earn"
+          >
+            Earn
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiStack-root css-4e6rn7-MuiStack-root"
+    >
+      <div
+        class="MuiBox-root css-u70uxf"
+        data-testid="protocol-morpho"
+      >
+        <div
+          class="MuiBox-root css-wioyy2"
+        >
+          <div
+            class="MuiStack-root css-5s31b2-MuiStack-root"
+          >
+            <div
+              class="MuiStack-root css-k0vgmj-MuiStack-root"
+            >
+              <div
+                class="MuiAvatar-root MuiAvatar-circular css-1we4ia9-MuiAvatar-root"
+              >
+                <img
+                  alt="morpho"
+                  class="MuiAvatar-img css-i4dfdj-MuiAvatar-img"
+                  loading="lazy"
+                  src="https://strapi.jumper.exchange/uploads/morpho_eef0686ee3_2e4b8e06a6.png"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-k8f1u5"
+          >
+            <div
+              class="MuiStack-root css-1g44ov9-MuiStack-root"
+            >
+              <div
+                class="MuiStack-root css-1x5pyaa-MuiStack-root"
+              >
+                <div
+                  class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-5ylplk-MuiAvatar-root"
+                >
+                  <span
+                    class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-1dpscep-MuiSkeleton-root"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-fxacz8"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-titleXSmall css-10j8ruw-MuiTypography-root"
+            data-testid="entity-chain-stack-title"
+          >
+            Moonwell Flagship USDC on base
+          </span>
+          <p
+            class="MuiTypography-root MuiTypography-bodyXSmall css-1gwx9ao-MuiTypography-root"
+            data-testid="entity-chain-stack-chain-name"
+          >
+            Base
+          </p>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-1gk85zv-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="apy-0.07150000000000001"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.apy
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.apy"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
+            >
+              7.15%
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="lockupPeriod-2"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.lockupPeriod
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.lockupPeriod"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
+            >
+              2 months
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-1gk85zv-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="tvl-62572415"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.tvl
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.tvl"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
+            >
+              $62.57M
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="assets-USDC"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.assets
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.assets"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <div
+              class="MuiBox-root css-1xdhyk6"
+            >
+              <div
+                class="MuiStack-root css-5s31b2-MuiStack-root"
+              >
+                <div
+                  class="MuiStack-root css-k0vgmj-MuiStack-root"
+                >
+                  <div
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+                  >
+                    <span
+                      class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-lvnl87-MuiSkeleton-root"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
+            >
+              USDC
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EarnCard snapshot > compact card with lockup months matches snapshot 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-aiq5q4"
+  >
+    <div
+      class="MuiStack-root css-10yhf5k-MuiStack-root"
+    >
+      <div
+        class="MuiStack-root css-101nimo-MuiStack-root"
+      >
+        <div
+          class="badge-container MuiBox-root css-1wzsofa"
+        >
+          <svg
+            fill="none"
+            height="12"
+            viewBox="0 0 20 20"
+            width="12"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              clip-path="url(#a)"
+            >
+              <path
+                d="M18.016 14.167c.573 0 1.057.166 1.45.5.393.333.587.722.58 1.166l-8.03 2.5-7-1.666v-7.5h1.95l7.27 2.241c.52.173.78.484.78.934 0 .26-.113.489-.34.683-.227.194-.513.297-.86.308h-2.8l-1.75-.558-.33.783 2.08.609h7Zm-4-11.475c.707-.684 1.607-1.025 2.7-1.025.907 0 1.673.277 2.3.833.627.556.96 1.194 1 1.917 0 .572-.333 1.255-1 2.05-.667.794-1.323 1.458-1.97 1.991-.647.534-1.657 1.325-3.03 2.375a116.845 116.845 0 0 1-3.06-2.375c-.653-.533-1.31-1.197-1.97-1.991-.66-.795-.983-1.478-.97-2.05 0-.756.323-1.395.97-1.917s1.427-.8 2.34-.833c1.067 0 1.963.341 2.69 1.025ZM-1 9.167h4.016v9.166H-1V9.167Z"
+                fill="currentColor"
+                fill-opacity="0.92"
+              />
+            </g>
+            <defs>
+              <clippath
+                id="a"
+              >
+                <path
+                  d="M0 0h20v20H0z"
+                  fill="#fff"
+                />
+              </clippath>
+            </defs>
+          </svg>
+        </div>
+        <div
+          class="badge-container MuiBox-root css-1wzsofa"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="earn-card-tag-staking"
+          >
+            Staking
+          </p>
+        </div>
+        <div
+          class="badge-container MuiBox-root css-1wzsofa"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="earn-card-tag-earn"
+          >
+            Earn
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiStack-root css-4e6rn7-MuiStack-root"
+    >
+      <div
+        class="MuiBox-root css-u70uxf"
+        data-testid="protocol-morpho"
+      >
+        <div
+          class="MuiBox-root css-wioyy2"
+        >
+          <div
+            class="MuiStack-root css-5s31b2-MuiStack-root"
+          >
+            <div
+              class="MuiStack-root css-k0vgmj-MuiStack-root"
+            >
+              <div
+                class="MuiAvatar-root MuiAvatar-circular css-1we4ia9-MuiAvatar-root"
+              >
+                <img
+                  alt="morpho"
+                  class="MuiAvatar-img css-i4dfdj-MuiAvatar-img"
+                  loading="lazy"
+                  src="https://strapi.jumper.exchange/uploads/morpho_eef0686ee3_2e4b8e06a6.png"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-k8f1u5"
+          >
+            <div
+              class="MuiStack-root css-1g44ov9-MuiStack-root"
+            >
+              <div
+                class="MuiStack-root css-1x5pyaa-MuiStack-root"
+              >
+                <div
+                  class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-5ylplk-MuiAvatar-root"
+                >
+                  <span
+                    class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-1dpscep-MuiSkeleton-root"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-fxacz8"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-titleXSmall css-10j8ruw-MuiTypography-root"
+            data-testid="entity-chain-stack-title"
+          >
+            Moonwell Flagship USDC on base
+          </span>
+          <p
+            class="MuiTypography-root MuiTypography-bodyXSmall css-1gwx9ao-MuiTypography-root"
+            data-testid="entity-chain-stack-chain-name"
+          >
+            Base
+          </p>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-1gk85zv-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="apy-0.07150000000000001"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.apy
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.apy"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
+            >
+              7.15%
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="lockupPeriod-2"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.lockupPeriod
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.lockupPeriod"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
+            >
+              2 months
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-1gk85zv-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="tvl-62572415"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.tvl
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.tvl"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
+            >
+              $62.57M
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="assets-USDC"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.assets
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.assets"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <div
+              class="MuiBox-root css-1xdhyk6"
+            >
+              <div
+                class="MuiStack-root css-5s31b2-MuiStack-root"
+              >
+                <div
+                  class="MuiStack-root css-k0vgmj-MuiStack-root"
+                >
+                  <div
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+                  >
+                    <span
+                      class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-lvnl87-MuiSkeleton-root"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
+            >
+              USDC
+            </p>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -1484,7 +2399,7 @@ exports[`EarnCard snapshot > compact card with two items matches snapshot 1`] = 
         class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-1gk85zv-MuiGrid-root"
       >
         <div
-          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-12 css-xvszvy-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
           data-testid="apy-0.0558"
         >
           <div
@@ -1516,6 +2431,42 @@ exports[`EarnCard snapshot > compact card with two items matches snapshot 1`] = 
               class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
             >
               5.58%
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="capInDollar-1000000000000000000"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.capInDollar
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.capInDollar"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyLargeStrong css-h1a9re-MuiTypography-root"
+            >
+              $1,000,000T
             </p>
           </div>
         </div>
@@ -1801,6 +2752,197 @@ exports[`EarnCard snapshot > list item card matches snapshot 1`] = `
 </div>
 `;
 
+exports[`EarnCard snapshot > list item card with cap in dollar matches snapshot 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-g8e8kl"
+  >
+    <div
+      class="MuiStack-root css-qvm35a-MuiStack-root"
+    >
+      <div
+        class="MuiBox-root css-u70uxf"
+        data-testid="protocol-morpho"
+      >
+        <div
+          class="MuiBox-root css-wioyy2"
+        >
+          <div
+            class="MuiStack-root css-5s31b2-MuiStack-root"
+          >
+            <div
+              class="MuiStack-root css-k0vgmj-MuiStack-root"
+            >
+              <div
+                class="MuiAvatar-root MuiAvatar-circular css-1vh1zud-MuiAvatar-root"
+              >
+                <img
+                  alt="morpho"
+                  class="MuiAvatar-img css-i4dfdj-MuiAvatar-img"
+                  loading="lazy"
+                  src="https://strapi.jumper.exchange/uploads/morpho_eef0686ee3_2e4b8e06a6.png"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-k8f1u5"
+          >
+            <div
+              class="MuiStack-root css-1g44ov9-MuiStack-root"
+            >
+              <div
+                class="MuiStack-root css-1x5pyaa-MuiStack-root"
+              >
+                <div
+                  class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ksgy38-MuiAvatar-root"
+                >
+                  <span
+                    class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-upfo8e-MuiSkeleton-root"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-fxacz8"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-titleXSmall css-10j8ruw-MuiTypography-root"
+            data-testid="entity-chain-stack-title"
+          >
+            Moonwell Flagship USDC on base
+          </span>
+          <p
+            class="MuiTypography-root MuiTypography-bodyXSmall css-1gwx9ao-MuiTypography-root"
+            data-testid="entity-chain-stack-chain-name"
+          >
+            Base
+          </p>
+        </div>
+      </div>
+      <div
+        class="MuiStack-root css-1x8l63s-MuiStack-root"
+      >
+        <div
+          class="badge-container MuiBox-root css-8wpak"
+        >
+          <svg
+            fill="none"
+            height="16"
+            viewBox="0 0 20 20"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              clip-path="url(#a)"
+            >
+              <path
+                d="M18.016 14.167c.573 0 1.057.166 1.45.5.393.333.587.722.58 1.166l-8.03 2.5-7-1.666v-7.5h1.95l7.27 2.241c.52.173.78.484.78.934 0 .26-.113.489-.34.683-.227.194-.513.297-.86.308h-2.8l-1.75-.558-.33.783 2.08.609h7Zm-4-11.475c.707-.684 1.607-1.025 2.7-1.025.907 0 1.673.277 2.3.833.627.556.96 1.194 1 1.917 0 .572-.333 1.255-1 2.05-.667.794-1.323 1.458-1.97 1.991-.647.534-1.657 1.325-3.03 2.375a116.845 116.845 0 0 1-3.06-2.375c-.653-.533-1.31-1.197-1.97-1.991-.66-.795-.983-1.478-.97-2.05 0-.756.323-1.395.97-1.917s1.427-.8 2.34-.833c1.067 0 1.963.341 2.69 1.025ZM-1 9.167h4.016v9.166H-1V9.167Z"
+                fill="currentColor"
+                fill-opacity="0.92"
+              />
+            </g>
+            <defs>
+              <clippath
+                id="a"
+              >
+                <path
+                  d="M0 0h20v20H0z"
+                  fill="#fff"
+                />
+              </clippath>
+            </defs>
+          </svg>
+        </div>
+        <div
+          class="badge-container MuiBox-root css-8wpak"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+          >
+            Staking
+          </p>
+        </div>
+        <div
+          class="badge-container MuiBox-root css-8wpak"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+          >
+            Earn
+          </p>
+        </div>
+        <div
+          aria-label="tooltips.apy"
+          class="MuiBox-root css-pq1w8v"
+          data-mui-internal-clone-element="true"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="apy-0.07150000000000001"
+          >
+            7.15% labels.apy
+          </p>
+        </div>
+        <div
+          aria-label="tooltips.lockupPeriod"
+          class="MuiBox-root css-pq1w8v"
+          data-mui-internal-clone-element="true"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="lockupPeriod-2"
+          >
+            2 months
+          </p>
+        </div>
+        <div
+          aria-label="tooltips.tvl"
+          class="MuiBox-root css-pq1w8v"
+          data-mui-internal-clone-element="true"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="tvl-62572415"
+          >
+            $62.57M labels.tvl
+          </p>
+        </div>
+        <div
+          aria-label="tooltips.assets"
+          class="MuiBox-root css-pq1w8v"
+          data-mui-internal-clone-element="true"
+        >
+          <div
+            class="MuiStack-root css-5s31b2-MuiStack-root"
+          >
+            <div
+              class="MuiStack-root css-k0vgmj-MuiStack-root"
+            >
+              <div
+                class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+              >
+                <span
+                  class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-lvnl87-MuiSkeleton-root"
+                />
+              </div>
+            </div>
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="assets-USDC"
+          >
+            USDC
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EarnCard snapshot > list item card with href matches snapshot 1`] = `
 <div>
   <a
@@ -2049,6 +3191,388 @@ exports[`EarnCard snapshot > list item card with loading matches snapshot 1`] = 
           class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-n8le6-MuiSkeleton-root"
           style="width: 40px; height: 40px;"
         />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EarnCard snapshot > list item card with lockup months and cap in dollar matches snapshot 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-g8e8kl"
+  >
+    <div
+      class="MuiStack-root css-qvm35a-MuiStack-root"
+    >
+      <div
+        class="MuiBox-root css-u70uxf"
+        data-testid="protocol-morpho"
+      >
+        <div
+          class="MuiBox-root css-wioyy2"
+        >
+          <div
+            class="MuiStack-root css-5s31b2-MuiStack-root"
+          >
+            <div
+              class="MuiStack-root css-k0vgmj-MuiStack-root"
+            >
+              <div
+                class="MuiAvatar-root MuiAvatar-circular css-1vh1zud-MuiAvatar-root"
+              >
+                <img
+                  alt="morpho"
+                  class="MuiAvatar-img css-i4dfdj-MuiAvatar-img"
+                  loading="lazy"
+                  src="https://strapi.jumper.exchange/uploads/morpho_eef0686ee3_2e4b8e06a6.png"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-k8f1u5"
+          >
+            <div
+              class="MuiStack-root css-1g44ov9-MuiStack-root"
+            >
+              <div
+                class="MuiStack-root css-1x5pyaa-MuiStack-root"
+              >
+                <div
+                  class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ksgy38-MuiAvatar-root"
+                >
+                  <span
+                    class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-upfo8e-MuiSkeleton-root"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-fxacz8"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-titleXSmall css-10j8ruw-MuiTypography-root"
+            data-testid="entity-chain-stack-title"
+          >
+            Moonwell Flagship USDC on base
+          </span>
+          <p
+            class="MuiTypography-root MuiTypography-bodyXSmall css-1gwx9ao-MuiTypography-root"
+            data-testid="entity-chain-stack-chain-name"
+          >
+            Base
+          </p>
+        </div>
+      </div>
+      <div
+        class="MuiStack-root css-1x8l63s-MuiStack-root"
+      >
+        <div
+          class="badge-container MuiBox-root css-8wpak"
+        >
+          <svg
+            fill="none"
+            height="16"
+            viewBox="0 0 20 20"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              clip-path="url(#a)"
+            >
+              <path
+                d="M18.016 14.167c.573 0 1.057.166 1.45.5.393.333.587.722.58 1.166l-8.03 2.5-7-1.666v-7.5h1.95l7.27 2.241c.52.173.78.484.78.934 0 .26-.113.489-.34.683-.227.194-.513.297-.86.308h-2.8l-1.75-.558-.33.783 2.08.609h7Zm-4-11.475c.707-.684 1.607-1.025 2.7-1.025.907 0 1.673.277 2.3.833.627.556.96 1.194 1 1.917 0 .572-.333 1.255-1 2.05-.667.794-1.323 1.458-1.97 1.991-.647.534-1.657 1.325-3.03 2.375a116.845 116.845 0 0 1-3.06-2.375c-.653-.533-1.31-1.197-1.97-1.991-.66-.795-.983-1.478-.97-2.05 0-.756.323-1.395.97-1.917s1.427-.8 2.34-.833c1.067 0 1.963.341 2.69 1.025ZM-1 9.167h4.016v9.166H-1V9.167Z"
+                fill="currentColor"
+                fill-opacity="0.92"
+              />
+            </g>
+            <defs>
+              <clippath
+                id="a"
+              >
+                <path
+                  d="M0 0h20v20H0z"
+                  fill="#fff"
+                />
+              </clippath>
+            </defs>
+          </svg>
+        </div>
+        <div
+          class="badge-container MuiBox-root css-8wpak"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+          >
+            Staking
+          </p>
+        </div>
+        <div
+          class="badge-container MuiBox-root css-8wpak"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+          >
+            Earn
+          </p>
+        </div>
+        <div
+          aria-label="tooltips.apy"
+          class="MuiBox-root css-pq1w8v"
+          data-mui-internal-clone-element="true"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="apy-0.07150000000000001"
+          >
+            7.15% labels.apy
+          </p>
+        </div>
+        <div
+          aria-label="tooltips.lockupPeriod"
+          class="MuiBox-root css-pq1w8v"
+          data-mui-internal-clone-element="true"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="lockupPeriod-2"
+          >
+            2 months
+          </p>
+        </div>
+        <div
+          aria-label="tooltips.tvl"
+          class="MuiBox-root css-pq1w8v"
+          data-mui-internal-clone-element="true"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="tvl-62572415"
+          >
+            $62.57M labels.tvl
+          </p>
+        </div>
+        <div
+          aria-label="tooltips.assets"
+          class="MuiBox-root css-pq1w8v"
+          data-mui-internal-clone-element="true"
+        >
+          <div
+            class="MuiStack-root css-5s31b2-MuiStack-root"
+          >
+            <div
+              class="MuiStack-root css-k0vgmj-MuiStack-root"
+            >
+              <div
+                class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+              >
+                <span
+                  class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-lvnl87-MuiSkeleton-root"
+                />
+              </div>
+            </div>
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="assets-USDC"
+          >
+            USDC
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EarnCard snapshot > list item card with lockup months matches snapshot 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-g8e8kl"
+  >
+    <div
+      class="MuiStack-root css-qvm35a-MuiStack-root"
+    >
+      <div
+        class="MuiBox-root css-u70uxf"
+        data-testid="protocol-morpho"
+      >
+        <div
+          class="MuiBox-root css-wioyy2"
+        >
+          <div
+            class="MuiStack-root css-5s31b2-MuiStack-root"
+          >
+            <div
+              class="MuiStack-root css-k0vgmj-MuiStack-root"
+            >
+              <div
+                class="MuiAvatar-root MuiAvatar-circular css-1vh1zud-MuiAvatar-root"
+              >
+                <img
+                  alt="morpho"
+                  class="MuiAvatar-img css-i4dfdj-MuiAvatar-img"
+                  loading="lazy"
+                  src="https://strapi.jumper.exchange/uploads/morpho_eef0686ee3_2e4b8e06a6.png"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-k8f1u5"
+          >
+            <div
+              class="MuiStack-root css-1g44ov9-MuiStack-root"
+            >
+              <div
+                class="MuiStack-root css-1x5pyaa-MuiStack-root"
+              >
+                <div
+                  class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ksgy38-MuiAvatar-root"
+                >
+                  <span
+                    class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-upfo8e-MuiSkeleton-root"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-fxacz8"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-titleXSmall css-10j8ruw-MuiTypography-root"
+            data-testid="entity-chain-stack-title"
+          >
+            Moonwell Flagship USDC on base
+          </span>
+          <p
+            class="MuiTypography-root MuiTypography-bodyXSmall css-1gwx9ao-MuiTypography-root"
+            data-testid="entity-chain-stack-chain-name"
+          >
+            Base
+          </p>
+        </div>
+      </div>
+      <div
+        class="MuiStack-root css-1x8l63s-MuiStack-root"
+      >
+        <div
+          class="badge-container MuiBox-root css-8wpak"
+        >
+          <svg
+            fill="none"
+            height="16"
+            viewBox="0 0 20 20"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              clip-path="url(#a)"
+            >
+              <path
+                d="M18.016 14.167c.573 0 1.057.166 1.45.5.393.333.587.722.58 1.166l-8.03 2.5-7-1.666v-7.5h1.95l7.27 2.241c.52.173.78.484.78.934 0 .26-.113.489-.34.683-.227.194-.513.297-.86.308h-2.8l-1.75-.558-.33.783 2.08.609h7Zm-4-11.475c.707-.684 1.607-1.025 2.7-1.025.907 0 1.673.277 2.3.833.627.556.96 1.194 1 1.917 0 .572-.333 1.255-1 2.05-.667.794-1.323 1.458-1.97 1.991-.647.534-1.657 1.325-3.03 2.375a116.845 116.845 0 0 1-3.06-2.375c-.653-.533-1.31-1.197-1.97-1.991-.66-.795-.983-1.478-.97-2.05 0-.756.323-1.395.97-1.917s1.427-.8 2.34-.833c1.067 0 1.963.341 2.69 1.025ZM-1 9.167h4.016v9.166H-1V9.167Z"
+                fill="currentColor"
+                fill-opacity="0.92"
+              />
+            </g>
+            <defs>
+              <clippath
+                id="a"
+              >
+                <path
+                  d="M0 0h20v20H0z"
+                  fill="#fff"
+                />
+              </clippath>
+            </defs>
+          </svg>
+        </div>
+        <div
+          class="badge-container MuiBox-root css-8wpak"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+          >
+            Staking
+          </p>
+        </div>
+        <div
+          class="badge-container MuiBox-root css-8wpak"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+          >
+            Earn
+          </p>
+        </div>
+        <div
+          aria-label="tooltips.apy"
+          class="MuiBox-root css-pq1w8v"
+          data-mui-internal-clone-element="true"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="apy-0.07150000000000001"
+          >
+            7.15% labels.apy
+          </p>
+        </div>
+        <div
+          aria-label="tooltips.lockupPeriod"
+          class="MuiBox-root css-pq1w8v"
+          data-mui-internal-clone-element="true"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="lockupPeriod-2"
+          >
+            2 months
+          </p>
+        </div>
+        <div
+          aria-label="tooltips.tvl"
+          class="MuiBox-root css-pq1w8v"
+          data-mui-internal-clone-element="true"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="tvl-62572415"
+          >
+            $62.57M labels.tvl
+          </p>
+        </div>
+        <div
+          aria-label="tooltips.assets"
+          class="MuiBox-root css-pq1w8v"
+          data-mui-internal-clone-element="true"
+        >
+          <div
+            class="MuiStack-root css-5s31b2-MuiStack-root"
+          >
+            <div
+              class="MuiStack-root css-k0vgmj-MuiStack-root"
+            >
+              <div
+                class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+              >
+                <span
+                  class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-lvnl87-MuiSkeleton-root"
+                />
+              </div>
+            </div>
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
+            data-testid="assets-USDC"
+          >
+            USDC
+          </p>
+        </div>
       </div>
     </div>
   </div>
@@ -3167,6 +4691,372 @@ exports[`EarnCard snapshot > overview card with badge matches snapshot 1`] = `
 </div>
 `;
 
+exports[`EarnCard snapshot > overview card with cap in dollar matches snapshot 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-13fpmno"
+  >
+    <div
+      class="MuiStack-root css-h345r2-MuiStack-root"
+    >
+      <div
+        class="MuiBox-root css-ynzgks"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-titleXSmall css-f793q6-MuiTypography-root"
+        >
+          labels.overview
+        </span>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-tms0j3-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="apy-0.07150000000000001"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.apy
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.apy"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              7.15%
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="capInDollar-1000000"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.capInDollar
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.capInDollar"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              $1M
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-tms0j3-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="tvl-62572415"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.tvl
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.tvl"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              $62.57M
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="assets-USDC"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.assets
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.assets"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <div
+              class="MuiBox-root css-1xdhyk6"
+            >
+              <div
+                class="MuiBox-root css-h1oaii"
+                data-testid="tokens-USD Coin"
+              >
+                <div
+                  class="MuiBox-root css-wioyy2"
+                >
+                  <div
+                    class="MuiStack-root css-5s31b2-MuiStack-root"
+                  >
+                    <div
+                      class="MuiStack-root css-k0vgmj-MuiStack-root"
+                    >
+                      <div
+                        class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+                      >
+                        <span
+                          class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-lvnl87-MuiSkeleton-root"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root css-k8f1u5"
+                  >
+                    <div
+                      class="MuiStack-root css-1g44ov9-MuiStack-root"
+                    >
+                      <div
+                        class="MuiStack-root css-1x5pyaa-MuiStack-root"
+                      >
+                        <div
+                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1itdt8o-MuiAvatar-root"
+                        >
+                          <span
+                            class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-9nsmbt-MuiSkeleton-root"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              USDC
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-tms0j3-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="chains-8453"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.chains
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.chains"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <div
+              class="MuiBox-root css-1xdhyk6"
+            >
+              <div
+                class="MuiStack-root css-5s31b2-MuiStack-root"
+              >
+                <div
+                  class="MuiStack-root css-k0vgmj-MuiStack-root"
+                >
+                  <div
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+                  >
+                    <span
+                      class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-lvnl87-MuiSkeleton-root"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              Base
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="protocol-morpho"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.protocol
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.protocol"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <div
+              class="MuiBox-root css-1xdhyk6"
+            >
+              <div
+                class="MuiBox-root css-h1oaii"
+                data-testid="protocol-morpho"
+              >
+                <div
+                  class="MuiBox-root css-wioyy2"
+                >
+                  <div
+                    class="MuiStack-root css-5s31b2-MuiStack-root"
+                  >
+                    <div
+                      class="MuiStack-root css-k0vgmj-MuiStack-root"
+                    >
+                      <div
+                        class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                      >
+                        <img
+                          alt="morpho"
+                          class="MuiAvatar-img css-i4dfdj-MuiAvatar-img"
+                          loading="lazy"
+                          src="https://strapi.jumper.exchange/uploads/morpho_eef0686ee3_2e4b8e06a6.png"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root css-k8f1u5"
+                  >
+                    <div
+                      class="MuiStack-root css-1g44ov9-MuiStack-root"
+                    >
+                      <div
+                        class="MuiStack-root css-1x5pyaa-MuiStack-root"
+                      >
+                        <div
+                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1itdt8o-MuiAvatar-root"
+                        >
+                          <span
+                            class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-9nsmbt-MuiSkeleton-root"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              Morpho
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EarnCard snapshot > overview card with loading matches snapshot 1`] = `
 <div>
   <div
@@ -3196,6 +5086,738 @@ exports[`EarnCard snapshot > overview card with loading matches snapshot 1`] = `
       <span
         class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse css-1o29s3j-MuiSkeleton-root"
       />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EarnCard snapshot > overview card with lockup months and cap in dollar matches snapshot 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-13fpmno"
+  >
+    <div
+      class="MuiStack-root css-h345r2-MuiStack-root"
+    >
+      <div
+        class="MuiBox-root css-ynzgks"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-titleXSmall css-f793q6-MuiTypography-root"
+        >
+          labels.overview
+        </span>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-tms0j3-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="apy-0.07150000000000001"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.apy
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.apy"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              7.15%
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="lockupPeriod-2"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.lockupPeriod
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.lockupPeriod"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              2 months
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-tms0j3-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="tvl-62572415"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.tvl
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.tvl"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              $62.57M
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="assets-USDC"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.assets
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.assets"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <div
+              class="MuiBox-root css-1xdhyk6"
+            >
+              <div
+                class="MuiBox-root css-h1oaii"
+                data-testid="tokens-USD Coin"
+              >
+                <div
+                  class="MuiBox-root css-wioyy2"
+                >
+                  <div
+                    class="MuiStack-root css-5s31b2-MuiStack-root"
+                  >
+                    <div
+                      class="MuiStack-root css-k0vgmj-MuiStack-root"
+                    >
+                      <div
+                        class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+                      >
+                        <span
+                          class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-lvnl87-MuiSkeleton-root"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root css-k8f1u5"
+                  >
+                    <div
+                      class="MuiStack-root css-1g44ov9-MuiStack-root"
+                    >
+                      <div
+                        class="MuiStack-root css-1x5pyaa-MuiStack-root"
+                      >
+                        <div
+                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1itdt8o-MuiAvatar-root"
+                        >
+                          <span
+                            class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-9nsmbt-MuiSkeleton-root"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              USDC
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-tms0j3-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="chains-8453"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.chains
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.chains"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <div
+              class="MuiBox-root css-1xdhyk6"
+            >
+              <div
+                class="MuiStack-root css-5s31b2-MuiStack-root"
+              >
+                <div
+                  class="MuiStack-root css-k0vgmj-MuiStack-root"
+                >
+                  <div
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+                  >
+                    <span
+                      class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-lvnl87-MuiSkeleton-root"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              Base
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="protocol-morpho"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.protocol
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.protocol"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <div
+              class="MuiBox-root css-1xdhyk6"
+            >
+              <div
+                class="MuiBox-root css-h1oaii"
+                data-testid="protocol-morpho"
+              >
+                <div
+                  class="MuiBox-root css-wioyy2"
+                >
+                  <div
+                    class="MuiStack-root css-5s31b2-MuiStack-root"
+                  >
+                    <div
+                      class="MuiStack-root css-k0vgmj-MuiStack-root"
+                    >
+                      <div
+                        class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                      >
+                        <img
+                          alt="morpho"
+                          class="MuiAvatar-img css-i4dfdj-MuiAvatar-img"
+                          loading="lazy"
+                          src="https://strapi.jumper.exchange/uploads/morpho_eef0686ee3_2e4b8e06a6.png"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root css-k8f1u5"
+                  >
+                    <div
+                      class="MuiStack-root css-1g44ov9-MuiStack-root"
+                    >
+                      <div
+                        class="MuiStack-root css-1x5pyaa-MuiStack-root"
+                      >
+                        <div
+                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1itdt8o-MuiAvatar-root"
+                        >
+                          <span
+                            class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-9nsmbt-MuiSkeleton-root"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              Morpho
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EarnCard snapshot > overview card with lockup months matches snapshot 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-13fpmno"
+  >
+    <div
+      class="MuiStack-root css-h345r2-MuiStack-root"
+    >
+      <div
+        class="MuiBox-root css-ynzgks"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-titleXSmall css-f793q6-MuiTypography-root"
+        >
+          labels.overview
+        </span>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-tms0j3-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="apy-0.07150000000000001"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.apy
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.apy"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              7.15%
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="lockupPeriod-2"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.lockupPeriod
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.lockupPeriod"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              2 months
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-tms0j3-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="tvl-62572415"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.tvl
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.tvl"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              $62.57M
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="assets-USDC"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.assets
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.assets"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <div
+              class="MuiBox-root css-1xdhyk6"
+            >
+              <div
+                class="MuiBox-root css-h1oaii"
+                data-testid="tokens-USD Coin"
+              >
+                <div
+                  class="MuiBox-root css-wioyy2"
+                >
+                  <div
+                    class="MuiStack-root css-5s31b2-MuiStack-root"
+                  >
+                    <div
+                      class="MuiStack-root css-k0vgmj-MuiStack-root"
+                    >
+                      <div
+                        class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+                      >
+                        <span
+                          class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-lvnl87-MuiSkeleton-root"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root css-k8f1u5"
+                  >
+                    <div
+                      class="MuiStack-root css-1g44ov9-MuiStack-root"
+                    >
+                      <div
+                        class="MuiStack-root css-1x5pyaa-MuiStack-root"
+                      >
+                        <div
+                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1itdt8o-MuiAvatar-root"
+                        >
+                          <span
+                            class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-9nsmbt-MuiSkeleton-root"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              USDC
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-tms0j3-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="chains-8453"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.chains
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.chains"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <div
+              class="MuiBox-root css-1xdhyk6"
+            >
+              <div
+                class="MuiStack-root css-5s31b2-MuiStack-root"
+              >
+                <div
+                  class="MuiStack-root css-k0vgmj-MuiStack-root"
+                >
+                  <div
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+                  >
+                    <span
+                      class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-lvnl87-MuiSkeleton-root"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              Base
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
+          data-testid="protocol-morpho"
+        >
+          <div
+            class="MuiBox-root css-5ul7dk"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-bodyXSmall css-ooebcp-MuiTypography-root"
+            >
+              labels.protocol
+            </p>
+            <svg
+              aria-hidden="true"
+              aria-label="tooltips.protocol"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bfwnwm-MuiSvgIcon-root"
+              data-mui-internal-clone-element="true"
+              data-testid="InfoIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-nqls9x"
+          >
+            <div
+              class="MuiBox-root css-1xdhyk6"
+            >
+              <div
+                class="MuiBox-root css-h1oaii"
+                data-testid="protocol-morpho"
+              >
+                <div
+                  class="MuiBox-root css-wioyy2"
+                >
+                  <div
+                    class="MuiStack-root css-5s31b2-MuiStack-root"
+                  >
+                    <div
+                      class="MuiStack-root css-k0vgmj-MuiStack-root"
+                    >
+                      <div
+                        class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                      >
+                        <img
+                          alt="morpho"
+                          class="MuiAvatar-img css-i4dfdj-MuiAvatar-img"
+                          loading="lazy"
+                          src="https://strapi.jumper.exchange/uploads/morpho_eef0686ee3_2e4b8e06a6.png"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root css-k8f1u5"
+                  >
+                    <div
+                      class="MuiStack-root css-1g44ov9-MuiStack-root"
+                    >
+                      <div
+                        class="MuiStack-root css-1x5pyaa-MuiStack-root"
+                      >
+                        <div
+                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1itdt8o-MuiAvatar-root"
+                        >
+                          <span
+                            class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-9nsmbt-MuiSkeleton-root"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-bodyXLargeStrong css-1b6mt9t-MuiTypography-root"
+            >
+              Morpho
+            </p>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/hooks/earn/useFormatDisplayEarnOpportunityData.tsx
+++ b/src/hooks/earn/useFormatDisplayEarnOpportunityData.tsx
@@ -21,6 +21,7 @@ import { EntityChainStackVariant } from 'src/components/composite/EntityChainSta
 import type { TFunction } from 'i18next';
 import { useChains } from '@/hooks/useChains';
 import { getChainName } from '@/utils/chains/getChainName';
+import { formatCapInDollar } from '@/utils/numbers/capInDollar';
 
 interface EarnCardOverviewItem {
   key: string;
@@ -69,6 +70,26 @@ const buildLockupItem = (
     tooltip: t('tooltips.lockupPeriod', {
       formattedLockupPeriod: formatted,
     }),
+  };
+};
+
+const buildCapInDollarItem = (
+  capInDollar: number | string | undefined,
+  variant: EarnCardVariant,
+  t: TFunction,
+): EarnCardOverviewItem | null => {
+  const capInDollarNumber = Number(capInDollar);
+  if (isNaN(capInDollarNumber) || !capInDollarNumber) {
+    return null;
+  }
+
+  const formatted = formatCapInDollar(capInDollarNumber);
+  return {
+    key: 'capInDollar',
+    dataTestId: `capInDollar-${capInDollarNumber}`,
+    label: t('labels.capInDollar'),
+    value: formatted,
+    tooltip: t('tooltips.capInDollar'),
   };
 };
 
@@ -197,6 +218,7 @@ export const useFormatDisplayEarnOpportunityData = (
 
   return useMemo(() => {
     const lockupMonths = earnOpportunity?.lockupMonths;
+    const capInDollar = earnOpportunity?.capInDollar;
     const protocol = earnOpportunity?.protocol;
     const assets = earnOpportunity?.asset ? [earnOpportunity.asset] : [];
 
@@ -210,7 +232,9 @@ export const useFormatDisplayEarnOpportunityData = (
     // Build all items, passing variant to each builder
     const overviewItems = [
       buildApyItem(apy, variant, t),
-      buildLockupItem(lockupMonths, variant, t),
+      lockupMonths
+        ? buildLockupItem(lockupMonths, variant, t)
+        : buildCapInDollarItem(capInDollar, variant, t),
       buildTvlItem(tvlUsd, variant, t),
       buildAssetsItem(assets, variant, t),
       buildChainsItem(chains, variant, t, (chain) =>

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -187,6 +187,7 @@ interface Resources {
       assets_one: 'Asset';
       assets_other: 'Assets';
       assets_other_one: 'Asset';
+      capInDollar: 'Capacity';
       chains_one: 'Chain';
       chains_other: 'Chains';
       lockupPeriod: 'Lockup Period';
@@ -595,6 +596,7 @@ interface Resources {
       assets_other: 'The assets you will earn from';
       assets_other_one: 'The asset you will earn from';
       boostedApy: '{{baseApy}}% is the expected yearly return rate of the underlying tokens invested. The extra {{boostedApy}}% in rewards - distributed in another token - are paid exclusively to the participant of this zap campaign.';
+      capInDollar: 'Available liquidity capacity of the market';
       chains_one: 'The chain you will earn from';
       chains_other: 'The chains you will earn from';
       deposit: 'The token on which the market is defined and yield accrues on.';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -312,7 +312,8 @@
     "chains_one": "The chain you will earn from",
     "chains_other": "The chains you will earn from",
     "protocol": "The protocol you will earn from",
-    "noPositionsToManage": "You do not have any positions to manage"
+    "noPositionsToManage": "You do not have any positions to manage",
+    "capInDollar": "Available liquidity capacity of the market"
   },
   "labels": {
     "apy": "APY",
@@ -324,7 +325,8 @@
     "chains_one": "Chain",
     "chains_other": "Chains",
     "protocol": "Protocol",
-    "overview": "Overview"
+    "overview": "Overview",
+    "capInDollar": "Capacity"
   },
   "earn": {
     "top": {

--- a/src/utils/formatNumbers.ts
+++ b/src/utils/formatNumbers.ts
@@ -105,6 +105,7 @@ export const formatValueWithConfig = (
       formatOptions.currency = 'USD';
       formatOptions.notation = 'compact';
       formatOptions.compactDisplay = 'short';
+      formatOptions.trailingZeroDisplay = 'stripIfInteger';
       break;
 
     case 'compact':

--- a/src/utils/numbers/capInDollar.ts
+++ b/src/utils/numbers/capInDollar.ts
@@ -1,0 +1,15 @@
+import {
+  formatValueWithConfig,
+  type ValueFormatConfig,
+} from '../formatNumbers';
+
+export const CAP_IN_DOLLAR_FORMAT_CONFIG: ValueFormatConfig = {
+  type: 'currency',
+  options: { maximumFractionDigits: 2 },
+};
+
+export const formatCapInDollar = (value: number | string): string => {
+  return formatValueWithConfig(value, CAP_IN_DOLLAR_FORMAT_CONFIG, {
+    includePrefixSuffix: true,
+  });
+};


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-16818

## Testing steps

1. Go to `/earn`
2. Go to all markets tab
3. Filter for `Aave` protocol
4. Check the `Aave Base EURC` opportunities
5. One of them should show `Capacity`, while 2 of them should show the `Lockup Period`
6. Go to `/earn/aave-base-eurc-on-base-capacity-lockup`
7. In the overview card you should see the `Lockup Period`
8. Now go to  /earn/aave-base-eurc-on-base-lockup`
9. In the overview card you should see the `Lockup Period`
10. Go to `/earn/aave-base-eurc-on-base-capacity`
11. In the overview card you should see the `Capacity`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Capacity" metric to earn cards showing available market liquidity in dollars, with label and tooltip translations and currency formatting.

* **Tests**
  * Added snapshot tests across EarnCard variants to validate capacity and lockup period display combinations and explicit undefined scenarios.

* **Bug Fixes**
  * Improved currency formatting to strip unnecessary trailing zeros for integer dollar values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->