### PR TITLE
feat: add overview page tracking for mission and earn

### DIFF
--- a/src/app/ui/earn/EarnPage.tsx
+++ b/src/app/ui/earn/EarnPage.tsx
@@ -12,6 +12,7 @@ import { EarnRelatedMarkets } from 'src/components/EarnRelatedMarkets/EarnRelate
 import { DepositFlowModal } from 'src/components/composite/DepositFlow/DepositFlow';
 import { WithdrawFlowModal } from '@/components/composite/WithdrawFlow/WithdrawFlow';
 import { ContactSupportEventProvider } from '@/components/Widgets/events/ContactSupportEventProvider';
+import { EarnPageTracking } from '@/components/headless/tracking/EarnPageTracking';
 
 interface EarnPageProps {
   slug: string;
@@ -58,6 +59,7 @@ export const EarnPage: FC<EarnPageProps> = async ({ slug }) => {
       <DepositFlowModal />
       <WithdrawFlowModal />
       <ContactSupportEventProvider />
+      <EarnPageTracking slug={slug} />
     </>
   );
 };

--- a/src/app/ui/earn/EarnsPage.tsx
+++ b/src/app/ui/earn/EarnsPage.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 
 import { EarnOpportunitiesAll } from './EarnOpportunitiesAll/EarnOpportunitiesAll';
 import { EarnTopOpportunities } from './EarnTopOpportunities';
+import { EarnPageTracking } from '@/components/headless/tracking/EarnPageTracking';
 
 interface EarnsPageProps {}
 
@@ -10,6 +11,7 @@ export const EarnsPage: FC<EarnsPageProps> = () => {
     <>
       <EarnTopOpportunities />
       <EarnOpportunitiesAll />
+      <EarnPageTracking />
     </>
   );
 };

--- a/src/app/ui/mission/MissionPage.tsx
+++ b/src/app/ui/mission/MissionPage.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import type { FC } from 'react';
 import { notFound } from 'next/navigation';
 
 import { getQuestBySlug } from 'src/app/lib/getQuestBySlug';
@@ -7,6 +7,7 @@ import { fetchOpportunitiesByRewardsIds } from 'src/utils/merkl/fetchQuestOpport
 import { MissionDetails } from './MissionDetails';
 import { MissionWidget } from './MissionWidget/MissionWidget';
 import { TwoColumnLayout } from 'src/components/TwoColumnLayout/TwoColumnLayout';
+import { MissionPageTracking } from '@/components/headless/tracking/MissionPageTracking';
 
 interface MissionPageProps {
   slug: string;
@@ -26,10 +27,17 @@ export const MissionPage: FC<MissionPageProps> = async ({ slug }) => {
   ]);
 
   return (
-    <TwoColumnLayout
-      mainContent={<MissionDetails mission={data} tasks={taskOpportunities} />}
-      sideContent={<MissionWidget customInformation={data.CustomInformation} />}
-      shouldStretchSideContent
-    />
+    <>
+      <TwoColumnLayout
+        mainContent={
+          <MissionDetails mission={data} tasks={taskOpportunities} />
+        }
+        sideContent={
+          <MissionWidget customInformation={data.CustomInformation} />
+        }
+        shouldStretchSideContent
+      />
+      <MissionPageTracking slug={slug} />
+    </>
   );
 };

--- a/src/app/ui/missions/MissionsPage.tsx
+++ b/src/app/ui/missions/MissionsPage.tsx
@@ -6,6 +6,7 @@ import { isBannerCampaign } from 'src/utils/isBannerCampaign';
 import { BannerCampaign } from './BannerCampaign/BannerCampaign';
 import { GridContainer } from 'src/components/Containers/GridContainer';
 import { MissionsSection } from './MissionsSection';
+import { MissionPageTracking } from '@/components/headless/tracking/MissionPageTracking';
 
 export const MissionsPage = async () => {
   const [{ data: campaigns }, { data: missionsResponse }] = await Promise.all([
@@ -36,6 +37,7 @@ export const MissionsPage = async () => {
           />
         </GridContainer>
       </MissionsSection>
+      <MissionPageTracking />
     </>
   );
 };

--- a/src/components/headless/tracking/EarnPageTracking.tsx
+++ b/src/components/headless/tracking/EarnPageTracking.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useEarnTracking } from '@/hooks/userTracking/useEarnTracking';
+import { useAccountAddress } from '@/hooks/earn/useAccountAddress';
+import { useEffect } from 'react';
+
+export const EarnPageTracking = ({ slug }: { slug?: string }) => {
+  const { trackEarnPageOverviewEvent } = useEarnTracking();
+  const accountAddress = useAccountAddress();
+
+  useEffect(() => {
+    trackEarnPageOverviewEvent(slug);
+  }, [accountAddress, slug, trackEarnPageOverviewEvent]);
+
+  return null;
+};

--- a/src/components/headless/tracking/MissionPageTracking.tsx
+++ b/src/components/headless/tracking/MissionPageTracking.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useAccountAddress } from '@/hooks/earn/useAccountAddress';
+import { useMissionTracking } from '@/hooks/userTracking/useMissionTracking';
+import { useEffect } from 'react';
+
+export const MissionPageTracking = ({ slug }: { slug?: string }) => {
+  const { trackMissionPageOverviewEvent } = useMissionTracking();
+  const accountAddress = useAccountAddress();
+
+  useEffect(() => {
+    trackMissionPageOverviewEvent(slug);
+  }, [accountAddress, slug, trackMissionPageOverviewEvent]);
+
+  return null;
+};

--- a/src/const/trackingKeys.ts
+++ b/src/const/trackingKeys.ts
@@ -125,6 +125,7 @@ export enum TrackingAction {
   ClickMissionCta = 'action_click_mission_cta',
   ClickMissionCtaSteps = 'action_click_mission_cta_steps',
   ClickMissionVerify = 'action_click_mission_task_verify',
+  MissionPageOverview = 'action_mission_page_overview',
 
   // Pagination
   ClickPagination = 'action_click_pagination',
@@ -141,6 +142,7 @@ export enum TrackingAction {
   // Earn
   ClickEarnDepositButton = 'action_click_earn_deposit_button',
   ClickEarnWithdrawButton = 'action_click_earn_withdraw_button',
+  EarnPageOverview = 'action_earn_page_overview',
 }
 
 export enum TrackingEventDataAction {
@@ -320,6 +322,7 @@ export enum TrackingEventParameter {
   MissionCtaStepsCTA = 'param_mission_cta_steps_cta',
   MissionCtaStepsIndex = 'param_mission_cta_steps_index',
   MissionTaskInputPrepend = 'param_mission_task_input_field_',
+  MissionSlug = 'param_mission_slug',
 
   // Search
   SearchValue = 'param_search_value',

--- a/src/hooks/userTracking/useEarnTracking.ts
+++ b/src/hooks/userTracking/useEarnTracking.ts
@@ -5,12 +5,13 @@ import {
 } from '@/const/trackingKeys';
 import { useUserTracking } from './useUserTracking';
 import type { JumperEventData } from '../useJumperTracking';
+import { useCallback } from 'react';
 
 export const useEarnTracking = () => {
   const { trackEvent } = useUserTracking();
 
-  return {
-    trackEarnPageOverviewEvent: (slug?: string) => {
+  const trackEarnPageOverviewEvent = useCallback(
+    (slug?: string) => {
       const data: JumperEventData = slug
         ? {
             [TrackingEventParameter.EarnOpportunitySlug]: slug,
@@ -23,25 +24,46 @@ export const useEarnTracking = () => {
         data,
       });
     },
-    trackEarnDepositClickEvent: (slug?: string) => {
+    [trackEvent],
+  );
+
+  const trackEarnDepositClickEvent = useCallback(
+    (slug?: string) => {
+      const data: JumperEventData = slug
+        ? {
+            [TrackingEventParameter.EarnOpportunitySlug]: slug,
+          }
+        : {};
       trackEvent({
         category: TrackingCategory.Earn,
         action: TrackingAction.ClickEarnDepositButton,
         label: 'click-earn-deposit-button',
-        data: {
-          [TrackingEventParameter.EarnOpportunitySlug]: slug || '',
-        },
+        data,
       });
     },
-    trackEarnWithdrawClickEvent: (slug?: string) => {
+    [trackEvent],
+  );
+
+  const trackEarnWithdrawClickEvent = useCallback(
+    (slug?: string) => {
+      const data: JumperEventData = slug
+        ? {
+            [TrackingEventParameter.EarnOpportunitySlug]: slug,
+          }
+        : {};
       trackEvent({
         category: TrackingCategory.Earn,
         action: TrackingAction.ClickEarnWithdrawButton,
         label: 'click-earn-withdraw-button',
-        data: {
-          [TrackingEventParameter.EarnOpportunitySlug]: slug || '',
-        },
+        data,
       });
     },
+    [trackEvent],
+  );
+
+  return {
+    trackEarnPageOverviewEvent,
+    trackEarnDepositClickEvent,
+    trackEarnWithdrawClickEvent,
   };
 };

--- a/src/hooks/userTracking/useEarnTracking.ts
+++ b/src/hooks/userTracking/useEarnTracking.ts
@@ -4,11 +4,25 @@ import {
   TrackingEventParameter,
 } from '@/const/trackingKeys';
 import { useUserTracking } from './useUserTracking';
+import type { JumperEventData } from '../useJumperTracking';
 
 export const useEarnTracking = () => {
   const { trackEvent } = useUserTracking();
 
   return {
+    trackEarnPageOverviewEvent: (slug?: string) => {
+      const data: JumperEventData = slug
+        ? {
+            [TrackingEventParameter.EarnOpportunitySlug]: slug,
+          }
+        : {};
+      trackEvent({
+        category: TrackingCategory.Earn,
+        action: TrackingAction.EarnPageOverview,
+        label: 'earn_page_overview',
+        data,
+      });
+    },
     trackEarnDepositClickEvent: (slug?: string) => {
       trackEvent({
         category: TrackingCategory.Earn,

--- a/src/hooks/userTracking/useMissionTracking.ts
+++ b/src/hooks/userTracking/useMissionTracking.ts
@@ -1,0 +1,27 @@
+import {
+  TrackingAction,
+  TrackingCategory,
+  TrackingEventParameter,
+} from '@/const/trackingKeys';
+import { useUserTracking } from './useUserTracking';
+import type { JumperEventData } from '../useJumperTracking';
+
+export const useMissionTracking = () => {
+  const { trackEvent } = useUserTracking();
+
+  return {
+    trackMissionPageOverviewEvent: (slug?: string) => {
+      const data: JumperEventData = slug
+        ? {
+            [TrackingEventParameter.MissionSlug]: slug,
+          }
+        : {};
+      trackEvent({
+        category: TrackingCategory.Quests,
+        action: TrackingAction.MissionPageOverview,
+        label: 'mission_page_overview',
+        data,
+      });
+    },
+  };
+};

--- a/src/hooks/userTracking/useMissionTracking.ts
+++ b/src/hooks/userTracking/useMissionTracking.ts
@@ -5,12 +5,13 @@ import {
 } from '@/const/trackingKeys';
 import { useUserTracking } from './useUserTracking';
 import type { JumperEventData } from '../useJumperTracking';
+import { useCallback } from 'react';
 
 export const useMissionTracking = () => {
   const { trackEvent } = useUserTracking();
 
-  return {
-    trackMissionPageOverviewEvent: (slug?: string) => {
+  const trackMissionPageOverviewEvent = useCallback(
+    (slug?: string) => {
       const data: JumperEventData = slug
         ? {
             [TrackingEventParameter.MissionSlug]: slug,
@@ -23,5 +24,10 @@ export const useMissionTracking = () => {
         data,
       });
     },
+    [trackEvent],
+  );
+
+  return {
+    trackMissionPageOverviewEvent,
   };
 };

--- a/src/hooks/userTracking/usePortfolioTracking.ts
+++ b/src/hooks/userTracking/usePortfolioTracking.ts
@@ -14,13 +14,14 @@ import type { CacheToken } from '@/types/portfolio';
 import { zeroAddress } from 'viem';
 import type { ChainId } from '@lifi/sdk';
 import { useChains } from '../useChains';
+import { useCallback } from 'react';
 
 export const usePortfolioTracking = () => {
   const { trackEvent } = useUserTracking();
   const { getChainById } = useChains();
 
-  return {
-    trackPortfolioPageOverviewEvent: (
+  const trackPortfolioPageOverviewEvent = useCallback(
+    (
       addresses: string[],
       tokens: MinimalToken[],
       defiPositionGroups: DefiPosition[][],
@@ -37,21 +38,23 @@ export const usePortfolioTracking = () => {
         data: trackingData,
       });
     },
-    trackPortfolioBalanceLoadedEvent: () => {
-      trackEvent({
-        category: TrackingCategory.Wallet,
-        action: TrackingAction.PortfolioLoaded,
-        label: 'portfolio_balance_loaded',
-        data: {
-          [TrackingEventParameter.Status]: 'success',
-          [TrackingEventParameter.Timestamp]: new Date().toUTCString(),
-        },
-      });
-    },
-    trackPortfolioMenuOverviewEvent: (
-      totalValue: number,
-      data: CacheToken[],
-    ) => {
+    [trackEvent],
+  );
+
+  const trackPortfolioBalanceLoadedEvent = useCallback(() => {
+    trackEvent({
+      category: TrackingCategory.Wallet,
+      action: TrackingAction.PortfolioLoaded,
+      label: 'portfolio_balance_loaded',
+      data: {
+        [TrackingEventParameter.Status]: 'success',
+        [TrackingEventParameter.Timestamp]: new Date().toUTCString(),
+      },
+    });
+  }, [trackEvent]);
+
+  const trackPortfolioMenuOverviewEvent = useCallback(
+    (totalValue: number, data: CacheToken[]) => {
       const returnNativeTokenAddresses = (chainsIds: ChainId[]) =>
         chainsIds.map(
           (chainId) =>
@@ -72,5 +75,12 @@ export const usePortfolioTracking = () => {
         data: trackingData,
       });
     },
+    [trackEvent, getChainById],
+  );
+
+  return {
+    trackPortfolioPageOverviewEvent,
+    trackPortfolioBalanceLoadedEvent,
+    trackPortfolioMenuOverviewEvent,
   };
 };


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-17222

## Testing steps

1. Open the network tab and filter for `/users/events`
2. Visit `/missions`
3. Check the `action_mission_page_overview` is sent
4. Now visit a mission detail page (eg. `/missions/test123`)
5. Check the `action_mission_page_overview` is sent with data field having the slug set
6. Visit `/earn`
7. Check the `action_earn_page_overview` is sent
8. Now visit an earn opportunity detail page
9. Check the `action_earn_page_overview` is sent with data field having the slug set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added page view tracking for Earn and Mission pages to better monitor engagement.

* **Chores**
  * Improved tracking handler performance and stabilized event calls.
  * Tidied import usage for minor efficiency gains.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->