### PR TITLE
fix: filter out empty positions

### DIFF
--- a/src/app/ui/portfolio/PortfolioDeFiProtocolsList.tsx
+++ b/src/app/ui/portfolio/PortfolioDeFiProtocolsList.tsx
@@ -10,6 +10,7 @@ import { DeFiPositionCardSkeleton } from '@/components/composite/DeFiPositionCar
 import { AnimatePresence } from 'motion/react';
 import { useContactSupportEvent } from '@/components/Widgets/events/hooks/useContactSupportEvent';
 import { PortfolioAnimatedAssetContainer } from './PortfolioAnimatedAssetContainer';
+import { hasPositionDataToDisplay } from '@/components/composite/DeFiPositionCard/utils';
 
 export const PortfolioDeFiProtocolsList = () => {
   useContactSupportEvent();

--- a/src/components/composite/DeFiPositionCard/utils.tsx
+++ b/src/components/composite/DeFiPositionCard/utils.tsx
@@ -192,3 +192,11 @@ export const renderBorrowedActions = ({}: {
     useFlexGap
   ></StyledPositionActions>
 );
+
+export const hasPositionDataToDisplay = (position: DefiPosition) => {
+  return (
+    position.supplyTokens?.length > 0 ||
+    position.borrowTokens?.length > 0 ||
+    position.rewardTokens?.length > 0
+  );
+};

--- a/src/hooks/portfolio/useFormatDisplayDeFiPositions.ts
+++ b/src/hooks/portfolio/useFormatDisplayDeFiPositions.ts
@@ -7,6 +7,7 @@ import {
   defiGroupSortAccessors,
   sortPortfolioItems,
 } from '@/app/ui/portfolio/utils';
+import { hasPositionDataToDisplay } from '@/components/composite/DeFiPositionCard/utils';
 
 const defaultGroupByProtocolName = (position: DefiPosition) =>
   position.protocol.name;
@@ -35,6 +36,10 @@ export const useFormatDisplayDeFiPositions = (
         defiGroupSortAccessors,
       );
     }
+
+    groups = groups
+      .map((positions) => positions.filter(hasPositionDataToDisplay))
+      .filter((positions) => positions.length > 0);
 
     return groups;
   }, [positions, groupByFn, sortBy, order]);


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-17207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed portfolio display to filter out empty DeFi protocol groups. Protocol groups without displayable positions are now hidden, showing only active positions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->