### PR TITLE
fix: earn cards height on mobile and safari

### DIFF
--- a/src/components/Cards/EarnCard/EarnCard.styles.ts
+++ b/src/components/Cards/EarnCard/EarnCard.styles.ts
@@ -55,7 +55,7 @@ export const CompactEarnCardContainer = styled(EarnCardContainer)(
   ({ theme }) => ({
     padding: theme.spacing(1.5),
     minHeight: 266,
-    height: '-webkit-fill-available',
+    height: '100%',
   }),
 );
 

--- a/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
+++ b/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EarnCard snapshot > compact card matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1wvwwcz"
+    class="MuiBox-root css-1mzv38v"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -344,7 +344,7 @@ exports[`EarnCard snapshot > compact card matches snapshot 1`] = `
 exports[`EarnCard snapshot > compact card with cap in dollar matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1wvwwcz"
+    class="MuiBox-root css-1mzv38v"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -662,7 +662,7 @@ exports[`EarnCard snapshot > compact card with href matches snapshot 1`] = `
     href="/earn/moonwell-flagship-usdc-on-base"
   >
     <div
-      class="MuiBox-root css-1kf7s28"
+      class="MuiBox-root css-ilbv8r"
     >
       <div
         class="MuiBox-root css-ohw5b5"
@@ -977,7 +977,7 @@ exports[`EarnCard snapshot > compact card with href matches snapshot 1`] = `
 exports[`EarnCard snapshot > compact card with loading matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1wvwwcz"
+    class="MuiBox-root css-1mzv38v"
   >
     <div
       class="MuiBox-root css-1wj7dar"
@@ -1034,7 +1034,7 @@ exports[`EarnCard snapshot > compact card with loading matches snapshot 1`] = `
 exports[`EarnCard snapshot > compact card with lockup months and cap in dollar matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1wvwwcz"
+    class="MuiBox-root css-1mzv38v"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -1348,7 +1348,7 @@ exports[`EarnCard snapshot > compact card with lockup months and cap in dollar m
 exports[`EarnCard snapshot > compact card with lockup months matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1wvwwcz"
+    class="MuiBox-root css-1mzv38v"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -1662,7 +1662,7 @@ exports[`EarnCard snapshot > compact card with lockup months matches snapshot 1`
 exports[`EarnCard snapshot > compact card with no recommendation matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1wvwwcz"
+    class="MuiBox-root css-1mzv38v"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -1972,7 +1972,7 @@ exports[`EarnCard snapshot > compact card with no recommendation matches snapsho
 exports[`EarnCard snapshot > compact card with single asset matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1wvwwcz"
+    class="MuiBox-root css-1mzv38v"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -2313,7 +2313,7 @@ exports[`EarnCard snapshot > compact card with single asset matches snapshot 1`]
 exports[`EarnCard snapshot > compact card with two items matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1wvwwcz"
+    class="MuiBox-root css-1mzv38v"
   >
     <div
       class="MuiBox-root css-ohw5b5"

--- a/src/components/Cards/HeroEarnCard/HeroEarnCard.styles.ts
+++ b/src/components/Cards/HeroEarnCard/HeroEarnCard.styles.ts
@@ -25,7 +25,7 @@ export const HeroEarnCardContainer = styled(Box, {
   padding: theme.spacing(4),
   gap: theme.spacing(0.5),
   minHeight: 312,
-  height: '-webkit-fill-available',
+  height: '100%',
   display: 'flex',
   flexDirection: 'column',
   [theme.breakpoints.up('md')]: {

--- a/src/components/Cards/HeroEarnCard/__snapshots__/HeroEarnCard.snapshot.spec.tsx.snap
+++ b/src/components/Cards/HeroEarnCard/__snapshots__/HeroEarnCard.snapshot.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`HeroEarnCard snapshot > hero card matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1y44ltr"
+    class="MuiBox-root css-4b41no"
   >
     <div
       class="MuiStack-root css-imab1l-MuiStack-root"
@@ -145,7 +145,7 @@ exports[`HeroEarnCard snapshot > hero card matches snapshot 1`] = `
 exports[`HeroEarnCard snapshot > hero card with EARN_UP_TO copy matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1y44ltr"
+    class="MuiBox-root css-4b41no"
   >
     <div
       class="MuiStack-root css-imab1l-MuiStack-root"
@@ -287,7 +287,7 @@ exports[`HeroEarnCard snapshot > hero card with EARN_UP_TO copy matches snapshot
 exports[`HeroEarnCard snapshot > hero card with MAKE_THE_JUMP copy matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1y44ltr"
+    class="MuiBox-root css-4b41no"
   >
     <div
       class="MuiStack-root css-imab1l-MuiStack-root"
@@ -429,7 +429,7 @@ exports[`HeroEarnCard snapshot > hero card with MAKE_THE_JUMP copy matches snaps
 exports[`HeroEarnCard snapshot > hero card with MAXIMIZE_YOUR_REVENUE copy matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1y44ltr"
+    class="MuiBox-root css-4b41no"
   >
     <div
       class="MuiStack-root css-imab1l-MuiStack-root"
@@ -575,7 +575,7 @@ exports[`HeroEarnCard snapshot > hero card with link matches snapshot 1`] = `
     href="/earn/moonwell-flagship-usdc-on-base"
   >
     <div
-      class="MuiBox-root css-yyhbh8"
+      class="MuiBox-root css-hmuyyx"
     >
       <div
         class="MuiStack-root css-imab1l-MuiStack-root"
@@ -718,7 +718,7 @@ exports[`HeroEarnCard snapshot > hero card with link matches snapshot 1`] = `
 exports[`HeroEarnCard snapshot > hero card with loading matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-gpbse"
+    class="MuiBox-root css-178nvb"
   >
     <div
       class="MuiStack-root css-imab1l-MuiStack-root"
@@ -761,7 +761,7 @@ exports[`HeroEarnCard snapshot > hero card with loading matches snapshot 1`] = `
 exports[`HeroEarnCard snapshot > hero card with single asset matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1y44ltr"
+    class="MuiBox-root css-4b41no"
   >
     <div
       class="MuiStack-root css-imab1l-MuiStack-root"


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/JUM-269

## Testing steps

1. Open Safari
2. Go to `/earn`
3. Check the hero and opportunity cards' height on desktop and mobile
4. Worth to check them also in the ios Simulator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced card container sizing for improved layout consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->