### PR TITLE
fix: apy value shown in defi card

### DIFF
--- a/src/components/composite/DeFiPositionCard/utils.tsx
+++ b/src/components/composite/DeFiPositionCard/utils.tsx
@@ -23,6 +23,7 @@ import {
 import type { TFunction } from 'i18next';
 import { WithdrawFlowOnDemandButton } from '../WithdrawFlow/WithdrawFlow';
 import { formatUnits } from 'viem';
+import { formatApy } from '@/utils/numbers/apy';
 
 export const formatTimeDifference = (date: string, t: TFunction) => {
   const now = new Date();
@@ -117,8 +118,7 @@ export const renderApyCell = ({
   const apyValue = position.latest?.apy?.total;
   return (
     <TitleWithHint
-      // TODO: use the APY formatting function once available
-      title={apyValue ? `${toFixedFractionDigits(apyValue, 0, 2)}%` : '-'}
+      title={apyValue ? formatApy(apyValue) : '-'}
       titleVariant={titleVariant}
     />
   );


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-17100

## Testing steps
1. Simplest way to test the fix is to open `/earn`
2. Switch to `Your positions` tab
3. Now open another tab and go to `/portfolio`
4. Switch to the `DeFi Protocols`
5. Search the positions that have a correlated entry in the earn page view you opened (check protocol name and apy value and to have the Deposit/Withdraw buttons available)
6. The apy value shown on both pages should be the same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved APY formatting in DeFi position cards for consistent, clearer display. APY values now use enhanced formatting for better precision, and a dash is shown when APY data is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->