### PR TITLE
feat: enable earn after date in prod

### DIFF
--- a/src/app/ui/gatekeeper/useGatekeeperStatus.ts
+++ b/src/app/ui/gatekeeper/useGatekeeperStatus.ts
@@ -1,4 +1,5 @@
 import { useAccountAddress } from '@/hooks/earn/useAccountAddress';
+import { isProduction } from '@/utils/isProduction';
 import { useQuery } from '@tanstack/react-query';
 
 export enum GatekeeperStatus {
@@ -14,10 +15,20 @@ interface GatekeeperData {
   error?: unknown;
 }
 
+const EARN_PUBLIC_RELEASE_DATE = new Date('2026-01-12T13:00:00Z');
+
+const isEarnEnabledByDefault = (): boolean => {
+  if (!isProduction) {
+    return true;
+  }
+  return new Date() >= EARN_PUBLIC_RELEASE_DATE;
+};
+
 export const useGatekeeperStatus = (flag: string): GatekeeperData => {
   console.log('7. useGatekeeperStatus');
 
   const accountAddress = useAccountAddress();
+  const earnEnabledByDefault = flag === 'hasEarn' && isEarnEnabledByDefault();
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['flags', accountAddress, flag],
@@ -30,8 +41,13 @@ export const useGatekeeperStatus = (flag: string): GatekeeperData => {
 
       return response.json();
     },
-    enabled: !!accountAddress,
+    enabled: !!accountAddress && !earnEnabledByDefault,
   });
+
+  // Enable hasEarn by default after the public release date (or always in non-production)
+  if (earnEnabledByDefault) {
+    return { status: GatekeeperStatus.SUCCESS };
+  }
 
   if (!accountAddress) {
     return { status: GatekeeperStatus.REQUIRES_CONNECT };


### PR DESCRIPTION
Enable earn and portfolio:
- in prod on monday 12, 1PM UTC
- in develop and staging, all the time

Testing:
- once this is merged and released, check on staging and develop that you can access the feature no matter the wallet (connected or not connected)
- check on develop this is not enabled,
- set a reminder for monday 1PM utc and check there that it's enabled

Contributes to

https://lifi.atlassian.net/browse/LF-16879
https://lifi.atlassian.net/browse/LF-16972

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced Earn feature availability logic with production-aware release date gating and optimized query conditions for improved feature control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->