### PR TITLE
feat: add missing position card and update content for empty list

### DIFF
--- a/src/app/ui/earn/EarnEmptyList/EarnEmptyListAllMarkets.tsx
+++ b/src/app/ui/earn/EarnEmptyList/EarnEmptyListAllMarkets.tsx
@@ -10,8 +10,8 @@ export const EarnEmptyListAllMarkets = () => {
     <PortfolioEmptyList
       title={t('earn.emptyList.noResults.title')}
       description={t('earn.emptyList.noResults.description')}
-      buttonLabel={t('earn.emptyList.noResults.clearFilters')}
-      onClick={clearFilters}
+      primaryButtonLabel={t('earn.emptyList.noResults.clearFilters')}
+      onPrimaryButtonClick={clearFilters}
     />
   );
 };

--- a/src/app/ui/earn/EarnEmptyList/EarnEmptyListYourPositions.tsx
+++ b/src/app/ui/earn/EarnEmptyList/EarnEmptyListYourPositions.tsx
@@ -2,19 +2,27 @@ import { PortfolioEmptyList } from '@/components/core/empty-content/PortfolioEmp
 import { useTranslation } from 'react-i18next';
 import { useEarnFiltering } from '../EarnFilteringContext';
 import { EarnFilterTab } from '../types';
+import { AppPaths } from '@/const/urls';
+import { useRouter } from 'next/navigation';
 
 export const EarnEmptyListYourPositions = () => {
   const { t } = useTranslation();
   const { changeTab } = useEarnFiltering();
+  const router = useRouter();
   const handleViewAllMarkets = () => {
     changeTab(EarnFilterTab.ALL);
+  };
+  const handleGoToPortfolio = () => {
+    router.push(AppPaths.Portfolio);
   };
   return (
     <PortfolioEmptyList
       title={t('earn.emptyList.yourPositions.title')}
       description={t('earn.emptyList.yourPositions.description')}
-      buttonLabel={t('earn.emptyList.yourPositions.viewAllMarkets')}
-      onClick={handleViewAllMarkets}
+      primaryButtonLabel={t('earn.emptyList.yourPositions.viewAllMarkets')}
+      onPrimaryButtonClick={handleViewAllMarkets}
+      secondaryButtonLabel={t('earn.actions.goToPortfolio')}
+      onSecondaryButtonClick={handleGoToPortfolio}
     />
   );
 };

--- a/src/app/ui/earn/EarnOpportunitiesAll/EarnOpportunitiesAll.tsx
+++ b/src/app/ui/earn/EarnOpportunitiesAll/EarnOpportunitiesAll.tsx
@@ -21,8 +21,14 @@ import { useContactSupportEvent } from '@/components/Widgets/events/hooks/useCon
 
 const EarnOpportunitiesAllInner = () => {
   useContactSupportEvent();
-  const { data, isLoading, isAllDataLoading, showForYou, changeTab } =
-    useEarnFiltering();
+  const {
+    data,
+    isLoading,
+    isAllDataLoading,
+    showForYou,
+    changeTab,
+    showYourPositions,
+  } = useEarnFiltering();
 
   const [variant, setVariant] = useState<EarnCardVariant>('compact');
 
@@ -73,6 +79,7 @@ const EarnOpportunitiesAllInner = () => {
           <EarnOpportunitiesCards
             items={data}
             isLoading={isLoading}
+            showPlaceholderCard={showYourPositions}
             variant={variant}
           />
           <EarnEmptyList />

--- a/src/app/ui/earn/EarnOpportunitiesCards.tsx
+++ b/src/app/ui/earn/EarnOpportunitiesCards.tsx
@@ -13,10 +13,12 @@ export const EarnOpportunitiesCards = ({
   items,
   isLoading,
   variant,
+  showPlaceholderCard,
 }: {
   items: EarnOpportunityWithLatestAnalytics[];
   isLoading: boolean;
   variant: EarnCardVariant;
+  showPlaceholderCard: boolean;
 }) => {
   const isCompact = variant === 'compact';
   const gridItems = useMemo(
@@ -69,6 +71,22 @@ export const EarnOpportunitiesCards = ({
             )}
           </motion.div>
         ))}
+        {showPlaceholderCard && gridItems.length > 0 && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            viewport={{ once: true, margin: '-50px' }}
+            transition={{ duration: 0.3, ease: 'easeInOut' }}
+          >
+            <EarnCard
+              variant={variant}
+              data={null}
+              isLoading={false}
+              isMissingPosition={true}
+            />
+          </motion.div>
+        )}
       </AnimatePresence>
     </GridContainer>
   );

--- a/src/app/ui/portfolio/PortfolioEmptyList.tsx
+++ b/src/app/ui/portfolio/PortfolioEmptyList.tsx
@@ -14,8 +14,8 @@ export const PortfolioEmptyList: FC<PortfolioEmptyListProps> = ({
     <BasePortfolioEmptyList
       title={t('portfolio.emptyList.title')}
       description={t('portfolio.emptyList.description')}
-      buttonLabel={t('portfolio.emptyList.clearFilters')}
-      onClick={onClearFilters}
+      primaryButtonLabel={t('portfolio.emptyList.clearFilters')}
+      onPrimaryButtonClick={onClearFilters}
     />
   );
 };

--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -3,7 +3,7 @@ import type { ButtonProps as MuiButtonProps } from '@mui/material';
 import { alpha, styled } from '@mui/material/styles';
 import MuiButton, { buttonClasses } from '@mui/material/Button';
 
-const ButtonBase = styled(MuiButton)<MuiButtonProps>(({ theme }) => ({
+export const ButtonBase = styled(MuiButton)<MuiButtonProps>(({ theme }) => ({
   borderRadius: '24px',
   fontSize: '16px',
   letterSpacing: 0,

--- a/src/components/Cards/EarnCard/EarnCard.styles.ts
+++ b/src/components/Cards/EarnCard/EarnCard.styles.ts
@@ -212,6 +212,23 @@ export const EarnCardMissingPositionInteractiveContent = styled(Stack, {
   gap: theme.spacing(1.5),
   alignItems: 'center',
   justifyContent: isCentered ? 'center' : 'space-between',
+  position: 'relative',
+  zIndex: 1,
+  '&:before': {
+    content: '""',
+    display: 'inline-block',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    zIndex: -1,
+    filter: 'blur(32px)',
+    backgroundColor: (theme.vars || theme).palette.surface2.main,
+    ...theme.applyStyles('light', {
+      backgroundColor: (theme.vars || theme).palette.surface1.main,
+    }),
+  },
 }));
 
 export const EarnCardMissingPositionDescription = styled(Stack, {

--- a/src/components/Cards/EarnCard/EarnCard.styles.ts
+++ b/src/components/Cards/EarnCard/EarnCard.styles.ts
@@ -1,9 +1,11 @@
 import Box from '@mui/material/Box';
+import type { StackProps } from '@mui/material/Stack';
 import Stack from '@mui/material/Stack';
 import InfoIcon from '@mui/icons-material/Info';
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material/styles';
 import { BaseSurfaceSkeleton } from 'src/components/core/skeletons/BaseSurfaceSkeleton/BaseSurfaceSkeleton.style';
+import { ButtonPrimary } from '@/components/Button/Button.style';
 
 interface EarnCardContainerProps {
   hasLink?: boolean;
@@ -191,5 +193,46 @@ export const OverviewEarnCardItemValueAppend = styled(Typography)(
     ...theme.applyStyles('light', {
       color: (theme.vars || theme).palette.alphaDark800.main,
     }),
+  }),
+);
+
+export const EarnCardMissingPositionContent = styled(Stack)(({ theme }) => ({
+  gap: theme.spacing(1.5),
+  alignItems: 'center',
+  justifyContent: 'center',
+}));
+
+interface EarnCardMissingPositionStackProps extends StackProps {
+  isCentered?: boolean;
+}
+
+export const EarnCardMissingPositionInteractiveContent = styled(Stack, {
+  shouldForwardProp: (prop) => prop !== 'isCentered',
+})<EarnCardMissingPositionStackProps>(({ theme, isCentered }) => ({
+  gap: theme.spacing(1.5),
+  alignItems: 'center',
+  justifyContent: isCentered ? 'center' : 'space-between',
+}));
+
+export const EarnCardMissingPositionDescription = styled(Stack, {
+  shouldForwardProp: (prop) => prop !== 'isCentered',
+})<EarnCardMissingPositionStackProps>(({ theme, isCentered }) => ({
+  gap: theme.spacing(1),
+  alignItems: isCentered ? 'center' : 'flex-start',
+  justifyContent: isCentered ? 'center' : 'flex-start',
+}));
+
+export const EarnCardMissingPositionButton = styled(ButtonPrimary)(
+  ({ theme }) => ({
+    ...theme.typography.bodyXSmallStrong,
+    padding: theme.spacing(1),
+    height: 'auto',
+    width: '100%',
+    minWidth: 'fit-content',
+    textAlign: 'center',
+    textDecoration: 'none',
+    [theme.breakpoints.up('sm')]: {
+      width: 'fit-content',
+    },
   }),
 );

--- a/src/components/Cards/EarnCard/EarnCard.types.tsx
+++ b/src/components/Cards/EarnCard/EarnCard.types.tsx
@@ -1,4 +1,4 @@
-import { EarnOpportunityWithLatestAnalytics } from 'src/types/jumper-backend';
+import type { EarnOpportunityWithLatestAnalytics } from 'src/types/jumper-backend';
 
 export type EarnCardVariant = 'compact' | 'list-item' | 'overview';
 
@@ -13,13 +13,22 @@ interface CommonEarnCardProps {
 export interface EarnCardNotEmptyProps extends CommonEarnCardProps {
   data: EarnOpportunityWithLatestAnalytics;
   isLoading?: boolean;
+  isMissingPosition?: false;
 }
 
 export interface EarnCardEmptyAndLoadingProps extends CommonEarnCardProps {
   data: null;
   isLoading: true;
+  isMissingPosition?: false;
+}
+
+export interface EarnCardMissingPositionProps extends CommonEarnCardProps {
+  data: null;
+  isLoading: false;
+  isMissingPosition: true;
 }
 
 export type EarnCardProps =
   | EarnCardNotEmptyProps
-  | EarnCardEmptyAndLoadingProps;
+  | EarnCardEmptyAndLoadingProps
+  | EarnCardMissingPositionProps;

--- a/src/components/Cards/EarnCard/variants/CompactEarnCard.tsx
+++ b/src/components/Cards/EarnCard/variants/CompactEarnCard.tsx
@@ -18,11 +18,13 @@ import { CompactEarnCardItem } from './CompactEarnCardItem';
 import { CompactEarnCardSkeleton } from './CompactEarnCardSkeleton';
 import { useFormatDisplayEarnOpportunityData } from 'src/hooks/earn/useFormatDisplayEarnOpportunityData';
 import { ConditionalLink } from 'src/components/Link/ConditionalLink';
+import { CompactEarnCardMissingPosition } from './CompactEarnCardMissingPosition';
 
 export const CompactEarnCard: FC<Omit<EarnCardProps, 'variant'>> = ({
   primaryAction,
   data,
   isLoading,
+  isMissingPosition,
   href,
 }) => {
   // Note: later we might want to keep rendering the card if it's loading but already has data (on ttl for examples).
@@ -53,6 +55,10 @@ export const CompactEarnCard: FC<Omit<EarnCardProps, 'variant'>> = ({
       />
     );
   });
+
+  if (isMissingPosition) {
+    return <CompactEarnCardMissingPosition />;
+  }
 
   if (isEmpty) {
     return <CompactEarnCardSkeleton />;

--- a/src/components/Cards/EarnCard/variants/CompactEarnCardMissingPosition.tsx
+++ b/src/components/Cards/EarnCard/variants/CompactEarnCardMissingPosition.tsx
@@ -1,0 +1,44 @@
+import PortfolioEmptyIllustration from '@/components/illustrations/PortfolioEmptyIllustration';
+import {
+  CompactEarnCardContainer,
+  EarnCardMissingPositionInteractiveContent,
+  EarnCardMissingPositionButton,
+  EarnCardMissingPositionContent,
+  EarnCardMissingPositionDescription,
+} from '../EarnCard.styles';
+import Typography from '@mui/material/Typography';
+import { Link } from '@/components/Link';
+import { AppPaths } from '@/const/urls';
+import { useTranslation } from 'react-i18next';
+
+export const CompactEarnCardMissingPosition = () => {
+  const { t } = useTranslation();
+  return (
+    <CompactEarnCardContainer>
+      <EarnCardMissingPositionContent>
+        <PortfolioEmptyIllustration
+          viewBox="0 0 246 246"
+          width={148}
+          height={148}
+        />
+        <EarnCardMissingPositionInteractiveContent isCentered>
+          <EarnCardMissingPositionDescription isCentered>
+            <Typography variant="titleXSmall">
+              {t('earn.missingPosition.title')}
+            </Typography>
+            <Typography
+              variant="bodySmall"
+              color="textSecondary"
+              textAlign="center"
+            >
+              {t('earn.missingPosition.description')}
+            </Typography>
+          </EarnCardMissingPositionDescription>
+          <EarnCardMissingPositionButton as={Link} href={AppPaths.Portfolio}>
+            {t('earn.actions.goToPortfolio')}
+          </EarnCardMissingPositionButton>
+        </EarnCardMissingPositionInteractiveContent>
+      </EarnCardMissingPositionContent>
+    </CompactEarnCardContainer>
+  );
+};

--- a/src/components/Cards/EarnCard/variants/CompactEarnCardMissingPosition.tsx
+++ b/src/components/Cards/EarnCard/variants/CompactEarnCardMissingPosition.tsx
@@ -5,6 +5,7 @@ import {
   EarnCardMissingPositionButton,
   EarnCardMissingPositionContent,
   EarnCardMissingPositionDescription,
+  CompactEarnCardBody,
 } from '../EarnCard.styles';
 import Typography from '@mui/material/Typography';
 import { Link } from '@/components/Link';
@@ -15,30 +16,37 @@ export const CompactEarnCardMissingPosition = () => {
   const { t } = useTranslation();
   return (
     <CompactEarnCardContainer>
-      <EarnCardMissingPositionContent>
-        <PortfolioEmptyIllustration
-          viewBox="0 0 246 246"
-          width={148}
-          height={148}
-        />
-        <EarnCardMissingPositionInteractiveContent isCentered>
-          <EarnCardMissingPositionDescription isCentered>
-            <Typography variant="titleXSmall">
-              {t('earn.missingPosition.title')}
-            </Typography>
-            <Typography
-              variant="bodySmall"
-              color="textSecondary"
-              textAlign="center"
-            >
-              {t('earn.missingPosition.description')}
-            </Typography>
-          </EarnCardMissingPositionDescription>
-          <EarnCardMissingPositionButton as={Link} href={AppPaths.Portfolio}>
-            {t('earn.actions.goToPortfolio')}
-          </EarnCardMissingPositionButton>
-        </EarnCardMissingPositionInteractiveContent>
-      </EarnCardMissingPositionContent>
+      <CompactEarnCardBody>
+        <EarnCardMissingPositionContent>
+          <PortfolioEmptyIllustration
+            viewBox="0 0 246 246"
+            width={148}
+            height={148}
+          />
+          <EarnCardMissingPositionInteractiveContent
+            isCentered
+            sx={(theme) => ({
+              marginTop: theme.spacing(-7.25),
+            })}
+          >
+            <EarnCardMissingPositionDescription isCentered>
+              <Typography variant="titleXSmall">
+                {t('earn.missingPosition.title')}
+              </Typography>
+              <Typography
+                variant="bodySmall"
+                color="textSecondary"
+                textAlign="center"
+              >
+                {t('earn.missingPosition.description')}
+              </Typography>
+            </EarnCardMissingPositionDescription>
+            <EarnCardMissingPositionButton as={Link} href={AppPaths.Portfolio}>
+              {t('earn.actions.goToPortfolio')}
+            </EarnCardMissingPositionButton>
+          </EarnCardMissingPositionInteractiveContent>
+        </EarnCardMissingPositionContent>
+      </CompactEarnCardBody>
     </CompactEarnCardContainer>
   );
 };

--- a/src/components/Cards/EarnCard/variants/ListItemEarnCard.tsx
+++ b/src/components/Cards/EarnCard/variants/ListItemEarnCard.tsx
@@ -17,11 +17,13 @@ import { ListItemEarnCardSkeleton } from './ListItemEarnCardSkeleton';
 import { ListItemTooltipBadge } from './ListItemTooltipBadge';
 import { useFormatDisplayEarnOpportunityData } from 'src/hooks/earn/useFormatDisplayEarnOpportunityData';
 import { ConditionalLink } from 'src/components/Link/ConditionalLink';
+import { ListItemEarnCardMissingPosition } from './ListItemEarnCardMissingPosition';
 
 export const ListItemEarnCard: FC<Omit<EarnCardProps, 'variant'>> = ({
   data,
   primaryAction,
   isLoading,
+  isMissingPosition,
   href,
 }) => {
   // Note: later we might want to keep rendering the card if it's loading but already has data (on ttl for examples).
@@ -48,6 +50,10 @@ export const ListItemEarnCard: FC<Omit<EarnCardProps, 'variant'>> = ({
       startIcon={item.valuePrepend}
     />
   ));
+
+  if (isMissingPosition) {
+    return <ListItemEarnCardMissingPosition />;
+  }
 
   if (isEmpty) {
     return <ListItemEarnCardSkeleton />;

--- a/src/components/Cards/EarnCard/variants/ListItemEarnCardMissingPosition.tsx
+++ b/src/components/Cards/EarnCard/variants/ListItemEarnCardMissingPosition.tsx
@@ -4,6 +4,7 @@ import {
   EarnCardMissingPositionButton,
   EarnCardMissingPositionDescription,
   ListItemEarnCardContainer,
+  ListItemEarnCardBody,
 } from '../EarnCard.styles';
 import { Link } from '@/components/Link/Link';
 import { AppPaths } from '@/const/urls';
@@ -13,19 +14,21 @@ export const ListItemEarnCardMissingPosition = () => {
   const { t } = useTranslation();
   return (
     <ListItemEarnCardContainer>
-      <EarnCardMissingPositionInteractiveContent direction="row">
-        <EarnCardMissingPositionDescription sx={{ gap: 0.5 }}>
-          <Typography variant="titleXSmall">
-            {t('earn.missingPosition.title')}
-          </Typography>
-          <Typography variant="bodySmall" color="textSecondary">
-            {t('earn.missingPosition.description')}
-          </Typography>
-        </EarnCardMissingPositionDescription>
-        <EarnCardMissingPositionButton as={Link} href={AppPaths.Portfolio}>
-          {t('earn.actions.goToPortfolio')}
-        </EarnCardMissingPositionButton>
-      </EarnCardMissingPositionInteractiveContent>
+      <ListItemEarnCardBody>
+        <EarnCardMissingPositionInteractiveContent direction="row">
+          <EarnCardMissingPositionDescription sx={{ gap: 0.5 }}>
+            <Typography variant="titleXSmall">
+              {t('earn.missingPosition.title')}
+            </Typography>
+            <Typography variant="bodySmall" color="textSecondary">
+              {t('earn.missingPosition.description')}
+            </Typography>
+          </EarnCardMissingPositionDescription>
+          <EarnCardMissingPositionButton as={Link} href={AppPaths.Portfolio}>
+            {t('earn.actions.goToPortfolio')}
+          </EarnCardMissingPositionButton>
+        </EarnCardMissingPositionInteractiveContent>
+      </ListItemEarnCardBody>
     </ListItemEarnCardContainer>
   );
 };

--- a/src/components/Cards/EarnCard/variants/ListItemEarnCardMissingPosition.tsx
+++ b/src/components/Cards/EarnCard/variants/ListItemEarnCardMissingPosition.tsx
@@ -1,0 +1,31 @@
+import Typography from '@mui/material/Typography';
+import {
+  EarnCardMissingPositionInteractiveContent,
+  EarnCardMissingPositionButton,
+  EarnCardMissingPositionDescription,
+  ListItemEarnCardContainer,
+} from '../EarnCard.styles';
+import { Link } from '@/components/Link/Link';
+import { AppPaths } from '@/const/urls';
+import { useTranslation } from 'react-i18next';
+
+export const ListItemEarnCardMissingPosition = () => {
+  const { t } = useTranslation();
+  return (
+    <ListItemEarnCardContainer>
+      <EarnCardMissingPositionInteractiveContent direction="row">
+        <EarnCardMissingPositionDescription sx={{ gap: 0.5 }}>
+          <Typography variant="titleXSmall">
+            {t('earn.missingPosition.title')}
+          </Typography>
+          <Typography variant="bodySmall" color="textSecondary">
+            {t('earn.missingPosition.description')}
+          </Typography>
+        </EarnCardMissingPositionDescription>
+        <EarnCardMissingPositionButton as={Link} href={AppPaths.Portfolio}>
+          {t('earn.actions.goToPortfolio')}
+        </EarnCardMissingPositionButton>
+      </EarnCardMissingPositionInteractiveContent>
+    </ListItemEarnCardContainer>
+  );
+};

--- a/src/components/core/empty-content/PortfolioEmptyList/PortfolioEmptyList.style.ts
+++ b/src/components/core/empty-content/PortfolioEmptyList/PortfolioEmptyList.style.ts
@@ -1,6 +1,7 @@
+import type { Theme } from '@mui/material/styles';
 import { styled } from '@mui/material/styles';
 import Stack from '@mui/material/Stack';
-import { ButtonPrimary } from '@/components/Button/Button.style';
+import { ButtonBase, ButtonPrimary } from '@/components/Button/Button.style';
 
 export const PortfolioEmptyListContainer = styled(Stack)(({ theme }) => ({
   alignItems: 'center',
@@ -43,8 +44,39 @@ export const PortfolioEmptyListDescriptionContainer = styled(Stack)(
   }),
 );
 
-export const PortfolioEmptyListButton = styled(ButtonPrimary)(({ theme }) => ({
+export const PortfolioEmptyListButtonsContainer = styled(Stack)(
+  ({ theme }) => ({
+    width: '100%',
+    gap: theme.spacing(2),
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    [theme.breakpoints.up('sm')]: {
+      flexDirection: 'row',
+    },
+  }),
+);
+
+const getButtonStyles = (theme: Theme) => ({
   height: 'auto',
   padding: theme.spacing(1.75, 2.75),
   ...theme.typography.bodyMediumStrong,
-}));
+});
+
+export const PortfolioEmptyListPrimaryButton = styled(ButtonPrimary)(
+  ({ theme }) => ({
+    ...getButtonStyles(theme),
+  }),
+);
+
+export const PortfolioEmptyListSecondaryButton = styled(ButtonBase)(
+  ({ theme }) => ({
+    ...getButtonStyles(theme),
+    color: (theme.vars || theme).palette.buttonLightAction,
+    backgroundColor: (theme.vars || theme).palette.buttonLightBg,
+    '&:hover': {
+      color: (theme.vars || theme).palette.buttonAlphaDarkAction,
+      backgroundColor: (theme.vars || theme).palette.buttonAlphaDarkBg,
+    },
+  }),
+);

--- a/src/components/core/empty-content/PortfolioEmptyList/PortfolioEmptyList.tsx
+++ b/src/components/core/empty-content/PortfolioEmptyList/PortfolioEmptyList.tsx
@@ -11,14 +11,25 @@ import {
 } from './PortfolioEmptyList.style';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
-interface PortfolioEmptyListProps {
+interface PortfolioEmptyListBaseProps {
   title: string;
   description: string;
   primaryButtonLabel: string;
   onPrimaryButtonClick: () => void;
-  secondaryButtonLabel?: string;
-  onSecondaryButtonClick?: () => void;
 }
+
+interface WithSecondaryButton {
+  secondaryButtonLabel: string;
+  onSecondaryButtonClick: () => void;
+}
+
+interface WithoutSecondaryButton {
+  secondaryButtonLabel?: never;
+  onSecondaryButtonClick?: never;
+}
+
+type PortfolioEmptyListProps = PortfolioEmptyListBaseProps &
+  (WithSecondaryButton | WithoutSecondaryButton);
 
 export const PortfolioEmptyList: FC<PortfolioEmptyListProps> = ({
   title,

--- a/src/components/core/empty-content/PortfolioEmptyList/PortfolioEmptyList.tsx
+++ b/src/components/core/empty-content/PortfolioEmptyList/PortfolioEmptyList.tsx
@@ -2,25 +2,33 @@ import PortfolioEmptyIllustration from '@/components/illustrations/PortfolioEmpt
 import Typography from '@mui/material/Typography';
 import type { FC } from 'react';
 import {
-  PortfolioEmptyListButton,
+  PortfolioEmptyListPrimaryButton,
   PortfolioEmptyListContainer,
   PortfolioEmptyListContentContainer,
   PortfolioEmptyListDescriptionContainer,
+  PortfolioEmptyListButtonsContainer,
+  PortfolioEmptyListSecondaryButton,
 } from './PortfolioEmptyList.style';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 interface PortfolioEmptyListProps {
   title: string;
   description: string;
-  buttonLabel: string;
-  onClick: () => void;
+  primaryButtonLabel: string;
+  onPrimaryButtonClick: () => void;
+  secondaryButtonLabel?: string;
+  onSecondaryButtonClick?: () => void;
 }
 
 export const PortfolioEmptyList: FC<PortfolioEmptyListProps> = ({
   title,
   description,
-  buttonLabel,
-  onClick,
+  primaryButtonLabel,
+  onPrimaryButtonClick,
+  secondaryButtonLabel,
+  onSecondaryButtonClick,
 }) => {
+  const isMobile = useMediaQuery((theme) => theme.breakpoints.down('sm'));
   return (
     <PortfolioEmptyListContainer>
       <PortfolioEmptyIllustration style={{ marginBottom: -48 }} />
@@ -30,14 +38,27 @@ export const PortfolioEmptyList: FC<PortfolioEmptyListProps> = ({
           <Typography
             variant="bodyMedium"
             color="textSecondary"
-            sx={{ textAlign: 'center' }}
+            sx={{ textAlign: 'center', whiteSpace: 'pre-line' }}
           >
             {description}
           </Typography>
         </PortfolioEmptyListDescriptionContainer>
-        <PortfolioEmptyListButton onClick={onClick}>
-          {buttonLabel}
-        </PortfolioEmptyListButton>
+        <PortfolioEmptyListButtonsContainer direction="row">
+          <PortfolioEmptyListPrimaryButton
+            onClick={onPrimaryButtonClick}
+            fullWidth={isMobile}
+          >
+            {primaryButtonLabel}
+          </PortfolioEmptyListPrimaryButton>
+          {secondaryButtonLabel && (
+            <PortfolioEmptyListSecondaryButton
+              onClick={onSecondaryButtonClick}
+              fullWidth={isMobile}
+            >
+              {secondaryButtonLabel}
+            </PortfolioEmptyListSecondaryButton>
+          )}
+        </PortfolioEmptyListButtonsContainer>
       </PortfolioEmptyListContentContainer>
     </PortfolioEmptyListContainer>
   );

--- a/src/components/illustrations/PortfolioEmptyIllustration.tsx
+++ b/src/components/illustrations/PortfolioEmptyIllustration.tsx
@@ -1,8 +1,7 @@
 import { useColorScheme, useTheme } from '@mui/material/styles';
-import * as React from 'react';
+import { useId } from 'react';
 
-interface PortfolioEmptyIllustrationProps
-  extends React.SVGProps<SVGSVGElement> {
+interface PortfolioEmptyIllustrationProps extends React.SVGProps<SVGSVGElement> {
   width?: number;
   height?: number;
 }
@@ -14,6 +13,13 @@ const PortfolioEmptyIllustration = ({
 }: PortfolioEmptyIllustrationProps) => {
   const theme = useTheme();
   const { mode } = useColorScheme();
+  const uniqueId = useId();
+  const clipPathId = `${uniqueId}-clip`;
+  const filterId = `${uniqueId}-filter`;
+  const gradientCId = `${uniqueId}-gradient-c`;
+  const gradientDId = `${uniqueId}-gradient-d`;
+  const gradientEId = `${uniqueId}-gradient-e`;
+
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -22,8 +28,13 @@ const PortfolioEmptyIllustration = ({
       fill="none"
       {...rest}
     >
-      <g clipPath="url(#a)">
-        <g stroke="#F7C2FF" strokeWidth={0.769} filter="url(#b)" opacity={0.3}>
+      <g clipPath={`url(#${clipPathId})`}>
+        <g
+          stroke="#F7C2FF"
+          strokeWidth={0.769}
+          filter={`url(#${filterId})`}
+          opacity={0.3}
+        >
           <circle cx={123} cy={123} r={54.197} />
           <circle cx={123} cy={123} r={78.028} />
           <circle cx={123} cy={123} r={101.091} />
@@ -43,7 +54,7 @@ const PortfolioEmptyIllustration = ({
           <circle cx={123} cy={123} r={100.706} opacity={0.5} />
           <circle cx={123} cy={123} r={122.231} opacity={0.2} />
         </g>
-        <circle cx={123} cy={123} r={27.675} fill="url(#c)" />
+        <circle cx={123} cy={123} r={27.675} fill={`url(#${gradientCId})`} />
         <path
           fill="#D35CFF"
           d="m118.053 116.377 5.504-5.504-1.376-1.376c-2.752-2.752-5.504-2.752-8.256 0l-1.376 1.376 5.504 5.504Z"
@@ -52,7 +63,12 @@ const PortfolioEmptyIllustration = ({
           fill="#BEA0EB"
           d="M123.557 124.633c-.609.624-11.008 11.007-11.008 11.007l1.376 1.376c1.376 1.376 5.504 2.752 8.256 0l11.007-11.007c1.376-1.376 1.376-4.128 0-5.504l-6.879-6.88-5.504 5.504 2.752 2.752c.688.688.608 2.127 0 2.752Z"
         />
-        <circle cx={59.194} cy={76.106} r={15.375} fill="url(#d)" />
+        <circle
+          cx={59.194}
+          cy={76.106}
+          r={15.375}
+          fill={`url(#${gradientDId})`}
+        />
         <path
           fill="#fff"
           d="M68.31 73.57h-1.824c-1.004-2.788-3.705-4.7-7.267-4.7h-5.858v4.7h-2.034v1.686h2.034v1.768h-2.034v1.686h2.034v4.643h5.858c3.521 0 6.201-1.896 7.232-4.643h1.86v-1.686h-1.45c.035-.297.056-.605.056-.912v-.041c0-.277-.016-.549-.041-.815h1.44V73.57h-.005Zm-13.309-3.198h4.218c2.614 0 4.556 1.286 5.453 3.193h-9.67v-3.193Zm4.218 11.464h-4.218v-3.131h9.66c-.901 1.876-2.838 3.131-5.442 3.131Zm6.002-5.688c0 .297-.021.589-.062.87H55.001v-1.767h10.163c.036.276.056.563.056.856v.04Z"
@@ -79,7 +95,7 @@ const PortfolioEmptyIllustration = ({
         />
         <circle cx={27.675} cy={147.6} r={9.225} fill="#000" />
         <path
-          fill="url(#e)"
+          fill={`url(#${gradientEId})`}
           d="m32.24 149.901-1.523 1.591a.36.36 0 0 1-.259.11H23.24a.176.176 0 0 1-.097-.029.169.169 0 0 1-.032-.261l1.524-1.591a.35.35 0 0 1 .258-.11h7.219c.034 0 .068.01.097.029a.17.17 0 0 1 .077.173.168.168 0 0 1-.045.088Zm-1.523-3.204a.365.365 0 0 0-.259-.109H23.24a.175.175 0 0 0-.162.103.168.168 0 0 0 .033.186l1.524 1.591a.35.35 0 0 0 .258.11h7.219c.034 0 .068-.01.097-.028a.178.178 0 0 0 .065-.076.167.167 0 0 0-.033-.186l-1.523-1.591Zm-7.478-1.143h7.22a.36.36 0 0 0 .258-.109l1.523-1.591a.174.174 0 0 0 .045-.089.164.164 0 0 0-.012-.097.178.178 0 0 0-.065-.076.184.184 0 0 0-.097-.028h-7.219a.358.358 0 0 0-.258.109l-1.524 1.591a.174.174 0 0 0-.044.089.164.164 0 0 0 .012.097.176.176 0 0 0 .161.104Z"
         />
         <circle cx={172.968} cy={63.038} r={15.375} fill="#40477A" />
@@ -122,7 +138,7 @@ const PortfolioEmptyIllustration = ({
       </g>
       <defs>
         <linearGradient
-          id="c"
+          id={gradientCId}
           x1={125.306}
           x2={125.306}
           y1={150.675}
@@ -133,7 +149,7 @@ const PortfolioEmptyIllustration = ({
           <stop offset={1} stopColor="#1E0A3D" />
         </linearGradient>
         <linearGradient
-          id="d"
+          id={gradientDId}
           x1={59.194}
           x2={59.194}
           y1={56.375}
@@ -144,7 +160,7 @@ const PortfolioEmptyIllustration = ({
           <stop offset={1} stopColor="#FBCC5F" />
         </linearGradient>
         <linearGradient
-          id="e"
+          id={gradientEId}
           x1={23.841}
           x2={31.191}
           y1={151.793}
@@ -158,11 +174,11 @@ const PortfolioEmptyIllustration = ({
           <stop offset={0.72} stopColor="#28E0B9" />
           <stop offset={0.97} stopColor="#19FB9B" />
         </linearGradient>
-        <clipPath id="a">
+        <clipPath id={clipPathId}>
           <path fill="#fff" d="M0 0h246v246H0z" />
         </clipPath>
         <filter
-          id="b"
+          id={filterId}
           width={221.4}
           height={221.4}
           x={12.3}

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -76,6 +76,7 @@ interface Resources {
     };
     earn: {
       actions: {
+        goToPortfolio: 'Go to Portfolio';
         seeMore: 'see more';
         viewAllMarkets: 'View all markets';
       };
@@ -90,7 +91,7 @@ interface Resources {
           title: 'No results';
         };
         yourPositions: {
-          description: "Looks like you don't have any active positions in any market yet. Let's change that!";
+          description: "Looks like you don't have any active positions in any market yet.\nIf you think a position is missing try visiting your portfolio.";
           title: 'No positions';
           viewAllMarkets: 'View all markets';
         };
@@ -107,6 +108,10 @@ interface Resources {
         selected: '{{count}} selected';
         tag: 'Type';
         tvl: 'TVL';
+      };
+      missingPosition: {
+        description: 'Check your portfolio tokens before contacting support.';
+        title: 'Missing a position ?';
       };
       overview: {
         updated: 'Updated {{time}} ago';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -392,15 +392,20 @@
     },
     "actions": {
       "viewAllMarkets": "View all markets",
-      "seeMore": "see more"
+      "seeMore": "see more",
+      "goToPortfolio": "Go to Portfolio"
     },
     "position": {
       "label": "Your position"
     },
+    "missingPosition": {
+      "title": "Missing a position ?",
+      "description": "Check your portfolio tokens before contacting support."
+    },
     "emptyList": {
       "yourPositions": {
         "title": "No positions",
-        "description": "Looks like you don't have any active positions in any market yet. Let's change that!",
+        "description": "Looks like you don't have any active positions in any market yet.\nIf you think a position is missing try visiting your portfolio.",
         "viewAllMarkets": "View all markets"
       },
       "noResults": {

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -399,7 +399,7 @@
       "label": "Your position"
     },
     "missingPosition": {
-      "title": "Missing a position ?",
+      "title": "Missing a position?",
       "description": "Check your portfolio tokens before contacting support."
     },
     "emptyList": {


### PR DESCRIPTION
Design ticket: https://www.notion.so/lifi/Task-Empty-state-for-mission-positions-2cdf0ff14ac7801e955fc16c68e8e22a?v=22bf0ff14ac780589fc3000c52efb3df
Jira ticket: https://lifi.atlassian.net/browse/LF-17160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "missing position" placeholder cards in Earn with direct navigation to Portfolio.
  * Earn lists can now show an extra placeholder card to hint missing positions.
  * Empty-state dialogs support a primary and optional secondary action (two-button layout).

* **Style / UI**
  * Improved SVG instances to avoid ID collisions and ensure correct rendering.

* **Documentation**
  * Added translations and copy for missing-position guidance and "Go to Portfolio" action.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->