### PR TITLE
fix: store earn card display variant to store

### DIFF
--- a/src/app/ui/earn/EarnOpportunitiesAll/EarnOpportunitiesAll.tsx
+++ b/src/app/ui/earn/EarnOpportunitiesAll/EarnOpportunitiesAll.tsx
@@ -3,7 +3,6 @@
 import type { FC } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useInView } from 'motion/react';
-import type { EarnCardVariant } from 'src/components/Cards/EarnCard/EarnCard.types';
 import { EarnFilterBar } from 'src/components/EarnFilterBar/EarnFilterBar';
 import {
   EarnFilteringProvider,
@@ -19,6 +18,7 @@ import { EarnFilterTab } from '../types';
 import { EarnEmptyList } from '../EarnEmptyList/EarnEmptyList';
 import { useContactSupportEvent } from '@/components/Widgets/events/hooks/useContactSupportEvent';
 import { HeaderHeight } from '@/const/headerHeight';
+import { useSettingsStore } from '@/stores/settings/SettingsStore';
 
 const EarnOpportunitiesAllInner = () => {
   useContactSupportEvent();
@@ -31,7 +31,10 @@ const EarnOpportunitiesAllInner = () => {
     showYourPositions,
   } = useEarnFiltering();
 
-  const [variant, setVariant] = useState<EarnCardVariant>('compact');
+  const [variant, setVariant] = useSettingsStore((state) => [
+    state.earnCardVariant,
+    state.setEarnCardVariant,
+  ]);
 
   const sectionRef = useRef<HTMLDivElement>(null);
   const isInView = useInView(sectionRef, { amount: 0, initial: true });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,8 +1,11 @@
+import type { EarnCardVariant } from '@/components/Cards/EarnCard/EarnCard.types';
+
 interface DefaultSettingsType {
   clientWallets: string[];
   disabledFeatureCards: string[];
   welcomeScreenClosed: boolean;
   portfolioWelcomeScreenClosed: Record<string, boolean>;
+  earnCardVariant: EarnCardVariant;
 }
 
 export const defaultSettings: DefaultSettingsType = {
@@ -10,6 +13,7 @@ export const defaultSettings: DefaultSettingsType = {
   disabledFeatureCards: [],
   welcomeScreenClosed: false,
   portfolioWelcomeScreenClosed: {},
+  earnCardVariant: 'compact',
 };
 
 interface DefaultFpType {

--- a/src/stores/settings/createSettingsStore.tsx
+++ b/src/stores/settings/createSettingsStore.tsx
@@ -5,6 +5,7 @@ import { shallow } from 'zustand/shallow';
 import { createWithEqualityFn } from 'zustand/traditional';
 import { defaultSettings } from '@/config/config';
 import type { SettingsProps, SettingsState } from '@/types/settings';
+import type { EarnCardVariant } from '@/components/Cards/EarnCard/EarnCard.types';
 
 export const createSettingsStore = (props: Partial<SettingsProps>) =>
   createWithEqualityFn(
@@ -59,6 +60,13 @@ export const createSettingsStore = (props: Partial<SettingsProps>) =>
         setDefaultSettings: () => {
           set({
             disabledFeatureCards: defaultSettings.disabledFeatureCards || [],
+          });
+        },
+
+        // Earn Card Variant
+        setEarnCardVariant: (variant: EarnCardVariant) => {
+          set({
+            earnCardVariant: variant,
           });
         },
       }),

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,3 +1,4 @@
+import type { EarnCardVariant } from '@/components/Cards/EarnCard/EarnCard.types';
 import type { StoreApi } from 'zustand';
 import type { UseBoundStoreWithEqualityFn } from 'zustand/traditional';
 
@@ -8,6 +9,7 @@ export interface SettingsProps {
   disabledFeatureCards: string[];
   welcomeScreenClosed: boolean;
   portfolioWelcomeScreenClosed: Record<string, boolean>;
+  earnCardVariant: EarnCardVariant;
 }
 
 export interface SettingsActions {
@@ -28,6 +30,9 @@ export interface SettingsActions {
     address: string | undefined,
     shown: boolean,
   ) => void;
+
+  // Earn Card Variant
+  setEarnCardVariant: (variant: EarnCardVariant) => void;
 }
 
 export type SettingsState = SettingsActions & SettingsProps;


### PR DESCRIPTION
Jira: https://lifi.atlassian.net/browse/LF-17232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global setting for the Earn card display so preference (e.g., compact) is stored and applied across the app.
* **Refactor**
  * Centralized Earn card view preference into the app settings for consistent behavior and easier preference updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->