### PR TITLE
feat: add tests for navigation to TOC and Newsletter pages

### DIFF
--- a/tests/mainMenu.spec.ts
+++ b/tests/mainMenu.spec.ts
@@ -255,4 +255,19 @@ test.describe('Main Menu flows', () => {
       await expect(sendMessageInIframe).toBeEnabled();
     },
   );
+
+  test('Should be able to navigate to the Terms & Conditions page', async ({
+    page,
+    context,
+  }) => {
+    await openOrCloseMainMenu(page);
+    await itemInNavigation(page, 'Terms & Conditions');
+    await openNewTabAndVerifyUrl(context, values.termsConditionsURL);
+  });
+
+  test('Should be able to open newsletter page', async ({ page }) => {
+    await openOrCloseMainMenu(page);
+    await itemInNavigation(page, 'Newsletter');
+    await expect(page).toHaveURL(values.newsletterPageURL);
+  });
 });

--- a/tests/mainMenu.spec.ts
+++ b/tests/mainMenu.spec.ts
@@ -256,16 +256,16 @@ test.describe('Main Menu flows', () => {
     },
   );
 
-  test('Should be able to navigate to the Terms & Conditions page', async ({
-    page,
-    context,
-  }) => {
-    await openOrCloseMainMenu(page);
-    await itemInNavigation(page, 'Terms & Conditions');
-    await openNewTabAndVerifyUrl(context, values.termsConditionsURL);
-  });
+  test(
+    qase(54, 'Should be able to navigate to the Terms & Conditions page'),
+    async ({ page, context }) => {
+      await openOrCloseMainMenu(page);
+      await itemInNavigation(page, 'Terms & Conditions');
+      await openNewTabAndVerifyUrl(context, values.termsConditionsURL);
+    },
+  );
 
-  test('Should be able to open newsletter page', async ({ page }) => {
+  test(qase(55, 'Should be able to open newsletter page'), async ({ page }) => {
     await openOrCloseMainMenu(page);
     await itemInNavigation(page, 'Newsletter');
     await expect(page).toHaveURL(values.newsletterPageURL);

--- a/tests/testData/values.json
+++ b/tests/testData/values.json
@@ -6,6 +6,8 @@
   "telegramURL": "https://t.me/officialjumperexchange",
   "link3URL": "https://link3.to/jumperexchange",
   "privacyPolicyURL": "/privacy-policy",
+  "termsConditionsURL": "https://li.fi/legal/terms-and-conditions/",
+  "newsletterPageURL": "/newsletter",
   "scanQRCodeTitle": "Scan this QR Code with your phone",
   "exploreFilamentURL": "/quests/rewards-from-filament",
   "aerodromeQuestsURL": "/quests/rewards-from-aerodrome-on-base",


### PR DESCRIPTION
### **Overview:**
This PR adds end-to-end test coverage for Terms & Conditions and Newsletter page navigation from the main menu, ensuring these navigation links are properly tested.
### **JIRA Ticket: ** https://lifi.atlassian.net/browse/LF-17086
### **Changes:**
 **Test Cases Added:**
 - Terms & Conditions Navigation Test: Verifies that clicking "Terms & Conditions" in the main menu opens the correct external URL in a new tab
 - Newsletter Navigation Test: Verifies that clicking "Newsletter" in the main menu navigates to the correct internal route
### **Test Data Updates:**
Added termsConditionsURL constant: "https://li.fi/legal/terms-and-conditions/"
Added newsletterPageURL constant: "/newsletter"
### **Files Changed:**
tests/mainMenu.spec.ts - Added two new test cases following existing patterns
tests/testData/values.json - Added URL constants for the new test cases
### **Testing:**
✅ Tests follow existing test patterns and conventions
✅ Tests use the same helper functions (openOrCloseMainMenu, itemInNavigation, openNewTabAndVerifyUrl)
✅ Test data is properly externalized to values.json
### **Notes:**
Terms & Conditions opens in a new tab (external link behavior)
Newsletter navigates in the same tab (internal route behavior)
Both tests are consistent with existing navigation tests in the same file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for navigating to Terms & Conditions and opening the Newsletter page from the main menu.
  * Included test data entries for the Terms & Conditions URL and Newsletter page path to support those flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->