### PR TITLE
Add risk categories to earn opportunity page

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,6 +30,12 @@ const nextConfig = {
   images: {
     remotePatterns: [
       {
+        protocol: 'http',
+        hostname: 'localhost',
+        port: '1337',
+        pathname: '/**',
+      },
+      {
         protocol: 'https',
         hostname: 'raw.githubusercontent.com',
         port: '',

--- a/src/app/ui/earn/EarnPage.tsx
+++ b/src/app/ui/earn/EarnPage.tsx
@@ -4,9 +4,10 @@ import { getOpportunityBySlug } from 'src/app/lib/getOpportunityBySlug';
 import { getOpportunityRelatedMarket } from 'src/app/lib/getOpportunityRelatedMarket';
 import { EarnDetailsAnalytics } from 'src/components/EarnDetails/EarnDetailsAnalytics';
 import { EarnDetailsSection } from 'src/components/EarnDetails/EarnDetailsSection';
+import { EarnDetailsIntro } from 'src/components/EarnDetails/EarnDetailsIntro';
+import { EarnDetailsRisks } from 'src/components/EarnDetails/EarnDetailsRisks';
 import { AppPaths } from 'src/const/urls';
 import { GoBack } from 'src/components/composite/GoBack/GoBack';
-import { EarnDetailsIntro } from 'src/components/EarnDetails/EarnDetailsIntro';
 import { EarnRelatedMarkets } from 'src/components/EarnRelatedMarkets/EarnRelatedMarkets';
 import { DepositFlowModal } from 'src/components/composite/DepositFlow/DepositFlow';
 import { WithdrawFlowModal } from '@/components/composite/WithdrawFlow/WithdrawFlow';
@@ -41,12 +42,15 @@ export const EarnPage: FC<EarnPageProps> = async ({ slug }) => {
 
   console.log('29. EarnPage relatedMarkets', relatedMarketsData);
 
+  const { tags, protocol } = opportunity.data;
+
   return (
     <>
       <EarnDetailsSection>
         <GoBack path={AppPaths.Earn} dataTestId="earn-back-button" />
         <EarnDetailsIntro data={opportunity.data} isLoading={false} />
         <EarnDetailsAnalytics slug={slug} />
+        <EarnDetailsRisks protocol={protocol} tags={tags} />
       </EarnDetailsSection>
       <EarnDetailsSection>
         <EarnRelatedMarkets relatedMarkets={relatedMarketsData} />

--- a/src/app/ui/earn/EarnPage.tsx
+++ b/src/app/ui/earn/EarnPage.tsx
@@ -5,7 +5,7 @@ import { getOpportunityRelatedMarket } from 'src/app/lib/getOpportunityRelatedMa
 import { EarnDetailsAnalytics } from 'src/components/EarnDetails/EarnDetailsAnalytics';
 import { EarnDetailsSection } from 'src/components/EarnDetails/EarnDetailsSection';
 import { EarnDetailsIntro } from 'src/components/EarnDetails/EarnDetailsIntro';
-import { EarnDetailsRisks } from 'src/components/EarnDetails/EarnDetailsRisks';
+import { EarnDetailsRisks } from 'src/components/EarnDetails/EarnDetailsRisks/EarnDetailsRisks';
 import { AppPaths } from 'src/const/urls';
 import { GoBack } from 'src/components/composite/GoBack/GoBack';
 import { EarnRelatedMarkets } from 'src/components/EarnRelatedMarkets/EarnRelatedMarkets';

--- a/src/components/Cards/ProtocolCard/ProtocolCard.styles.tsx
+++ b/src/components/Cards/ProtocolCard/ProtocolCard.styles.tsx
@@ -4,7 +4,6 @@ import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import Image from 'next/image';
 import { BaseSurfaceSkeleton } from 'src/components/core/skeletons/BaseSurfaceSkeleton/BaseSurfaceSkeleton.style';
-import { Link } from 'src/components/Link/Link';
 import { getTextEllipsisStyles } from 'src/utils/styles/getTextEllipsisStyles';
 import { SectionCardContainer } from '../SectionCard/SectionCard.style';
 import Button from '@mui/material/Button';
@@ -139,24 +138,6 @@ export const ProtocolCardDescriptionContainer = styled(Typography)(
     marginBottom: 'auto',
   }),
 );
-
-export const ProtocolCardLink = styled(Link)(({ theme }) => ({
-  color: (theme.vars || theme).palette.text.primary,
-  ...theme.typography.bodyMediumStrong,
-  textDecoration: 'none',
-  display: 'inline-flex',
-  width: 'fit-content',
-  alignItems: 'center',
-  gap: theme.spacing(0.75),
-  transition: 'color 0.3s ease',
-  '&:hover': {
-    color: (theme.vars || theme).palette.primary.main,
-  },
-  '& svg': {
-    width: 20,
-    height: 20,
-  },
-}));
 
 export const BaseSkeleton = styled(BaseSurfaceSkeleton)(({ theme }) => ({}));
 

--- a/src/components/Cards/ProtocolCard/ProtocolCard.tsx
+++ b/src/components/Cards/ProtocolCard/ProtocolCard.tsx
@@ -8,7 +8,6 @@ import {
   ProtocolCardHeaderBadgeContainer,
   ProtocolCardHeaderContainer,
   ProtocolCardHeaderContentContainer,
-  ProtocolCardLink,
   ProtocolCardProtocolAvatar,
   ProtocolCardProtocolTitle,
   ProtocolCardTagsContainer,
@@ -17,6 +16,7 @@ import {
 import { PROTOCOL_CARD_SIZES } from './constants';
 import Typography from '@mui/material/Typography';
 import { Badge } from 'src/components/Badge/Badge';
+import { ExternalLink } from 'src/components/Link/ExternalLink';
 import { BadgeSize, BadgeVariant } from 'src/components/Badge/Badge.styles';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import CodeRoundedIcon from '@mui/icons-material/CodeRounded';
@@ -153,10 +153,10 @@ export const ProtocolCard: FC<ProtocolCardProps> = ({
             onSeeMoreClick={() => setIsDescriptionModalOpen(true)}
           />
           {protocol?.name && url && (
-            <ProtocolCardLink target="_blank" href={url}>
+            <ExternalLink href={url}>
               {t('links.discover', { name: capitalizeString(protocol?.name) })}
               <ArrowForwardIcon />
-            </ProtocolCardLink>
+            </ExternalLink>
           )}
         </ProtocolCardContentContainer>
       </ProtocolCardContainer>

--- a/src/components/Cards/ProtocolCard/ProtocolCard.tsx
+++ b/src/components/Cards/ProtocolCard/ProtocolCard.tsx
@@ -16,7 +16,6 @@ import {
 import { PROTOCOL_CARD_SIZES } from './constants';
 import Typography from '@mui/material/Typography';
 import { Badge } from 'src/components/Badge/Badge';
-import { ExternalLink } from 'src/components/Link/ExternalLink';
 import { BadgeSize, BadgeVariant } from 'src/components/Badge/Badge.styles';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import CodeRoundedIcon from '@mui/icons-material/CodeRounded';
@@ -152,12 +151,6 @@ export const ProtocolCard: FC<ProtocolCardProps> = ({
             text={description}
             onSeeMoreClick={() => setIsDescriptionModalOpen(true)}
           />
-          {protocol?.name && url && (
-            <ExternalLink href={url}>
-              {t('links.discover', { name: capitalizeString(protocol?.name) })}
-              <ArrowForwardIcon />
-            </ExternalLink>
-          )}
         </ProtocolCardContentContainer>
       </ProtocolCardContainer>
       <ProtocolCardDescriptionModal

--- a/src/components/Cards/ProtocolCard/__snapshots__/ProtocolCard.snapshot.spec.tsx.snap
+++ b/src/components/Cards/ProtocolCard/__snapshots__/ProtocolCard.snapshot.spec.tsx.snap
@@ -79,25 +79,6 @@ Lenders earn yield from interest paid by borrowers. Borrowers deposit collateral
           earn.actions.seeMore
         </button>
       </p>
-      <a
-        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-a7vmzy-MuiTypography-root-MuiLink-root"
-        href="https://app.morpho.org"
-        rel="noopener noreferrer nofollow"
-        target="_blank"
-      >
-        links.discover
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-4uxqju-MuiSvgIcon-root"
-          data-testid="ArrowForwardIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-          />
-        </svg>
-      </a>
     </div>
   </div>
 </div>
@@ -195,25 +176,6 @@ Lenders earn yield from interest paid by borrowers. Borrowers deposit collateral
           earn.actions.seeMore
         </button>
       </p>
-      <a
-        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-a7vmzy-MuiTypography-root-MuiLink-root"
-        href="https://app.morpho.org"
-        rel="noopener noreferrer nofollow"
-        target="_blank"
-      >
-        links.discover
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-4uxqju-MuiSvgIcon-root"
-          data-testid="ArrowForwardIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-          />
-        </svg>
-      </a>
     </div>
   </div>
 </div>
@@ -330,25 +292,6 @@ Lenders earn yield from interest paid by borrowers. Borrowers deposit collateral
           earn.actions.seeMore
         </button>
       </p>
-      <a
-        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-a7vmzy-MuiTypography-root-MuiLink-root"
-        href="https://app.morpho.org"
-        rel="noopener noreferrer nofollow"
-        target="_blank"
-      >
-        links.discover
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-4uxqju-MuiSvgIcon-root"
-          data-testid="ArrowForwardIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-          />
-        </svg>
-      </a>
     </div>
   </div>
 </div>

--- a/src/components/Cards/ProtocolCard/__snapshots__/ProtocolCard.snapshot.spec.tsx.snap
+++ b/src/components/Cards/ProtocolCard/__snapshots__/ProtocolCard.snapshot.spec.tsx.snap
@@ -82,6 +82,7 @@ Lenders earn yield from interest paid by borrowers. Borrowers deposit collateral
       <a
         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-a7vmzy-MuiTypography-root-MuiLink-root"
         href="https://app.morpho.org"
+        rel="noopener noreferrer nofollow"
         target="_blank"
       >
         links.discover
@@ -197,6 +198,7 @@ Lenders earn yield from interest paid by borrowers. Borrowers deposit collateral
       <a
         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-a7vmzy-MuiTypography-root-MuiLink-root"
         href="https://app.morpho.org"
+        rel="noopener noreferrer nofollow"
         target="_blank"
       >
         links.discover
@@ -331,6 +333,7 @@ Lenders earn yield from interest paid by borrowers. Borrowers deposit collateral
       <a
         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-a7vmzy-MuiTypography-root-MuiLink-root"
         href="https://app.morpho.org"
+        rel="noopener noreferrer nofollow"
         target="_blank"
       >
         links.discover

--- a/src/components/EarnDetails/EarnDetails.styles.ts
+++ b/src/components/EarnDetails/EarnDetails.styles.ts
@@ -43,6 +43,9 @@ export const EarnDetailsRisksNavButton = styled(ButtonTransparent, {
   ...theme.applyStyles('light', {
     backgroundColor: 'transparent',
   }),
+  ...theme.applyStyles('dark', {
+    backgroundColor: 'transparent',
+  }),
   paddingLeft: theme.spacing(2),
   paddingRight: theme.spacing(2),
   height: theme.spacing(5),
@@ -55,6 +58,9 @@ export const EarnDetailsRisksNavButton = styled(ButtonTransparent, {
       props: ({ isActive }) => isActive,
       style: {
         ...theme.applyStyles('light', {
+          backgroundColor: theme.palette.alpha100.main,
+        }),
+        ...theme.applyStyles('dark', {
           backgroundColor: theme.palette.alpha100.main,
         }),
       },

--- a/src/components/EarnDetails/EarnDetails.styles.ts
+++ b/src/components/EarnDetails/EarnDetails.styles.ts
@@ -24,63 +24,6 @@ export const EarnDetailsAnalyticsContainer = styled(
   gap: theme.spacing(3),
 }));
 
-export const EarnDetailsRisksContainer = styled(EarnDetailsSectionContainer)(
-  ({ theme }) => ({
-    gap: theme.spacing(3),
-    [theme.breakpoints.up('md')]: {
-      flexDirection: 'row',
-    },
-  }),
-);
-
-interface EarnDetailsRisksNavButtonProps extends ButtonProps {
-  isActive: boolean;
-}
-
-export const EarnDetailsRisksNavButton = styled(ButtonTransparent, {
-  shouldForwardProp: (prop) => prop !== 'isActive',
-})<EarnDetailsRisksNavButtonProps>(({ theme }) => ({
-  ...theme.applyStyles('light', {
-    backgroundColor: 'transparent',
-  }),
-  ...theme.applyStyles('dark', {
-    backgroundColor: 'transparent',
-  }),
-  paddingLeft: theme.spacing(2),
-  paddingRight: theme.spacing(2),
-  height: theme.spacing(5),
-  fontSize: theme.typography.body2.fontSize,
-  '&:not(:first-of-type)': {
-    marginLeft: theme.spacing(1),
-  },
-  variants: [
-    {
-      props: ({ isActive }) => isActive,
-      style: {
-        ...theme.applyStyles('light', {
-          backgroundColor: theme.palette.alpha100.main,
-        }),
-        ...theme.applyStyles('dark', {
-          backgroundColor: theme.palette.alpha100.main,
-        }),
-      },
-    },
-  ],
-}));
-
-export const EarnRiskTagsContainer = styled(Stack)(({ theme }) => ({
-  backgroundColor: (theme.vars || theme).palette.alpha100.main,
-  padding: theme.spacing(3),
-  borderRadius: theme.spacing(2),
-  [theme.breakpoints.up('md')]: {
-    flex: 1,
-  },
-}));
-
-export const EarnRiskMissingWarning = styled('span')(({ theme }) => ({
-  color: (theme.vars || theme).palette.statusError,
-}));
-
 export const EarnDetailsAnalyticsHeaderContainer = styled(Stack)(
   ({ theme }) => ({
     gap: theme.spacing(2),

--- a/src/components/EarnDetails/EarnDetails.styles.ts
+++ b/src/components/EarnDetails/EarnDetails.styles.ts
@@ -1,8 +1,10 @@
 import Box from '@mui/material/Box';
+import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
 import { styled } from '@mui/material/styles';
-import { ButtonPrimary, ButtonProps, ButtonTransparent } from '../Button';
-import Skeleton from '@mui/material/Skeleton';
+
+import type { ButtonProps } from '../Button';
+import { ButtonPrimary, ButtonTransparent } from '../Button';
 
 export const EarnDetailsSectionContainer = styled(Box)(({ theme }) => ({
   display: 'flex',
@@ -20,6 +22,57 @@ export const EarnDetailsAnalyticsContainer = styled(
   EarnDetailsSectionContainer,
 )(({ theme }) => ({
   gap: theme.spacing(3),
+}));
+
+export const EarnDetailsRisksContainer = styled(EarnDetailsSectionContainer)(
+  ({ theme }) => ({
+    gap: theme.spacing(3),
+    [theme.breakpoints.up('md')]: {
+      flexDirection: 'row',
+    },
+  }),
+);
+
+interface EarnDetailsRisksNavButtonProps extends ButtonProps {
+  isActive: boolean;
+}
+
+export const EarnDetailsRisksNavButton = styled(ButtonTransparent, {
+  shouldForwardProp: (prop) => prop !== 'isActive',
+})<EarnDetailsRisksNavButtonProps>(({ theme }) => ({
+  ...theme.applyStyles('light', {
+    backgroundColor: 'transparent',
+  }),
+  paddingLeft: theme.spacing(2),
+  paddingRight: theme.spacing(2),
+  height: theme.spacing(5),
+  fontSize: theme.typography.body2.fontSize,
+  '&:not(:first-of-type)': {
+    marginLeft: theme.spacing(1),
+  },
+  variants: [
+    {
+      props: ({ isActive }) => isActive,
+      style: {
+        ...theme.applyStyles('light', {
+          backgroundColor: theme.palette.alpha100.main,
+        }),
+      },
+    },
+  ],
+}));
+
+export const EarnRiskTagsContainer = styled(Stack)(({ theme }) => ({
+  backgroundColor: (theme.vars || theme).palette.alpha100.main,
+  padding: theme.spacing(3),
+  borderRadius: theme.spacing(2),
+  [theme.breakpoints.up('md')]: {
+    flex: 1,
+  },
+}));
+
+export const EarnRiskMissingWarning = styled('span')(({ theme }) => ({
+  color: theme.palette.error.main,
 }));
 
 export const EarnDetailsAnalyticsHeaderContainer = styled(Stack)(

--- a/src/components/EarnDetails/EarnDetails.styles.ts
+++ b/src/components/EarnDetails/EarnDetails.styles.ts
@@ -78,7 +78,7 @@ export const EarnRiskTagsContainer = styled(Stack)(({ theme }) => ({
 }));
 
 export const EarnRiskMissingWarning = styled('span')(({ theme }) => ({
-  color: theme.palette.error.main,
+  color: (theme.vars || theme).palette.statusError,
 }));
 
 export const EarnDetailsAnalyticsHeaderContainer = styled(Stack)(

--- a/src/components/EarnDetails/EarnDetailsRisks.tsx
+++ b/src/components/EarnDetails/EarnDetailsRisks.tsx
@@ -36,21 +36,32 @@ export const EarnDetailsRisks: React.FC<EarnDetailsRisksProps> = ({
 
   const [selectedTag, setSelectedTag] = useState<RiskTag>(tags[0] as RiskTag);
 
+  const handleTabChange = useCallback((value: string) => {
+    setSelectedTag(value as RiskTag);
+  }, []);
+
+  const protocolName = useMemo(
+    () => capitalizeString(protocol.name),
+    [protocol.name],
+  );
+
+  if (!tags.length) {
+    return null;
+  }
+
+  const linkText = `${protocolName} ${t('earn.riskDescriptions.website')}`;
+
   const tabOptions = tags.map((tag) => {
-    const label = `${tag} ${t('earn.riskDescriptions.risk')}` || (
+    const label = t('earn.riskDescriptions.risk') || (
       <EarnRiskMissingWarning>
         ATTENTION! Risk description for {tag} is missing! Please provide this.
       </EarnRiskMissingWarning>
     );
     return {
       value: tag,
-      label,
+      label: `${tag} ${label}`,
     };
   });
-
-  const handleTabChange = useCallback((value: string) => {
-    setSelectedTag(value as RiskTag);
-  }, []);
 
   const riskDescription = protocol.riskDescription || (
     <EarnRiskMissingWarning>
@@ -58,11 +69,6 @@ export const EarnDetailsRisks: React.FC<EarnDetailsRisksProps> = ({
     </EarnRiskMissingWarning>
   );
   const tagRiskDescription = t(`earn.riskDescriptions.riskTag.${selectedTag}`);
-  const protocolName = useMemo(
-    () => capitalizeString(protocol.name),
-    [protocol.name],
-  );
-  const linkText = `${protocolName} ${t('earn.riskDescriptions.website')}`;
 
   return (
     <EarnDetailsRisksContainer>
@@ -90,19 +96,22 @@ export const EarnDetailsRisks: React.FC<EarnDetailsRisksProps> = ({
           </ExternalLink>
         )}
       </Stack>
-      <EarnRiskTagsContainer>
-        <Box sx={(theme) => ({ marginBottom: theme.spacing(4) })}>
-          {tabOptions.map((tab) => (
-            <EarnDetailsRisksNavButton
-              isActive={selectedTag === tab.value}
-              onClick={() => handleTabChange(tab.value)}
-            >
-              {tab.label}
-            </EarnDetailsRisksNavButton>
-          ))}
-        </Box>
-        <Typography variant="body2">{tagRiskDescription}</Typography>
-      </EarnRiskTagsContainer>
+      {selectedTag && (
+        <EarnRiskTagsContainer>
+          <Box sx={(theme) => ({ marginBottom: theme.spacing(4) })}>
+            {tabOptions.map((tab) => (
+              <EarnDetailsRisksNavButton
+                key={tab.value}
+                isActive={selectedTag === tab.value}
+                onClick={() => handleTabChange(tab.value)}
+              >
+                {tab.label}
+              </EarnDetailsRisksNavButton>
+            ))}
+          </Box>
+          <Typography variant="body2">{tagRiskDescription}</Typography>
+        </EarnRiskTagsContainer>
+      )}
     </EarnDetailsRisksContainer>
   );
 };

--- a/src/components/EarnDetails/EarnDetailsRisks.tsx
+++ b/src/components/EarnDetails/EarnDetailsRisks.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import OpenInNew from '@mui/icons-material/OpenInNew';
+import { Typography } from '@mui/material';
+
+import type { Protocol } from 'src/types/jumper-backend';
+import { ExternalLink } from 'src/components/Link/ExternalLink';
+
+import type Resources from '../../i18n/resources';
+import { capitalizeString } from '../../utils/capitalizeString';
+import {
+  EarnDetailsRisksNavButton,
+  EarnDetailsRisksContainer,
+  EarnRiskMissingWarning,
+  EarnRiskTagsContainer,
+} from './EarnDetails.styles';
+
+// Eventually we want to get those from the API
+type RiskTag =
+  keyof Resources['translation']['earn']['riskDescriptions']['riskTag'];
+
+interface EarnDetailsRisksProps {
+  protocol: Protocol;
+  tags: string[];
+}
+
+export const EarnDetailsRisks: React.FC<EarnDetailsRisksProps> = ({
+  protocol,
+  tags,
+}) => {
+  const { t } = useTranslation();
+
+  const [selectedTag, setSelectedTag] = useState<RiskTag>(tags[0] as RiskTag);
+
+  const tabOptions = tags.map((tag) => {
+    const label = `${tag} ${t('earn.riskDescriptions.risk')}` || (
+      <EarnRiskMissingWarning>
+        ATTENTION! Risk description for {tag} is missing! Please provide this.
+      </EarnRiskMissingWarning>
+    );
+    return {
+      value: tag,
+      label,
+    };
+  });
+
+  const handleTabChange = useCallback((value: string) => {
+    setSelectedTag(value as RiskTag);
+  }, []);
+
+  const riskDescription = protocol.riskDescription || (
+    <EarnRiskMissingWarning>
+      ATTENTION! Risk description missing! Please provide this.
+    </EarnRiskMissingWarning>
+  );
+  const tagRiskDescription = t(`earn.riskDescriptions.riskTag.${selectedTag}`);
+  const protocolName = useMemo(
+    () => capitalizeString(protocol.name),
+    [protocol.name],
+  );
+  const linkText = `${protocolName} ${t('earn.riskDescriptions.website')}`;
+
+  return (
+    <EarnDetailsRisksContainer>
+      <Stack
+        sx={(theme) => ({
+          flex: { md: 1 },
+          paddingY: { sm: theme.spacing(2), md: theme.spacing(6) },
+        })}
+      >
+        <Typography
+          variant="headerXSmall"
+          sx={(theme) => ({ marginBottom: theme.spacing(1) })}
+        >
+          {capitalizeString(protocol.name)}
+        </Typography>
+        <Typography
+          variant="body1"
+          sx={(theme) => ({ marginBottom: theme.spacing(2) })}
+        >
+          {riskDescription}
+        </Typography>
+        {protocol.url && (
+          <ExternalLink href={protocol.url}>
+            {linkText} <OpenInNew />
+          </ExternalLink>
+        )}
+      </Stack>
+      <EarnRiskTagsContainer>
+        <Box sx={(theme) => ({ marginBottom: theme.spacing(4) })}>
+          {tabOptions.map((tab) => (
+            <EarnDetailsRisksNavButton
+              isActive={selectedTag === tab.value}
+              onClick={() => handleTabChange(tab.value)}
+            >
+              {tab.label}
+            </EarnDetailsRisksNavButton>
+          ))}
+        </Box>
+        <Typography variant="body2">{tagRiskDescription}</Typography>
+      </EarnRiskTagsContainer>
+    </EarnDetailsRisksContainer>
+  );
+};

--- a/src/components/EarnDetails/EarnDetailsRisks/EarnDetailsRisks.styles.ts
+++ b/src/components/EarnDetails/EarnDetailsRisks/EarnDetailsRisks.styles.ts
@@ -1,0 +1,63 @@
+import Stack from '@mui/material/Stack';
+import { styled } from '@mui/material/styles';
+
+import { ButtonTransparent, type ButtonProps } from '@/components/Button';
+
+import { EarnDetailsSectionContainer } from '../EarnDetails.styles';
+
+export const EarnDetailsRisksContainer = styled(EarnDetailsSectionContainer)(
+  ({ theme }) => ({
+    gap: theme.spacing(3),
+    [theme.breakpoints.up('md')]: {
+      flexDirection: 'row',
+    },
+  }),
+);
+
+interface EarnDetailsRisksNavButtonProps extends ButtonProps {
+  isActive: boolean;
+}
+
+export const EarnDetailsRisksNavButton = styled(ButtonTransparent, {
+  shouldForwardProp: (prop) => prop !== 'isActive',
+})<EarnDetailsRisksNavButtonProps>(({ theme }) => ({
+  ...theme.applyStyles('light', {
+    backgroundColor: 'transparent',
+  }),
+  ...theme.applyStyles('dark', {
+    backgroundColor: 'transparent',
+  }),
+  paddingLeft: theme.spacing(2),
+  paddingRight: theme.spacing(2),
+  height: theme.spacing(5),
+  fontSize: theme.typography.body2.fontSize,
+  '&:not(:first-of-type)': {
+    marginLeft: theme.spacing(1),
+  },
+  variants: [
+    {
+      props: ({ isActive }) => isActive,
+      style: {
+        ...theme.applyStyles('light', {
+          backgroundColor: theme.palette.alpha100.main,
+        }),
+        ...theme.applyStyles('dark', {
+          backgroundColor: theme.palette.alpha100.main,
+        }),
+      },
+    },
+  ],
+}));
+
+export const EarnRiskTagsContainer = styled(Stack)(({ theme }) => ({
+  backgroundColor: (theme.vars || theme).palette.alpha100.main,
+  padding: theme.spacing(3),
+  borderRadius: theme.spacing(2),
+  [theme.breakpoints.up('md')]: {
+    flex: 1,
+  },
+}));
+
+export const EarnRiskMissingWarning = styled('span')(({ theme }) => ({
+  color: (theme.vars || theme).palette.statusError,
+}));

--- a/src/components/EarnDetails/EarnDetailsRisks/EarnDetailsRisks.tsx
+++ b/src/components/EarnDetails/EarnDetailsRisks/EarnDetailsRisks.tsx
@@ -2,26 +2,28 @@
 
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import OpenInNew from '@mui/icons-material/OpenInNew';
-import { Typography } from '@mui/material';
+import { Typography, useMediaQuery, type Theme } from '@mui/material';
 
-import type { Protocol } from 'src/types/jumper-backend';
-import { ExternalLink } from 'src/components/Link/ExternalLink';
+import type { Protocol } from '@/types/jumper-backend';
+import { ExternalLink } from '@/components/Link/ExternalLink';
+import type Resources from '@/i18n/resources';
+import { capitalizeString } from '@/utils/capitalizeString';
 
-import type Resources from '../../i18n/resources';
-import { capitalizeString } from '../../utils/capitalizeString';
 import {
-  EarnDetailsRisksNavButton,
   EarnDetailsRisksContainer,
   EarnRiskMissingWarning,
   EarnRiskTagsContainer,
-} from './EarnDetails.styles';
+} from './EarnDetailsRisks.styles';
+import { EarnRiskTagsNav } from './EarnRiskTagsNav';
+import { EarnRiskTagsSelect } from './EarnRiskTagsSelect';
 
 // Eventually we want to get those from the API
-type RiskTag =
+export type RiskTag =
   keyof Resources['translation']['earn']['riskDescriptions']['riskTag'];
+
+export type RiskTagOptions = { value: string; label: string }[];
 
 interface EarnDetailsRisksProps {
   protocol: Protocol;
@@ -34,9 +36,13 @@ export const EarnDetailsRisks: React.FC<EarnDetailsRisksProps> = ({
 }) => {
   const { t } = useTranslation();
 
+  const isMobile = useMediaQuery((theme: Theme) =>
+    theme.breakpoints.down('md'),
+  );
+
   const [selectedTag, setSelectedTag] = useState<RiskTag>(tags[0] as RiskTag);
 
-  const handleTabChange = useCallback((value: string) => {
+  const handleTagChange = useCallback((value: string) => {
     setSelectedTag(value as RiskTag);
   }, []);
 
@@ -45,23 +51,20 @@ export const EarnDetailsRisks: React.FC<EarnDetailsRisksProps> = ({
     [protocol.name],
   );
 
+  const tagOptions = useMemo(
+    () =>
+      tags.map((tag) => ({
+        value: tag,
+        label: `${tag} ${t('earn.riskDescriptions.risk')}`,
+      })),
+    [t, tags],
+  );
+
   if (!tags.length) {
     return null;
   }
 
   const linkText = `${protocolName} ${t('earn.riskDescriptions.website')}`;
-
-  const tabOptions = tags.map((tag) => {
-    const label = t('earn.riskDescriptions.risk') || (
-      <EarnRiskMissingWarning>
-        ATTENTION! Risk description for {tag} is missing! Please provide this.
-      </EarnRiskMissingWarning>
-    );
-    return {
-      value: tag,
-      label: `${tag} ${label}`,
-    };
-  });
 
   const riskDescription = protocol.riskDescription || (
     <EarnRiskMissingWarning>
@@ -98,17 +101,19 @@ export const EarnDetailsRisks: React.FC<EarnDetailsRisksProps> = ({
       </Stack>
       {selectedTag && (
         <EarnRiskTagsContainer>
-          <Box sx={(theme) => ({ marginBottom: theme.spacing(4) })}>
-            {tabOptions.map((tab) => (
-              <EarnDetailsRisksNavButton
-                key={tab.value}
-                isActive={selectedTag === tab.value}
-                onClick={() => handleTabChange(tab.value)}
-              >
-                {tab.label}
-              </EarnDetailsRisksNavButton>
-            ))}
-          </Box>
+          {isMobile ? (
+            <EarnRiskTagsSelect
+              onTagChange={handleTagChange}
+              options={tagOptions}
+              selectedTag={selectedTag}
+            />
+          ) : (
+            <EarnRiskTagsNav
+              onTagChange={handleTagChange}
+              options={tagOptions}
+              selectedTag={selectedTag}
+            />
+          )}
           <Typography variant="body2">{tagRiskDescription}</Typography>
         </EarnRiskTagsContainer>
       )}

--- a/src/components/EarnDetails/EarnDetailsRisks/EarnDetailsRisks.tsx
+++ b/src/components/EarnDetails/EarnDetailsRisks/EarnDetailsRisks.tsx
@@ -87,8 +87,9 @@ export const EarnDetailsRisks: React.FC<EarnDetailsRisksProps> = ({
           {protocolName}
         </Typography>
         <Typography
-          variant="body1"
-          sx={(theme) => ({ marginBottom: theme.spacing(2) })}
+          variant="bodyMediumParagraph"
+          color="textSecondary"
+          sx={(theme) => ({ marginBottom: theme.spacing(3) })}
         >
           {riskDescription}
         </Typography>
@@ -111,7 +112,9 @@ export const EarnDetailsRisks: React.FC<EarnDetailsRisksProps> = ({
               selectedTag={selectedTag}
             />
           )}
-          <Typography variant="body2">{tagRiskDescription}</Typography>
+          <Typography variant="bodySmallParagraph" color="textSecondary">
+            {tagRiskDescription}
+          </Typography>
         </EarnRiskTagsContainer>
       )}
     </EarnDetailsRisksContainer>

--- a/src/components/EarnDetails/EarnDetailsRisks/EarnDetailsRisks.tsx
+++ b/src/components/EarnDetails/EarnDetailsRisks/EarnDetailsRisks.tsx
@@ -84,7 +84,7 @@ export const EarnDetailsRisks: React.FC<EarnDetailsRisksProps> = ({
           variant="headerXSmall"
           sx={(theme) => ({ marginBottom: theme.spacing(1) })}
         >
-          {capitalizeString(protocol.name)}
+          {protocolName}
         </Typography>
         <Typography
           variant="body1"

--- a/src/components/EarnDetails/EarnDetailsRisks/EarnDetailsRisks.tsx
+++ b/src/components/EarnDetails/EarnDetailsRisks/EarnDetailsRisks.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Stack from '@mui/material/Stack';
-import OpenInNew from '@mui/icons-material/OpenInNew';
 import { Typography, useMediaQuery, type Theme } from '@mui/material';
 
 import type { Protocol } from '@/types/jumper-backend';
@@ -94,9 +93,7 @@ export const EarnDetailsRisks: React.FC<EarnDetailsRisksProps> = ({
           {riskDescription}
         </Typography>
         {protocol.url && (
-          <ExternalLink href={protocol.url}>
-            {linkText} <OpenInNew />
-          </ExternalLink>
+          <ExternalLink href={protocol.url}>{linkText}</ExternalLink>
         )}
       </Stack>
       {selectedTag && (

--- a/src/components/EarnDetails/EarnDetailsRisks/EarnRiskTagsNav.tsx
+++ b/src/components/EarnDetails/EarnDetailsRisks/EarnRiskTagsNav.tsx
@@ -1,0 +1,30 @@
+import Box from '@mui/material/Box';
+
+import type { RiskTag, RiskTagOptions } from './EarnDetailsRisks';
+import { EarnDetailsRisksNavButton } from './EarnDetailsRisks.styles';
+
+interface EarnRiskTagsNavProps {
+  onTagChange: (tag: string) => void;
+  options: RiskTagOptions;
+  selectedTag: RiskTag;
+}
+
+export const EarnRiskTagsNav = ({
+  onTagChange,
+  options,
+  selectedTag,
+}: EarnRiskTagsNavProps) => {
+  return (
+    <Box sx={(theme) => ({ marginBottom: theme.spacing(4) })}>
+      {options.map((tab) => (
+        <EarnDetailsRisksNavButton
+          key={tab.value}
+          isActive={selectedTag === tab.value}
+          onClick={() => onTagChange(tab.value)}
+        >
+          {tab.label}
+        </EarnDetailsRisksNavButton>
+      ))}
+    </Box>
+  );
+};

--- a/src/components/EarnDetails/EarnDetailsRisks/EarnRiskTagsSelect.tsx
+++ b/src/components/EarnDetails/EarnDetailsRisks/EarnRiskTagsSelect.tsx
@@ -19,6 +19,7 @@ export const EarnRiskTagsSelect = ({
   return (
     <Box sx={(theme) => ({ marginBottom: theme.spacing(2) })}>
       <Select
+        debounceMs={0}
         options={options}
         value={selectedTag}
         onChange={onTagChange}

--- a/src/components/EarnDetails/EarnDetailsRisks/EarnRiskTagsSelect.tsx
+++ b/src/components/EarnDetails/EarnDetailsRisks/EarnRiskTagsSelect.tsx
@@ -1,0 +1,30 @@
+import { Box } from '@mui/system';
+
+import { SelectVariant } from '@/components/core/form/Select/Select.types';
+import { Select } from '@/components/core/form/Select/Select';
+
+import type { RiskTag, RiskTagOptions } from './EarnDetailsRisks';
+
+interface EarnRiskTagsSelectProps {
+  onTagChange: (tag: string) => void;
+  options: RiskTagOptions;
+  selectedTag: RiskTag;
+}
+
+export const EarnRiskTagsSelect = ({
+  onTagChange,
+  options,
+  selectedTag,
+}: EarnRiskTagsSelectProps) => {
+  return (
+    <Box sx={(theme) => ({ marginBottom: theme.spacing(2) })}>
+      <Select
+        options={options}
+        value={selectedTag}
+        onChange={onTagChange}
+        variant={SelectVariant.Single}
+        menuPlacementX="left"
+      />
+    </Box>
+  );
+};

--- a/src/components/Link/ExternalLink.snapshot.spec.tsx
+++ b/src/components/Link/ExternalLink.snapshot.spec.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { render } from '../../../vitest.setup';
+
+import { ExternalLink } from './ExternalLink';
+
+describe('ExternalLink snapshot', () => {
+  it('external link matches snapshot', async () => {
+    const { container } = render(
+      <ExternalLink href="https://example.com">Goes outside...</ExternalLink>,
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/Link/ExternalLink.snapshot.spec.tsx
+++ b/src/components/Link/ExternalLink.snapshot.spec.tsx
@@ -5,7 +5,7 @@ import { render } from '../../../vitest.setup';
 import { ExternalLink } from './ExternalLink';
 
 describe('ExternalLink snapshot', () => {
-  it('external link matches snapshot', async () => {
+  it('external link matches snapshot', () => {
     const { container } = render(
       <ExternalLink href="https://example.com">Goes outside...</ExternalLink>,
     );

--- a/src/components/Link/ExternalLink.tsx
+++ b/src/components/Link/ExternalLink.tsx
@@ -1,0 +1,31 @@
+import type { ComponentType } from 'react';
+
+import { styled } from '@mui/material/styles';
+
+import { Link, type LinkProps } from './Link';
+
+const StyledExternalLink = styled(Link)(({ theme }) => ({
+  color: (theme.vars || theme).palette.text.primary,
+  ...theme.typography.bodyMediumStrong,
+  textDecoration: 'none',
+  display: 'inline-flex',
+  width: 'fit-content',
+  alignItems: 'center',
+  gap: theme.spacing(0.75),
+  transition: 'color 0.3s ease',
+  '&:hover': {
+    color: (theme.vars || theme).palette.primary.main,
+  },
+  '& svg': {
+    width: 20,
+    height: 20,
+  },
+})) as ComponentType<LinkProps>;
+
+export const ExternalLink = (props: LinkProps) => (
+  <StyledExternalLink
+    target="_blank"
+    rel="noopener noreferrer nofollow"
+    {...props}
+  />
+);

--- a/src/components/Link/ExternalLink.tsx
+++ b/src/components/Link/ExternalLink.tsx
@@ -29,6 +29,7 @@ export const ExternalLink = ({ children, ...props }: LinkProps) => (
     rel="noopener noreferrer nofollow"
     {...props}
   >
-    {children} <OpenInNew />
+    {children}
+    <OpenInNew aria-hidden />
   </StyledExternalLink>
 );

--- a/src/components/Link/ExternalLink.tsx
+++ b/src/components/Link/ExternalLink.tsx
@@ -1,5 +1,6 @@
 import type { ComponentType } from 'react';
 
+import { OpenInNew } from '@mui/icons-material';
 import { styled } from '@mui/material/styles';
 
 import { Link, type LinkProps } from './Link';
@@ -22,10 +23,12 @@ const StyledExternalLink = styled(Link)(({ theme }) => ({
   },
 })) as ComponentType<LinkProps>;
 
-export const ExternalLink = (props: LinkProps) => (
+export const ExternalLink = ({ children, ...props }: LinkProps) => (
   <StyledExternalLink
     target="_blank"
     rel="noopener noreferrer nofollow"
     {...props}
-  />
+  >
+    {children} <OpenInNew />
+  </StyledExternalLink>
 );

--- a/src/components/Link/__snapshots__/ExternalLink.snapshot.spec.tsx.snap
+++ b/src/components/Link/__snapshots__/ExternalLink.snapshot.spec.tsx.snap
@@ -9,7 +9,6 @@ exports[`ExternalLink snapshot > external link matches snapshot 1`] = `
     target="_blank"
   >
     Goes outside...
-     
     <svg
       aria-hidden="true"
       class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-4uxqju-MuiSvgIcon-root"

--- a/src/components/Link/__snapshots__/ExternalLink.snapshot.spec.tsx.snap
+++ b/src/components/Link/__snapshots__/ExternalLink.snapshot.spec.tsx.snap
@@ -1,0 +1,26 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ExternalLink snapshot > external link matches snapshot 1`] = `
+<div>
+  <a
+    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-a7vmzy-MuiTypography-root-MuiLink-root"
+    href="https://example.com"
+    rel="noopener noreferrer nofollow"
+    target="_blank"
+  >
+    Goes outside...
+     
+    <svg
+      aria-hidden="true"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-4uxqju-MuiSvgIcon-root"
+      data-testid="OpenInNewIcon"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
+      />
+    </svg>
+  </a>
+</div>
+`;

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -102,21 +102,19 @@ interface Resources {
       riskDescriptions: {
         risk: 'Risk';
         riskTag: {
-          'Basis Trading': 'Basis Trading Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          'Basis Trading': 'Basis Trading may encounter several risk vectors that could influence the vault’s performance: funding rate inversion, spread compression, execution slippage, liquidation risk, exchange solvency risk, smart-contract risk, market volatility disrupting hedges, counterparty risk.';
           Bridge: 'Bridge Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
           CDP: 'CDP Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
-          Credit: 'Credit Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          Credit: 'Credit may encounter several risk vectors that could influence the vault’s performance: borrower default, counterparty insolvency, collateral devaluation, liquidation failure, liquidity risk, interest-rate volatility, smart contract exploits';
           Farming: 'Farming Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
-          Lending: 'Lending Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
-          'Liquid Staking': 'Liquid Staking Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          Lending: 'Lending may encounter several risk vectors that could influence the vault’s performance: oracle manipulation, collateral price crashes leading to borrower liquidation events, liquidity withdrawal constraints, depegs, interest-rate instability, smart contract exploits';
+          'Liquid Staking': 'Liquid Staking may encounter several risk vectors that could influence the vault’s performance: slashing events, validator downtime, liquid staking token peg instability, liquidity shortages, smart contract exploits';
           Liquidity: 'Liquidity Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
           RWA: 'RWA Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
           Staking: 'Staking Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
           Structured: 'Structured Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
-          Synthetic: 'Synthetic Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
-          'Top Opportunity': 'Top Opportunity Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
-          'Top Performing': 'Top Performing Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
-          'Yield Aggregator': 'Yield Aggregator Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          Synthetic: 'Synthetic may encounter several risk vectors that could influence the vault’s performance: oracle manipulation, under-collateralization,  market dislocations impacting peg, liquidity gaps, counterparty risk, smart contract exploits';
+          'Yield Aggregator': 'Yield Aggregator may encounter several risk vectors that could influence the vault’s performance: auto-compounder logic failures, rebalancing errors, strategy misconfiguration, dependency risk from integrated protocols, multisig or governance compromise, stacked smart-contract risk across underlying protocols';
         };
         website: 'website';
       };

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -103,17 +103,17 @@ interface Resources {
         risk: 'Risk';
         riskTag: {
           'Basis Trading': 'Basis Trading may encounter several risk vectors that could influence the vault’s performance: funding rate inversion, spread compression, execution slippage, liquidation risk, exchange solvency risk, smart-contract risk, market volatility disrupting hedges, counterparty risk.';
-          Bridge: 'Bridge Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
-          CDP: 'CDP Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          Bridge: 'Bridge liquidity provisioning may face risks such as cross-chain message failure, bridge contract exploits, validator misbehavior, chain reorganizations, liquidity shortages, bridged-asset depegs, and counterparty insolvency.';
+          CDP: 'CDP strategies may face risks including collateral price crashes, oracle manipulation, failed liquidations, rate volatility, collateral concentration, protocol changes, and stablecoin depegs.';
           Credit: 'Credit may encounter several risk vectors that could influence the vault’s performance: borrower default, counterparty insolvency, collateral devaluation, liquidation failure, liquidity risk, interest-rate volatility, smart contract exploits';
-          Farming: 'Farming Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          Farming: 'Farming strategies may face risks such as reward-token volatility, impermanent loss, emission dilution, liquidity migration, execution slippage, and smart-contract exploits.';
           Lending: 'Lending may encounter several risk vectors that could influence the vault’s performance: oracle manipulation, collateral price crashes leading to borrower liquidation events, liquidity withdrawal constraints, depegs, interest-rate instability, smart contract exploits';
           'Liquid Staking': 'Liquid Staking may encounter several risk vectors that could influence the vault’s performance: slashing events, validator downtime, liquid staking token peg instability, liquidity shortages, smart contract exploits';
-          Liquidity: 'Liquidity Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
-          RWA: 'RWA Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
-          Staking: 'Staking Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
-          Structured: 'Structured Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
-          Synthetic: 'Synthetic may encounter several risk vectors that could influence the vault’s performance: oracle manipulation, under-collateralization,  market dislocations impacting peg, liquidity gaps, counterparty risk, smart contract exploits';
+          Liquidity: 'Liquidity provisioning may face risks including impermanent loss, pool imbalance, liquidity drains, volatility disrupting ranges, oracle failures, and smart-contract exploits.';
+          RWA: 'RWA strategies may face risks such as issuer default, legal or jurisdictional issues, custodial failure, redemption delays, liquidity constraints, and valuation mismatches between on-chain and off-chain markets.';
+          Staking: 'Staking strategies may face risks including validator downtime, slashing, LST peg instability, withdrawal delays, governance shifts, and smart-contract exploits.';
+          Structured: 'Structured products may face risks such as model errors, volatility shifts, barrier breaches, rebalancing slippage, liquidity gaps, counterparty defaults, and oracle failures.';
+          Synthetic: "Synthetic may encounter several risk vectors that could influence the vault's performance: oracle manipulation, under-collateralization, market dislocations impacting peg, liquidity gaps, counterparty risk, smart contract exploits";
           'Yield Aggregator': 'Yield Aggregator may encounter several risk vectors that could influence the vault’s performance: auto-compounder logic failures, rebalancing errors, strategy misconfiguration, dependency risk from integrated protocols, multisig or governance compromise, stacked smart-contract risk across underlying protocols';
         };
         website: 'website';

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -99,6 +99,27 @@ interface Resources {
       relatedMarkets: {
         title: 'Related Markets';
       };
+      riskDescriptions: {
+        risk: 'Risk';
+        riskTag: {
+          'Basis Trading': 'Basis Trading Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          Bridge: 'Bridge Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          CDP: 'CDP Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          Credit: 'Credit Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          Farming: 'Farming Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          Lending: 'Lending Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          'Liquid Staking': 'Liquid Staking Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          Liquidity: 'Liquidity Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          RWA: 'RWA Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          Staking: 'Staking Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          Structured: 'Structured Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          Synthetic: 'Synthetic Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          'Top Opportunity': 'Top Opportunity Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          'Top Performing': 'Top Performing Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+          'Yield Aggregator': 'Yield Aggregator Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.';
+        };
+        website: 'website';
+      };
       sorting: {
         apy: 'APY';
         sort: 'Sort';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -215,13 +215,11 @@
             "description": "You need to sign the transaction to confirm ownership of the wallet address.",
             "tryAgain": "Try again"
           },
-
           "unsupportedWallet": {
             "title": "Unsupported wallet",
             "description": "We don't support this wallet type. Please use a different wallet to complete this mission.",
             "switchWallet": "Switch wallet"
           },
-
           "unknown": {
             "title": "Unknown error",
             "description": "An unknown error occurred. Please try again.",
@@ -364,6 +362,27 @@
     },
     "relatedMarkets": {
       "title": "Related Markets"
+    },
+    "riskDescriptions": {
+      "risk": "Risk",
+      "riskTag": {
+        "Lending": "Lending Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "Staking": "Staking Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "Liquidity": "Liquidity Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "Farming": "Farming Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "Structured": "Structured Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "CDP": "CDP Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "RWA": "RWA Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "Yield Aggregator": "Yield Aggregator Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "Top Opportunity": "Top Opportunity Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "Top Performing": "Top Performing Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "Liquid Staking": "Liquid Staking Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "Synthetic": "Synthetic Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "Bridge": "Bridge Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "Credit": "Credit Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "Basis Trading": "Basis Trading Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation."
+      },
+      "website": "website"
     },
     "overview": {
       "updated": "Updated {{time}} ago"
@@ -552,31 +571,26 @@
         "howToUsePerk": "How to use your perk ?",
         "howToUsePerkDescription": "Simply add the code we provide you in the checkout of the Nansen website."
       },
-
       "signatureFailed": {
         "title": "Signature required",
         "description": "You need to sign the transaction to confirm ownership of the wallet address.",
         "tryAgain": "Try again"
       },
-
       "validationFailed": {
         "title": "Validation failed",
         "description": "Please check the fields and try again.",
         "close": "Close"
       },
-
       "unsupportedWallet": {
         "title": "Unsupported wallet",
         "description": "We don't support this wallet type. Please use a different wallet to complete this mission.",
         "switchWallet": "Switch wallet"
       },
-
       "unknown": {
         "title": "Unknown error",
         "description": "An unknown error occurred. Please try again.",
         "tryAgain": "Try again"
       },
-
       "stepper": {
         "steps": {
           "username": {

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -377,7 +377,7 @@
         "RWA": "RWA strategies may face risks such as issuer default, legal or jurisdictional issues, custodial failure, redemption delays, liquidity constraints, and valuation mismatches between on-chain and off-chain markets.",
         "Staking": "Staking strategies may face risks including validator downtime, slashing, LST peg instability, withdrawal delays, governance shifts, and smart-contract exploits.",
         "Structured": "Structured products may face risks such as model errors, volatility shifts, barrier breaches, rebalancing slippage, liquidity gaps, counterparty defaults, and oracle failures.",
-        "Synthetic": "Synthetic may encounter several risk vectors that could influence the vault’s performance: oracle manipulation, under-collateralization,  market dislocations impacting peg, liquidity gaps, counterparty risk, smart contract exploits",
+        "Synthetic": "Synthetic may encounter several risk vectors that could influence the vault's performance: oracle manipulation, under-collateralization, market dislocations impacting peg, liquidity gaps, counterparty risk, smart contract exploits",
         "Yield Aggregator": "Yield Aggregator may encounter several risk vectors that could influence the vault’s performance: auto-compounder logic failures, rebalancing errors, strategy misconfiguration, dependency risk from integrated protocols, multisig or governance compromise, stacked smart-contract risk across underlying protocols"
       },
       "website": "website"

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -367,19 +367,18 @@
       "risk": "Risk",
       "riskTag": {
         "Basis Trading": "Basis Trading may encounter several risk vectors that could influence the vault’s performance: funding rate inversion, spread compression, execution slippage, liquidation risk, exchange solvency risk, smart-contract risk, market volatility disrupting hedges, counterparty risk.",
+        "Bridge": "Bridge liquidity provisioning may face risks such as cross-chain message failure, bridge contract exploits, validator misbehavior, chain reorganizations, liquidity shortages, bridged-asset depegs, and counterparty insolvency.",
+        "CDP": "CDP strategies may face risks including collateral price crashes, oracle manipulation, failed liquidations, rate volatility, collateral concentration, protocol changes, and stablecoin depegs.",
         "Credit": "Credit may encounter several risk vectors that could influence the vault’s performance: borrower default, counterparty insolvency, collateral devaluation, liquidation failure, liquidity risk, interest-rate volatility, smart contract exploits",
+        "Farming": "Farming strategies may face risks such as reward-token volatility, impermanent loss, emission dilution, liquidity migration, execution slippage, and smart-contract exploits.",
         "Lending": "Lending may encounter several risk vectors that could influence the vault’s performance: oracle manipulation, collateral price crashes leading to borrower liquidation events, liquidity withdrawal constraints, depegs, interest-rate instability, smart contract exploits",
         "Liquid Staking": "Liquid Staking may encounter several risk vectors that could influence the vault’s performance: slashing events, validator downtime, liquid staking token peg instability, liquidity shortages, smart contract exploits",
+        "Liquidity": "Liquidity provisioning may face risks including impermanent loss, pool imbalance, liquidity drains, volatility disrupting ranges, oracle failures, and smart-contract exploits.",
+        "RWA": "RWA strategies may face risks such as issuer default, legal or jurisdictional issues, custodial failure, redemption delays, liquidity constraints, and valuation mismatches between on-chain and off-chain markets.",
+        "Staking": "Staking strategies may face risks including validator downtime, slashing, LST peg instability, withdrawal delays, governance shifts, and smart-contract exploits.",
+        "Structured": "Structured products may face risks such as model errors, volatility shifts, barrier breaches, rebalancing slippage, liquidity gaps, counterparty defaults, and oracle failures.",
         "Synthetic": "Synthetic may encounter several risk vectors that could influence the vault’s performance: oracle manipulation, under-collateralization,  market dislocations impacting peg, liquidity gaps, counterparty risk, smart contract exploits",
-        "Yield Aggregator": "Yield Aggregator may encounter several risk vectors that could influence the vault’s performance: auto-compounder logic failures, rebalancing errors, strategy misconfiguration, dependency risk from integrated protocols, multisig or governance compromise, stacked smart-contract risk across underlying protocols",
-
-        "Bridge": "Bridge Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "CDP": "CDP Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "Farming": "Farming Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "Liquidity": "Liquidity Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "RWA": "RWA Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "Staking": "Staking Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "Structured": "Structured Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation."
+        "Yield Aggregator": "Yield Aggregator may encounter several risk vectors that could influence the vault’s performance: auto-compounder logic failures, rebalancing errors, strategy misconfiguration, dependency risk from integrated protocols, multisig or governance compromise, stacked smart-contract risk across underlying protocols"
       },
       "website": "website"
     },

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -366,21 +366,20 @@
     "riskDescriptions": {
       "risk": "Risk",
       "riskTag": {
-        "Lending": "Lending Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "Staking": "Staking Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "Liquidity": "Liquidity Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "Farming": "Farming Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "Structured": "Structured Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "CDP": "CDP Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "RWA": "RWA Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "Yield Aggregator": "Yield Aggregator Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "Top Opportunity": "Top Opportunity Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "Top Performing": "Top Performing Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "Liquid Staking": "Liquid Staking Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "Synthetic": "Synthetic Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "Basis Trading": "Basis Trading may encounter several risk vectors that could influence the vault’s performance: funding rate inversion, spread compression, execution slippage, liquidation risk, exchange solvency risk, smart-contract risk, market volatility disrupting hedges, counterparty risk.",
+        "Credit": "Credit may encounter several risk vectors that could influence the vault’s performance: borrower default, counterparty insolvency, collateral devaluation, liquidation failure, liquidity risk, interest-rate volatility, smart contract exploits",
+        "Lending": "Lending may encounter several risk vectors that could influence the vault’s performance: oracle manipulation, collateral price crashes leading to borrower liquidation events, liquidity withdrawal constraints, depegs, interest-rate instability, smart contract exploits",
+        "Liquid Staking": "Liquid Staking may encounter several risk vectors that could influence the vault’s performance: slashing events, validator downtime, liquid staking token peg instability, liquidity shortages, smart contract exploits",
+        "Synthetic": "Synthetic may encounter several risk vectors that could influence the vault’s performance: oracle manipulation, under-collateralization,  market dislocations impacting peg, liquidity gaps, counterparty risk, smart contract exploits",
+        "Yield Aggregator": "Yield Aggregator may encounter several risk vectors that could influence the vault’s performance: auto-compounder logic failures, rebalancing errors, strategy misconfiguration, dependency risk from integrated protocols, multisig or governance compromise, stacked smart-contract risk across underlying protocols",
+
         "Bridge": "Bridge Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "Credit": "Credit Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
-        "Basis Trading": "Basis Trading Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation."
+        "CDP": "CDP Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "Farming": "Farming Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "Liquidity": "Liquidity Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "RWA": "RWA Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "Staking": "Staking Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation.",
+        "Structured": "Structured Do eiusmod ipsum minim irure aliqua aliqua ad occaecat cupidatat officia nisi exercitation."
       },
       "website": "website"
     },

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -705,8 +705,8 @@ export const themeCustomized: Omit<Theme, 'applyStyles'> & CssVarsTheme =
       headerXSmall: {
         fontStyle: 'normal',
         fontWeight: 700,
-        fontSize: '18px',
-        lineHeight: '24px',
+        fontSize: '16px',
+        lineHeight: '20px',
         letterSpacing: 0,
       },
       bodyXLargeStrong: {

--- a/src/types/jumper-backend.ts
+++ b/src/types/jumper-backend.ts
@@ -831,6 +831,7 @@ export interface Protocol {
   product?: string;
   version?: string;
   logo?: string;
+  riskDescription?: string;
   url?: string;
 }
 


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-16879

## Testing steps

1. Go to `Earn`
2. Open any earn opportunity
3. You should see the earn opportunity's risk description

<img width="1141" height="406" alt="image" src="https://github.com/user-attachments/assets/61d69a57-6afa-4a83-bd35-27d2b00b3d56" />

NOTE: Earn descriptions have not been added for every protocol yet, I am in the process of adding them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Risk details section on Earn pages with selectable risk categories and protocol-provided risk content.
  * External link component for opening protocol sites in a new tab.

* **Style**
  * Adjusted header typography sizing.
  * Improved responsive styling for risk info and tag navigation.

* **Refactor**
  * Removed protocol-name link from protocol cards.

* **Localization**
  * Added localized riskDescriptions under Earn related markets.

* **Tests**
  * Snapshot test for the external link component.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->