### PR TITLE
fix: fetch remaining token balances for evm with default method

### DIFF
--- a/src/utils/getTokens/fetchAllTokensBalanceByChain.ts
+++ b/src/utils/getTokens/fetchAllTokensBalanceByChain.ts
@@ -9,7 +9,11 @@ import type {
   ExtendedTokenAmount,
   ExtendedTokenAmountWithChain,
 } from '@/utils/getTokens/index';
-import { getBalance, mergeTokenIntoSymbolMap } from '@/utils/getTokens/utils';
+import {
+  getBalance,
+  mergeTokenIntoSymbolMap,
+  deduplicateByChainAndAddress,
+} from '@/utils/getTokens/utils';
 
 const MAX_CROSS_CHAIN_FETCH = 10000; // Maximum tokens per fetch round across all chains
 const MAX_TOKENS_PER_CHAIN = 300; // Maximum tokens to fetch per chain per round
@@ -98,8 +102,8 @@ export function fetchAllTokensBalanceByChain(
 
     const fetchResults = await Promise.all(fetchPromises);
 
-    const detailedBalances: ExtendedTokenAmount[] = fetchResults
-      .flat()
+    const uniqueResults = deduplicateByChainAndAddress(fetchResults.flat());
+    const detailedBalances: ExtendedTokenAmount[] = uniqueResults
       .filter((t) => t.amount && t.amount > BigInt(0))
       .map((balance) => {
         const humanReadableBalance = getBalance(balance);

--- a/src/utils/getTokens/fetchAllTokensBalanceByChain.ts
+++ b/src/utils/getTokens/fetchAllTokensBalanceByChain.ts
@@ -122,11 +122,16 @@ export function fetchAllTokensBalanceByChain(
     totalPriceUSD += roundPriceUSD;
 
     for (const balance of detailedBalances) {
+      const formattedBalance = getBalance(balance);
+      const chainToken: ExtendedTokenAmountWithChain = {
+        ...balance,
+        cumulatedBalance: formattedBalance,
+      };
       const tokenWithChain: ExtendedTokenAmountWithChain = {
         ...balance,
-        cumulatedBalance: getBalance(balance),
+        cumulatedBalance: formattedBalance,
         cumulatedTotalUSD: balance.totalPriceUSD,
-        chains: [balance],
+        chains: [chainToken],
       };
       mergeTokenIntoSymbolMap(symbolMap, tokenWithChain);
     }

--- a/src/utils/getTokens/fetchAllTokensBalanceByChain.ts
+++ b/src/utils/getTokens/fetchAllTokensBalanceByChain.ts
@@ -1,4 +1,3 @@
-// Constants
 import type {
   ExtendedChain,
   Token,
@@ -10,7 +9,7 @@ import type {
   ExtendedTokenAmount,
   ExtendedTokenAmountWithChain,
 } from '@/utils/getTokens/index';
-import { getBalance } from '@/utils/getTokens/utils';
+import { getBalance, mergeTokenIntoSymbolMap } from '@/utils/getTokens/utils';
 
 const MAX_CROSS_CHAIN_FETCH = 10000; // Maximum tokens per fetch round across all chains
 const MAX_TOKENS_PER_CHAIN = 300; // Maximum tokens to fetch per chain per round
@@ -45,8 +44,7 @@ export function fetchAllTokensBalanceByChain(
   let totalPriceUSD: number = 0;
   let round = 1;
 
-  // This will store all fetched tokens indexed by their symbol
-  const symbolMap: Record<string, ExtendedTokenAmount> = {};
+  const symbolMap: Record<string, ExtendedTokenAmountWithChain> = {};
 
   const tokensByChain: Record<string, Token[]> = Object.keys(tokens).reduce(
     (acc, chainId) => {
@@ -123,53 +121,14 @@ export function fetchAllTokensBalanceByChain(
 
     totalPriceUSD += roundPriceUSD;
 
-    // Update symbolMap with fetched tokens and compute cumulated totals
     for (const balance of detailedBalances) {
-      let existingToken = symbolMap[balance.symbol];
-
-      if (existingToken) {
-        // If this symbol already exists, add this balance as a "chain" entry
-        existingToken.chains = existingToken.chains || [];
-        const chain = chains.find((c) => c.id === balance.chainId);
-        const humanReadableBalance = getBalance(balance);
-
-        existingToken = {
-          ...existingToken,
-          chains: [
-            ...existingToken.chains,
-            {
-              ...balance,
-              chainLogoURI: chain?.logoURI,
-              chainName: chain?.name,
-              cumulatedBalance: humanReadableBalance,
-              totalPriceUSD:
-                humanReadableBalance * parseFloat(balance.priceUSD),
-            },
-          ],
-        };
-
-        existingToken.chains = existingToken.chains.sort(
-          (a, b) => (b.totalPriceUSD ?? 0) - (a.totalPriceUSD ?? 0),
-        );
-        existingToken.cumulatedBalance = existingToken.chains.reduce(
-          (sum, chain) => sum + (chain.cumulatedBalance ?? 0),
-          0,
-        );
-        existingToken.cumulatedTotalUSD = existingToken.chains.reduce(
-          (sum, chain) => sum + (chain.totalPriceUSD ?? 0),
-          0,
-        );
-        symbolMap[balance.symbol] = existingToken;
-      } else {
-        balance.cumulatedBalance = getBalance(balance);
-
-        // If this symbol is new, store it in the symbol map
-        symbolMap[balance.symbol] = {
-          ...balance,
-          chains: [balance],
-          cumulatedTotalUSD: balance.totalPriceUSD!,
-        };
-      }
+      const tokenWithChain: ExtendedTokenAmountWithChain = {
+        ...balance,
+        cumulatedBalance: getBalance(balance),
+        cumulatedTotalUSD: balance.totalPriceUSD,
+        chains: [balance],
+      };
+      mergeTokenIntoSymbolMap(symbolMap, tokenWithChain);
     }
 
     // Pass the cumulative sum, cumulative price, and current state of the symbolMap to onProgress

--- a/src/utils/getTokens/index.ts
+++ b/src/utils/getTokens/index.ts
@@ -10,7 +10,11 @@ import {
 import type { Account } from '@lifi/wallet-management';
 import { fetchAllTokensBalanceByChain } from '@/utils/getTokens/fetchAllTokensBalanceByChain';
 import { transformWalletBalances } from '@/utils/getTokens/transformWalletBalances';
-import { sumBy } from 'lodash';
+import {
+  mergeTokenBalances,
+  filterExcludedTokens,
+} from '@/utils/getTokens/utils';
+import { sumBy, some } from 'lodash';
 
 export interface ExtendedTokenAmountWithChain extends ExtendedTokenAmount {
   chainLogoURI?: string;
@@ -43,31 +47,54 @@ async function getTokens(
   events: Events,
 ): Promise<undefined | ExtendedTokenAmountWithChain[]> {
   try {
-    const chains = await getChains({
-      chainTypes: [account.chainType],
-    });
+    const isEVM = account.chainType === ChainType.EVM && account.address;
 
-    if (account.chainType === ChainType.EVM && account.address) {
-      const walletBalances = await getWalletBalances(account.address);
+    const [chains, { tokens: allTokens }, walletBalances] = await Promise.all([
+      getChains({ chainTypes: [account.chainType] }),
+      LifiGetTokens({ chainTypes: [account.chainType] }),
+      isEVM ? getWalletBalances(account.address!) : Promise.resolve(null),
+    ]);
+
+    if (isEVM && walletBalances) {
       const transformed = transformWalletBalances(walletBalances, chains);
-
       const cumulativePriceUSD = sumBy(transformed, 'totalPriceUSD');
 
-      events.onProgress(account.address, 1, cumulativePriceUSD, transformed);
+      events.onProgress(account.address!, 1, cumulativePriceUSD, transformed);
 
-      return transformed;
+      const remainingTokens = filterExcludedTokens(allTokens, walletBalances);
+      const hasRemainingTokens = some(
+        remainingTokens,
+        (tokens) => tokens.length > 0,
+      );
+
+      if (!hasRemainingTokens) {
+        return transformed;
+      }
+
+      return new Promise((resolve) => {
+        fetchAllTokensBalanceByChain(
+          account.address!,
+          chains,
+          remainingTokens,
+          (addr, round, additionalPriceUSD, additionalBalances) => {
+            const merged = mergeTokenBalances(transformed, additionalBalances);
+            const totalPriceUSD = sumBy(merged, 'cumulatedTotalUSD');
+            events.onProgress(addr, round + 1, totalPriceUSD, merged);
+          },
+          (additionalBalances) => {
+            const merged = mergeTokenBalances(transformed, additionalBalances);
+            resolve(merged);
+          },
+        );
+      });
     }
-
-    const { tokens } = await LifiGetTokens({
-      chainTypes: [account.chainType],
-    });
 
     return new Promise((resolve, reject) => {
       try {
         fetchAllTokensBalanceByChain(
           account.address!,
           chains,
-          tokens,
+          allTokens,
           events.onProgress,
           (combinedBalance) => {
             resolve(combinedBalance);

--- a/src/utils/getTokens/index.ts
+++ b/src/utils/getTokens/index.ts
@@ -13,6 +13,7 @@ import { transformWalletBalances } from '@/utils/getTokens/transformWalletBalanc
 import {
   mergeTokenBalances,
   filterExcludedTokens,
+  deduplicateWalletBalances,
 } from '@/utils/getTokens/utils';
 import { sumBy, some } from 'lodash';
 
@@ -56,12 +57,16 @@ async function getTokens(
     ]);
 
     if (isEVM && walletBalances) {
-      const transformed = transformWalletBalances(walletBalances, chains);
+      const uniqueWalletBalances = deduplicateWalletBalances(walletBalances);
+      const transformed = transformWalletBalances(uniqueWalletBalances, chains);
       const cumulativePriceUSD = sumBy(transformed, 'totalPriceUSD');
 
       events.onProgress(account.address!, 1, cumulativePriceUSD, transformed);
 
-      const remainingTokens = filterExcludedTokens(allTokens, walletBalances);
+      const remainingTokens = filterExcludedTokens(
+        allTokens,
+        uniqueWalletBalances,
+      );
       const hasRemainingTokens = some(
         remainingTokens,
         (tokens) => tokens.length > 0,

--- a/src/utils/getTokens/utils.ts
+++ b/src/utils/getTokens/utils.ts
@@ -1,5 +1,16 @@
-import type { TokenAmount } from '@lifi/sdk';
+import type { Token, TokenAmount, TokensResponse } from '@lifi/sdk';
+import type { ExtendedTokenAmountWithChain } from '@/utils/getTokens/index';
 import { formatUnits } from 'viem';
+import {
+  orderBy,
+  sumBy,
+  concat,
+  first,
+  flatMap,
+  map,
+  reduce,
+  filter,
+} from 'lodash';
 
 export function getBalance(tokenBalance: Partial<TokenAmount>): number {
   return tokenBalance?.amount && tokenBalance?.decimals
@@ -16,4 +27,89 @@ export function arraysEqual(arr1: string[], arr2: string[]): boolean {
   const sortedArr2 = arr2.slice().sort();
 
   return sortedArr1.every((value, index) => value === sortedArr2[index]);
+}
+
+export function mergeTokenIntoSymbolMap(
+  symbolMap: Record<string, ExtendedTokenAmountWithChain>,
+  token: ExtendedTokenAmountWithChain,
+): void {
+  const existing = symbolMap[token.symbol];
+
+  if (existing) {
+    const mergedChains = concat(existing.chains || [], token.chains || []);
+    const sortedChains = orderBy(
+      mergedChains,
+      [(c) => c.totalPriceUSD ?? 0],
+      ['desc'],
+    );
+
+    const cumulatedBalance = sumBy(
+      sortedChains,
+      (c) => c.cumulatedBalance ?? 0,
+    );
+    const cumulatedTotalUSD = sumBy(sortedChains, (c) => c.totalPriceUSD ?? 0);
+
+    const primaryChain = first(sortedChains);
+
+    symbolMap[token.symbol] = {
+      ...existing,
+      chainId: primaryChain?.chainId ?? existing.chainId,
+      chainLogoURI: primaryChain?.chainLogoURI ?? existing.chainLogoURI,
+      chainName: primaryChain?.chainName ?? existing.chainName,
+      totalPriceUSD: primaryChain?.totalPriceUSD ?? existing.totalPriceUSD,
+      chains: sortedChains,
+      cumulatedBalance,
+      cumulatedTotalUSD,
+    };
+  } else {
+    symbolMap[token.symbol] = { ...token };
+  }
+}
+
+export function mergeTokenBalances(
+  primary: ExtendedTokenAmountWithChain[],
+  additional: ExtendedTokenAmountWithChain[],
+): ExtendedTokenAmountWithChain[] {
+  const symbolMap: Record<string, ExtendedTokenAmountWithChain> = {};
+
+  for (const token of primary) {
+    mergeTokenIntoSymbolMap(symbolMap, token);
+  }
+
+  for (const token of additional) {
+    mergeTokenIntoSymbolMap(symbolMap, token);
+  }
+
+  return orderBy(
+    Object.values(symbolMap),
+    [(t) => t.cumulatedTotalUSD ?? 0],
+    ['desc'],
+  );
+}
+
+export function filterExcludedTokens(
+  allTokens: TokensResponse['tokens'],
+  walletBalances: Record<number, { address: string }[]>,
+): TokensResponse['tokens'] {
+  const walletTokenKeys = new Set(
+    flatMap(walletBalances, (tokens, chainId) =>
+      map(tokens, (token) => `${chainId}:${token.address.toLowerCase()}`),
+    ),
+  );
+
+  return reduce(
+    allTokens,
+    (acc, tokens, chainId) => {
+      const filtered = filter(
+        tokens,
+        (token: Token) =>
+          !walletTokenKeys.has(`${chainId}:${token.address.toLowerCase()}`),
+      );
+      if (filtered.length > 0) {
+        acc[Number(chainId)] = filtered;
+      }
+      return acc;
+    },
+    {} as TokensResponse['tokens'],
+  );
 }

--- a/src/utils/getTokens/utils.ts
+++ b/src/utils/getTokens/utils.ts
@@ -10,6 +10,8 @@ import {
   map,
   reduce,
   filter,
+  uniqBy,
+  mapValues,
 } from 'lodash';
 
 export function getBalance(tokenBalance: Partial<TokenAmount>): number {
@@ -84,6 +86,20 @@ export function mergeTokenBalances(
     Object.values(symbolMap),
     [(t) => t.cumulatedTotalUSD ?? 0],
     ['desc'],
+  );
+}
+
+export function deduplicateByChainAndAddress<
+  T extends { chainId: number; address: string },
+>(tokens: T[]): T[] {
+  return uniqBy(tokens, (t) => `${t.chainId}:${t.address.toLowerCase()}`);
+}
+
+export function deduplicateWalletBalances<
+  T extends { chainId: number; address: string },
+>(walletBalances: Record<number, T[]>): Record<number, T[]> {
+  return mapValues(walletBalances, (tokens) =>
+    deduplicateByChainAndAddress(tokens),
   );
 }
 


### PR DESCRIPTION
Contributes to fixing missing wallet balances for https://lifi.atlassian.net/browse/LF-15787

This is only a workaround, as the `getWalletBalances` should retrieve all tokens available for a given wallet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster token balance retrieval with parallel fetching, an EVM-specific fast path using wallet balances, and early exit to avoid unnecessary fetches.

* **Refactor**
  * Centralized, consistent aggregation and deduplication of balances across chains with improved incremental progress reporting.

* **New Features**
  * Reusable utilities for merging, deduplicating, and filtering token balances to produce ordered, consolidated results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->