### PR TITLE
fix: your positions tab when no wallet connected

### DIFF
--- a/src/app/ui/earn/EarnEmptyList/EarnEmptyListYourPositions.tsx
+++ b/src/app/ui/earn/EarnEmptyList/EarnEmptyListYourPositions.tsx
@@ -4,17 +4,39 @@ import { useEarnFiltering } from '../EarnFilteringContext';
 import { EarnFilterTab } from '../types';
 import { AppPaths } from '@/const/urls';
 import { useRouter } from 'next/navigation';
+import { useAccount, useWalletMenu } from '@lifi/wallet-management';
 
 export const EarnEmptyListYourPositions = () => {
   const { t } = useTranslation();
   const { changeTab } = useEarnFiltering();
   const router = useRouter();
+  const { account } = useAccount();
+  const { openWalletMenu } = useWalletMenu();
+  const isConnected = account.isConnected;
+
+  const handleConnectWallet = () => {
+    openWalletMenu();
+  };
   const handleViewAllMarkets = () => {
     changeTab(EarnFilterTab.ALL);
   };
   const handleGoToPortfolio = () => {
     router.push(AppPaths.Portfolio);
   };
+
+  if (!isConnected) {
+    return (
+      <PortfolioEmptyList
+        title={t('earn.emptyList.yourPositionsNotConnected.title')}
+        description={t('earn.emptyList.yourPositionsNotConnected.description')}
+        primaryButtonLabel={t(
+          'earn.emptyList.yourPositionsNotConnected.viewAllMarkets',
+        )}
+        onPrimaryButtonClick={handleConnectWallet}
+      />
+    );
+  }
+
   return (
     <PortfolioEmptyList
       title={t('earn.emptyList.yourPositions.title')}

--- a/src/app/ui/earn/EarnFilteringContext.tsx
+++ b/src/app/ui/earn/EarnFilteringContext.tsx
@@ -116,13 +116,18 @@ export const EarnFilteringProvider = ({
     },
   });
 
-  const all = useEarnFilterOpportunities({
-    filter: {
-      ...filter,
-      ...(showYourPositions ? { hasPositions: true, address } : {}),
-      sortBy: sortBy,
+  const all = useEarnFilterOpportunities(
+    {
+      filter: {
+        ...filter,
+        ...(showYourPositions ? { hasPositions: true, address } : {}),
+        sortBy: sortBy,
+      },
     },
-  });
+    {
+      enabled: showYourPositions ? !!address : true,
+    },
+  );
 
   const allNoFilter = useEarnFilterOpportunities({
     filter: {},

--- a/src/hooks/earn/useEarnFilterOpportunities.ts
+++ b/src/hooks/earn/useEarnFilterOpportunities.ts
@@ -1,7 +1,7 @@
 import type { EarnOpportunityFilter } from '@/app/lib/getOpportunitiesFiltered';
 import { getOpportunitiesFiltered } from '@/app/lib/getOpportunitiesFiltered';
 import type { EarnOpportunities } from '@/types/jumper-backend';
-import type { UseQueryResult } from '@tanstack/react-query';
+import type { UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 import { ONE_HOUR_MS } from 'src/const/time';
 
@@ -20,7 +20,13 @@ export type Result = UseQueryResult<
   unknown
 >;
 
-export const useEarnFilterOpportunities = ({ filter }: Props): Result => {
+export const useEarnFilterOpportunities = (
+  { filter }: Props,
+  options: Omit<
+    UseQueryOptions<EarnOpportunities>,
+    'queryKey' | 'queryFn' | 'select' | 'placeholderData'
+  > = {},
+): Result => {
   return useQuery({
     queryKey: ['earn-filter-opportunities', filter],
     queryFn: async () => {
@@ -37,6 +43,8 @@ export const useEarnFilterOpportunities = ({ filter }: Props): Result => {
       };
     },
     refetchInterval: ONE_HOUR_MS,
-    placeholderData: (previousData) => previousData,
+    placeholderData: (previousData) =>
+      options.enabled ? previousData : undefined,
+    ...options,
   });
 };

--- a/src/hooks/earn/useEarnFilterOpportunities.ts
+++ b/src/hooks/earn/useEarnFilterOpportunities.ts
@@ -25,7 +25,7 @@ export const useEarnFilterOpportunities = (
   options: Omit<
     UseQueryOptions<EarnOpportunities>,
     'queryKey' | 'queryFn' | 'select' | 'placeholderData'
-  > = {},
+  > = { enabled: true },
 ): Result => {
   return useQuery({
     queryKey: ['earn-filter-opportunities', filter],
@@ -44,7 +44,7 @@ export const useEarnFilterOpportunities = (
     },
     refetchInterval: ONE_HOUR_MS,
     placeholderData: (previousData) =>
-      options.enabled ? previousData : undefined,
+      !('enabled' in options) || options.enabled ? previousData : undefined,
     ...options,
   });
 };

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -98,6 +98,11 @@ interface Resources {
           title: 'No positions';
           viewAllMarkets: 'View all markets';
         };
+        yourPositionsNotConnected: {
+          description: 'Connect your wallet to view your positions.';
+          title: 'No wallet connected';
+          viewAllMarkets: 'Connect wallet';
+        };
       };
       filter: {
         apy: 'APY';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -419,6 +419,11 @@
         "description": "Looks like you don't have any active positions in any market yet.\nIf you think a position is missing try visiting your portfolio.",
         "viewAllMarkets": "View all markets"
       },
+      "yourPositionsNotConnected": {
+        "title": "No wallet connected",
+        "description": "Connect your wallet to view your positions.",
+        "viewAllMarkets": "Connect wallet"
+      },
       "noResults": {
         "title": "No results",
         "description": "Unfortunately there are no results for your search, try clearing your filters.",


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-17234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Earn detects wallet connection and shows a tailored empty state for "Your positions", with a clear CTA to connect when not signed in.
  * Data loading for "Your positions" is now gated to run only when the wallet view is active and connected, reducing unnecessary fetches.

* **Documentation**
  * Added localized copy for the not-connected empty state (title, description, CTA).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->