### PR TITLE
fix: remove wallet filter if single wallet is connected

### DIFF
--- a/src/components/EarnFilterBar/layouts/EarnFilterBarContentAllDesktop.tsx
+++ b/src/components/EarnFilterBar/layouts/EarnFilterBarContentAllDesktop.tsx
@@ -1,4 +1,4 @@
-import { FC, PropsWithChildren } from 'react';
+import type { FC, PropsWithChildren } from 'react';
 import { Select } from '../../core/form/Select/Select';
 import { SelectVariant } from '../../core/form/Select/Select.types';
 import { EarnAnimatedLayoutContainer } from '../components/EarnAnimatedLayoutContainer';
@@ -36,7 +36,7 @@ export const EarnFilterBarContentAllDesktop: FC<PropsWithChildren> = ({
   return (
     <EarnFilterBarContentContainer>
       <EarnAnimatedLayoutContainer>
-        {chainOptions.length > 0 && (
+        {chainOptions.length > 1 && (
           <Select
             options={chainOptions}
             value={filter?.chains?.map(String) ?? []}
@@ -47,7 +47,7 @@ export const EarnFilterBarContentAllDesktop: FC<PropsWithChildren> = ({
             data-testid="earn-filter-chain-select"
           />
         )}
-        {protocolOptions.length > 0 && (
+        {protocolOptions.length > 1 && (
           <Select
             options={protocolOptions}
             value={filter?.protocols || []}
@@ -59,7 +59,7 @@ export const EarnFilterBarContentAllDesktop: FC<PropsWithChildren> = ({
           />
         )}
 
-        {tagOptions.length > 0 && (
+        {tagOptions.length > 1 && (
           <Select
             options={tagOptions}
             value={filter?.tags || []}
@@ -71,7 +71,7 @@ export const EarnFilterBarContentAllDesktop: FC<PropsWithChildren> = ({
           />
         )}
 
-        {assetOptions.length > 0 && (
+        {assetOptions.length > 1 && (
           <Select
             options={assetOptions}
             value={filter?.assets || []}

--- a/src/components/EarnFilterBar/layouts/EarnFilterBarContentAllTablet.tsx
+++ b/src/components/EarnFilterBar/layouts/EarnFilterBarContentAllTablet.tsx
@@ -1,10 +1,10 @@
 import { MultiLayerDrawer } from 'src/components/composite/MultiLayerDrawer/MultiLayerDrawer';
 import { useEarnFilterBar } from '../hooks';
-import { CategoryConfig } from 'src/components/composite/MultiLayerDrawer/MultiLayerDrawer.types';
+import type { CategoryConfig } from 'src/components/composite/MultiLayerDrawer/MultiLayerDrawer.types';
 import { usePendingFilters } from 'src/components/composite/MultiLayerDrawer/hooks';
 import { useTranslation } from 'react-i18next';
 import { formatSliderValue } from 'src/components/core/form/Select/utils';
-import { SortByEnum } from 'src/app/ui/earn/types';
+import type { SortByEnum } from 'src/app/ui/earn/types';
 import { EarnAnimatedLayoutContainer } from '../components/EarnAnimatedLayoutContainer';
 import { toFixedFractionDigits } from 'src/utils/formatNumbers';
 import {
@@ -111,7 +111,7 @@ export const EarnFilterBarContentAllTablet = () => {
 
   const categories: CategoryConfig[] = [];
 
-  if (chainOptions.length > 0) {
+  if (chainOptions.length > 1) {
     categories.push(
       createMultiSelectCategory<string>({
         id: 'chain',
@@ -128,7 +128,7 @@ export const EarnFilterBarContentAllTablet = () => {
       }),
     );
   }
-  if (protocolOptions.length > 0) {
+  if (protocolOptions.length > 1) {
     categories.push(
       createMultiSelectCategory({
         id: 'protocol',
@@ -145,7 +145,7 @@ export const EarnFilterBarContentAllTablet = () => {
       }),
     );
   }
-  if (tagOptions.length > 0) {
+  if (tagOptions.length > 1) {
     categories.push(
       createMultiSelectCategory({
         id: 'tag',
@@ -162,7 +162,7 @@ export const EarnFilterBarContentAllTablet = () => {
       }),
     );
   }
-  if (assetOptions.length > 0) {
+  if (assetOptions.length > 1) {
     categories.push(
       createMultiSelectCategory({
         id: 'asset',
@@ -195,7 +195,7 @@ export const EarnFilterBarContentAllTablet = () => {
     );
   }
 
-  if (sortByOptions.length > 0) {
+  if (sortByOptions.length > 1) {
     categories.push(
       createSingleSelectCategory<SortByEnum>({
         id: 'sortBy',

--- a/src/components/Menus/WalletMenu/WalletMenu.tsx
+++ b/src/components/Menus/WalletMenu/WalletMenu.tsx
@@ -44,6 +44,7 @@ export const WalletMenu = () => {
 
   return (
     <CustomDrawer
+      data-testid="wallet-drawer"
       open={_openWalletMenu}
       anchor="right"
       onClose={() => {
@@ -83,6 +84,7 @@ export const WalletMenu = () => {
         ([walletAddress, account]) => (
           <WalletBalanceCard
             key={walletAddress}
+            data-testid="wallet-balance-card"
             walletAddress={walletAddress}
             refetch={account.refetch}
             isFetching={account.isFetching}

--- a/src/components/PortfolioFilterBar/layouts/PortfolioFilterBarDeFiDesktop.tsx
+++ b/src/components/PortfolioFilterBar/layouts/PortfolioFilterBarDeFiDesktop.tsx
@@ -44,7 +44,7 @@ export const PortfolioFilterBarDeFiDesktop: FC<PropsWithChildren> = ({
             filterBy={t('portfolio.filter.chain').toLowerCase()}
             label={t('portfolio.filter.chain')}
             variant={SelectVariant.Multi}
-            data-testid="portfolio-defi-filter-chain-select"
+            data-testid="portfolio-filter-chain-select"
           />
         )}
 
@@ -56,7 +56,7 @@ export const PortfolioFilterBarDeFiDesktop: FC<PropsWithChildren> = ({
             filterBy={t('portfolio.filter.protocol').toLowerCase()}
             label={t('portfolio.filter.protocol')}
             variant={SelectVariant.Multi}
-            data-testid="portfolio-defi-filter-protocol-select"
+            data-testid="portfolio-filter-protocol-select"
           />
         )}
 
@@ -68,7 +68,7 @@ export const PortfolioFilterBarDeFiDesktop: FC<PropsWithChildren> = ({
             filterBy={t('portfolio.filter.type').toLowerCase()}
             label={t('portfolio.filter.type')}
             variant={SelectVariant.Multi}
-            data-testid="portfolio-defi-filter-type-select"
+            data-testid="portfolio-filter-type-select"
           />
         )}
 
@@ -80,7 +80,7 @@ export const PortfolioFilterBarDeFiDesktop: FC<PropsWithChildren> = ({
             filterBy={t('portfolio.filter.asset').toLowerCase()}
             label={t('portfolio.filter.asset')}
             variant={SelectVariant.Multi}
-            data-testid="portfolio-defi-filter-asset-select"
+            data-testid="portfolio-filter-asset-select"
           />
         )}
 
@@ -95,14 +95,14 @@ export const PortfolioFilterBarDeFiDesktop: FC<PropsWithChildren> = ({
               onChange={handleValueChange}
               label={t('portfolio.filter.value')}
               variant={SelectVariant.Slider}
-              data-testid="portfolio-defi-filter-value-select"
+              data-testid="portfolio-filter-value-select"
             />
           )}
 
         {hasFilterApplied && (
           <PortfolioFilterBarClearFiltersButton
             onClick={handleClearAllFilters}
-            data-testid="portfolio-defi-filter-clear-filters-button"
+            data-testid="portfolio-filter-clear-filters-button"
           >
             <DeleteOutlineIcon sx={{ height: 22, width: 22 }} />
           </PortfolioFilterBarClearFiltersButton>

--- a/src/components/PortfolioFilterBar/layouts/PortfolioFilterBarDeFiDesktop.tsx
+++ b/src/components/PortfolioFilterBar/layouts/PortfolioFilterBarDeFiDesktop.tsx
@@ -36,7 +36,7 @@ export const PortfolioFilterBarDeFiDesktop: FC<PropsWithChildren> = ({
   return (
     <PortfolioFilterBarContentContainer>
       <PortfolioAnimatedLayoutContainer>
-        {chainOptions.length > 0 && (
+        {chainOptions.length > 1 && (
           <Select
             options={chainOptions}
             value={filter?.defiChains?.map(String) ?? []}
@@ -48,7 +48,7 @@ export const PortfolioFilterBarDeFiDesktop: FC<PropsWithChildren> = ({
           />
         )}
 
-        {protocolOptions.length > 0 && (
+        {protocolOptions.length > 1 && (
           <Select
             options={protocolOptions}
             value={filter?.defiProtocols || []}
@@ -60,7 +60,7 @@ export const PortfolioFilterBarDeFiDesktop: FC<PropsWithChildren> = ({
           />
         )}
 
-        {typeOptions.length > 0 && (
+        {typeOptions.length > 1 && (
           <Select
             options={typeOptions}
             value={filter?.defiTypes || []}
@@ -72,7 +72,7 @@ export const PortfolioFilterBarDeFiDesktop: FC<PropsWithChildren> = ({
           />
         )}
 
-        {assetOptions.length > 0 && (
+        {assetOptions.length > 1 && (
           <Select
             options={assetOptions}
             value={filter?.defiAssets || []}

--- a/src/components/PortfolioFilterBar/layouts/PortfolioFilterBarDeFiTablet.tsx
+++ b/src/components/PortfolioFilterBar/layouts/PortfolioFilterBarDeFiTablet.tsx
@@ -113,7 +113,7 @@ export const PortfolioFilterBarDeFiTablet: FC = () => {
 
   const categories: CategoryConfig[] = [];
 
-  if (chainOptions.length > 0) {
+  if (chainOptions.length > 1) {
     categories.push(
       createMultiSelectCategory({
         id: 'chain',
@@ -131,7 +131,7 @@ export const PortfolioFilterBarDeFiTablet: FC = () => {
     );
   }
 
-  if (protocolOptions.length > 0) {
+  if (protocolOptions.length > 1) {
     categories.push(
       createMultiSelectCategory({
         id: 'protocol',
@@ -149,7 +149,7 @@ export const PortfolioFilterBarDeFiTablet: FC = () => {
     );
   }
 
-  if (typeOptions.length > 0) {
+  if (typeOptions.length > 1) {
     categories.push(
       createMultiSelectCategory({
         id: 'type',
@@ -167,7 +167,7 @@ export const PortfolioFilterBarDeFiTablet: FC = () => {
     );
   }
 
-  if (assetOptions.length > 0) {
+  if (assetOptions.length > 1) {
     categories.push(
       createMultiSelectCategory({
         id: 'asset',
@@ -204,7 +204,7 @@ export const PortfolioFilterBarDeFiTablet: FC = () => {
     );
   }
 
-  if (sortByOptions.length > 0) {
+  if (sortByOptions.length > 1) {
     categories.push(
       createSingleSelectCategory<SortByEnum>({
         id: 'sortBy',

--- a/src/components/PortfolioFilterBar/layouts/PortfolioFilterBarDeFiTablet.tsx
+++ b/src/components/PortfolioFilterBar/layouts/PortfolioFilterBarDeFiTablet.tsx
@@ -126,7 +126,7 @@ export const PortfolioFilterBarDeFiTablet: FC = () => {
         searchPlaceholder: t('portfolio.filter.search', {
           filterBy: t('portfolio.filter.chain').toLowerCase(),
         }),
-        testId: 'portfolio-defi-filter-chain-select-mobile',
+        testId: 'portfolio-filter-chain-select-mobile',
       }),
     );
   }
@@ -144,7 +144,7 @@ export const PortfolioFilterBarDeFiTablet: FC = () => {
         searchPlaceholder: t('portfolio.filter.search', {
           filterBy: t('portfolio.filter.protocol').toLowerCase(),
         }),
-        testId: 'portfolio-defi-filter-protocol-select-mobile',
+        testId: 'portfolio-filter-protocol-select-mobile',
       }),
     );
   }
@@ -162,7 +162,7 @@ export const PortfolioFilterBarDeFiTablet: FC = () => {
         searchPlaceholder: t('portfolio.filter.search', {
           filterBy: t('portfolio.filter.type').toLowerCase(),
         }),
-        testId: 'portfolio-defi-filter-type-select-mobile',
+        testId: 'portfolio-filter-type-select-mobile',
       }),
     );
   }
@@ -180,7 +180,7 @@ export const PortfolioFilterBarDeFiTablet: FC = () => {
         searchPlaceholder: t('portfolio.filter.search', {
           filterBy: t('portfolio.filter.asset').toLowerCase(),
         }),
-        testId: 'portfolio-defi-filter-asset-select-mobile',
+        testId: 'portfolio-filter-asset-select-mobile',
       }),
     );
   }
@@ -199,7 +199,7 @@ export const PortfolioFilterBarDeFiTablet: FC = () => {
         onChange: (value) => setPendingValue('defiValue', value),
         min: valueRangeMin,
         max: valueRangeMax,
-        testId: 'portfolio-defi-filter-value-select-mobile',
+        testId: 'portfolio-filter-value-select-mobile',
       }),
     );
   }
@@ -235,7 +235,7 @@ export const PortfolioFilterBarDeFiTablet: FC = () => {
         appliedFiltersCount={filtersCount}
         disableApply={!hasPendingFiltersApplied}
         disableClear={!hasPendingFiltersApplied}
-        testId="portfolio-defi-filters-mobile-drawer"
+        testId="portfolio-filters-mobile-drawer"
         defaultTriggerSx={{ justifyContent: 'flex-end' }}
       />
     </PortfolioAnimatedLayoutContainer>

--- a/src/components/PortfolioFilterBar/layouts/PortfolioFilterBarTokensDesktop.tsx
+++ b/src/components/PortfolioFilterBar/layouts/PortfolioFilterBarTokensDesktop.tsx
@@ -46,7 +46,7 @@ export const PortfolioFilterBarTokensDesktop: FC<PropsWithChildren> = ({
           />
         )}
 
-        {chainOptions.length > 0 && (
+        {chainOptions.length > 1 && (
           <Select
             options={chainOptions}
             value={filter?.tokensChains?.map(String) ?? []}
@@ -58,7 +58,7 @@ export const PortfolioFilterBarTokensDesktop: FC<PropsWithChildren> = ({
           />
         )}
 
-        {assetOptions.length > 0 && (
+        {assetOptions.length > 1 && (
           <Select
             options={assetOptions}
             value={filter?.tokensAssets || []}

--- a/src/components/PortfolioFilterBar/layouts/PortfolioFilterBarTokensDesktop.tsx
+++ b/src/components/PortfolioFilterBar/layouts/PortfolioFilterBarTokensDesktop.tsx
@@ -34,7 +34,7 @@ export const PortfolioFilterBarTokensDesktop: FC<PropsWithChildren> = ({
   return (
     <PortfolioFilterBarContentContainer>
       <PortfolioAnimatedLayoutContainer>
-        {walletOptions.length > 0 && (
+        {walletOptions.length > 1 && (
           <Select
             options={walletOptions}
             value={filter?.tokensWallets || []}

--- a/src/components/PortfolioFilterBar/layouts/PortfolioFilterBarTokensTablet.tsx
+++ b/src/components/PortfolioFilterBar/layouts/PortfolioFilterBarTokensTablet.tsx
@@ -106,7 +106,7 @@ export const PortfolioFilterBarTokensTablet: FC = () => {
 
   const categories: CategoryConfig[] = [];
 
-  if (walletOptions.length > 0) {
+  if (walletOptions.length > 1) {
     categories.push(
       createMultiSelectCategory({
         id: 'wallet',

--- a/src/components/PortfolioFilterBar/layouts/PortfolioFilterBarTokensTablet.tsx
+++ b/src/components/PortfolioFilterBar/layouts/PortfolioFilterBarTokensTablet.tsx
@@ -124,7 +124,7 @@ export const PortfolioFilterBarTokensTablet: FC = () => {
     );
   }
 
-  if (chainOptions.length > 0) {
+  if (chainOptions.length > 1) {
     categories.push(
       createMultiSelectCategory({
         id: 'chain',
@@ -142,7 +142,7 @@ export const PortfolioFilterBarTokensTablet: FC = () => {
     );
   }
 
-  if (assetOptions.length > 0) {
+  if (assetOptions.length > 1) {
     categories.push(
       createMultiSelectCategory({
         id: 'asset',
@@ -179,7 +179,7 @@ export const PortfolioFilterBarTokensTablet: FC = () => {
     );
   }
 
-  if (sortByOptions.length > 0) {
+  if (sortByOptions.length > 1) {
     categories.push(
       createSingleSelectCategory<SortByEnum>({
         id: 'sortBy',

--- a/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
+++ b/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
@@ -28,6 +28,7 @@ export const WalletBalanceCard: FC<WalletBalanceCardProps> = ({
   isFetching,
   isSuccess,
   data,
+  'data-testid': dataTestId,
 }) => {
   const { accounts } = useAccount();
   const account = accounts?.find(
@@ -72,7 +73,7 @@ export const WalletBalanceCard: FC<WalletBalanceCardProps> = ({
     }
   };
   return (
-    <WalletBalanceCardContainer>
+    <WalletBalanceCardContainer data-testid={dataTestId}>
       <StyledAccordion
         defaultExpanded={!hasMultipleAccountsConnected}
         expanded={isExpanded}

--- a/src/components/composite/WalletBalanceCard/WalletBalanceCard.types.ts
+++ b/src/components/composite/WalletBalanceCard/WalletBalanceCard.types.ts
@@ -1,5 +1,5 @@
-import { CacheToken } from 'src/types/portfolio';
-import { ExtendedTokenAmount } from 'src/utils/getTokens';
+import type { CacheToken } from 'src/types/portfolio';
+import type { ExtendedTokenAmount } from 'src/utils/getTokens';
 
 export interface WalletBalanceCardProps {
   walletAddress: string;
@@ -7,4 +7,5 @@ export interface WalletBalanceCardProps {
   isFetching: boolean;
   isSuccess: boolean;
   data: (ExtendedTokenAmount | CacheToken)[];
+  ['data-testid']?: string;
 }

--- a/tests/pages/PortfolioPage.ts
+++ b/tests/pages/PortfolioPage.ts
@@ -1,4 +1,9 @@
 import { expect, type Locator, type Page } from '@playwright/test';
+import {
+  openWalletDrawer,
+  getConnectedWalletCount,
+  closeWalletDrawer,
+} from '../testData/connectWalletFunctions';
 
 export class PortfolioPage {
   private readonly getStartedButton: Locator;
@@ -77,11 +82,33 @@ export class PortfolioPage {
   }
 
   async verifyFiltersAreVisibleOnTokensTab(): Promise<void> {
-    await this.verifyFiltersVisible(this.tokensFilterLocators);
+    await openWalletDrawer(this.page);
+    const connectedWalletCount = await getConnectedWalletCount(this.page);
+    await closeWalletDrawer(this.page);
+
+    const filtersToCheck =
+      connectedWalletCount > 1
+        ? this.tokensFilterLocators
+        : this.tokensFilterLocators.filter(
+            (f) => f !== this.walletSelectFilter,
+          );
+
+    await this.verifyFiltersVisible(filtersToCheck);
   }
 
   async verifyFiltersAreVisibleOnDefiProtocolsTab(): Promise<void> {
-    await this.verifyFiltersVisible(this.defiProtocolsFilterLocators);
+    await openWalletDrawer(this.page);
+    const connectedWalletCount = await getConnectedWalletCount(this.page);
+    await closeWalletDrawer(this.page);
+
+    const filtersToCheck =
+      connectedWalletCount > 1
+        ? this.defiProtocolsFilterLocators
+        : this.defiProtocolsFilterLocators.filter(
+            (f) => f !== this.walletSelectFilter,
+          );
+
+    await this.verifyFiltersVisible(filtersToCheck);
   }
 
   async verifyAllFiltersAreVisible(): Promise<void> {

--- a/tests/testData/connectWalletFunctions.ts
+++ b/tests/testData/connectWalletFunctions.ts
@@ -42,3 +42,28 @@ export const connectAnotherWalletButton = (page: Page) => {
 export const disconnectWalletButton = (page: Page) => {
   return page.locator('#disconnect-wallet-button');
 };
+
+export const walletDrawer = (page: Page) => {
+  return page.getByTestId('wallet-drawer');
+};
+
+export const walletCards = (page: Page) => {
+  return walletDrawer(page).getByTestId('wallet-balance-card');
+};
+
+export const openWalletDrawer = async (page: Page) => {
+  await page.locator('#wallet-digest-button').click();
+  await expect(walletDrawer(page)).toBeVisible();
+};
+
+export const getConnectedWalletCount = async (page: Page) => {
+  return walletCards(page).count();
+};
+
+export const expectConnectedWalletCount = async (page: Page, count: number) => {
+  await expect(walletCards(page)).toHaveCount(count);
+};
+
+export const closeWalletDrawer = async (page: Page) => {
+  await walletDrawer(page).getByRole('button', { name: 'close' }).click();
+};


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-17037

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Filter bars (Earn & Portfolio, desktop/tablet) now omit categories when only a single option exists, reducing clutter; some filter test IDs were standardized/renamed.

* **New Features**
  * Wallet drawer and wallet balance cards expose test IDs for UI testing.
  * Wallet balance card accepts an optional data-testid attribute.

* **Tests**
  * Test utilities added to open/close the wallet drawer and count connected wallets; tests adapt assertions based on connected wallet count.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->