### PR TITLE
feat: add earn and portfolio posthog events

### DIFF
--- a/src/app/ui/portfolio/PortfolioHeaderBreakdown.tsx
+++ b/src/app/ui/portfolio/PortfolioHeaderBreakdown.tsx
@@ -1,14 +1,17 @@
 'use client';
 
 import { AssetOverviewCard } from '@/components/composite/AssetOverviewCard/AssetOverviewCard';
+import { TrackingCategory, TrackingAction } from '@/const/trackingKeys';
 import { useFormatDisplayDeFiPositions } from '@/hooks/portfolio/useFormatDisplayDeFiPositions';
 import { useFormatDisplayWalletTokens } from '@/hooks/portfolio/useFormatDisplayWalletTokens';
 import { usePortfolioDeFiPositions } from '@/hooks/portfolio/usePortfolioDeFiPositions';
+import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
 import { useSettingsStore } from '@/stores/settings/SettingsStore';
 import { usePortfolioTokens } from '@/utils/getTokens/usePortfolioTokens';
+import { parseEarnPortfolioDataToTrackingData } from '@/utils/tracking/portfolio';
 import { ChainType } from '@lifi/sdk';
 import { useAccount } from '@lifi/wallet-management';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import type { MinimalToken } from 'src/types/tokens';
 import type { Hex } from 'viem';
 
@@ -16,6 +19,8 @@ export const PortfolioHeaderBreakdown = () => {
   const portfolioWelcomeScreenClosed = useSettingsStore(
     (state) => state.portfolioWelcomeScreenClosed,
   );
+  const { trackEvent } = useUserTracking();
+  const portfolioHasBeenTracked = useRef(false);
   const { accounts } = useAccount();
   const connectedAddresses = useMemo(() => {
     return accounts
@@ -34,7 +39,9 @@ export const PortfolioHeaderBreakdown = () => {
   const { data: allTokens, isFetching: isFetchingTokens } =
     usePortfolioTokens();
 
-  const isLoading = isLoadingPositions || isFetchingTokens;
+  const isLoading = useMemo(() => {
+    return isLoadingPositions || isFetchingTokens;
+  }, [isLoadingPositions, isFetchingTokens]);
 
   const formattedTokens = useFormatDisplayWalletTokens(allTokens);
 
@@ -62,6 +69,35 @@ export const PortfolioHeaderBreakdown = () => {
 
     return formattedPositions;
   }, [formattedPositions, portfolioWelcomeScreenClosed]);
+
+  useEffect(() => {
+    if (
+      isLoading ||
+      portfolioHasBeenTracked.current ||
+      !portfolioWelcomeScreenClosed
+    ) {
+      return;
+    }
+    portfolioHasBeenTracked.current = true;
+    const trackingData = parseEarnPortfolioDataToTrackingData(
+      connectedAddresses,
+      tokens,
+      defiPositionGroups,
+    );
+    trackEvent({
+      category: TrackingCategory.Portfolio,
+      action: TrackingAction.PortfolioPageOverview,
+      label: 'portfolio_page_overview',
+      data: trackingData,
+    });
+  }, [
+    trackEvent,
+    portfolioWelcomeScreenClosed,
+    isLoading,
+    tokens,
+    defiPositionGroups,
+    connectedAddresses,
+  ]);
 
   return (
     <AssetOverviewCard

--- a/src/app/ui/portfolio/PortfolioHeaderBreakdown.tsx
+++ b/src/app/ui/portfolio/PortfolioHeaderBreakdown.tsx
@@ -1,14 +1,12 @@
 'use client';
 
 import { AssetOverviewCard } from '@/components/composite/AssetOverviewCard/AssetOverviewCard';
-import { TrackingCategory, TrackingAction } from '@/const/trackingKeys';
 import { useFormatDisplayDeFiPositions } from '@/hooks/portfolio/useFormatDisplayDeFiPositions';
 import { useFormatDisplayWalletTokens } from '@/hooks/portfolio/useFormatDisplayWalletTokens';
 import { usePortfolioDeFiPositions } from '@/hooks/portfolio/usePortfolioDeFiPositions';
-import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
+import { usePortfolioTracking } from '@/hooks/userTracking/usePortfolioTracking';
 import { useSettingsStore } from '@/stores/settings/SettingsStore';
 import { usePortfolioTokens } from '@/utils/getTokens/usePortfolioTokens';
-import { parseEarnPortfolioDataToTrackingData } from '@/utils/tracking/portfolio';
 import { ChainType } from '@lifi/sdk';
 import { useAccount } from '@lifi/wallet-management';
 import { useEffect, useMemo, useRef } from 'react';
@@ -19,7 +17,7 @@ export const PortfolioHeaderBreakdown = () => {
   const portfolioWelcomeScreenClosed = useSettingsStore(
     (state) => state.portfolioWelcomeScreenClosed,
   );
-  const { trackEvent } = useUserTracking();
+  const { trackPortfolioPageOverviewEvent } = usePortfolioTracking();
   const portfolioHasBeenTracked = useRef(false);
   const { accounts } = useAccount();
   const connectedAddresses = useMemo(() => {
@@ -39,9 +37,7 @@ export const PortfolioHeaderBreakdown = () => {
   const { data: allTokens, isFetching: isFetchingTokens } =
     usePortfolioTokens();
 
-  const isLoading = useMemo(() => {
-    return isLoadingPositions || isFetchingTokens;
-  }, [isLoadingPositions, isFetchingTokens]);
+  const isLoading = isLoadingPositions || isFetchingTokens;
 
   const formattedTokens = useFormatDisplayWalletTokens(allTokens);
 
@@ -72,32 +68,20 @@ export const PortfolioHeaderBreakdown = () => {
 
   useEffect(() => {
     if (
-      isLoading ||
       portfolioHasBeenTracked.current ||
-      !portfolioWelcomeScreenClosed
+      isLoading ||
+      !portfolioWelcomeScreenClosed ||
+      !connectedAddresses.length
     ) {
       return;
     }
-    portfolioHasBeenTracked.current = true;
-    const trackingData = parseEarnPortfolioDataToTrackingData(
+    trackPortfolioPageOverviewEvent(
       connectedAddresses,
       tokens,
       defiPositionGroups,
     );
-    trackEvent({
-      category: TrackingCategory.Portfolio,
-      action: TrackingAction.PortfolioPageOverview,
-      label: 'portfolio_page_overview',
-      data: trackingData,
-    });
-  }, [
-    trackEvent,
-    portfolioWelcomeScreenClosed,
-    isLoading,
-    tokens,
-    defiPositionGroups,
-    connectedAddresses,
-  ]);
+    portfolioHasBeenTracked.current = true;
+  });
 
   return (
     <AssetOverviewCard

--- a/src/components/Zap/ZapWidgetStack.tsx
+++ b/src/components/Zap/ZapWidgetStack.tsx
@@ -16,6 +16,7 @@ import { useEnhancedZapData } from 'src/hooks/zaps/useEnhancedZapData';
 import { SweepTokensCard } from '../ZapWidget/SweepTokensCard/SweepTokensCard';
 import { useZapQuestIdStorage } from 'src/providers/hooks';
 import envConfig from 'src/config/env-config';
+import { TrackingAction, TrackingEventDataAction } from '@/const/trackingKeys';
 
 export interface ZapWidgetStackProps {
   customInformation?: CustomInformation;
@@ -54,7 +55,22 @@ export const ZapWidgetStack: FC<ZapWidgetStackProps> = ({
   const hasWithdrawAbi = !!zapData?.abi?.withdraw;
 
   return (
-    <WidgetTrackingProvider>
+    <WidgetTrackingProvider
+      trackingActionKeys={{
+        sourceChainAndTokenSelection:
+          TrackingAction.OnSourceChainAndTokenSelectionZap,
+        availableRoutes: TrackingAction.OnAvailableRoutesZap,
+        routeExecutionStarted: TrackingAction.OnRouteExecutionStartedZap,
+        routeExecutionCompleted: TrackingAction.OnRouteExecutionCompletedZap,
+        routeExecutionFailed: TrackingAction.OnRouteExecutionFailedZap,
+        changeSettings: TrackingAction.OnChangeSettingsZap,
+      }}
+      trackingDataActionKeys={{
+        routeExecutionStarted: TrackingEventDataAction.ExecutionStartZap,
+        routeExecutionCompleted: TrackingEventDataAction.ExecutionCompletedZap,
+        routeExecutionFailed: TrackingEventDataAction.ExecutionFailedZap,
+      }}
+    >
       <Box
         sx={{
           height: '100%',

--- a/src/components/composite/DepositFlow/DepositFlow.tsx
+++ b/src/components/composite/DepositFlow/DepositFlow.tsx
@@ -8,14 +8,9 @@ import { DepositButton } from '../DepositButton/DepositButton';
 import type { DepositButtonProps } from '../DepositButton/DepositButton.types';
 import { DepositModal } from '../DepositModal/DepositModal';
 import { useEarnOpportunityBySlug } from '@/hooks/earn/useEarnOpportunityBySlug';
-import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
-import {
-  TrackingAction,
-  TrackingCategory,
-  TrackingEventDataAction,
-  TrackingEventParameter,
-} from '@/const/trackingKeys';
+import { TrackingAction, TrackingEventDataAction } from '@/const/trackingKeys';
 import { WidgetTrackingProvider } from '@/providers/WidgetTrackingProvider';
+import { useEarnTracking } from '@/hooks/userTracking/useEarnTracking';
 
 export const DepositFlowModal = () => {
   const { selectedEarnOpportunity, isModalOpen, closeModal } =
@@ -66,19 +61,11 @@ export const DepositFlowButton: FC<DepositFlowButtonProps> = ({
   ...props
 }) => {
   const { t } = useTranslation();
-  const { trackEvent } = useUserTracking();
+  const { trackEarnDepositClickEvent } = useEarnTracking();
   const openModal = useDepositFlowStore((state) => state.openModal);
 
   const handleClick = () => {
-    trackEvent({
-      category: TrackingCategory.Earn,
-      action: TrackingAction.ClickEarnDepositButton,
-      label: 'click-earn-deposit-button',
-      data: {
-        [TrackingEventParameter.EarnOpportunitySlug]:
-          earnOpportunity.slug || '',
-      },
-    });
+    trackEarnDepositClickEvent(earnOpportunity.slug);
     openModal(earnOpportunity, refetchCallback);
   };
   return (
@@ -96,7 +83,7 @@ export const DepositFlowOnDemandButton: FC<
   }
 > = ({ earnOpportunitySlug, refetchCallback, ...props }) => {
   const { t } = useTranslation();
-  const { trackEvent } = useUserTracking();
+  const { trackEarnDepositClickEvent } = useEarnTracking();
   const openModal = useDepositFlowStore((state) => state.openModal);
   const { refetch: fetchEarnOpportunity } =
     useEarnOpportunityBySlug(earnOpportunitySlug);
@@ -105,15 +92,7 @@ export const DepositFlowOnDemandButton: FC<
     if (!earnOpportunity) {
       return;
     }
-    trackEvent({
-      category: TrackingCategory.Earn,
-      action: TrackingAction.ClickEarnDepositButton,
-      label: 'click-earn-deposit-button',
-      data: {
-        [TrackingEventParameter.EarnOpportunitySlug]:
-          earnOpportunity.slug || '',
-      },
-    });
+    trackEarnDepositClickEvent(earnOpportunity.slug);
     openModal(
       {
         ...earnOpportunity,

--- a/src/components/composite/DepositFlow/DepositFlow.tsx
+++ b/src/components/composite/DepositFlow/DepositFlow.tsx
@@ -8,6 +8,14 @@ import { DepositButton } from '../DepositButton/DepositButton';
 import type { DepositButtonProps } from '../DepositButton/DepositButton.types';
 import { DepositModal } from '../DepositModal/DepositModal';
 import { useEarnOpportunityBySlug } from '@/hooks/earn/useEarnOpportunityBySlug';
+import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
+import {
+  TrackingAction,
+  TrackingCategory,
+  TrackingEventDataAction,
+  TrackingEventParameter,
+} from '@/const/trackingKeys';
+import { WidgetTrackingProvider } from '@/providers/WidgetTrackingProvider';
 
 export const DepositFlowModal = () => {
   const { selectedEarnOpportunity, isModalOpen, closeModal } =
@@ -18,11 +26,33 @@ export const DepositFlowModal = () => {
   }
 
   return (
-    <DepositModal
-      isOpen={isModalOpen}
-      onClose={closeModal}
-      earnOpportunity={selectedEarnOpportunity!}
-    />
+    <WidgetTrackingProvider
+      trackingActionKeys={{
+        sourceChainAndTokenSelection:
+          TrackingAction.OnSourceChainAndTokenSelectionEarnDeposit,
+        availableRoutes: TrackingAction.OnAvailableRoutesEarnDeposit,
+        routeExecutionStarted:
+          TrackingAction.OnRouteExecutionStartedEarnDeposit,
+        routeExecutionCompleted:
+          TrackingAction.OnRouteExecutionCompletedEarnDeposit,
+        routeExecutionFailed: TrackingAction.OnRouteExecutionFailedEarnDeposit,
+        changeSettings: TrackingAction.OnChangeSettingsEarnDeposit,
+      }}
+      trackingDataActionKeys={{
+        routeExecutionStarted:
+          TrackingEventDataAction.ExecutionStartEarnDeposit,
+        routeExecutionCompleted:
+          TrackingEventDataAction.ExecutionCompletedEarnDeposit,
+        routeExecutionFailed:
+          TrackingEventDataAction.ExecutionFailedEarnDeposit,
+      }}
+    >
+      <DepositModal
+        isOpen={isModalOpen}
+        onClose={closeModal}
+        earnOpportunity={selectedEarnOpportunity!}
+      />
+    </WidgetTrackingProvider>
   );
 };
 
@@ -36,10 +66,24 @@ export const DepositFlowButton: FC<DepositFlowButtonProps> = ({
   ...props
 }) => {
   const { t } = useTranslation();
+  const { trackEvent } = useUserTracking();
   const openModal = useDepositFlowStore((state) => state.openModal);
+
+  const handleClick = () => {
+    trackEvent({
+      category: TrackingCategory.Earn,
+      action: TrackingAction.ClickEarnDepositButton,
+      label: 'click-earn-deposit-button',
+      data: {
+        [TrackingEventParameter.EarnOpportunitySlug]:
+          earnOpportunity.slug || '',
+      },
+    });
+    openModal(earnOpportunity, refetchCallback);
+  };
   return (
     <DepositButton
-      onClick={() => openModal(earnOpportunity, refetchCallback)}
+      onClick={handleClick}
       label={t('buttons.depositButtonLabel')}
       {...props}
     />
@@ -52,6 +96,7 @@ export const DepositFlowOnDemandButton: FC<
   }
 > = ({ earnOpportunitySlug, refetchCallback, ...props }) => {
   const { t } = useTranslation();
+  const { trackEvent } = useUserTracking();
   const openModal = useDepositFlowStore((state) => state.openModal);
   const { refetch: fetchEarnOpportunity } =
     useEarnOpportunityBySlug(earnOpportunitySlug);
@@ -60,6 +105,15 @@ export const DepositFlowOnDemandButton: FC<
     if (!earnOpportunity) {
       return;
     }
+    trackEvent({
+      category: TrackingCategory.Earn,
+      action: TrackingAction.ClickEarnDepositButton,
+      label: 'click-earn-deposit-button',
+      data: {
+        [TrackingEventParameter.EarnOpportunitySlug]:
+          earnOpportunity.slug || '',
+      },
+    });
     openModal(
       {
         ...earnOpportunity,

--- a/src/components/composite/DepositModal/DepositModal.tsx
+++ b/src/components/composite/DepositModal/DepositModal.tsx
@@ -1,7 +1,6 @@
 import type { FC } from 'react';
 import { ClientOnly } from 'src/components/ClientOnly';
 import { ZapDepositBackendWidget } from 'src/components/Widgets/variants/base/ZapWidget/ZapDepositBackendWidget';
-import { WidgetTrackingProvider } from 'src/providers/WidgetTrackingProvider';
 import { TaskType } from 'src/types/strapi';
 import type { ModalContainerProps } from 'src/components/core/modals/ModalContainer/ModalContainer';
 import { ModalContainer } from 'src/components/core/modals/ModalContainer/ModalContainer';
@@ -29,34 +28,32 @@ export const DepositModal: FC<DepositModalProps> = ({
   const refetchCallback = useDepositFlowStore((state) => state.refetchCallback);
 
   return (
-    <WidgetTrackingProvider>
-      <ModalContainer isOpen={isOpen} onClose={onClose}>
-        <ClientOnly>
-          <ZapDepositBackendWidget
-            ctx={{
-              theme: {
-                container: {
-                  maxHeight: 'calc(100vh - 6rem)',
-                  minWidth: '100%',
-                  maxWidth: 400,
-                  borderRadius: '24px',
-                  [theme.breakpoints.up('sm')]: {
-                    minWidth: 400,
-                  },
+    <ModalContainer isOpen={isOpen} onClose={onClose}>
+      <ClientOnly>
+        <ZapDepositBackendWidget
+          ctx={{
+            theme: {
+              container: {
+                maxHeight: 'calc(100vh - 6rem)',
+                minWidth: '100%',
+                maxWidth: 400,
+                borderRadius: '24px',
+                [theme.breakpoints.up('sm')]: {
+                  minWidth: 400,
                 },
               },
-              taskType: TaskType.Zap,
-              overrideHeader: 'Quick deposit',
-            }}
-            customInformation={{ projectData }}
-            zapData={zapData}
-            isZapDataSuccess={true}
-            refetchDepositToken={refetchCallback}
-            depositSuccessMessageKey="widget.earn.depositSuccess"
-            integrator={envConfig.NEXT_PUBLIC_WIDGET_INTEGRATOR_EARN}
-          />
-        </ClientOnly>
-      </ModalContainer>
-    </WidgetTrackingProvider>
+            },
+            taskType: TaskType.Zap,
+            overrideHeader: 'Quick deposit',
+          }}
+          customInformation={{ projectData }}
+          zapData={zapData}
+          isZapDataSuccess={true}
+          refetchDepositToken={refetchCallback}
+          depositSuccessMessageKey="widget.earn.depositSuccess"
+          integrator={envConfig.NEXT_PUBLIC_WIDGET_INTEGRATOR_EARN}
+        />
+      </ClientOnly>
+    </ModalContainer>
   );
 };

--- a/src/components/composite/WithdrawFlow/WithdrawFlow.tsx
+++ b/src/components/composite/WithdrawFlow/WithdrawFlow.tsx
@@ -8,6 +8,14 @@ import { WithdrawButton } from '../WithdrawButton/WithdrawButton';
 import type { WithdrawButtonProps } from '../WithdrawButton/WithdrawButton.types';
 import { WithdrawModal } from '../WithdrawModal/WithdrawModal';
 import { useEarnOpportunityBySlug } from '@/hooks/earn/useEarnOpportunityBySlug';
+import { WidgetTrackingProvider } from '@/providers/WidgetTrackingProvider';
+import {
+  TrackingAction,
+  TrackingCategory,
+  TrackingEventDataAction,
+  TrackingEventParameter,
+} from '@/const/trackingKeys';
+import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
 
 export const WithdrawFlowModal = () => {
   const { selectedEarnOpportunity, isModalOpen, closeModal } =
@@ -18,11 +26,33 @@ export const WithdrawFlowModal = () => {
   }
 
   return (
-    <WithdrawModal
-      isOpen={isModalOpen}
-      onClose={closeModal}
-      earnOpportunity={selectedEarnOpportunity!}
-    />
+    <WidgetTrackingProvider
+      trackingActionKeys={{
+        destinationChainAndTokenSelection:
+          TrackingAction.OnDestinationChainAndTokenSelectionEarnWithdraw,
+        availableRoutes: TrackingAction.OnAvailableRoutesEarnWithdraw,
+        routeExecutionStarted:
+          TrackingAction.OnRouteExecutionStartedEarnWithdraw,
+        routeExecutionCompleted:
+          TrackingAction.OnRouteExecutionCompletedEarnWithdraw,
+        routeExecutionFailed: TrackingAction.OnRouteExecutionFailedEarnWithdraw,
+        changeSettings: TrackingAction.OnChangeSettingsEarnWithdraw,
+      }}
+      trackingDataActionKeys={{
+        routeExecutionStarted:
+          TrackingEventDataAction.ExecutionStartEarnWithdraw,
+        routeExecutionCompleted:
+          TrackingEventDataAction.ExecutionCompletedEarnWithdraw,
+        routeExecutionFailed:
+          TrackingEventDataAction.ExecutionFailedEarnWithdraw,
+      }}
+    >
+      <WithdrawModal
+        isOpen={isModalOpen}
+        onClose={closeModal}
+        earnOpportunity={selectedEarnOpportunity!}
+      />
+    </WidgetTrackingProvider>
   );
 };
 
@@ -36,10 +66,23 @@ export const WithdrawFlowButton: FC<WithdrawFlowButtonProps> = ({
   ...props
 }) => {
   const { t } = useTranslation();
+  const { trackEvent } = useUserTracking();
   const openModal = useWithdrawFlowStore((state) => state.openModal);
+  const handleClick = () => {
+    trackEvent({
+      category: TrackingCategory.Earn,
+      action: TrackingAction.ClickEarnWithdrawButton,
+      label: 'click-earn-withdraw-button',
+      data: {
+        [TrackingEventParameter.EarnOpportunitySlug]:
+          earnOpportunity.slug || '',
+      },
+    });
+    openModal(earnOpportunity, refetchCallback);
+  };
   return (
     <WithdrawButton
-      onClick={() => openModal(earnOpportunity, refetchCallback)}
+      onClick={handleClick}
       label={t('buttons.withdrawButtonLabel')}
       {...props}
     />
@@ -52,6 +95,7 @@ export const WithdrawFlowOnDemandButton: FC<
   }
 > = ({ earnOpportunitySlug, refetchCallback, ...props }) => {
   const { t } = useTranslation();
+  const { trackEvent } = useUserTracking();
   const openModal = useWithdrawFlowStore((state) => state.openModal);
   const { refetch: fetchEarnOpportunity } =
     useEarnOpportunityBySlug(earnOpportunitySlug);
@@ -65,6 +109,15 @@ export const WithdrawFlowOnDemandButton: FC<
         console.error('Invalid earn opportunity: missing lpToken.address');
         return;
       }
+      trackEvent({
+        category: TrackingCategory.Earn,
+        action: TrackingAction.ClickEarnWithdrawButton,
+        label: 'click-earn-withdraw-button',
+        data: {
+          [TrackingEventParameter.EarnOpportunitySlug]:
+            earnOpportunity.slug || '',
+        },
+      });
       openModal(
         {
           ...earnOpportunity,

--- a/src/components/composite/WithdrawFlow/WithdrawFlow.tsx
+++ b/src/components/composite/WithdrawFlow/WithdrawFlow.tsx
@@ -9,13 +9,8 @@ import type { WithdrawButtonProps } from '../WithdrawButton/WithdrawButton.types
 import { WithdrawModal } from '../WithdrawModal/WithdrawModal';
 import { useEarnOpportunityBySlug } from '@/hooks/earn/useEarnOpportunityBySlug';
 import { WidgetTrackingProvider } from '@/providers/WidgetTrackingProvider';
-import {
-  TrackingAction,
-  TrackingCategory,
-  TrackingEventDataAction,
-  TrackingEventParameter,
-} from '@/const/trackingKeys';
-import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
+import { TrackingAction, TrackingEventDataAction } from '@/const/trackingKeys';
+import { useEarnTracking } from '@/hooks/userTracking/useEarnTracking';
 
 export const WithdrawFlowModal = () => {
   const { selectedEarnOpportunity, isModalOpen, closeModal } =
@@ -66,18 +61,10 @@ export const WithdrawFlowButton: FC<WithdrawFlowButtonProps> = ({
   ...props
 }) => {
   const { t } = useTranslation();
-  const { trackEvent } = useUserTracking();
+  const { trackEarnWithdrawClickEvent } = useEarnTracking();
   const openModal = useWithdrawFlowStore((state) => state.openModal);
   const handleClick = () => {
-    trackEvent({
-      category: TrackingCategory.Earn,
-      action: TrackingAction.ClickEarnWithdrawButton,
-      label: 'click-earn-withdraw-button',
-      data: {
-        [TrackingEventParameter.EarnOpportunitySlug]:
-          earnOpportunity.slug || '',
-      },
-    });
+    trackEarnWithdrawClickEvent(earnOpportunity.slug);
     openModal(earnOpportunity, refetchCallback);
   };
   return (
@@ -95,7 +82,7 @@ export const WithdrawFlowOnDemandButton: FC<
   }
 > = ({ earnOpportunitySlug, refetchCallback, ...props }) => {
   const { t } = useTranslation();
-  const { trackEvent } = useUserTracking();
+  const { trackEarnWithdrawClickEvent } = useEarnTracking();
   const openModal = useWithdrawFlowStore((state) => state.openModal);
   const { refetch: fetchEarnOpportunity } =
     useEarnOpportunityBySlug(earnOpportunitySlug);
@@ -109,15 +96,7 @@ export const WithdrawFlowOnDemandButton: FC<
         console.error('Invalid earn opportunity: missing lpToken.address');
         return;
       }
-      trackEvent({
-        category: TrackingCategory.Earn,
-        action: TrackingAction.ClickEarnWithdrawButton,
-        label: 'click-earn-withdraw-button',
-        data: {
-          [TrackingEventParameter.EarnOpportunitySlug]:
-            earnOpportunity.slug || '',
-        },
-      });
+      trackEarnWithdrawClickEvent(earnOpportunity.slug);
       openModal(
         {
           ...earnOpportunity,

--- a/src/components/composite/WithdrawModal/WithdrawModal.tsx
+++ b/src/components/composite/WithdrawModal/WithdrawModal.tsx
@@ -1,6 +1,5 @@
 import type { FC } from 'react';
 import { ZapWithdrawWidget } from 'src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget';
-import { WidgetTrackingProvider } from 'src/providers/WidgetTrackingProvider';
 import { TaskType } from 'src/types/strapi';
 import type { ModalContainerProps } from 'src/components/core/modals/ModalContainer/ModalContainer';
 import { ModalContainer } from 'src/components/core/modals/ModalContainer/ModalContainer';
@@ -26,28 +25,26 @@ export const WithdrawModal: FC<WithdrawModalProps> = ({
   //   const refetchCallback = useDepositFlowStore((state) => state.refetchCallback);
 
   return (
-    <WidgetTrackingProvider>
-      <ModalContainer isOpen={isOpen} onClose={onClose}>
-        <ZapWithdrawWidget
-          customInformation={{ projectData }}
-          zapData={zapData}
-          ctx={{
-            theme: {
-              container: {
-                maxHeight: 'calc(100vh - 6rem)',
-                minWidth: '100%',
-                maxWidth: 400,
-                borderRadius: '24px',
-                [theme.breakpoints.up('sm')]: {
-                  minWidth: 400,
-                },
+    <ModalContainer isOpen={isOpen} onClose={onClose}>
+      <ZapWithdrawWidget
+        customInformation={{ projectData }}
+        zapData={zapData}
+        ctx={{
+          theme: {
+            container: {
+              maxHeight: 'calc(100vh - 6rem)',
+              minWidth: '100%',
+              maxWidth: 400,
+              borderRadius: '24px',
+              [theme.breakpoints.up('sm')]: {
+                minWidth: 400,
               },
             },
-            taskType: TaskType.Zap,
-            overrideHeader: t('widget.withdraw.title'),
-          }}
-        />
-      </ModalContainer>
-    </WidgetTrackingProvider>
+          },
+          taskType: TaskType.Zap,
+          overrideHeader: t('widget.withdraw.title'),
+        }}
+      />
+    </ModalContainer>
   );
 };

--- a/src/const/trackingKeys.ts
+++ b/src/const/trackingKeys.ts
@@ -19,6 +19,7 @@ export enum TrackingAction {
   SwitchChain = 'action_switch_chain',
   PortfolioLoaded = 'action_portfolio_loaded',
   PortfolioOverview = 'action_portfolio_balance_overview',
+  PortfolioPageOverview = 'action_portfolio_page_overview',
 
   // Widget
   OnRouteSelected = 'action_on_route_selected',
@@ -54,6 +55,22 @@ export enum TrackingAction {
   OnRouteExecutionCompletedZap = 'action_on_route_exec_completed_zap',
   OnRouteExecutionFailedZap = 'action_on_route_exec_failed_zap',
   OnChangeSettingsZap = 'action_change_settings_zap',
+
+  // Earn Deposit Widget
+  OnSourceChainAndTokenSelectionEarnDeposit = 'action_on_source_selection_earn_deposit',
+  OnAvailableRoutesEarnDeposit = 'action_available_routes_earn_deposit',
+  OnRouteExecutionStartedEarnDeposit = 'action_on_route_exec_started_earn_deposit',
+  OnRouteExecutionCompletedEarnDeposit = 'action_on_route_exec_completed_earn_deposit',
+  OnRouteExecutionFailedEarnDeposit = 'action_on_route_exec_failed_earn_deposit',
+  OnChangeSettingsEarnDeposit = 'action_change_settings_earn_deposit',
+
+  // Earn Withdraw Widget
+  OnDestinationChainAndTokenSelectionEarnWithdraw = 'action_on_destination_selection_earn_withdraw',
+  OnAvailableRoutesEarnWithdraw = 'action_available_routes_earn_withdraw',
+  OnRouteExecutionStartedEarnWithdraw = 'action_on_route_exec_started_earn_withdraw',
+  OnRouteExecutionCompletedEarnWithdraw = 'action_on_route_exec_completed_earn_withdraw',
+  OnRouteExecutionFailedEarnWithdraw = 'action_on_route_exec_failed_earn_withdraw',
+  OnChangeSettingsEarnWithdraw = 'action_change_settings_earn_withdraw',
 
   // Welcome_Screen
   ShowWelcomeMessageScreen = 'action_show_welcome_screen',
@@ -120,6 +137,10 @@ export enum TrackingAction {
   //Banner
   ClickBanner = 'action_click_banner',
   ClickCampaignBanner = 'action_click_campaign_banner',
+
+  // Earn
+  ClickEarnDepositButton = 'action_click_earn_deposit_button',
+  ClickEarnWithdrawButton = 'action_click_earn_withdraw_button',
 }
 
 export enum TrackingEventDataAction {
@@ -133,6 +154,12 @@ export enum TrackingEventDataAction {
   ExecutionStartMission = 'execution_start_mission',
   ExecutionCompletedMission = 'execution_completed_mission',
   ExecutionFailedMission = 'execution_failed_mission',
+  ExecutionStartEarnDeposit = 'execution_start_earn_deposit',
+  ExecutionCompletedEarnDeposit = 'execution_completed_earn_deposit',
+  ExecutionFailedEarnDeposit = 'execution_failed_earn_deposit',
+  ExecutionStartEarnWithdraw = 'execution_start_earn_withdraw',
+  ExecutionCompletedEarnWithdraw = 'execution_completed_earn_withdraw',
+  ExecutionFailedEarnWithdraw = 'execution_failed_earn_withdraw',
 }
 
 export enum TrackingCategory {
@@ -167,6 +194,7 @@ export enum TrackingCategory {
   Quests = 'cat_quests',
   Banner = 'cat_banner',
   CampaignBanner = 'cat_campaign_banner',
+  Earn = 'cat_earn',
 }
 
 // can be used as custom dimensions / metrics
@@ -184,6 +212,7 @@ export enum TrackingEventParameter {
   SwitchedLanguage = 'param_switched_language',
   Wallet = 'param_wallet',
   WalletAddress = 'param_wallet_address',
+  WalletAddresses = 'param_wallet_addresses',
   Ecosystem = 'param_ecosystem',
   Integrator = 'param_integrator',
 
@@ -314,4 +343,15 @@ export enum TrackingEventParameter {
   PortfolioNativeTokensBalanceUSD = 'param_portfolio_native_tokens_balance_usd',
   PortfolioStableTokensBalanceUSD = 'param_portfolio_stable_tokens_balance_usd',
   PortfolioOtherTokensBalanceUSD = 'param_portfolio_other_tokens_balance_usd',
+  PortfolioTokenAmountUSD = 'param_portfolio_token_amount_usd',
+  PortfolioPositionsAmountUSD = 'param_portfolio_positions_amount_usd',
+  PortfolioTop3Tokens = 'param_portfolio_top_3_tokens',
+  PortfolioTop3Protocols = 'param_portfolio_top_3_protocols',
+  ProtocolName = 'param_protocol_name',
+  ProtocolTotalPriceUSD = 'param_protocol_total_price_usd',
+  TokenName = 'param_token_name',
+  TokenTotalPriceUSD = 'param_token_total_price_usd',
+
+  // Earn
+  EarnOpportunitySlug = 'param_earn_opportunity_slug',
 }

--- a/src/hooks/userTracking/useEarnTracking.ts
+++ b/src/hooks/userTracking/useEarnTracking.ts
@@ -1,0 +1,33 @@
+import {
+  TrackingCategory,
+  TrackingAction,
+  TrackingEventParameter,
+} from '@/const/trackingKeys';
+import { useUserTracking } from './useUserTracking';
+
+export const useEarnTracking = () => {
+  const { trackEvent } = useUserTracking();
+
+  return {
+    trackEarnDepositClickEvent: (slug?: string) => {
+      trackEvent({
+        category: TrackingCategory.Earn,
+        action: TrackingAction.ClickEarnDepositButton,
+        label: 'click-earn-deposit-button',
+        data: {
+          [TrackingEventParameter.EarnOpportunitySlug]: slug || '',
+        },
+      });
+    },
+    trackEarnWithdrawClickEvent: (slug?: string) => {
+      trackEvent({
+        category: TrackingCategory.Earn,
+        action: TrackingAction.ClickEarnWithdrawButton,
+        label: 'click-earn-withdraw-button',
+        data: {
+          [TrackingEventParameter.EarnOpportunitySlug]: slug || '',
+        },
+      });
+    },
+  };
+};

--- a/src/hooks/userTracking/usePortfolioTracking.ts
+++ b/src/hooks/userTracking/usePortfolioTracking.ts
@@ -1,0 +1,29 @@
+import { parseEarnPortfolioDataToTrackingData } from '@/utils/tracking/portfolio';
+import { useUserTracking } from './useUserTracking';
+import { TrackingCategory, TrackingAction } from '@/const/trackingKeys';
+import type { DefiPosition } from '@/types/jumper-backend';
+import type { MinimalToken } from '@/types/tokens';
+
+export const usePortfolioTracking = () => {
+  const { trackEvent } = useUserTracking();
+
+  return {
+    trackPortfolioPageOverviewEvent: (
+      addresses: string[],
+      tokens: MinimalToken[],
+      defiPositionGroups: DefiPosition[][],
+    ) => {
+      const trackingData = parseEarnPortfolioDataToTrackingData(
+        addresses,
+        tokens,
+        defiPositionGroups,
+      );
+      trackEvent({
+        category: TrackingCategory.Portfolio,
+        action: TrackingAction.PortfolioPageOverview,
+        label: 'portfolio_page_overview',
+        data: trackingData,
+      });
+    },
+  };
+};

--- a/src/providers/WidgetTrackingProvider.tsx
+++ b/src/providers/WidgetTrackingProvider.tsx
@@ -1,16 +1,15 @@
-import {
+import type {
   ChainTokenSelected,
   Route,
   RouteExecutionUpdate,
   RouteHighValueLossUpdate,
   SettingUpdated,
-  useWidgetEvents,
 } from '@lifi/widget';
+import { useWidgetEvents } from '@lifi/widget';
 import { isEqual, omit } from 'lodash';
+import type { FC, PropsWithChildren } from 'react';
 import {
   createContext,
-  FC,
-  PropsWithChildren,
   useCallback,
   useContext,
   useEffect,
@@ -18,10 +17,10 @@ import {
   useRef,
 } from 'react';
 import { makePosthogTracker } from 'src/components/Widgets/PosthogTracker';
+import type { WidgetEventsConfig } from 'src/components/Widgets/WidgetEventsManager';
 import {
   setupWidgetEvents,
   teardownWidgetEvents,
-  WidgetEventsConfig,
 } from 'src/components/Widgets/WidgetEventsManager';
 import {
   TrackingAction,
@@ -30,8 +29,8 @@ import {
   TrackingEventParameter,
 } from 'src/const/trackingKeys';
 import { useUserTracking } from 'src/hooks/userTracking';
-import { TransformedRoute } from 'src/types/internal';
-import { TrackTransactionDataProps } from 'src/types/userTracking';
+import type { TransformedRoute } from 'src/types/internal';
+import type { TrackTransactionDataProps } from 'src/types/userTracking';
 import { handleRouteData } from 'src/utils/routes';
 import { parseWidgetSettingsToTrackingData } from 'src/utils/tracking/widget';
 
@@ -60,7 +59,7 @@ export const useWidgetTrackingContext = () => {
 interface WidgetTrackingProviderProps extends PropsWithChildren {
   trackingActionKeys?: {
     destinationChainAndTokenSelection?: TrackingAction;
-    sourceChainAndTokenSelection: TrackingAction;
+    sourceChainAndTokenSelection?: TrackingAction;
     availableRoutes: TrackingAction;
     routeExecutionStarted: TrackingAction;
     routeExecutionCompleted: TrackingAction;
@@ -82,8 +81,7 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
   children,
   trackingActionKeys = {
     destinationChainAndTokenSelection: '',
-    sourceChainAndTokenSelection:
-      TrackingAction.OnSourceChainAndTokenSelectionZap,
+    sourceChainAndTokenSelection: '',
     availableRoutes: TrackingAction.OnAvailableRoutesZap,
     routeExecutionStarted: TrackingAction.OnRouteExecutionStartedZap,
     routeExecutionCompleted: TrackingAction.OnRouteExecutionCompletedZap,
@@ -116,6 +114,9 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
 
   const sourceChainTokenSelected = useCallback(
     (sourceToken: ChainTokenSelected) => {
+      if (!trackingActionKeys.sourceChainAndTokenSelection) {
+        return;
+      }
       trackEvent({
         category: TrackingCategory.WidgetEvent,
         action: trackingActionKeys.sourceChainAndTokenSelection,

--- a/src/utils/tracking/portfolio.ts
+++ b/src/utils/tracking/portfolio.ts
@@ -1,6 +1,13 @@
-import { ChainId } from '@lifi/widget';
+import {
+  calculateTotalPrice,
+  mapPositionGroupsToProtocolData,
+  sortAssetsByPrice,
+} from '@/components/composite/AssetOverviewCard/utils';
+import type { DefiPosition } from '@/types/jumper-backend';
+import type { MinimalToken } from '@/types/tokens';
+import type { ChainId } from '@lifi/widget';
 import { TrackingEventParameter } from 'src/const/trackingKeys';
-import { CacheToken } from 'src/types/portfolio';
+import type { CacheToken } from 'src/types/portfolio';
 
 const FLEXIBLE_STABLE_COINS_REGEX =
   /^.*(USD|EUR|XAU|YEN|IDR|CHF|CAD|CNH|MXN).*$/;
@@ -59,5 +66,63 @@ export const parsePortfolioDataToTrackingData = (
       stableTokensBalanceUSD.toFixed(2),
     [TrackingEventParameter.PortfolioOtherTokensBalanceUSD]:
       otherTokensBalanceUSD.toFixed(2),
+  };
+};
+
+export const parseEarnPortfolioDataToTrackingData = (
+  addresses: string[],
+  tokens: MinimalToken[],
+  defiPositionGroups: DefiPosition[][],
+) => {
+  const protocolGroups = mapPositionGroupsToProtocolData(defiPositionGroups);
+  const sortedProtocolGroups = sortAssetsByPrice(protocolGroups);
+  const sortedTokens = sortAssetsByPrice(tokens);
+
+  const top3ProtocolGroups = sortedProtocolGroups.slice(0, 3);
+  const top3Tokens = sortedTokens.slice(0, 3);
+
+  const tokensOverallPriceInUSD = calculateTotalPrice(tokens);
+  const positionsOverallPriceInUSD = calculateTotalPrice(protocolGroups);
+
+  const totalBalanceUSD = tokensOverallPriceInUSD + positionsOverallPriceInUSD;
+
+  const chainIds = new Set<ChainId>();
+
+  for (const token of tokens) {
+    chainIds.add(token.chain.chainId);
+    for (const relatedToken of token.relatedTokens ?? []) {
+      chainIds.add(relatedToken.chain.chainId);
+    }
+  }
+
+  for (const positionGroup of defiPositionGroups) {
+    for (const position of positionGroup) {
+      chainIds.add(position.chain.chainId);
+    }
+  }
+
+  return {
+    [TrackingEventParameter.PortfolioTotalBalanceUSD]:
+      totalBalanceUSD.toFixed(2),
+    [TrackingEventParameter.PortfolioTokenAmountUSD]:
+      tokensOverallPriceInUSD.toFixed(2),
+    [TrackingEventParameter.PortfolioPositionsAmountUSD]:
+      positionsOverallPriceInUSD.toFixed(2),
+    [TrackingEventParameter.PortfolioNumberOfChains]: chainIds.size,
+    [TrackingEventParameter.PortfolioTop3Tokens]: JSON.stringify(
+      top3Tokens.map((token) => ({
+        [TrackingEventParameter.TokenName]: token.symbol,
+        [TrackingEventParameter.TokenTotalPriceUSD]:
+          token.totalPriceUSD.toFixed(2),
+      })),
+    ),
+    [TrackingEventParameter.PortfolioTop3Protocols]: JSON.stringify(
+      top3ProtocolGroups.map((group) => ({
+        [TrackingEventParameter.ProtocolName]: group.protocol.name,
+        [TrackingEventParameter.ProtocolTotalPriceUSD]:
+          group.totalPriceUSD.toFixed(2),
+      })),
+    ),
+    [TrackingEventParameter.WalletAddresses]: addresses.join(','),
   };
 };


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-17034

> [!IMPORTANT]
> For all transaction related events, please filter for endpoint calls `wallets/transactions`
> Events affected: `execution_start_earn(_deposit|withdraw)`, `execution_completed_earn(_deposit|withdraw)` and `execution_failed_earn(_deposit|withdraw)`

## Testing steps

1. Go to `Portfolio`
2. Open the network tab and filter for `users/events`
3. Close the welcome screen
4. Once the top-right card has finished loading, an event with action `action_portfolio_page_overview` should be sent 
<img width="1886" height="780" alt="Screenshot 2025-12-11 at 13 00 39" src="https://github.com/user-attachments/assets/4cef52f4-da0d-4233-9a86-aa83756c29b9" />

5. Now switch to DeFi Protocols
6. On a protcol having the withdraw button, click on it
7. An event related to withdraw button click should be triggered
<img width="1663" height="837" alt="Screenshot 2025-12-11 at 13 01 15" src="https://github.com/user-attachments/assets/96a915d0-5f3c-415c-b138-004557b88214" />

8. Perform a withdrawal and check the following events are triggered: `action_on_destination_selection_earn_withdraw`, `action_available_routes_earn_withdraw` and `action_change_settings_earn_withdraw`
Filter for `wallets/transactions` in the network tab and check these events are trigerred: `execution_start_earn_withdraw`, `execution_completed_earn_withdraw`, `execution_failed_earn_withdraw` (if tx fails)
9. Now click on the deposit button
10. An event related to deposit button click should be triggered
<img width="1590" height="861" alt="Screenshot 2025-12-11 at 13 01 28" src="https://github.com/user-attachments/assets/9e0be81b-0eda-42ea-b4dd-5156f96ff707" />

11. Perform a deposit and check the following events are triggered: `action_on_source_selection_earn_deposit`, `action_available_routes_earn_deposit` and `action_change_settings_earn_deposit`
Filter for `wallets/transactions` in the network tab and check these events are triggered: `execution_start_earn_deposit`, `execution_completed_earn_deposit`, `execution_failed_earn_deposit` (if tx fails ofc)

12. Now go to `Earn` page
13. Check steps 9-11 from the Quick deposit icon (flash icon)
14. Now open an earn opportunity detail page
15. Verify steps 7-11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emits a one-time portfolio overview event on initial load capturing total balance, top tokens, top protocols, chain count and wallet addresses.
  * Tracks Earn deposit/withdraw interactions and Zap widget route/execution flows, including explicit button click events.

* **Chores**
  * Expanded tracking schema and event parameters to support portfolio, Earn opportunity, and route execution details.
  * Added centralized tracking hooks/providers for Earn and portfolio events.

* **Bug Fixes**
  * Prevents duplicate portfolio tracking by guarding repeated emissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->