### PR TITLE
feat: add filter visibility verification for Your Positions tab on Ea…

### DIFF
--- a/tests/earnPage.spec.ts
+++ b/tests/earnPage.spec.ts
@@ -7,6 +7,7 @@ import {
   verifyAllCardsShowChain,
   verifyOnlySelectedTagIsVisible,
   verifyAnalyticsButtonsAreVisible,
+  verifyFiltersAreVisible,
 } from './testData/earnPageFunctions';
 import { qase } from 'playwright-qase-reporter';
 import { injectMockWallet } from './utils/mockWallet';
@@ -37,23 +38,24 @@ test.describe('Chains filters on Earn page', () => {
       await test.step('Verify Earn tabs are visible', async () => {
         const allMarketsTab = page.getByTestId('earn-filter-tab-all');
         const forYouTab = page.getByTestId('earn-filter-tab-foryou');
-        const tabs = [allMarketsTab, forYouTab];
+        const yourPositionsTab = page.getByTestId(
+          'earn-filter-tab-your-positions',
+        );
+        const tabs = [allMarketsTab, forYouTab, yourPositionsTab];
         for (const tab of tabs) {
           await expect(tab).toBeVisible();
         }
       });
+      await test.step('Verify if all filters are visible on Your Positions tab', async () => {
+        const yourPositionsTab = page.getByTestId(
+          'earn-filter-tab-your-positions',
+        );
+        await yourPositionsTab.click();
+        await verifyFiltersAreVisible(page);
+      });
 
       await test.step('Validate if filters are visible on All Markets tab', async () => {
-        const filterIds = [
-          'earn-filter-chain-select',
-          'earn-filter-protocol-select',
-          'earn-filter-tag-select',
-          'earn-filter-asset-select',
-          'earn-filter-apy-select',
-        ];
-        for (const filterId of filterIds) {
-          await expect(page.getByTestId(filterId)).toBeVisible();
-        }
+        await verifyFiltersAreVisible(page);
       });
     },
   );

--- a/tests/earnPage.spec.ts
+++ b/tests/earnPage.spec.ts
@@ -46,15 +46,16 @@ test.describe('Chains filters on Earn page', () => {
           await expect(tab).toBeVisible();
         }
       });
+
+      await test.step('Validate if filters are visible on All Markets tab', async () => {
+        await verifyFiltersAreVisible(page);
+      });
+
       await test.step('Verify if all filters are visible on Your Positions tab', async () => {
         const yourPositionsTab = page.getByTestId(
           'earn-filter-tab-your-positions',
         );
         await yourPositionsTab.click();
-        await verifyFiltersAreVisible(page);
-      });
-
-      await test.step('Validate if filters are visible on All Markets tab', async () => {
         await verifyFiltersAreVisible(page);
       });
     },

--- a/tests/testData/earnPageFunctions.ts
+++ b/tests/testData/earnPageFunctions.ts
@@ -165,3 +165,16 @@ export async function verifyOnlySelectedTagIsVisible(
 
   expect(selectedTagCount).toBeGreaterThan(0); //verify that at least one tag is visible
 }
+
+export async function verifyFiltersAreVisible(page: Page) {
+  const filterIds = [
+    'earn-filter-chain-select',
+    'earn-filter-protocol-select',
+    'earn-filter-tag-select',
+    'earn-filter-asset-select',
+    'earn-filter-apy-select',
+  ];
+  for (const filterId of filterIds) {
+    await expect(page.getByTestId(filterId)).toBeVisible();
+  }
+}


### PR DESCRIPTION
Refactor: Unify Filter Visibility Verification in Earn Page Tests
corresponding JIRA ticket https://lifi.atlassian.net/browse/JUM-208
### **Summary**
Refactored repetitive filter visibility verification code in Earn page tests by extracting a reusable helper function and fixing a missing function reference error.

### Problem
Test was calling non-existent function verifyFiltersAreVisibleOnYourPositionsTab, causing a compilation error

Duplicate filter verification code existed in multiple test steps, violating DRY principles

Same filter IDs array was repeated in two different test steps

### Solution
Created a new reusable helper function verifyFiltersAreVisible() in earnPageFunctions.ts

Extracted the common filter verification logic into the helper function

Updated test steps to use the new helper function instead of inline verification code

Added test step to verify filters are visible on "Your Positions" tab

### Changes Made
**Added**
verifyFiltersAreVisible(page: Page) function in tests/testData/earnPageFunctions.ts

Verifies visibility of all 5 filter dropdowns: chain, protocol, tag, asset, and APY

### Modified
tests/earnPage.spec.ts

Added import for verifyFiltersAreVisible helper function

Replaced inline filter verification code with helper function calls

Added test step to verify filters on "Your Positions" tab

Updated "All Markets" tab test step to use the helper function

Benefits
✅ Eliminates code duplication

✅ Improves maintainability - filter changes only need to be updated in one place

✅ Fixes compilation error

✅ Enhances test readability

✅ Ensures consistent filter verification across all tabs

Testing
All existing tests continue to pass

No linter errors introduced

TypeScript compilation successful

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened Earn page tests: added a reusable test helper to assert filter visibility, replaced inline checks with the helper, and added verification for the new "Your Positions" tab alongside All Markets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->