### PR TITLE
fix: add missing callback on withdraw execution completed

### DIFF
--- a/src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget.tsx
@@ -24,12 +24,14 @@ import { ZapPlaceholderWidget } from './ZapPlaceholderWidget';
 interface ZapWithdrawWidgetProps extends Omit<WidgetProps, 'type'> {
   ctx: ZapWidgetContext;
   zapData?: ZapDataResponse | null;
+  refetchWithdrawToken?: () => void;
 }
 
 export const ZapWithdrawWidget: FC<ZapWithdrawWidgetProps> = ({
   zapData,
   customInformation,
   ctx,
+  refetchWithdrawToken,
 }) => {
   const projectData = useMemo(() => {
     return customInformation?.projectData;
@@ -88,16 +90,28 @@ export const ZapWithdrawWidget: FC<ZapWithdrawWidgetProps> = ({
   const widgetEvents = useWidgetEvents();
   // Custom effect to refetch the balance
   useEffect(() => {
+    function onRouteExecutionCompleted() {
+      refetchWithdrawToken?.();
+    }
     const onRouteContactSupport = () => {
       setSupportModalState(true);
     };
 
+    widgetEvents.on(
+      WidgetEvent.RouteExecutionCompleted,
+      onRouteExecutionCompleted,
+    );
+
     widgetEvents.on(WidgetEvent.ContactSupport, onRouteContactSupport);
 
     return () => {
+      widgetEvents.off(
+        WidgetEvent.RouteExecutionCompleted,
+        onRouteExecutionCompleted,
+      );
       widgetEvents.off(WidgetEvent.ContactSupport, onRouteContactSupport);
     };
-  }, [widgetEvents, setSupportModalState]);
+  }, [widgetEvents, refetchWithdrawToken, setSupportModalState]);
 
   const widgetConfig = useWidgetConfig('zap', enhancedCtx);
 

--- a/src/components/composite/WithdrawModal/WithdrawModal.tsx
+++ b/src/components/composite/WithdrawModal/WithdrawModal.tsx
@@ -8,6 +8,7 @@ import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import type { EarnOpportunityExtended } from '@/stores/withdrawFlow/WithdrawFlowStore';
 import { useZapEarnOpportunitySlugStorage } from '@/providers/hooks';
+import { useWithdrawFlowStore } from '@/stores/withdrawFlow/WithdrawFlowStore';
 
 interface WithdrawModalProps extends ModalContainerProps {
   earnOpportunity: EarnOpportunityExtended;
@@ -24,13 +25,16 @@ export const WithdrawModal: FC<WithdrawModalProps> = ({
   const { projectData, zapData } =
     useProjectLikeDataFromEarnOpportunity(earnOpportunity);
 
-  //   const refetchCallback = useDepositFlowStore((state) => state.refetchCallback);
+  const refetchCallback = useWithdrawFlowStore(
+    (state) => state.refetchCallback,
+  );
 
   return (
     <ModalContainer isOpen={isOpen} onClose={onClose}>
       <ZapWithdrawWidget
         customInformation={{ projectData }}
         zapData={zapData}
+        refetchWithdrawToken={refetchCallback}
         ctx={{
           theme: {
             container: {


### PR DESCRIPTION
Contributes to withdraw issue noticed by QA on https://lifi.atlassian.net/browse/LF-17171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Token balance now automatically refreshes upon completion of withdrawal transactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->