### PR TITLE
fix: add scrollMarginTop to earn opportunities section

### DIFF
--- a/src/app/ui/earn/EarnOpportunitiesAll/EarnOpportunitiesAll.tsx
+++ b/src/app/ui/earn/EarnOpportunitiesAll/EarnOpportunitiesAll.tsx
@@ -18,6 +18,7 @@ import { EarnViewAllMarketsButton } from '../EarnViewAllMarketsButton';
 import { EarnFilterTab } from '../types';
 import { EarnEmptyList } from '../EarnEmptyList/EarnEmptyList';
 import { useContactSupportEvent } from '@/components/Widgets/events/hooks/useContactSupportEvent';
+import { HeaderHeight } from '@/const/headerHeight';
 
 const EarnOpportunitiesAllInner = () => {
   useContactSupportEvent();
@@ -58,6 +59,11 @@ const EarnOpportunitiesAllInner = () => {
       <SectionCardContainer
         ref={sectionRef}
         sx={(theme) => ({
+          scrollMarginTop: {
+            xs: HeaderHeight.XS,
+            sm: HeaderHeight.SM,
+            md: HeaderHeight.MD,
+          },
           padding: theme.spacing(2),
           [theme.breakpoints.up('md')]: {
             padding: theme.spacing(3),


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-16971

## Testing steps
1. Go to `/earn`
2. On the `For you` tab click on `View all markets`
3. Check the whole section header (including tabs) are visible on the tab change
4. Select the mobile/table view and repeat steps `2-4`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved scroll navigation spacing: responsive top spacing now adjusts across breakpoints so section headers align correctly beneath the app header on small, medium, and large screens.
  * Result: smoother visual alignment and more consistent scrolling behavior when jumping between sections, especially on devices with different header sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->