### PR TITLE
fix: Portfolio welcome screen now disappears

### DIFF
--- a/src/app/ui/app/App.tsx
+++ b/src/app/ui/app/App.tsx
@@ -1,13 +1,14 @@
 'use client';
+import { Box } from '@mui/material';
+import type React from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { AnnouncementBanner } from 'src/components/AnnouncementBanner/AnnouncementBanner';
+import { VerticalTabs } from 'src/components/Menus/VerticalMenu';
+import { HeaderHeight } from 'src/const/headerHeight';
+import { WelcomeOverlayLayout } from '@/components/WelcomeOverlayLayout/WelcomeOverlayLayout';
 import { WelcomeScreen } from '@/components/WelcomeScreen/WelcomeScreen';
 import { TrackingAction, TrackingCategory } from '@/const/trackingKeys';
 import { useWelcomeScreen } from '@/hooks/useWelcomeScreen';
-import { Box } from '@mui/material';
-import { VerticalTabs } from 'src/components/Menus/VerticalMenu';
-import React, { useEffect, useRef, useState } from 'react';
-import { AnnouncementBanner } from 'src/components/AnnouncementBanner/AnnouncementBanner';
-import { HeaderHeight } from 'src/const/headerHeight';
-import { WelcomeOverlayLayout } from '@/components/WelcomeOverlayLayout/WelcomeOverlayLayout';
 
 export interface AppProps {
   children: React.ReactNode;

--- a/src/app/ui/portfolio/PortfolioHeaderBreakdown.tsx
+++ b/src/app/ui/portfolio/PortfolioHeaderBreakdown.tsx
@@ -11,11 +11,10 @@ import { useSettingsStore } from '@/stores/settings/SettingsStore';
 import { usePortfolioTokens } from '@/utils/getTokens/usePortfolioTokens';
 import { useEffect, useMemo, useRef } from 'react';
 import type { MinimalToken } from 'src/types/tokens';
+import { usePortfolioWelcomeScreen } from '@/hooks/usePortfolioWelcomeScreen';
 
 export const PortfolioHeaderBreakdown = () => {
-  const portfolioWelcomeScreenClosed = useSettingsStore(
-    (state) => state.portfolioWelcomeScreenClosed,
-  );
+  const { portfolioWelcomeScreenClosed } = usePortfolioWelcomeScreen();
   const { trackPortfolioPageOverviewEvent } = usePortfolioTracking();
   const portfolioHasBeenTracked = useRef(false);
   const connectedAddresses = useConnectedEvmAddresses();

--- a/src/app/ui/portfolio/PortfolioHeaderOverview.tsx
+++ b/src/app/ui/portfolio/PortfolioHeaderOverview.tsx
@@ -18,11 +18,10 @@ import { useSettingsStore } from '@/stores/settings/SettingsStore';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import Typography from '@mui/material/Typography';
+import { usePortfolioWelcomeScreen } from '@/hooks/usePortfolioWelcomeScreen';
 
 export const PortfolioHeaderOverview = () => {
-  const portfolioWelcomeScreenClosed = useSettingsStore(
-    (state) => state.portfolioWelcomeScreenClosed,
-  );
+  const { portfolioWelcomeScreenClosed } = usePortfolioWelcomeScreen();
   const { t } = useTranslation();
   const theme = useTheme();
   const connectedAddresses = useConnectedEvmAddresses();

--- a/src/app/ui/portfolio/PortfolioPageOverlayLayout.tsx
+++ b/src/app/ui/portfolio/PortfolioPageOverlayLayout.tsx
@@ -2,7 +2,6 @@
 
 import { useAccount } from '@lifi/wallet-management';
 import type { FC, PropsWithChildren } from 'react';
-import { useEffect } from 'react';
 import { WelcomeOverlayLayout } from '@/components/WelcomeOverlayLayout/WelcomeOverlayLayout';
 import { HeaderHeight } from '@/const/headerHeight';
 import { TrackingAction, TrackingCategory } from '@/const/trackingKeys';
@@ -17,13 +16,6 @@ export const PortfolioPageOverlayLayout: FC<PropsWithChildren> = ({
 
   const { portfolioWelcomeScreenClosed, setPortfolioWelcomeScreenClosed } =
     usePortfolioWelcomeScreen();
-
-  useEffect(() => {
-    if (account?.address) {
-      return;
-    }
-    setPortfolioWelcomeScreenClosed(false);
-  }, [account?.address, setPortfolioWelcomeScreenClosed]);
 
   const handleOverlayClose = () => {
     setPortfolioWelcomeScreenClosed(true);

--- a/src/app/ui/portfolio/PortfolioPageOverlayLayout.tsx
+++ b/src/app/ui/portfolio/PortfolioPageOverlayLayout.tsx
@@ -1,25 +1,22 @@
 'use client';
 
-import { WelcomeOverlayLayout } from '@/components/WelcomeOverlayLayout/WelcomeOverlayLayout';
-import { TrackingCategory, TrackingAction } from '@/const/trackingKeys';
-import { HeaderHeight } from '@/const/headerHeight';
-import { useSettingsStore } from '@/stores/settings/SettingsStore';
-import { PortfolioWelcomeScreen } from './PortfolioWelcomeScreen';
 import { useAccount } from '@lifi/wallet-management';
-import { useEffect } from 'react';
 import type { FC, PropsWithChildren } from 'react';
+import { useEffect } from 'react';
+import { WelcomeOverlayLayout } from '@/components/WelcomeOverlayLayout/WelcomeOverlayLayout';
+import { HeaderHeight } from '@/const/headerHeight';
+import { TrackingAction, TrackingCategory } from '@/const/trackingKeys';
+import { usePortfolioWelcomeScreen } from '@/hooks/usePortfolioWelcomeScreen';
 import { PortfolioPageOverlayContentContainer } from './PortfolioPage.styles';
+import { PortfolioWelcomeScreen } from './PortfolioWelcomeScreen';
 
 export const PortfolioPageOverlayLayout: FC<PropsWithChildren> = ({
   children,
 }) => {
   const { account } = useAccount();
 
-  const [portfolioWelcomeScreenClosed, setPortfolioWelcomeScreenClosed] =
-    useSettingsStore((state) => [
-      state.portfolioWelcomeScreenClosed,
-      state.setPortfolioWelcomeScreenClosed,
-    ]);
+  const { portfolioWelcomeScreenClosed, setPortfolioWelcomeScreenClosed } =
+    usePortfolioWelcomeScreen();
 
   useEffect(() => {
     if (account?.address) {
@@ -57,7 +54,7 @@ export const PortfolioPageOverlayLayout: FC<PropsWithChildren> = ({
       fullWidthGlowEffect
     >
       <PortfolioPageOverlayContentContainer
-        portfolioWelcomeScreenClosed={portfolioWelcomeScreenClosed}
+        portfolioWelcomeScreenClosed={portfolioWelcomeScreenClosed ?? false}
       >
         {children}
       </PortfolioPageOverlayContentContainer>

--- a/src/app/ui/portfolio/PortfolioWelcomeScreen.tsx
+++ b/src/app/ui/portfolio/PortfolioWelcomeScreen.tsx
@@ -1,20 +1,21 @@
 'use client';
 
-import { CustomColor } from '@/components/CustomColorTypography.style';
-import { TrackingAction, TrackingCategory } from '@/const/trackingKeys';
-import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
+import Typography from '@mui/material/Typography';
 import type { FC, MouseEventHandler } from 'react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Trans } from 'react-i18next/TransWithoutContext';
+import { CustomColor } from '@/components/CustomColorTypography.style';
 import { ToolCards } from '@/components/WelcomeScreen/ToolCard/ToolCards';
 import {
   ContentWrapper,
   WelcomeContent,
   WelcomeScreenSubtitle,
 } from '@/components/WelcomeScreen/WelcomeScreen.style';
+import { TrackingAction, TrackingCategory } from '@/const/trackingKeys';
 import { AppPaths } from '@/const/urls';
-import Typography from '@mui/material/Typography';
+import { usePortfolioWelcomeScreen } from '@/hooks/usePortfolioWelcomeScreen';
+import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
 import {
   PortfolioWelcomeScreenButton,
   PortfolioWelcomeScreenButtonsContainer,
@@ -28,28 +29,35 @@ interface PortfolioWelcomeScreenProps {
 export const PortfolioWelcomeScreen: FC<PortfolioWelcomeScreenProps> = ({
   onClose,
 }) => {
+  const { portfolioWelcomeScreenClosed, setPortfolioWelcomeScreenClosed } =
+    usePortfolioWelcomeScreen();
   const { t } = useTranslation();
   const { trackEvent } = useUserTracking();
   const [openChainsToolModal, setOpenChainsToolModal] = useState(false);
   const [openBridgesToolModal, setOpenBridgesToolModal] = useState(false);
   const [openDexsToolModal, setOpenDexsToolModal] = useState(false);
   useEffect(() => {
-    trackEvent({
-      category: TrackingCategory.Portfolio,
-      action: TrackingAction.ShowWelcomeMessageScreen,
-      label: 'open-welcome-screen',
-    });
-  }, [trackEvent]);
+    if (portfolioWelcomeScreenClosed) {
+      trackEvent({
+        category: TrackingCategory.Portfolio,
+        action: TrackingAction.ShowWelcomeMessageScreen,
+        label: 'open-portfolio-welcome-screen',
+      });
+    }
+  }, [trackEvent, portfolioWelcomeScreenClosed]);
 
   const handleGetStarted: MouseEventHandler<HTMLButtonElement> = (event) => {
     event.stopPropagation();
     onClose();
-    trackEvent({
-      category: TrackingCategory.Portfolio,
-      action: TrackingAction.CloseWelcomeScreen,
-      label: 'enter_portfolio_welcome_screen',
-      enableAddressable: true,
-    });
+    if (!portfolioWelcomeScreenClosed) {
+      setPortfolioWelcomeScreenClosed(true);
+      trackEvent({
+        category: TrackingCategory.Portfolio,
+        action: TrackingAction.CloseWelcomeScreen,
+        label: 'enter_portfolio_welcome_screen',
+        enableAddressable: true,
+      });
+    }
   };
 
   return (

--- a/src/app/ui/portfolio/PortfolioWelcomeScreen.tsx
+++ b/src/app/ui/portfolio/PortfolioWelcomeScreen.tsx
@@ -21,6 +21,7 @@ import {
   PortfolioWelcomeScreenButtonsContainer,
   PortfolioWelcomeScreenLink,
 } from './PortfolioPage.styles';
+import { useAccount, useWalletMenu } from '@lifi/wallet-management';
 
 interface PortfolioWelcomeScreenProps {
   onClose: () => void;
@@ -33,6 +34,9 @@ export const PortfolioWelcomeScreen: FC<PortfolioWelcomeScreenProps> = ({
     usePortfolioWelcomeScreen();
   const { t } = useTranslation();
   const { trackEvent } = useUserTracking();
+  const { account } = useAccount();
+  const { openWalletMenu } = useWalletMenu();
+
   const [openChainsToolModal, setOpenChainsToolModal] = useState(false);
   const [openBridgesToolModal, setOpenBridgesToolModal] = useState(false);
   const [openDexsToolModal, setOpenDexsToolModal] = useState(false);
@@ -47,6 +51,10 @@ export const PortfolioWelcomeScreen: FC<PortfolioWelcomeScreenProps> = ({
   }, [trackEvent, portfolioWelcomeScreenClosed]);
 
   const handleGetStarted: MouseEventHandler<HTMLButtonElement> = (event) => {
+    if (!account.address) {
+      openWalletMenu();
+    }
+
     event.stopPropagation();
     onClose();
     if (!portfolioWelcomeScreenClosed) {

--- a/src/components/WelcomeScreen/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen/WelcomeScreen.tsx
@@ -22,8 +22,8 @@ interface WelcomeScreenProps {
 }
 
 export const WelcomeScreen = ({ activeTheme }: WelcomeScreenProps) => {
-  const { welcomeScreenClosed, setWelcomeScreenClosed } =
-    useWelcomeScreen();
+  const { welcomeScreenClosed, setWelcomeScreenClosed } = useWelcomeScreen();
+
   const { t } = useTranslation();
   const { trackEvent } = useUserTracking();
   const [openChainsToolModal, setOpenChainsToolModal] = useState(false);

--- a/src/components/composite/WalletBalanceCard/components/WalletWithActions.tsx
+++ b/src/components/composite/WalletBalanceCard/components/WalletWithActions.tsx
@@ -1,15 +1,3 @@
-import {
-  TrackingAction,
-  TrackingCategory,
-  TrackingEventParameter,
-} from '@/const/trackingKeys';
-import { useChains } from '@/hooks/useChains';
-import { useMultisig } from '@/hooks/useMultisig';
-import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
-import { useMenuStore } from '@/stores/menu';
-import { usePortfolioStore } from '@/stores/portfolio';
-import { openInNewTab } from '@/utils/openInNewTab';
-import { walletDigest } from '@/utils/walletDigest';
 import type { Account } from '@lifi/wallet-management';
 import {
   getConnectorIcon,
@@ -22,26 +10,36 @@ import { Stack, Typography } from '@mui/material';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import AvatarBadge from 'src/components/AvatarBadge/AvatarBadge';
 import { ButtonTransparent } from 'src/components/Button';
 import { JUMPER_SCAN_PATH } from 'src/const/urls';
+import {
+  TrackingAction,
+  TrackingCategory,
+  TrackingEventParameter,
+} from '@/const/trackingKeys';
+import { useDominantColorFromImage } from '@/hooks/images/useGetColorsFromImage';
+import { useChains } from '@/hooks/useChains';
+import { useMultisig } from '@/hooks/useMultisig';
+import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
+import { useMenuStore } from '@/stores/menu';
+import { usePortfolioStore } from '@/stores/portfolio';
+import { useSettingsStore } from '@/stores/settings/SettingsStore';
+import { openInNewTab } from '@/utils/openInNewTab';
+import { walletDigest } from '@/utils/walletDigest';
 import {
   DarkIconButton,
   SecondaryIconButton,
   WalletBalanceSharedContainer,
   WalletInfoContainer,
 } from '../WalletBalanceCard.styles';
-import AvatarBadge from 'src/components/AvatarBadge/AvatarBadge';
-import { useDominantColorFromImage } from '@/hooks/images/useGetColorsFromImage';
-import { useSettingsStore } from '@/stores/settings/SettingsStore';
 
 interface WalletWithActionsProps {
   account: Account;
 }
 export const WalletWithActions = ({ account }: WalletWithActionsProps) => {
   const { t } = useTranslation();
-  const setPortfolioWelcomeScreenClosed = useSettingsStore(
-    (state) => state.setPortfolioWelcomeScreenClosed,
-  );
+
   const disconnectWallet = useAccountDisconnect();
   const { trackEvent } = useUserTracking();
   const { chains } = useChains();
@@ -141,7 +139,6 @@ export const WalletWithActions = ({ account }: WalletWithActionsProps) => {
 
     disconnectWallet(account).then(() => {
       deleteCacheTokenAddress(walletAddress);
-      setPortfolioWelcomeScreenClosed(false);
     });
 
     trackEvent({

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -2,14 +2,14 @@ interface DefaultSettingsType {
   clientWallets: string[];
   disabledFeatureCards: string[];
   welcomeScreenClosed: boolean;
-  portfolioWelcomeScreenClosed: boolean;
+  portfolioWelcomeScreenClosed: Record<string, boolean>;
 }
 
 export const defaultSettings: DefaultSettingsType = {
   clientWallets: [],
   disabledFeatureCards: [],
   welcomeScreenClosed: false,
-  portfolioWelcomeScreenClosed: false,
+  portfolioWelcomeScreenClosed: {},
 };
 
 interface DefaultFpType {

--- a/src/hooks/usePortfolioWelcomeScreen.ts
+++ b/src/hooks/usePortfolioWelcomeScreen.ts
@@ -1,38 +1,64 @@
-import { useCallback } from 'react';
-import { useMainPaths } from '@/hooks/useMainPaths';
+import { useAccount } from '@lifi/wallet-management';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSettingsStore } from '@/stores/settings';
 
 interface UsePortfolioWelcomeScreenResult {
   portfolioWelcomeScreenClosed: boolean | undefined;
   setPortfolioWelcomeScreenClosed: (closed: boolean) => void;
-  enabled: boolean;
 }
 
 export const usePortfolioWelcomeScreen =
   (): UsePortfolioWelcomeScreenResult => {
-    const { isMainPaths } = useMainPaths();
+    const { account } = useAccount();
+    const [
+      temporaryPortfolioWelcomeClosed,
+      setTemporaryPortfolioWelcomeClosed,
+    ] = useState(false);
 
-    const [portfolioWelcomeScreenClosed, setPortfolioWelcomeScreenClosed] =
+    const [allPortfolioWelcomeScreenClosed, setPortfolioWelcomeScreenClosed] =
       useSettingsStore((state) => [
         state.portfolioWelcomeScreenClosed,
         state.setPortfolioWelcomeScreenClosed,
       ]);
 
-    const enabled = !!isMainPaths;
-
+    const portfolioWelcomeScreenClosed = useMemo(() => {
+      if (!account.address) {
+        return false;
+      }
+      return (
+        allPortfolioWelcomeScreenClosed[account.address] ||
+        temporaryPortfolioWelcomeClosed
+      );
+    }, [
+      account.address,
+      temporaryPortfolioWelcomeClosed,
+      allPortfolioWelcomeScreenClosed,
+    ]);
     const updateState = useCallback(
       (closed: boolean) => {
-        if (!enabled) {
-          return;
-        }
-        setPortfolioWelcomeScreenClosed(closed);
+        setTemporaryPortfolioWelcomeClosed(closed);
+        setPortfolioWelcomeScreenClosed(account.address, closed);
       },
-      [enabled, setPortfolioWelcomeScreenClosed],
+      [account.address, setPortfolioWelcomeScreenClosed],
     );
+
+    useEffect(() => {
+      if (
+        temporaryPortfolioWelcomeClosed &&
+        account &&
+        !portfolioWelcomeScreenClosed
+      ) {
+        updateState(true);
+      }
+    }, [
+      account,
+      portfolioWelcomeScreenClosed,
+      temporaryPortfolioWelcomeClosed,
+      updateState,
+    ]);
 
     return {
       portfolioWelcomeScreenClosed,
       setPortfolioWelcomeScreenClosed: updateState,
-      enabled,
     };
   };

--- a/src/hooks/usePortfolioWelcomeScreen.ts
+++ b/src/hooks/usePortfolioWelcomeScreen.ts
@@ -21,6 +21,29 @@ export const usePortfolioWelcomeScreen =
         state.setPortfolioWelcomeScreenClosed,
       ]);
 
+    const updateState = useCallback(
+      (closed: boolean) => {
+        setTemporaryPortfolioWelcomeClosed(closed);
+        setPortfolioWelcomeScreenClosed(account.address, closed);
+      },
+      [account.address, setPortfolioWelcomeScreenClosed],
+    );
+
+    useEffect(() => {
+      if (
+        temporaryPortfolioWelcomeClosed &&
+        account?.address &&
+        !allPortfolioWelcomeScreenClosed[account.address]
+      ) {
+        updateState(true);
+      }
+    }, [
+      account.address,
+      allPortfolioWelcomeScreenClosed,
+      temporaryPortfolioWelcomeClosed,
+      updateState,
+    ]);
+
     const portfolioWelcomeScreenClosed = useMemo(() => {
       if (!account.address) {
         return false;
@@ -33,28 +56,6 @@ export const usePortfolioWelcomeScreen =
       account.address,
       temporaryPortfolioWelcomeClosed,
       allPortfolioWelcomeScreenClosed,
-    ]);
-    const updateState = useCallback(
-      (closed: boolean) => {
-        setTemporaryPortfolioWelcomeClosed(closed);
-        setPortfolioWelcomeScreenClosed(account.address, closed);
-      },
-      [account.address, setPortfolioWelcomeScreenClosed],
-    );
-
-    useEffect(() => {
-      if (
-        temporaryPortfolioWelcomeClosed &&
-        account &&
-        !portfolioWelcomeScreenClosed
-      ) {
-        updateState(true);
-      }
-    }, [
-      account,
-      portfolioWelcomeScreenClosed,
-      temporaryPortfolioWelcomeClosed,
-      updateState,
     ]);
 
     return {

--- a/src/hooks/usePortfolioWelcomeScreen.ts
+++ b/src/hooks/usePortfolioWelcomeScreen.ts
@@ -1,15 +1,12 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback } from 'react';
 import { useMainPaths } from '@/hooks/useMainPaths';
 import { useSettingsStore } from '@/stores/settings';
-import { useThemeStore } from '@/stores/theme';
 
 interface usePortfolioWelcomeScreenResult {
   portfolioWelcomeScreenClosed: boolean | undefined;
   setPortfolioWelcomeScreenClosed: (closed: boolean) => void;
   enabled: boolean;
 }
-
-export const validThemes = ['default', 'light', 'dark', 'system'];
 
 export const usePortfolioWelcomeScreen =
   (): usePortfolioWelcomeScreenResult => {

--- a/src/hooks/usePortfolioWelcomeScreen.ts
+++ b/src/hooks/usePortfolioWelcomeScreen.ts
@@ -2,14 +2,14 @@ import { useCallback } from 'react';
 import { useMainPaths } from '@/hooks/useMainPaths';
 import { useSettingsStore } from '@/stores/settings';
 
-interface usePortfolioWelcomeScreenResult {
+interface UsePortfolioWelcomeScreenResult {
   portfolioWelcomeScreenClosed: boolean | undefined;
   setPortfolioWelcomeScreenClosed: (closed: boolean) => void;
   enabled: boolean;
 }
 
 export const usePortfolioWelcomeScreen =
-  (): usePortfolioWelcomeScreenResult => {
+  (): UsePortfolioWelcomeScreenResult => {
     const { isMainPaths } = useMainPaths();
 
     const [portfolioWelcomeScreenClosed, setPortfolioWelcomeScreenClosed] =

--- a/src/hooks/usePortfolioWelcomeScreen.ts
+++ b/src/hooks/usePortfolioWelcomeScreen.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { useMainPaths } from '@/hooks/useMainPaths';
+import { useSettingsStore } from '@/stores/settings';
+import { useThemeStore } from '@/stores/theme';
+
+interface usePortfolioWelcomeScreenResult {
+  portfolioWelcomeScreenClosed: boolean | undefined;
+  setPortfolioWelcomeScreenClosed: (closed: boolean) => void;
+  enabled: boolean;
+}
+
+export const validThemes = ['default', 'light', 'dark', 'system'];
+
+export const usePortfolioWelcomeScreen =
+  (): usePortfolioWelcomeScreenResult => {
+    const { isMainPaths } = useMainPaths();
+
+    const [portfolioWelcomeScreenClosed, setPortfolioWelcomeScreenClosed] =
+      useSettingsStore((state) => [
+        state.portfolioWelcomeScreenClosed,
+        state.setPortfolioWelcomeScreenClosed,
+      ]);
+
+    const enabled = !!isMainPaths;
+
+    const updateState = useCallback(
+      (closed: boolean) => {
+        if (!enabled) {
+          return;
+        }
+        setPortfolioWelcomeScreenClosed(closed);
+      },
+      [enabled, setPortfolioWelcomeScreenClosed],
+    );
+
+    return {
+      portfolioWelcomeScreenClosed,
+      setPortfolioWelcomeScreenClosed: updateState,
+      enabled,
+    };
+  };

--- a/src/hooks/usePortfolioWelcomeScreen.ts
+++ b/src/hooks/usePortfolioWelcomeScreen.ts
@@ -32,15 +32,17 @@ export const usePortfolioWelcomeScreen =
     useEffect(() => {
       if (
         temporaryPortfolioWelcomeClosed &&
-        account?.address &&
+        account.address &&
         !allPortfolioWelcomeScreenClosed[account.address]
       ) {
         updateState(true);
+        setTemporaryPortfolioWelcomeClosed(false);
       }
     }, [
       account.address,
       allPortfolioWelcomeScreenClosed,
       temporaryPortfolioWelcomeClosed,
+      setTemporaryPortfolioWelcomeClosed,
       updateState,
     ]);
 

--- a/src/stores/settings/SettingsStore.tsx
+++ b/src/stores/settings/SettingsStore.tsx
@@ -1,10 +1,10 @@
 'use client';
 import type { SettingsState, SettingsStore } from '@/types/settings';
 import type { PropsWithChildren } from 'react';
-import { createContext, useContext, useEffect, useRef } from 'react';
+import { createContext, useContext, useRef } from 'react';
 import { shallow } from 'zustand/shallow';
 import { createSettingsStore } from './createSettingsStore';
-import { useColorScheme, useMediaQuery } from '@mui/material';
+import { useColorScheme } from '@mui/material';
 
 export const SettingsStoreContext = createContext<SettingsStore | null>(null);
 

--- a/src/stores/settings/createSettingsStore.tsx
+++ b/src/stores/settings/createSettingsStore.tsx
@@ -64,7 +64,7 @@ export const createSettingsStore = (props: Partial<SettingsProps>) =>
       }),
       {
         name: 'jumper-store',
-        version: 3,
+        version: 4,
         migrate: (persistedState: any, version: number) => {
           if (version === 0) {
             const newStore = { ...persistedState };
@@ -87,6 +87,15 @@ export const createSettingsStore = (props: Partial<SettingsProps>) =>
 
             console.debug('welcomeScreenClosed cookie migrated');
 
+            return newStore;
+          }
+          if (version === 3) {
+            const newStore = { ...persistedState };
+            if (
+              typeof persistedState.portfolioWelcomeScreenClosed !== 'object'
+            ) {
+              newStore.portfolioWelcomeScreenClosed = {};
+            }
             return newStore;
           }
           return persistedState;

--- a/src/stores/settings/createSettingsStore.tsx
+++ b/src/stores/settings/createSettingsStore.tsx
@@ -92,7 +92,7 @@ export const createSettingsStore = (props: Partial<SettingsProps>) =>
           if (version === 3) {
             const newStore = { ...persistedState };
             if (
-              typeof persistedState.portfolioWelcomeScreenClosed !== 'object'
+              typeof persistedState.portfolioWelcomeScreenClosed === 'boolean'
             ) {
               newStore.portfolioWelcomeScreenClosed = {};
             }

--- a/src/stores/settings/createSettingsStore.tsx
+++ b/src/stores/settings/createSettingsStore.tsx
@@ -1,10 +1,10 @@
-import { defaultSettings } from '@/config/config';
-import type { SettingsProps, SettingsState } from '@/types/settings';
+import Cookies from 'universal-cookie';
 import type { StateCreator } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { shallow } from 'zustand/shallow';
 import { createWithEqualityFn } from 'zustand/traditional';
-import Cookies from 'universal-cookie';
+import { defaultSettings } from '@/config/config';
+import type { SettingsProps, SettingsState } from '@/types/settings';
 
 export const createSettingsStore = (props: Partial<SettingsProps>) =>
   createWithEqualityFn(
@@ -33,9 +33,18 @@ export const createSettingsStore = (props: Partial<SettingsProps>) =>
         },
 
         // Portfolio Welcome Screen
-        setPortfolioWelcomeScreenClosed: (shown: boolean) => {
+        setPortfolioWelcomeScreenClosed: (
+          address: string | undefined,
+          shown: boolean,
+        ) => {
+          if (!address) {
+            return;
+          }
           set({
-            portfolioWelcomeScreenClosed: shown,
+            portfolioWelcomeScreenClosed: {
+              ...(get() as SettingsProps).portfolioWelcomeScreenClosed,
+              [address]: shown,
+            },
           });
         },
 

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -7,7 +7,7 @@ export interface SettingsProps {
   clientWallets: string[];
   disabledFeatureCards: string[];
   welcomeScreenClosed: boolean;
-  portfolioWelcomeScreenClosed: boolean;
+  portfolioWelcomeScreenClosed: Record<string, boolean>;
 }
 
 export interface SettingsActions {
@@ -24,7 +24,10 @@ export interface SettingsActions {
   setWelcomeScreenClosed: (shown: boolean) => void;
 
   // Portfolio Welcome Screen
-  setPortfolioWelcomeScreenClosed: (shown: boolean) => void;
+  setPortfolioWelcomeScreenClosed: (
+    address: string | undefined,
+    shown: boolean,
+  ) => void;
 }
 
 export type SettingsState = SettingsActions & SettingsProps;


### PR DESCRIPTION
This PR aims at allowing the portfolio welcome screen to disappear after the first visit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Welcome dismissal is now tracked per-account and centralized via a new hook for consistent UI behavior.
* **New Features**
  * "Get Started" now prompts the wallet UI when no account is present.
  * Avatars use computed dominant colors for richer visuals.
* **Bug Fixes**
  * Tracking events are guarded to fire only after state updates to prevent duplicates.
* **Chores**
  * Settings storage migrated to per-account flags; persisted store version updated.

No public API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->