### PR TITLE
fix: wrap address sanitisation in try catch

### DIFF
--- a/src/components/ProfilePage/components/ClaimPerkModal/validation/schemas.ts
+++ b/src/components/ProfilePage/components/ClaimPerkModal/validation/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { sanitizeAddress } from 'src/utils/image-generation/sanitizeParams';
+import { sanitizeAddressOrEmpty } from 'src/utils/image-generation/sanitizeParams';
 import { isValidAddress } from 'src/utils/regex-patterns';
 import { AvailableSteps } from '../ClaimPerkModal.types';
 
@@ -30,16 +30,7 @@ export const createStepSchema = (step: AvailableSteps) => {
     case AvailableSteps.Wallet:
       return z
         .string()
-        .transform((val) => {
-          if (!val) {
-            return '';
-          }
-          try {
-            return sanitizeAddress(val);
-          } catch (error) {
-            return '';
-          }
-        })
+        .transform((val) => sanitizeAddressOrEmpty(val))
         .refine((val) => isValidAddress(val), 'Invalid wallet address');
 
     default:

--- a/src/components/ProfilePage/components/ClaimPerkModal/validation/schemas.ts
+++ b/src/components/ProfilePage/components/ClaimPerkModal/validation/schemas.ts
@@ -20,7 +20,8 @@ export const createStepSchema = (step: AvailableSteps) => {
         );
 
     case AvailableSteps.Email:
-      return z.email('Invalid email address')
+      return z
+        .email('Invalid email address')
         .refine(
           (val) => val.length <= 80,
           'Email must not exceed 80 characters',
@@ -29,7 +30,16 @@ export const createStepSchema = (step: AvailableSteps) => {
     case AvailableSteps.Wallet:
       return z
         .string()
-        .transform((val) => (val ? sanitizeAddress(val) : ''))
+        .transform((val) => {
+          if (!val) {
+            return '';
+          }
+          try {
+            return sanitizeAddress(val);
+          } catch (error) {
+            return '';
+          }
+        })
         .refine((val) => isValidAddress(val), 'Invalid wallet address');
 
     default:

--- a/src/utils/image-generation/sanitizeParams.ts
+++ b/src/utils/image-generation/sanitizeParams.ts
@@ -55,3 +55,11 @@ export const sanitizeAddress = (address: string): string => {
     'Invalid address: Must be a valid Ethereum, Solana, UTXO, or SUI address',
   );
 };
+
+export const sanitizeAddressOrEmpty = (address: string): string => {
+  try {
+    return sanitizeAddress(address);
+  } catch (error) {
+    return '';
+  }
+};

--- a/src/utils/validation-schemas.ts
+++ b/src/utils/validation-schemas.ts
@@ -41,7 +41,13 @@ export const amountSchema = z
  */
 const baseAddressSchema = z
   .string()
-  .transform((val) => sanitizeAddress(val))
+  .transform((val) => {
+    try {
+      return sanitizeAddress(val);
+    } catch (error) {
+      return '';
+    }
+  })
   .refine((val) => {
     return isValidAddress(val);
   }, 'Invalid address format. Must be either an Ethereum address (0x...), a Solana address (base58), a UTXO address (1..., 3..., or bc1...), or a SUI address');
@@ -108,8 +114,8 @@ export const walletAddressSchema = z
   .string()
   .transform((val) => sanitizeAddress(val))
   .refine((val) => val.length > 0, {
-      error: 'Wallet address cannot be empty'
-});
+    error: 'Wallet address cannot be empty',
+  });
 
 /**
  * Schema for quest slugs (alphanumeric, hyphens, and underscores)
@@ -134,7 +140,8 @@ export const transactionHashSchema = z
       return isValidTransaction(val);
     },
     {
-        error: 'Invalid transaction hash format. Must be either an Ethereum transaction hash (0x...), a UTXO transaction hash (64 hex chars), a Solana transaction signature, or a SUI transaction digest'
+      error:
+        'Invalid transaction hash format. Must be either an Ethereum transaction hash (0x...), a UTXO transaction hash (64 hex chars), a Solana transaction signature, or a SUI transaction digest',
     },
   );
 
@@ -181,8 +188,8 @@ export const scanParamsSchema = z.object({
         return scanAddressSchema.safeParse(value).success;
       },
       {
-          error: 'Invalid scan segments format'
-    },
+        error: 'Invalid scan segments format',
+      },
     ),
 });
 
@@ -198,7 +205,8 @@ export const bridgeSegmentsSchema = z
       return parts.length === 2;
     },
     {
-        error: 'Bridge segments must be in format: sourceChain-sourceToken-to-destinationChain-destinationToken'
+      error:
+        'Bridge segments must be in format: sourceChain-sourceToken-to-destinationChain-destinationToken',
     },
   )
   .transform((val) => {
@@ -217,14 +225,14 @@ export const bridgeSegmentsSchema = z
     (val) =>
       isAlphanumeric(val.sourceToken) && isAlphanumeric(val.destinationToken),
     {
-        error: 'Token names must contain only alphanumeric characters'
+      error: 'Token names must contain only alphanumeric characters',
     },
   )
   .refine(
     (val) =>
       isAlphanumeric(val.sourceChain) && isAlphanumeric(val.destinationChain),
     {
-        error: 'Chain names must contain only alphanumeric characters'
+      error: 'Chain names must contain only alphanumeric characters',
     },
   );
 

--- a/src/utils/validation-schemas.ts
+++ b/src/utils/validation-schemas.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import {
-  sanitizeAddress,
+  sanitizeAddressOrEmpty,
   sanitizeNumeric,
 } from './image-generation/sanitizeParams';
 import { isValidAddress, isValidTransaction } from './regex-patterns';
@@ -41,13 +41,7 @@ export const amountSchema = z
  */
 const baseAddressSchema = z
   .string()
-  .transform((val) => {
-    try {
-      return sanitizeAddress(val);
-    } catch (error) {
-      return '';
-    }
-  })
+  .transform((val) => sanitizeAddressOrEmpty(val))
   .refine((val) => {
     return isValidAddress(val);
   }, 'Invalid address format. Must be either an Ethereum address (0x...), a Solana address (base58), a UTXO address (1..., 3..., or bc1...), or a SUI address');
@@ -112,7 +106,7 @@ export function slugify(text: string): string {
  */
 export const walletAddressSchema = z
   .string()
-  .transform((val) => sanitizeAddress(val))
+  .transform((val) => sanitizeAddressOrEmpty(val))
   .refine((val) => val.length > 0, {
     error: 'Wallet address cannot be empty',
   });


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-17080

## Testing steps

1. Try opening `/scan/wallet/oidsjoighrosidhgosirghosighio`
2. Check the 404 page is rendered and not an `Internal Server Error` screen
3. Try opening the scan for an existing wallet
4. Check the normal view is shown


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now handles invalid or empty wallet inputs more gracefully to avoid failures.
* **Behavior Change**
  * Transaction/hash inputs are preserved with original casing (no forced lowercasing).
* **Chores**
  * Small formatting and validation tweaks to improve robustness and error recovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->