### PR TITLE
refactor: introduce (Simple|Extended)Token classes

### DIFF
--- a/src/components/Cards/EarnCard/EarnCard.snapshot.spec.tsx
+++ b/src/components/Cards/EarnCard/EarnCard.snapshot.spec.tsx
@@ -84,10 +84,8 @@ vi.mock('src/hooks/useChains', () => ({
 
 vi.mock('src/hooks/useTokens', () => ({
   useTokens: () => ({
-    data: {
-      tokens: mockedTokens,
-    },
-    getTokenByAddressAndChain: (address: string, chainId: number) =>
+    tokens: mockedTokens,
+    getToken: (chainId: number, address: string) =>
       mockedTokens.find(
         (token) => token.address === address && token.chain.chainId === chainId,
       ),

--- a/src/components/EarnDetails/EarnDetailsActionsPosition.tsx
+++ b/src/components/EarnDetails/EarnDetailsActionsPosition.tsx
@@ -3,8 +3,11 @@ import type { TooltipProps } from '@mui/material/Tooltip';
 import { type FC, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Address } from 'viem';
+
 import { useToken } from '@/hooks/useToken';
 import type { Token } from '@/types/jumper-backend';
+
+import { formatUSD } from '../../utils/formatNumbers';
 import { SimpleToken } from '../../utils/Token';
 import { SelectCard } from '../Cards/SelectCard/SelectCard';
 import { SelectCardMode } from '../Cards/SelectCard/SelectCard.styles';
@@ -64,7 +67,7 @@ export const EarnDetailsActionsPosition: FC<
         formattedAmountUSD = extendedToken.formatAmountUSD(amount);
       } else if (amountUSD) {
         formattedAmount = extendedToken.formatAmountFromUSD(amountUSD);
-        formattedAmountUSD = extendedToken.formatAmountUSD(amountUSD);
+        formattedAmountUSD = formatUSD(amountUSD);
       } else {
         formattedAmount = extendedToken.formatZeroAmount();
         formattedAmountUSD = extendedToken.formatZeroUSD();

--- a/src/components/EarnDetails/EarnDetailsActionsPosition.tsx
+++ b/src/components/EarnDetails/EarnDetailsActionsPosition.tsx
@@ -1,36 +1,23 @@
-import {
-  priceToTokenAmount,
-  formatTokenPrice,
-  formatTokenAmount,
-} from '@lifi/widget';
-import { useMemo, type FC } from 'react';
+import Box from '@mui/material/Box';
+import type { TooltipProps } from '@mui/material/Tooltip';
+import { type FC, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { Address } from 'viem';
+import { useToken } from '@/hooks/useToken';
+import type { Token } from '@/types/jumper-backend';
+import { SimpleToken } from '../../utils/Token';
 import { SelectCard } from '../Cards/SelectCard/SelectCard';
 import { SelectCardMode } from '../Cards/SelectCard/SelectCard.styles';
 import { EntityChainStack } from '../composite/EntityChainStack/EntityChainStack';
 import { EntityChainStackVariant } from '../composite/EntityChainStack/EntityChainStack.types';
 import { AvatarSize } from '../core/AvatarStack/AvatarStack.types';
-import { useTokens } from '@/hooks/useTokens';
-import type { Token } from '@/types/jumper-backend';
-import { currencyFormatter } from '@/utils/formatNumbers';
-import { useTranslation } from 'react-i18next';
-import { useToken } from '@/hooks/useToken';
 import { Tooltip } from '../core/Tooltip/Tooltip';
-import Box from '@mui/material/Box';
-import type { TooltipProps } from '@mui/material/Tooltip';
 
 interface EarnDetailsActionsPositionProps {
   token: Token;
   amountUSD?: number;
   amount?: bigint | number;
 }
-
-const formatUSD = currencyFormatter('en-US', {
-  notation: 'compact',
-  currency: 'USD',
-  useGrouping: true,
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
 
 const selectCardStyles = {
   padding: 0,
@@ -59,74 +46,50 @@ export const EarnDetailsActionsPosition: FC<
   EarnDetailsActionsPositionProps
 > = ({ token, amountUSD, amount }) => {
   const { t } = useTranslation();
-  // IMPORTANT: We use the useToken hook to get the token data instead of the useTokens hook as the override is only present on /token for now
-  const { token: tokenData, isSuccess: isSuccessTokens } = useToken(
+
+  const { token: extendedToken } = useToken(
     token.chain.chainId,
-    token.address,
+    token.address as Address,
+    // Get with USD price information
+    { extended: true },
   );
 
-  const tokenPriceUSD = tokenData?.priceUSD ?? '0';
-  const hasTokenPriceUSD = Number(tokenPriceUSD) > 0;
-  const shouldActivateFallbackToken = !hasTokenPriceUSD && isSuccessTokens;
+  const priceData = useMemo(() => {
+    if (extendedToken?.hasPriceUSD()) {
+      let formattedAmount: string;
+      let formattedAmountUSD: string;
 
-  const { token: fallbackToken } = useToken(
-    token.chain.chainId,
-    token.address,
-    shouldActivateFallbackToken,
-  );
-
-  const effectivePriceUSD = hasTokenPriceUSD
-    ? tokenPriceUSD
-    : (fallbackToken?.priceUSD ?? '0');
-
-  const hasEffectivePriceUSD = Number(effectivePriceUSD) > 0;
-
-  const { formattedAmount, formattedAmountUSD, hasAmount } = useMemo(() => {
-    const calculateTokenAmount = (): string => {
       if (amount) {
-        return formatTokenAmount(BigInt(amount), token.decimals);
+        formattedAmount = extendedToken.formatAmount(amount);
+        formattedAmountUSD = extendedToken.formatAmountUSD(amount);
+      } else if (amountUSD) {
+        formattedAmount = extendedToken.formatAmountFromUSD(amountUSD);
+        formattedAmountUSD = extendedToken.formatAmountUSD(amountUSD);
+      } else {
+        formattedAmount = extendedToken.formatZeroAmount();
+        formattedAmountUSD = extendedToken.formatZeroUSD();
       }
-      if (amountUSD && hasEffectivePriceUSD) {
-        return priceToTokenAmount(amountUSD.toString(), effectivePriceUSD);
-      }
-      return '0';
-    };
 
-    const calculateAmountUSD = (): number => {
-      if (amount && hasEffectivePriceUSD) {
-        const formattedTokenAmount = formatTokenAmount(
-          BigInt(amount),
-          token.decimals,
-        );
-        return formatTokenPrice(formattedTokenAmount, effectivePriceUSD);
-      }
-      if (amountUSD) {
-        return amountUSD;
-      }
-      return 0;
-    };
-
-    const computedAmount = calculateTokenAmount();
-    const computedAmountUSD = calculateAmountUSD();
-    const hasAmount = computedAmount !== '0' || computedAmountUSD !== 0;
-
-    return {
-      formattedAmount: `${computedAmount} ${token.symbol ?? ''}`,
-      formattedAmountUSD: formatUSD(computedAmountUSD),
-      hasAmount,
-    };
-  }, [
-    amountUSD,
-    amount,
-    token.decimals,
-    token.symbol,
-    hasEffectivePriceUSD,
-    effectivePriceUSD,
-  ]);
+      return {
+        formattedAmount,
+        formattedAmountUSD,
+        hasAmount: (amount && amount > 0) || (amountUSD && amountUSD > 0),
+      };
+    } else {
+      const simpleToken = new SimpleToken(token);
+      return {
+        formattedAmount: simpleToken.formatAmount(amount || 0),
+        formattedAmountUSD: simpleToken.formatZeroUSD(),
+        hasAmount: false,
+      };
+    }
+  }, [token, extendedToken, amount, amountUSD]);
 
   return (
     <Tooltip
-      title={!hasAmount ? t('tooltips.noPositionsToManage') : undefined}
+      title={
+        !priceData.hasAmount ? t('tooltips.noPositionsToManage') : undefined
+      }
       placement="top"
       enterTouchDelay={0}
       arrow
@@ -137,8 +100,8 @@ export const EarnDetailsActionsPosition: FC<
           mode={SelectCardMode.Display}
           label={t('earn.position.label')}
           labelVariant="bodyXSmall"
-          value={formattedAmountUSD}
-          description={formattedAmount}
+          value={priceData.formattedAmountUSD}
+          description={priceData.formattedAmount}
           placeholder="0"
           isClickable={false}
           startAdornment={
@@ -151,7 +114,7 @@ export const EarnDetailsActionsPosition: FC<
             />
           }
           sx={
-            hasAmount
+            priceData.hasAmount
               ? selectCardStyles
               : { ...selectCardStyles, cursor: 'not-allowed' }
           }

--- a/src/components/ZapWidget/WithdrawWidget/WithdrawForm.tsx
+++ b/src/components/ZapWidget/WithdrawWidget/WithdrawForm.tsx
@@ -1,22 +1,20 @@
-import { FC, useCallback, useEffect, useMemo, useState } from 'react';
-import { WithdrawFormContainer } from './WithdrawWidget.style';
-import { AbiParameter, formatUnits, parseUnits } from 'viem';
-import { Button } from 'src/components/Button/Button';
-import { ConnectButton } from 'src/components/ConnectButton';
-import {
-  useSwitchChain,
-  useWaitForTransactionReceipt,
-  useWriteContract,
-} from 'wagmi';
 import { useAccount } from '@lifi/wallet-management';
-import { useToken } from 'src/hooks/useToken';
-import { WithdrawInput } from './WithdrawInput';
+import type { Theme } from '@mui/material/styles';
+import type { FC } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import type { Address } from 'viem';
+import { formatUnits } from 'viem';
+import { useSwitchChain } from 'wagmi';
+
+import { Button } from '@/components/Button/Button';
+import { ConnectButton } from '@/components/ConnectButton';
+import { useToken } from '@/hooks/useToken';
+
 import BadgeWithChain from '../BadgeWithChain';
-import { useUserTracking } from 'src/hooks/userTracking/useUserTracking';
-import { TrackingCategory } from 'src/const/trackingKeys';
+import { WithdrawInput } from './WithdrawInput';
 import WithdrawInputEndAdornment from './WithdrawInputEndAdornment';
-import { WithdrawFormProps } from './WithdrawWidget.types';
-import { Theme } from '@mui/material/styles';
+import { WithdrawFormContainer } from './WithdrawWidget.style';
+import type { WithdrawFormProps } from './WithdrawWidget.types';
 
 const buttonStyles = (theme: Theme) => ({
   marginTop: theme.spacing(2),
@@ -40,9 +38,12 @@ export const WithdrawForm: FC<WithdrawFormProps> = ({
 }) => {
   const [value, setValue] = useState<string>('');
   const { account } = useAccount();
-  const { trackEvent } = useUserTracking();
   const { switchChainAsync } = useSwitchChain();
-  const { token: tokenInfo } = useToken(token.chainId, token.address);
+  const { token: tokenInfo } = useToken(
+    token.chainId,
+    token.address as Address,
+    { extended: true },
+  );
 
   const maxFormattedAmount = useMemo(() => {
     return parseFloat(formatUnits(BigInt(balance), lpTokenDecimals));
@@ -51,14 +52,6 @@ export const WithdrawForm: FC<WithdrawFormProps> = ({
   const maxAmount = useMemo(() => {
     return BigInt(balance);
   }, [balance]);
-
-  const helperText = useMemo(
-    () => ({
-      left: 'Available balance',
-      right: balance,
-    }),
-    [balance],
-  );
 
   const hintEndAdornment = useMemo(() => {
     return (

--- a/src/components/composite/AssetOverviewCard/AssetOverviewCard.snapshot.spec.tsx
+++ b/src/components/composite/AssetOverviewCard/AssetOverviewCard.snapshot.spec.tsx
@@ -6,10 +6,8 @@ import { defiPositionGroups, tokens, tokenTinyAmounts } from './fixtures';
 
 vi.mock('src/hooks/useTokens', () => ({
   useTokens: () => ({
-    data: {
-      tokens: tokens,
-    },
-    getTokenByAddressAndChain: (address: string, chainId: number) =>
+    tokens,
+    getToken: (chainId: number, address: string) =>
       tokens.find(
         (token) => token.address === address && token.chain.chainId === chainId,
       ),

--- a/src/components/composite/AssetProgress/AssetProgress.snapshot.spec.tsx
+++ b/src/components/composite/AssetProgress/AssetProgress.snapshot.spec.tsx
@@ -19,10 +19,8 @@ const mockedTokens = [
 
 vi.mock('src/hooks/useTokens', () => ({
   useTokens: () => ({
-    data: {
-      tokens: mockedTokens,
-    },
-    getTokenByAddressAndChain: (address: string, chainId: number) =>
+    tokens: mockedTokens,
+    getToken: (chainId: number, address: string) =>
       mockedTokens.find(
         (token) => token.address === address && token.chain.chainId === chainId,
       ),

--- a/src/components/composite/AssetProgress/variants/TokenProgress.tsx
+++ b/src/components/composite/AssetProgress/variants/TokenProgress.tsx
@@ -1,31 +1,29 @@
 import type { FC } from 'react';
 import { useMemo } from 'react';
-import type { TokenAssetProgressProps } from '../AssetProgress.types';
-import { BaseProgress } from './BaseProgress';
-import { useTokens } from 'src/hooks/useTokens';
 import {
   Avatar,
   AvatarPlaceholder,
   AvatarSkeleton,
 } from 'src/components/core/AvatarStack/AvatarStack.styles';
+import type { Address } from 'viem';
+import { useTokens } from '@/hooks/useTokens';
+import type { TokenAssetProgressProps } from '../AssetProgress.types';
+import { BaseProgress } from './BaseProgress';
 
 export const TokenProgress: FC<Omit<TokenAssetProgressProps, 'variant'>> = ({
   token,
   progress,
   amount,
 }) => {
-  const { getTokenByAddressAndChain } = useTokens();
+  const { getToken } = useTokens();
   const enhancedToken = useMemo(() => {
-    const _token = getTokenByAddressAndChain(
-      token.address,
-      token.chain.chainId,
-    );
+    const tokenInner = getToken(token.chain.chainId, token.address as Address);
     return {
-      id: (_token?.address ?? token.address) + token.chain.chainId,
-      src: _token?.logoURI || '',
-      alt: _token?.name || '',
+      id: (tokenInner?.address ?? token.address) + token.chain.chainId,
+      src: tokenInner?.logoURI || '',
+      alt: tokenInner?.name || '',
     };
-  }, [token, getTokenByAddressAndChain]);
+  }, [token, getToken]);
 
   return (
     <BaseProgress progress={progress} amount={amount}>

--- a/src/components/composite/TokenStack/TokenStack.tsx
+++ b/src/components/composite/TokenStack/TokenStack.tsx
@@ -1,11 +1,13 @@
-import type { FC } from 'react';
-import { useMemo } from 'react';
-import { AvatarStack } from 'src/components/core/AvatarStack/AvatarStack';
+import { type FC, useMemo } from 'react';
+import type { Address } from 'viem';
+
+import { AvatarStack } from '@/components/core/AvatarStack/AvatarStack';
 import type {
   AvatarSize,
   AvatarStackDirection,
-} from 'src/components/core/AvatarStack/AvatarStack.types';
-import { useTokens } from 'src/hooks/useTokens';
+} from '@/components/core/AvatarStack/AvatarStack.types';
+import { useTokens } from '@/hooks/useTokens';
+
 import type { TokenStackToken } from './types';
 
 interface TokenStackProps {
@@ -23,24 +25,21 @@ export const TokenStack: FC<TokenStackProps> = ({
   direction = 'row',
   limit,
 }) => {
-  const { getTokenByAddressAndChain } = useTokens();
+  const { getToken } = useTokens();
   const enhancedTokens = useMemo(() => {
     return tokens.map((token) => {
-      const _token = getTokenByAddressAndChain(
-        token.address,
+      const tokenInner = getToken(
         token.chain.chainId,
+        token.address as Address,
       );
 
-      const id = token.address + token.chain.chainId;
-      const src = _token?.logoURI || token.logoURI;
-      const alt = token.name || token.symbol || token.address;
       return {
-        id,
-        src,
-        alt,
+        id: (tokenInner?.address ?? token.address) + token.chain.chainId,
+        src: tokenInner?.logoURI || token.logoURI,
+        alt: token.name || token.symbol || token.address,
       };
     });
-  }, [tokens, getTokenByAddressAndChain]);
+  }, [tokens, getToken]);
 
   return (
     <AvatarStack

--- a/src/hooks/portfolio/usePortfolioDeFiPositions.ts
+++ b/src/hooks/portfolio/usePortfolioDeFiPositions.ts
@@ -1,13 +1,13 @@
+import { useQueries } from '@tanstack/react-query';
+import { min } from 'date-fns';
+import { useCallback, useMemo } from 'react';
+import { ONE_HOUR_MS } from 'src/const/time';
+import type { Address, Hex } from 'viem';
 import type { PortfolioPositionsQuery } from '@/app/lib/getPositionsForAddress';
 import { getPositionsForAddress } from '@/app/lib/getPositionsForAddress';
 import type { DefiPosition, WalletPositions } from '@/types/jumper-backend';
 import type { GetTokenUSDPrice } from '@/utils/positions/update-price';
 import { updateWalletPositionsPrice } from '@/utils/positions/update-price';
-import { useQueries } from '@tanstack/react-query';
-import { min } from 'date-fns';
-import { useCallback, useMemo } from 'react';
-import { ONE_HOUR_MS } from 'src/const/time';
-import type { Hex } from 'viem';
 import { useTokens } from '../useTokens';
 
 export interface Props {
@@ -27,19 +27,12 @@ export const usePortfolioDeFiPositions = ({
   addresses,
   filter,
 }: Props): Result => {
-  const {
-    getTokenByAddressAndChain,
-    isLoading: isLoadingTokens,
-    updatedAt,
-  } = useTokens();
+  const { getToken, isLoading: isLoadingTokens, updatedAt } = useTokens();
 
   const getTokenUSDPrice: GetTokenUSDPrice = useCallback(
     (token: { chainId: number; address: string }) => {
       try {
-        const tokenFound = getTokenByAddressAndChain(
-          token.address,
-          token.chainId,
-        );
+        const tokenFound = getToken(token.chainId, token.address as Address);
 
         if (!tokenFound) {
           throw new Error(
@@ -61,7 +54,7 @@ export const usePortfolioDeFiPositions = ({
         return undefined;
       }
     },
-    [getTokenByAddressAndChain],
+    [getToken],
   );
 
   const queries = useQueries({

--- a/src/hooks/useToken.ts
+++ b/src/hooks/useToken.ts
@@ -1,46 +1,83 @@
-import type { ChainId, Token } from '@lifi/sdk';
-import { getToken } from '@lifi/sdk';
+import { type ChainId, getToken } from '@lifi/sdk';
 import { useQuery } from '@tanstack/react-query';
-
-export interface TokenProps {
-  token: Token | null;
-  isLoading: boolean;
-  isSuccess: boolean;
-  isError: boolean;
-  error: unknown;
-}
+import type { Address } from 'viem';
+import type { SimpleToken } from '../utils/Token';
+import { ExtendedToken } from '../utils/Token';
+import { useTokens } from './useTokens';
 
 export async function getTokenQuery(chainId?: ChainId, tokenAddress?: string) {
   if (!chainId || !tokenAddress) {
     return;
   }
-  const token = await getToken(chainId, tokenAddress);
-  return token;
+  return getToken(chainId, tokenAddress);
 }
 
-export const useToken = (
-  chainId?: ChainId,
-  tokenAddress?: string,
-  enabled: boolean = true,
-): TokenProps => {
+type UseTokenReturn<T> = {
+  error: Error | null;
+  isError: boolean;
+  isLoading: boolean;
+  isSuccess: boolean;
+  updatedAt: number;
+  token: T | undefined;
+};
+
+export function useToken(
+  chainId: ChainId,
+  address: Address,
+  options: { extended: true },
+): UseTokenReturn<ExtendedToken>;
+
+export function useToken(
+  chainId: ChainId,
+  address: Address,
+  options?: { extended?: false },
+): UseTokenReturn<SimpleToken>;
+
+export function useToken(
+  chainId: ChainId,
+  address: Address,
+  options?: { extended?: boolean },
+): UseTokenReturn<ExtendedToken | SimpleToken> {
   const {
-    data: token,
-    isLoading,
-    isSuccess,
-    isError,
-    error,
+    getToken,
+    error: bulkError,
+    isError: isBulkError,
+    isSuccess: isBulkSuccess,
+    isLoading: isBulkLoading,
+    updatedAt: bulkUpdatedAt,
+  } = useTokens();
+  const {
+    data: individualToken,
+    error: individualError,
+    isError: isIndividualError,
+    isLoading: isIndividualLoading,
+    isSuccess: isIndividualSuccess,
+    dataUpdatedAt: individualUpdatedAt,
   } = useQuery({
-    queryKey: ['token', chainId, tokenAddress],
-    queryFn: () => getTokenQuery(chainId, tokenAddress),
-    enabled: !!chainId && !!tokenAddress && !!enabled,
-    refetchInterval: 1000 * 60 * 60, // Refetch every hour
+    queryKey: ['token', chainId, address],
+    queryFn: () => getTokenQuery(chainId, address),
+    enabled: options?.extended,
+    staleTime: 1000 * 60 * 5,
+    refetchInterval: 1000 * 60 * 5,
   });
 
+  if (options?.extended) {
+    return {
+      error: individualError,
+      isError: isIndividualError,
+      isLoading: isIndividualLoading,
+      isSuccess: isIndividualSuccess,
+      token: individualToken ? new ExtendedToken(individualToken) : undefined,
+      updatedAt: individualUpdatedAt,
+    };
+  }
+
   return {
-    token: token || null,
-    isLoading,
-    isSuccess,
-    isError,
-    error,
+    error: bulkError,
+    isError: isBulkError,
+    isLoading: isBulkLoading,
+    isSuccess: isBulkSuccess,
+    token: getToken(chainId, address),
+    updatedAt: bulkUpdatedAt,
   };
-};
+}

--- a/src/hooks/useTokens.ts
+++ b/src/hooks/useTokens.ts
@@ -1,72 +1,61 @@
-import {
-  getNativeTokenForChain as getNativeTokenForChainHelper,
-  getTokenByAddressOnSpecificChain as getTokenByAddressOnSpecificChainHelper,
-  getTokenByName as getTokenByNameHelper,
-  getTokenBySymbol as getTokenBySymbolHelper,
-} from '@/utils/tokenAndChain';
-import type { TokensResponse } from '@lifi/sdk';
+import type { ChainId, Token } from '@lifi/sdk';
 import { ChainType, getTokens } from '@lifi/sdk';
 import { useQuery } from '@tanstack/react-query';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
+import type { Address } from 'viem';
 
-export const queryKey = ['tokenStats'];
+import { ExtendedToken } from '../utils/Token';
 
-export const getTokensQuery = async () => {
-  const tokens = await getTokens({
+// NOTE: We are using the StaticToken type here as USD prices from the /tokens
+// endpoint tend to be incorrect. Use useToken() instead
+// TODO: This needs to be StaticToken
+export type AllTokens = { tokens: { [chainId: number]: Token[] } };
+
+export const getTokensQuery = async (): Promise<AllTokens> => {
+  const data = await getTokens({
     chainTypes: [ChainType.EVM, ChainType.SVM, ChainType.UTXO, ChainType.MVM],
   });
-  return tokens;
+
+  return data as { tokens: { [chainId: number]: Token[] } };
 };
 
 export const useTokens = () => {
-  const { data, isSuccess, isLoading, dataUpdatedAt } = useQuery({
-    queryKey,
-    queryFn: getTokensQuery,
-    enabled: true,
-    refetchInterval: 1000 * 60 * 60,
-  });
+  const { data, isLoading, isSuccess, isError, error, dataUpdatedAt } =
+    useQuery({
+      queryKey: ['tokens'],
+      queryFn: getTokensQuery,
+      refetchInterval: 1000 * 60 * 60,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+    });
 
-  const tokens = useMemo<TokensResponse['tokens']>(
-    () => data?.tokens ?? {},
-    [data?.tokens],
-  );
-
-  const getTokenBySymbol = useCallback(
-    (symbol: string) => {
-      return getTokenBySymbolHelper(tokens, symbol);
+  const getToken = useCallback(
+    (chainId: ChainId, address: Address) => {
+      if (!data) {
+        return;
+      }
+      if (!data.tokens[chainId]) {
+        return;
+      }
+      const tokenData = data.tokens[chainId].find(
+        (token) => token.address.toLowerCase() === address.toLowerCase(),
+      );
+      if (!tokenData) {
+        return;
+      }
+      // TODO: This needs to be SimpleToken
+      return new ExtendedToken(tokenData);
     },
-    [tokens],
-  );
-
-  const getTokenByName = useCallback(
-    (name: string) => {
-      return getTokenByNameHelper(tokens, name);
-    },
-    [tokens],
-  );
-
-  const getTokenByAddressAndChain = useCallback(
-    (address: string, chainId: number) => {
-      return getTokenByAddressOnSpecificChainHelper(tokens, chainId, address);
-    },
-    [tokens],
-  );
-
-  const getNativeTokenForChain = useCallback(
-    (chainId: number) => {
-      return getNativeTokenForChainHelper(tokens, chainId);
-    },
-    [tokens],
+    [data],
   );
 
   return {
-    getTokenBySymbol,
-    getTokenByName,
-    getTokenByAddressAndChain,
-    getNativeTokenForChain,
-    tokens,
-    isSuccess,
+    getToken,
+    error,
+    isError,
     isLoading,
+    isSuccess,
+    tokens: data,
     updatedAt: dataUpdatedAt,
   };
 };

--- a/src/utils/Token.spec.ts
+++ b/src/utils/Token.spec.ts
@@ -1,0 +1,345 @@
+import type { StaticToken, Token, TokenExtended } from '@lifi/sdk';
+import { CoinKey, type TokenTag } from '@lifi/widget';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Token as JumperToken } from '@/types/jumper-backend';
+import { ExtendedToken, SimpleToken } from './Token';
+
+const STATIC_TOKEN_FIXTURE: StaticToken = {
+  chainId: 100,
+  address: '0x0000000000000000000000000000000000000000',
+  symbol: 'xDAI',
+  name: 'xDAI Native Token',
+  decimals: 18,
+  coinKey: CoinKey.DAI,
+  logoURI:
+    'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png',
+  tags: ['stablecoin' as TokenTag.STABLECOIN],
+};
+
+const JUMPER_TOKEN_FIXTURE: JumperToken = {
+  chain: {
+    chainId: 100,
+    chainKey: 'dai',
+  },
+  address: '0x0000000000000000000000000000000000000000',
+  symbol: 'xDAI',
+  name: 'xDAI Native Token',
+  decimals: 18,
+  logo: 'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png',
+};
+
+const TOKEN_FIXTURE: Token = {
+  chainId: 100,
+  address: '0x0000000000000000000000000000000000000000',
+  symbol: 'xDAI',
+  name: 'xDAI Native Token',
+  decimals: 18,
+  priceUSD: '0.812',
+  coinKey: CoinKey.DAI,
+  logoURI:
+    'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png',
+};
+
+const EXTENDED_TOKEN_FIXTURE: TokenExtended = {
+  chainId: 100,
+  address: '0x0000000000000000000000000000000000000000',
+  symbol: 'xDAI',
+  name: 'xDAI Native Token',
+  decimals: 18,
+  priceUSD: '0.99972137',
+  coinKey: CoinKey.DAI,
+  logoURI:
+    'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png',
+  marketCapUSD: null,
+  volumeUSD24H: 732678,
+};
+
+describe('SimpleToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should create SimpleToken from StaticToken', () => {
+      const token = new SimpleToken(STATIC_TOKEN_FIXTURE);
+
+      expect(token.chainId).toBe(100);
+      expect(token.address).toBe('0x0000000000000000000000000000000000000000');
+      expect(token.symbol).toBe('xDAI');
+      expect(token.name).toBe('xDAI Native Token');
+      expect(token.decimals).toBe(18);
+      expect(token.logoURI).toBe(
+        'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png',
+      );
+      expect(token.coinKey).toBe('DAI');
+      expect(token.tags).toEqual(['stablecoin']);
+    });
+
+    it('should create SimpleToken from JumperToken', () => {
+      const token = new SimpleToken(JUMPER_TOKEN_FIXTURE);
+
+      expect(token.chainId).toBe(100);
+      expect(token.address).toBe('0x0000000000000000000000000000000000000000');
+      expect(token.symbol).toBe('xDAI');
+      expect(token.name).toBe('xDAI Native Token');
+      expect(token.decimals).toBe(18);
+      expect(token.logoURI).toBe(
+        'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png',
+      );
+      expect(token.coinKey).toBeUndefined();
+      expect(token.tags).toBeUndefined();
+    });
+  });
+
+  describe('formatAmount', () => {
+    it('should format amount with string input', () => {
+      const token = new SimpleToken(STATIC_TOKEN_FIXTURE);
+
+      const result = token.formatAmount('1000000000000000000');
+
+      expect(result).toBe('1 xDAI');
+    });
+
+    it('should format amount with number input', () => {
+      const token = new SimpleToken({ ...STATIC_TOKEN_FIXTURE, decimals: 6 });
+
+      const result = token.formatAmount(2500000);
+
+      expect(result).toBe('2.5 xDAI');
+    });
+
+    it('should format amount with bigint input', () => {
+      const token = new SimpleToken(STATIC_TOKEN_FIXTURE);
+
+      const result = token.formatAmount(10000000000000000000n);
+
+      expect(result).toBe('10 xDAI');
+    });
+
+    it('should format small fractional amount', () => {
+      const token = new SimpleToken(STATIC_TOKEN_FIXTURE);
+
+      const result = token.formatAmount('14353125728879');
+
+      expect(result).toBe('0.000014353125728879 xDAI');
+    });
+
+    it('should handle token with no symbol', () => {
+      const token = new SimpleToken({
+        ...STATIC_TOKEN_FIXTURE,
+        symbol: '',
+      });
+
+      const result = token.formatAmount('1000000000000000000');
+
+      expect(result).toBe('1 ---');
+    });
+  });
+
+  describe('formatZeroAmount', () => {
+    it('should format zero amount', () => {
+      const token = new SimpleToken(STATIC_TOKEN_FIXTURE);
+
+      const result = token.formatZeroAmount();
+
+      expect(result).toBe('0 xDAI');
+    });
+  });
+
+  describe('formatZeroUSD', () => {
+    it('should format zero USD', () => {
+      const token = new SimpleToken(STATIC_TOKEN_FIXTURE);
+
+      const result = token.formatZeroUSD();
+      expect(result).toBe('$0.00');
+    });
+  });
+});
+
+describe('ExtendedToken', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('constructor', () => {
+    it('should create ExtendedToken from Token', () => {
+      const token = new ExtendedToken(TOKEN_FIXTURE);
+
+      expect(token.chainId).toBe(100);
+      expect(token.address).toBe('0x0000000000000000000000000000000000000000');
+      expect(token.priceUSD).toBe('0.812');
+      expect(token.marketCapUSD).toBeUndefined();
+      expect(token.volumeUSD24H).toBeUndefined();
+      expect(token.fdvUSD).toBeUndefined();
+    });
+
+    it('should create ExtendedToken from TokenExtended with market data', () => {
+      const token = new ExtendedToken(EXTENDED_TOKEN_FIXTURE);
+
+      expect(token.chainId).toBe(100);
+      expect(token.address).toBe('0x0000000000000000000000000000000000000000');
+      expect(token.priceUSD).toBe('0.99972137');
+      expect(token.marketCapUSD).toBe(null);
+      expect(token.volumeUSD24H).toBe(732678);
+      expect(token.fdvUSD).toBeUndefined();
+    });
+  });
+
+  describe('hasPriceUSD', () => {
+    it('should return true when price is greater than 0', () => {
+      const token = new ExtendedToken(TOKEN_FIXTURE);
+
+      expect(token.hasPriceUSD()).toBe(true);
+    });
+
+    it('should return false when price is 0', () => {
+      const token = new ExtendedToken({
+        ...TOKEN_FIXTURE,
+        priceUSD: '0',
+      });
+
+      expect(token.hasPriceUSD()).toBe(false);
+    });
+
+    it('should return false when price is 0.0', () => {
+      const token = new ExtendedToken({
+        ...TOKEN_FIXTURE,
+        priceUSD: '0.0',
+      });
+
+      expect(token.hasPriceUSD()).toBe(false);
+    });
+  });
+
+  describe('formatPriceUSD', () => {
+    it('should format price in USD', () => {
+      const token = new ExtendedToken(TOKEN_FIXTURE);
+
+      const result = token.formatPriceUSD();
+
+      expect(result).toBe('$0.81');
+    });
+
+    it('should format high price in USD', () => {
+      const token = new ExtendedToken({
+        ...EXTENDED_TOKEN_FIXTURE,
+        priceUSD: '123.456',
+      });
+
+      const result = token.formatPriceUSD();
+
+      expect(result).toBe('$123.46');
+    });
+
+    it('should return undefined and log error when price is missing', () => {
+      const token = new ExtendedToken({
+        ...TOKEN_FIXTURE,
+        priceUSD: '',
+      });
+
+      const result = token.formatPriceUSD();
+
+      expect(result).toBeUndefined();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        `Token formatPriceUSD: Could not find price for token with address 0x0000000000000000000000000000000000000000`,
+      );
+    });
+  });
+
+  describe('formatAmountUSD', () => {
+    it('should format amount in USD with string input', () => {
+      const token = new ExtendedToken(TOKEN_FIXTURE);
+
+      const result = token.formatAmountUSD('10000000000000000000');
+
+      expect(result).toBe('$8.12');
+    });
+
+    it('should format amount in USD with number input', () => {
+      const token = new ExtendedToken({ ...TOKEN_FIXTURE, decimals: 6 });
+
+      const result = token.formatAmountUSD(2500000);
+
+      expect(result).toBe('$2.03');
+    });
+
+    it('should format amount in USD with bigint input', () => {
+      const token = new ExtendedToken(TOKEN_FIXTURE);
+
+      const result = token.formatAmountUSD(10000000000000000000n);
+
+      expect(result).toBe('$8.12');
+    });
+
+    it('should format amount in USD with high price token', () => {
+      const token = new ExtendedToken({
+        ...EXTENDED_TOKEN_FIXTURE,
+        priceUSD: '1234.56',
+      });
+
+      const result = token.formatAmountUSD('1000000000000000000');
+
+      expect(result).toBe('$1.23K');
+    });
+
+    it('should format zero USD when price is missing', () => {
+      const token = new ExtendedToken({
+        ...TOKEN_FIXTURE,
+        priceUSD: '',
+      });
+
+      const result = token.formatAmountUSD('1000000000000000000');
+
+      expect(result).toBe('$0.00');
+    });
+  });
+
+  describe('formatAmountFromUSD', () => {
+    it('should format token amount from USD with string input', () => {
+      const token = new ExtendedToken(TOKEN_FIXTURE);
+
+      const result = token.formatAmountFromUSD('1.0');
+
+      expect(result).toBe('1.231527093596059 xDAI');
+    });
+
+    it('should format token amount from USD with number input', () => {
+      const token = new ExtendedToken(TOKEN_FIXTURE);
+
+      const result = token.formatAmountFromUSD(2.5);
+
+      expect(result).toBe('3.0788177339901477 xDAI');
+    });
+
+    it('should format token amount from USD with bigint input', () => {
+      const token = new ExtendedToken(TOKEN_FIXTURE);
+
+      const result = token.formatAmountFromUSD(10n);
+
+      expect(result).toBe('12.31527093596059 xDAI');
+    });
+
+    it('should format token amount from USD with high price token', () => {
+      const token = new ExtendedToken(EXTENDED_TOKEN_FIXTURE);
+
+      const result = token.formatAmountFromUSD('1.0');
+
+      expect(result).toBe('1.0002787076563142 xDAI');
+    });
+
+    it('should format large USD amount to token amount', () => {
+      const token = new ExtendedToken(TOKEN_FIXTURE);
+
+      const result = token.formatAmountFromUSD(1000n);
+
+      expect(result).toBe('1231.527093596059 xDAI');
+    });
+  });
+});

--- a/src/utils/Token.ts
+++ b/src/utils/Token.ts
@@ -1,0 +1,143 @@
+import type {
+  ChainId,
+  CoinKey,
+  StaticToken,
+  Token,
+  TokenExtended,
+  TokenTag,
+} from '@lifi/sdk';
+import {
+  formatTokenAmount,
+  formatTokenPrice,
+  priceToTokenAmount,
+} from '@lifi/widget';
+
+import type { Token as JumperToken } from '@/types/jumper-backend';
+import { currencyFormatter } from '@/utils/formatNumbers';
+
+const isJumperToken = (
+  token: StaticToken | JumperToken,
+): token is JumperToken => {
+  return 'chain' in token;
+};
+
+const hasMarketData = (
+  token: Token | TokenExtended,
+): token is TokenExtended => {
+  return 'marketCapUSD' in token;
+};
+
+const formatUSD = currencyFormatter('en-US', {
+  notation: 'compact',
+  currency: 'USD',
+  useGrouping: true,
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+// TODO: Think whether it might make more sense to use t('format.decimal', { value: token.balance }), somehow
+export class SimpleToken {
+  chainId: ChainId;
+  address: string;
+  symbol: string;
+  decimals: number;
+  name: string;
+  coinKey?: CoinKey;
+  logoURI?: string;
+  tags?: TokenTag[];
+
+  constructor(token: StaticToken | JumperToken) {
+    this.address = token.address;
+    this.symbol = token.symbol;
+    this.name = token.name;
+    this.decimals = token.decimals;
+
+    if (isJumperToken(token)) {
+      this.chainId = token.chain.chainId;
+      this.logoURI = token.logo;
+    } else {
+      this.chainId = token.chainId;
+      this.logoURI = token.logoURI;
+      this.coinKey = token.coinKey;
+      this.tags = token.tags;
+    }
+  }
+
+  protected formatTokenWithSymbol(amount: string) {
+    return `${amount} ${this.symbol || '---'}`;
+  }
+
+  formatAmount(amount: string | number | bigint) {
+    if (typeof amount == 'number' && !Number.isInteger(amount)) {
+      console.error(`Token formatAmount: number ${amount} is not an integer`);
+    }
+    return this.formatTokenWithSymbol(
+      formatTokenAmount(BigInt(amount), this.decimals),
+    );
+  }
+
+  // Like formatAmount, but using 0 as the amount. Helper function to get a consistent formatting
+  formatZeroAmount() {
+    return this.formatAmount(0);
+  }
+
+  // Like formatAmountUSD, but using 0 as the amount. Helper function to get a consistent formatting
+  formatZeroUSD() {
+    return formatUSD(0);
+  }
+}
+
+export class ExtendedToken extends SimpleToken {
+  priceUSD: string;
+  marketCapUSD?: number | null;
+  volumeUSD24H?: number | null;
+  fdvUSD?: number | null;
+
+  constructor(token: Token | TokenExtended) {
+    super(token);
+    this.priceUSD = token.priceUSD;
+    if (hasMarketData(token)) {
+      this.marketCapUSD = token.marketCapUSD;
+      this.volumeUSD24H = token.volumeUSD24H;
+      this.fdvUSD = token.fdvUSD;
+    }
+  }
+
+  hasPriceUSD() {
+    return parseFloat(this.priceUSD) > 0;
+  }
+
+  formatPriceUSD() {
+    if (!this.priceUSD) {
+      console.error(
+        `Token formatPriceUSD: Could not find price for token with address ${this.address}`,
+      );
+      return undefined;
+    }
+
+    return formatUSD(this.priceUSD);
+  }
+
+  formatAmountUSD(amountToken: string | number | bigint): string {
+    if (typeof amountToken == 'number' && !Number.isInteger(amountToken)) {
+      console.error(
+        `Token formatAmountUSD: number ${amountToken} is not an integer`,
+      );
+    }
+
+    const amount = this.priceUSD
+      ? formatTokenPrice(
+          formatTokenAmount(BigInt(amountToken), this.decimals),
+          this.priceUSD,
+        )
+      : 0;
+    return formatUSD(amount);
+  }
+
+  formatAmountFromUSD(amountUSD: string | number | bigint) {
+    const amount = this.priceUSD
+      ? priceToTokenAmount(amountUSD.toString(), this.priceUSD)
+      : '0';
+    return this.formatTokenWithSymbol(amount);
+  }
+}

--- a/src/utils/Token.ts
+++ b/src/utils/Token.ts
@@ -13,7 +13,7 @@ import {
 } from '@lifi/widget';
 
 import type { Token as JumperToken } from '@/types/jumper-backend';
-import { currencyFormatter } from '@/utils/formatNumbers';
+import { formatUSD } from './formatNumbers';
 
 const isJumperToken = (
   token: StaticToken | JumperToken,
@@ -26,14 +26,6 @@ const hasMarketData = (
 ): token is TokenExtended => {
   return 'marketCapUSD' in token;
 };
-
-const formatUSD = currencyFormatter('en-US', {
-  notation: 'compact',
-  currency: 'USD',
-  useGrouping: true,
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
 
 // TODO: Think whether it might make more sense to use t('format.decimal', { value: token.balance }), somehow
 export class SimpleToken {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -8,6 +8,7 @@ export const precisionFormatter = new Intl.NumberFormat('en', {
   useGrouping: false,
 });
 
+// TODO: Use the (Simple|Extended)Token formatters for this
 export function formatTokenAmount(amount: bigint = 0n, decimals: number) {
   const formattedAmount = formatUnits(amount, decimals);
   const parsedAmount = parseFloat(formattedAmount);
@@ -17,6 +18,7 @@ export function formatTokenAmount(amount: bigint = 0n, decimals: number) {
   return precisionFormatter.format(parsedAmount);
 }
 
+// TODO: Use the (Simple|Extended)Token formatters for this
 export function formatTokenPrice(amount?: string, price?: string) {
   if (!amount || !price) {
     return 0;

--- a/src/utils/formatNumbers.ts
+++ b/src/utils/formatNumbers.ts
@@ -120,3 +120,11 @@ export const formatValueWithConfig = (
 
   return new Intl.NumberFormat('en-US', formatOptions).format(numValue);
 };
+
+export const formatUSD = currencyFormatter('en-US', {
+  notation: 'compact',
+  currency: 'USD',
+  useGrouping: true,
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});

--- a/src/utils/tokenAndChain.ts
+++ b/src/utils/tokenAndChain.ts
@@ -1,5 +1,6 @@
 import type { Chain, ChainId, ExtendedChain, TokensResponse } from '@lifi/sdk';
 import { zeroAddress } from 'viem';
+import { AllTokens } from '../hooks/useTokens';
 
 export const getChainById = (chains: ExtendedChain[], id: ChainId) => {
   if (!chains.length || !id) {
@@ -34,47 +35,4 @@ export const getTokenBySymbolOnSpecificChain = (
     (el) => el.symbol.toLowerCase() === symbol.toLowerCase(),
   );
   return filteredToken;
-};
-
-export const getTokenBySymbol = (
-  tokens: TokensResponse['tokens'],
-  symbol: string,
-) => {
-  return Object.values(tokens)
-    .flat()
-    .filter((el) => {
-      return el.symbol.toLowerCase() === symbol.toLowerCase();
-    });
-};
-
-export const getTokenByName = (
-  tokens: TokensResponse['tokens'],
-  name: string,
-) => {
-  return Object.values(tokens)
-    .flat()
-    .filter((el) => {
-      return el.name.toLowerCase() === name.toLowerCase();
-    });
-};
-
-export const getTokenByAddressOnSpecificChain = (
-  tokens: TokensResponse['tokens'],
-  chainId: number,
-  address: string,
-) => {
-  const chainTokens = tokens[chainId] ?? [];
-  const filteredToken = chainTokens.find(
-    (el) => el.address.toLowerCase() === address.toLowerCase(),
-  );
-  return filteredToken;
-};
-
-// @Note: this works only for EVM chains
-export const getNativeTokenForChain = (
-  tokens: TokensResponse['tokens'],
-  chainId: number,
-) => {
-  const chainTokens = tokens[chainId] ?? [];
-  return chainTokens.find((token) => token.address === zeroAddress);
 };


### PR DESCRIPTION
This is an attempt to unify the tokens math'ing and the general concept of tokens (especially the differentiation of when an updated price is available).

This is _probably_ still ongoing as we're only using the `Simple`/`Extended` tokens in one place so far.

Also I found that in a lot of places we're not _really_ using the updated prices. One TODO is to make the updated prices available to all places that _really_ need it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended token pricing with USD values improves displayed USD amounts, conversions, and avatars across the app.

* **Refactor**
  * Unified token and price handling for consistent amount and USD formatting, improved fallbacks when price is missing, and streamlined token data used in withdraws, positions, and cards.
  * Tooltips and selection cards now reflect the new formatted amount and USD display.

* **Tests**
  * Added unit and snapshot tests covering token models and formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->