### PR TITLE
fix: update navigation test to reflect new Terms Of Business URL

### DIFF
--- a/tests/mainMenu.spec.ts
+++ b/tests/mainMenu.spec.ts
@@ -244,10 +244,10 @@ test.describe('Main Menu flows', () => {
   );
 
   test(
-    qase(54, 'Should be able to navigate to the Terms & Conditions page'),
+    qase(54, 'Should be able to navigate to the Terms Of Business page'),
     async ({ page, context }) => {
-      await itemInNavigation(page, 'Terms & Conditions');
-      await openNewTabAndVerifyUrl(context, values.termsConditionsURL);
+      await itemInNavigation(page, 'Terms Of Business');
+      await openNewTabAndVerifyUrl(context, values.termsOfBusinessURL);
     },
   );
 

--- a/tests/mainMenu.spec.ts
+++ b/tests/mainMenu.spec.ts
@@ -245,9 +245,9 @@ test.describe('Main Menu flows', () => {
 
   test(
     qase(54, 'Should be able to navigate to the Terms Of Business page'),
-    async ({ page, context }) => {
+    async ({ page }) => {
       await itemInNavigation(page, 'Terms Of Business');
-      await openNewTabAndVerifyUrl(context, values.termsOfBusinessURL);
+      await expect(page).toHaveURL(values.termsOfBusinessURL);
     },
   );
 

--- a/tests/testData/values.json
+++ b/tests/testData/values.json
@@ -6,7 +6,7 @@
   "telegramURL": "https://t.me/officialjumperexchange",
   "link3URL": "https://link3.to/jumperexchange",
   "privacyPolicyURL": "/privacy-policy",
-  "termsConditionsURL": "https://li.fi/legal/terms-and-conditions/",
+  "termsOfBusinessURL": "http://localhost:3000/terms-of-business",
   "newsletterPageURL": "/newsletter",
   "scanQRCodeTitle": "Scan this QR Code with your phone",
   "exploreFilamentURL": "/quests/rewards-from-filament",

--- a/tests/testData/values.json
+++ b/tests/testData/values.json
@@ -6,7 +6,7 @@
   "telegramURL": "https://t.me/officialjumperexchange",
   "link3URL": "https://link3.to/jumperexchange",
   "privacyPolicyURL": "/privacy-policy",
-  "termsOfBusinessURL": "http://localhost:3000/terms-of-business",
+  "termsOfBusinessURL": "/terms-of-business",
   "newsletterPageURL": "/newsletter",
   "scanQRCodeTitle": "Scan this QR Code with your phone",
   "exploreFilamentURL": "/quests/rewards-from-filament",


### PR DESCRIPTION
[DO NOT MERGE] until - https://github.com/jumperexchange/jumper-exchange/pull/2615 is merged 

Corresponding ticket : https://lifi.atlassian.net/browse/LF-17260 

### Summary
Updates the main menu navigation test to use the new "Terms Of Business" page instead of "Terms & Conditions", aligning the test with the current application structure.
### Changes
Updated test case (Qase ID: 54):
Changed test name from "Should be able to navigate to the Terms & Conditions page" to "Should be able to navigate to the Terms Of Business page"
Updated navigation target from "Terms & Conditions" to "Terms Of Business"
Updated URL reference from termsConditionsURL to termsOfBusinessURL
Updated test data (values.json):
Replaced termsConditionsURL with termsOfBusinessURL
Changed URL from external (https://li.fi/legal/terms-and-conditions/) to localhost (http://localhost:3000/terms-of-business)
### Impact
Test now validates navigation to the correct "Terms Of Business" page
URL reference updated to match the new page structure
Test data reflects the local development environment URL
### Files Changed
tests/mainMenu.spec.ts - Updated test case and navigation target
tests/testData/values.json - Updated URL key and value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated tests to reference "Terms Of Business" instead of "Terms & Conditions" to reflect the renamed navigation target.
  * Adjusted test data and URL expectations to use the new Terms Of Business path (moved from the previous external URL to the updated relative path) to keep navigation checks accurate.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->