### PR TITLE
feat: add navigation to "Your Positions" tab on Earn page

### DIFF
--- a/tests/earnPage.spec.ts
+++ b/tests/earnPage.spec.ts
@@ -8,6 +8,7 @@ import {
   verifyOnlySelectedTagIsVisible,
   verifyAnalyticsButtonsAreVisible,
   verifyFiltersAreVisible,
+  selectYourPositionsTab,
 } from './testData/earnPageFunctions';
 import { qase } from 'playwright-qase-reporter';
 import { injectMockWallet } from './utils/mockWallet';
@@ -249,6 +250,27 @@ test.describe('Analytics filters on Earn page', () => {
     async ({ page }) => {
       await test.step('Verify analytics range filters are visible', async () => {
         await verifyAnalyticsButtonsAreVisible(page);
+      });
+    },
+  );
+});
+
+test.describe('Should be able to navigate to the "Your Positions" tab', () => {
+  test.beforeEach(async ({ page, context }) => {
+    await context.addInitScript({ content: injectMockWallet() });
+    await page.goto('/earn');
+    await expect(connectButton(page)).toBeVisible();
+    await connectButton(page).click();
+    await expectSelectWalletOptionToBeVisible(page);
+    await selectWalletOption(page, 'MetaMask');
+    await selectYourPositionsTab(page);
+  });
+
+  test(
+    qase(56, 'Should be able to navigate to the "Your Positions" tab'),
+    async ({ page }) => {
+      await test.step('Navigate to the "Your Positions" tab and verify filters are visible', async () => {
+        await verifyFiltersAreVisible(page);
       });
     },
   );

--- a/tests/testData/earnPageFunctions.ts
+++ b/tests/testData/earnPageFunctions.ts
@@ -5,6 +5,10 @@ export async function selectAllMarketsTab(page: Page) {
   await allMarketsTab.click();
 }
 
+export async function selectYourPositionsTab(page: Page) {
+  const yourPositionsTab = page.getByTestId('earn-filter-tab-your-positions');
+  await yourPositionsTab.click();
+}
 export async function verifyAnalyticsButtonsAreVisible(page: Page) {
   const chartButtons = [
     'analytics-range-week',
@@ -173,6 +177,7 @@ export async function verifyFiltersAreVisible(page: Page) {
     'earn-filter-tag-select',
     'earn-filter-asset-select',
     'earn-filter-apy-select',
+    'earn-filter-tvl-select',
   ];
   for (const filterId of filterIds) {
     await expect(page.getByTestId(filterId)).toBeVisible();


### PR DESCRIPTION
Related ticket : https://lifi.atlassian.net/browse/JUM-266 

### Summary
Adds a Playwright test suite to verify navigation to the "Your Positions" tab on the Earn page and ensures filters are visible after navigation.
### Changes
Added test suite: "Should be able to navigate to the 'Your Positions' tab"
Verifies navigation to the "Your Positions" tab
Confirms all filters are visible after navigation
Added helper function selectYourPositionsTab in earnPageFunctions.ts
Reusable function to navigate to the "Your Positions" tab
Uses test ID earn-filter-tab-your-positions
Updated verifyFiltersAreVisible to include earn-filter-tvl-select in the filter verification list
### Testing
New test case (Qase ID: 56) covers navigation to the "Your Positions" tab
Test follows existing patterns with proper setup/teardown
Includes wallet connection setup and filter visibility verification
### Files Changed
tests/earnPage.spec.ts - Added new test suite
tests/testData/earnPageFunctions.ts - Added selectYourPositionsTab helper function and updated filter verification


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the Earn page "Your Positions" tab with improved test utilities for navigation and filter verification.

---

**Note:** This release contains only internal test improvements with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->