### PR TITLE
chore: capitalize protocol name for protocol card

### DIFF
--- a/src/components/Cards/ProtocolCard/ProtocolCard.tsx
+++ b/src/components/Cards/ProtocolCard/ProtocolCard.tsx
@@ -17,7 +17,6 @@ import { PROTOCOL_CARD_SIZES } from './constants';
 import Typography from '@mui/material/Typography';
 import { Badge } from 'src/components/Badge/Badge';
 import { BadgeSize, BadgeVariant } from 'src/components/Badge/Badge.styles';
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import CodeRoundedIcon from '@mui/icons-material/CodeRounded';
 import { useTranslation } from 'react-i18next';
 import { capitalizeString } from 'src/utils/capitalizeString';
@@ -141,7 +140,7 @@ export const ProtocolCard: FC<ProtocolCardProps> = ({
                 color: protocolImageContrastColor,
               }}
             >
-              {protocol?.name}
+              {protocol?.name ? capitalizeString(protocol.name) : ''}
             </ProtocolCardProtocolTitle>
           </ProtocolCardHeaderContentContainer>
         </ProtocolCardHeaderContainer>

--- a/src/components/Cards/ProtocolCard/__snapshots__/ProtocolCard.snapshot.spec.tsx.snap
+++ b/src/components/Cards/ProtocolCard/__snapshots__/ProtocolCard.snapshot.spec.tsx.snap
@@ -22,7 +22,7 @@ exports[`ProtocolCard snapshot > protocol card matches snapshot 1`] = `
         <p
           class="MuiTypography-root MuiTypography-body1 css-15kxehp-MuiTypography-root"
         >
-          morpho
+          Morpho
         </p>
       </div>
     </div>
@@ -119,7 +119,7 @@ exports[`ProtocolCard snapshot > protocol card with badge matches snapshot 1`] =
         <p
           class="MuiTypography-root MuiTypography-body1 css-15kxehp-MuiTypography-root"
         >
-          morpho
+          Morpho
         </p>
       </div>
     </div>
@@ -235,7 +235,7 @@ exports[`ProtocolCard snapshot > protocol card with long title matches snapshot 
         <p
           class="MuiTypography-root MuiTypography-body1 css-15kxehp-MuiTypography-root"
         >
-          this is a very long protocol name that should be truncated
+          This is a very long protocol name that should be truncated
         </p>
       </div>
     </div>


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-17230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Protocol names now display with proper capitalization formatting, ensuring names appear consistently capitalized in the UI rather than in their original raw form. This improves readability and visual consistency across lists and cards where protocol names are shown.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->