### PR TITLE
fix: use primary balance based on sorted chain

### DIFF
--- a/src/utils/getTokens/transformWalletBalances.ts
+++ b/src/utils/getTokens/transformWalletBalances.ts
@@ -57,17 +57,18 @@ function createTokenGroup(
     ['desc'],
   );
   const primaryChain = first(sortedChains);
-  const firstBalance = first(balances)!;
+  const primaryBalance =
+    find(balances, { chainId: primaryChain?.chainId }) ?? first(balances)!;
 
   return {
-    address: firstBalance.address,
-    symbol: firstBalance.symbol,
-    chainId: primaryChain?.chainId ?? firstBalance.chainId,
-    amount: safeBigInt(firstBalance.amount),
-    name: firstBalance.name,
-    priceUSD: firstBalance.priceUSD,
-    decimals: firstBalance.decimals,
-    logoURI: firstBalance.logoURI,
+    address: primaryBalance.address,
+    symbol: primaryBalance.symbol,
+    chainId: primaryChain?.chainId ?? primaryBalance.chainId,
+    amount: safeBigInt(primaryBalance.amount),
+    name: primaryBalance.name,
+    priceUSD: primaryBalance.priceUSD,
+    decimals: primaryBalance.decimals,
+    logoURI: primaryBalance.logoURI,
     chainLogoURI: primaryChain?.chainLogoURI,
     chainName: primaryChain?.chainName,
     cumulatedBalance: sumBy(sortedChains, (c) => c.cumulatedBalance ?? 0),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Token grouping now prioritizes balances from the primary chain when present, so displayed token details (address, symbol, chain, amount, name, price, decimals, logo) reflect the primary-chain balance. Chain name/logo and aggregated balance remain as before.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->