### PR TITLE
fix: same chain by default on deposit withdrawal

### DIFF
--- a/src/components/Widgets/variants/base/ZapWidget/ZapDepositBackendWidget.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapDepositBackendWidget.tsx
@@ -80,6 +80,14 @@ export const ZapDepositBackendWidget: FC<ZapDepositBackendWidgetProps> = ({
     return zapData?.market?.depositToken.chainId;
   }, [zapData?.market?.depositToken.chainId]);
 
+  const fromToken = useMemo(() => {
+    return zapData?.market?.depositToken.address;
+  }, [zapData?.market?.depositToken.address]);
+
+  const fromChain = useMemo(() => {
+    return zapData?.market?.depositToken.chainId;
+  }, [zapData?.market?.depositToken.chainId]);
+
   const minFromAmountUSD = useMemo(() => {
     return projectData?.minFromAmountUSD
       ? Number(projectData?.minFromAmountUSD)
@@ -169,6 +177,8 @@ export const ZapDepositBackendWidget: FC<ZapDepositBackendWidgetProps> = ({
       }
       contractComponent={
         <ZapDepositSettings
+          fromChain={fromChain}
+          fromToken={fromToken}
           toChain={toChain}
           toToken={toToken}
           contractCalls={[]}

--- a/src/components/Widgets/variants/base/ZapWidget/ZapDepositSettings.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapDepositSettings.tsx
@@ -1,7 +1,10 @@
 import { type ContractCall, useFieldActions } from '@lifi/widget';
-import { FC, useEffect } from 'react';
+import type { FC } from 'react';
+import { useEffect } from 'react';
 
 interface ZapDepositSettingsProps {
+  fromChain?: number;
+  fromToken?: string;
   toChain: number;
   toToken: string;
   contractCalls: ContractCall[];
@@ -10,6 +13,8 @@ interface ZapDepositSettingsProps {
 // @Note unfortunately using the formRef did not provide the correct updates without the buildUrl set to true in the widget config
 // So sticking with this solution for now
 export const ZapDepositSettings: FC<ZapDepositSettingsProps> = ({
+  fromChain,
+  fromToken,
   toChain,
   toToken,
   contractCalls,
@@ -17,10 +22,16 @@ export const ZapDepositSettings: FC<ZapDepositSettingsProps> = ({
   const { setFieldValue } = useFieldActions();
 
   useEffect(() => {
+    if (fromChain) {
+      setFieldValue('fromChain', fromChain, { isTouched: true });
+    }
+    if (fromToken) {
+      setFieldValue('fromToken', fromToken, { isTouched: true });
+    }
     setFieldValue('toChain', toChain, { isTouched: true });
     setFieldValue('toToken', toToken, { isTouched: true });
     setFieldValue('contractCalls', contractCalls ?? [], { isTouched: true });
-  }, [setFieldValue, toChain, toToken, contractCalls]);
+  }, [setFieldValue, toChain, toToken, contractCalls, fromChain, fromToken]);
 
   return null;
 };

--- a/src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget.tsx
@@ -71,6 +71,16 @@ export const ZapWithdrawWidget: FC<ZapWithdrawWidgetProps> = ({
     };
   }, [projectData?.chainId, projectData?.chain]);
 
+  const toChain = useMemo(() => {
+    if (!projectData?.chainId) {
+      return undefined;
+    }
+    return {
+      chainId: projectData?.chainId,
+      chainKey: projectData?.chain ?? '',
+    };
+  }, [projectData?.chainId, projectData?.chain]);
+
   const enhancedCtx = useMemo(() => {
     return {
       ...ctx,
@@ -83,9 +93,10 @@ export const ZapWithdrawWidget: FC<ZapWithdrawWidgetProps> = ({
       formData: {
         sourceToken: fromToken,
         sourceChain: fromChain,
+        destinationChain: toChain,
       },
     };
-  }, [ctx, fromToken, fromChain]);
+  }, [ctx, fromToken, fromChain, toChain]);
 
   const widgetEvents = useWidgetEvents();
   // Custom effect to refetch the balance


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-17236

## Testing steps

1. Go to `/earn`
2. Select any opportunity
3. Check on deposit the from chain is the opportunity chain
4. Check the from token is the asset token (visible in the overview card)
5. Now for an opportunity into which you have deposited, open the withdraw modal
6. Check the to chain is the same chain as the opportunity chain
7. Go to `/portfolio`
8. Open the deposit/withdraw modals from there and perform steps `2-6`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Deposit flow now pre-fills the source token and source chain in deposit settings so forms reflect the selected deposit context.
  * Withdrawal flow now reliably tracks and applies the destination chain, ensuring widget configuration and form data update correctly when the target chain changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->