### PR TITLE
feat: stacked APY rewards -- LF-17256

### DIFF
--- a/src/app/lib/getOpportunityApyAnalytics.ts
+++ b/src/app/lib/getOpportunityApyAnalytics.ts
@@ -1,0 +1,17 @@
+import type { ApyAnalyticsHistory, HttpResponse } from '@/types/jumper-backend';
+import { makeClient } from './client';
+
+export type ApyAnalyticsRangeField = 'day' | 'week' | 'month' | 'year';
+
+export type GetOpportunityApyAnalyticsResult = HttpResponse<
+  ApyAnalyticsHistory,
+  unknown
+>;
+
+export async function getOpportunityApyAnalytics(
+  slug: string,
+  query: { range: ApyAnalyticsRangeField },
+): Promise<GetOpportunityApyAnalyticsResult> {
+  const client = makeClient();
+  return client.v1.earnControllerGetApyAnalyticsV1(slug, query);
+}

--- a/src/components/EarnDetails/EarnDetailsAnalytics.tsx
+++ b/src/components/EarnDetails/EarnDetailsAnalytics.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useState } from 'react';
 import {
   EarnDetailsAnalyticsButton,
   EarnDetailsAnalyticsButtonsContainer,
@@ -8,13 +8,10 @@ import {
   EarnDetailsAnalyticsHeaderContainer,
   EarnDetailsAnalyticsLineChartContainer,
 } from './EarnDetails.styles';
-import { LineChart } from '../core/charts/LineChart/LineChart';
-import { useAnalyticsChartData, useAnalyticsQuery } from './hooks';
+import { EarnDetailsApyChart } from './EarnDetailsApyChart';
+import { EarnDetailsTvlChart } from './EarnDetailsTvlChart';
 import { AnalyticsRangeFieldEnum, AnalyticsValueFieldEnum } from './types';
 import { capitalizeString } from 'src/utils/capitalizeString';
-import type { ValueFormatConfig } from 'src/utils/formatNumbers';
-import { APY_FORMAT_CONFIG } from 'src/utils/numbers/apy';
-import { TVL_FORMAT_CONFIG } from 'src/utils/numbers/tvl';
 
 interface EarnDetailsAnalyticsProps {
   slug: string;
@@ -23,20 +20,14 @@ interface EarnDetailsAnalyticsProps {
 export const EarnDetailsAnalytics: React.FC<EarnDetailsAnalyticsProps> = ({
   slug,
 }) => {
-  const { isLoading, error, data, value, range, setValue, setRange } =
-    useAnalyticsQuery(slug);
+  const [value, setValue] = useState<AnalyticsValueFieldEnum>(
+    AnalyticsValueFieldEnum.APY,
+  );
+  const [range, setRange] = useState<AnalyticsRangeFieldEnum>(
+    AnalyticsRangeFieldEnum.WEEK,
+  );
 
-  const valueFormatConfig = useMemo<ValueFormatConfig>(() => {
-    return value === AnalyticsValueFieldEnum.APY
-      ? APY_FORMAT_CONFIG
-      : TVL_FORMAT_CONFIG;
-  }, [value]);
-
-  const {
-    data: chartData,
-    theme: chartTheme,
-    dateFormat: chartDateFormat,
-  } = useAnalyticsChartData(data, range);
+  const isApy = value === AnalyticsValueFieldEnum.APY;
 
   return (
     <EarnDetailsAnalyticsContainer>
@@ -69,15 +60,11 @@ export const EarnDetailsAnalytics: React.FC<EarnDetailsAnalyticsProps> = ({
         </EarnDetailsAnalyticsButtonsContainer>
       </EarnDetailsAnalyticsHeaderContainer>
       <EarnDetailsAnalyticsLineChartContainer>
-        <LineChart
-          isLoading={isLoading}
-          data={chartData}
-          dateFormat={chartDateFormat}
-          dataSetId={value}
-          valueFormatConfig={valueFormatConfig}
-          theme={chartTheme}
-          data-testid="analytics-chart"
-        />
+        {isApy ? (
+          <EarnDetailsApyChart slug={slug} range={range} />
+        ) : (
+          <EarnDetailsTvlChart slug={slug} range={range} />
+        )}
       </EarnDetailsAnalyticsLineChartContainer>
     </EarnDetailsAnalyticsContainer>
   );

--- a/src/components/EarnDetails/EarnDetailsApyChart.tsx
+++ b/src/components/EarnDetails/EarnDetailsApyChart.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEarnApyAnalytics } from 'src/hooks/earn/useEarnApyAnalytics';
-import { StackedAreaChart } from '../core/charts/StackedAreaChart';
+import { StackedAreaChart } from '../core/charts/StackedAreaChart/StackedAreaChart';
 import { useApyAnalyticsChartConfig } from './hooks';
 import type { AnalyticsRangeFieldEnum } from './types';
 

--- a/src/components/EarnDetails/EarnDetailsApyChart.tsx
+++ b/src/components/EarnDetails/EarnDetailsApyChart.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEarnApyAnalytics } from 'src/hooks/earn/useEarnApyAnalytics';
+import { StackedAreaChart } from '../core/charts/StackedAreaChart';
+import { useApyAnalyticsChartConfig } from './hooks';
+import type { AnalyticsRangeFieldEnum } from './types';
+
+interface EarnDetailsApyChartProps {
+  slug: string;
+  range: AnalyticsRangeFieldEnum;
+}
+
+export const EarnDetailsApyChart: React.FC<EarnDetailsApyChartProps> = ({
+  slug,
+  range,
+}) => {
+  const { isLoading, data: rawData } = useEarnApyAnalytics({ slug, range });
+  const config = useApyAnalyticsChartConfig(rawData, range);
+
+  return (
+    <StackedAreaChart
+      isLoading={isLoading}
+      data-testid="analytics-chart"
+      {...config}
+    />
+  );
+};

--- a/src/components/EarnDetails/EarnDetailsTvlChart.tsx
+++ b/src/components/EarnDetails/EarnDetailsTvlChart.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEarnAnalytics } from 'src/hooks/earn/useEarnAnalytics';
+import { TVL_FORMAT_CONFIG } from 'src/utils/numbers/tvl';
+import { LineChart } from '../core/charts/LineChart/LineChart';
+import { useSimpleAnalyticsChartConfig } from './hooks';
+import type { AnalyticsRangeFieldEnum } from './types';
+
+interface EarnDetailsTvlChartProps {
+  slug: string;
+  range: AnalyticsRangeFieldEnum;
+}
+
+export const EarnDetailsTvlChart: React.FC<EarnDetailsTvlChartProps> = ({
+  slug,
+  range,
+}) => {
+  const { isLoading, data } = useEarnAnalytics({
+    slug,
+    query: { value: 'tvl', range },
+  });
+
+  const config = useSimpleAnalyticsChartConfig(data, range);
+
+  return (
+    <LineChart
+      isLoading={isLoading}
+      dataSetId="tvl"
+      data-testid="analytics-chart"
+      valueFormatConfig={TVL_FORMAT_CONFIG}
+      {...config}
+    />
+  );
+};

--- a/src/components/EarnDetails/hooks.ts
+++ b/src/components/EarnDetails/hooks.ts
@@ -1,51 +1,25 @@
+import { APY_FORMAT_CONFIG } from '@/utils/numbers/apy';
 import { useColorScheme, useTheme } from '@mui/material/styles';
-import { useState, useCallback, useMemo } from 'react';
-import type { EarnOpportunityAnalyticsQuery } from 'src/app/lib/getOpportunityAnalytics';
-import { useEarnAnalytics } from 'src/hooks/earn/useEarnAnalytics';
-import type { EarnOpportunityHistory } from 'src/types/jumper-backend';
-import { AnalyticsRangeFieldEnum, AnalyticsValueFieldEnum } from './types';
+import { useMemo } from 'react';
+import type {
+  ApyAnalyticsHistory,
+  EarnOpportunityHistory,
+} from 'src/types/jumper-backend';
+import type { LineChartProps } from '../core/charts/LineChart/LineChart';
+import type { StackedAreaChartProps } from '../core/charts/StackedAreaChart/StackedAreaChart';
+import { AnalyticsRangeFieldEnum } from './types';
 
-export const useAnalyticsQuery = (slug: string) => {
-  const [query, setQuery] = useState<EarnOpportunityAnalyticsQuery>({
-    value: AnalyticsValueFieldEnum.APY,
-    range: AnalyticsRangeFieldEnum.WEEK,
-  });
-
-  const result = useEarnAnalytics({ slug, query });
-
-  const setValue = useCallback(
-    (value: AnalyticsValueFieldEnum) => {
-      setQuery((query) => ({ ...query, value }));
-    },
-    [setQuery],
-  );
-
-  const setRange = useCallback(
-    (range: AnalyticsRangeFieldEnum) => {
-      setQuery((query) => ({ ...query, range }));
-    },
-    [setQuery],
-  );
-
-  return useMemo(
-    () => ({
-      ...result,
-      value: query.value,
-      range: query.range,
-      setValue,
-      setRange,
-    }),
-    [result, query, setValue, setRange],
-  );
+const useDefaultDateFormat = (range: AnalyticsRangeFieldEnum) => {
+  return range === AnalyticsRangeFieldEnum.WEEK ||
+    range === AnalyticsRangeFieldEnum.MONTH
+    ? 'dd MMM'
+    : 'MMM yyyy';
 };
 
-export const useAnalyticsChartData = (
+export const useSimpleAnalyticsChartConfig = (
   rawData: EarnOpportunityHistory | undefined,
-  range: EarnOpportunityAnalyticsQuery['range'],
-) => {
-  const theme = useTheme();
-  const { mode } = useColorScheme();
-  const isLightTheme = mode === 'light';
+  range: AnalyticsRangeFieldEnum,
+): LineChartProps => {
   const data = useMemo(() => {
     return (
       rawData?.points.map((point) => ({
@@ -55,24 +29,81 @@ export const useAnalyticsChartData = (
     );
   }, [rawData]);
 
+  const dateFormat = useDefaultDateFormat(range);
+  const theme = useBaseChartTheme();
+
   return useMemo(() => {
     return {
       data,
-      dateFormat:
-        range === AnalyticsRangeFieldEnum.WEEK ||
-        range === AnalyticsRangeFieldEnum.MONTH
-          ? 'dd MMM'
-          : 'MMM yyyy',
-      theme: {
-        areaTopColor: isLightTheme
-          ? `#F2D9F6`
-          : (theme.vars || theme).palette.accent2Alt,
-        areaBottomColor: isLightTheme
-          ? (theme.vars || theme).palette.white.main
-          : (theme.vars || theme).palette.bg.main,
-        pointColor: (theme.vars || theme).palette.accent1.main,
-        lineColor: (theme.vars || theme).palette.accent2.main,
-      },
+      dateFormat,
+      theme,
     };
-  }, [data, theme, isLightTheme, range]);
+  }, [data, dateFormat, theme]);
+};
+
+export const useApyAnalyticsChartConfig = (
+  rawData: ApyAnalyticsHistory | undefined,
+  range: AnalyticsRangeFieldEnum,
+): StackedAreaChartProps => {
+  const data = useMemo(() => {
+    return (
+      rawData?.points.map((point) => ({
+        date: new Date(point.t).toISOString(),
+        base: point.base,
+        reward: point.reward,
+      })) ?? []
+    );
+  }, [rawData]);
+
+  const theme = useRewardChartTheme();
+  const dateFormat = useDefaultDateFormat(range);
+
+  return useMemo(
+    () => ({
+      data,
+      theme,
+      dateFormat,
+      valueFormatConfig: APY_FORMAT_CONFIG,
+    }),
+    [data, theme, dateFormat],
+  );
+};
+
+export const useBaseChartTheme = (): LineChartProps['theme'] => {
+  const theme = useTheme();
+  const { mode } = useColorScheme();
+  const isLightTheme = mode === 'light';
+
+  return {
+    areaTopColor: isLightTheme
+      ? `#F2D9F6`
+      : (theme.vars || theme).palette.accent2Alt,
+    areaBottomColor: isLightTheme
+      ? (theme.vars || theme).palette.white.main
+      : (theme.vars || theme).palette.bg.main,
+    pointColor: (theme.vars || theme).palette.accent1.main,
+    lineColor: (theme.vars || theme).palette.accent2.main,
+  };
+};
+
+export const useRewardChartTheme = (): StackedAreaChartProps['theme'] => {
+  const theme = useTheme();
+  const { mode } = useColorScheme();
+  const isLightTheme = mode === 'light';
+
+  return {
+    baseLineColor: (theme.vars || theme).palette.accent2.main,
+    baseAreaTopColor: isLightTheme
+      ? `#F2D9F6`
+      : (theme.vars || theme).palette.accent2Alt,
+    baseAreaBottomColor: isLightTheme
+      ? (theme.vars || theme).palette.white.main
+      : (theme.vars || theme).palette.bg.main,
+    rewardLineColor: isLightTheme ? '#7B61FF' : '#9B8AFF',
+    rewardAreaTopColor: isLightTheme ? '#E8E4FF' : '#3D3270',
+    rewardAreaBottomColor: isLightTheme
+      ? (theme.vars || theme).palette.white.main
+      : (theme.vars || theme).palette.bg.main,
+    pointColor: (theme.vars || theme).palette.accent1.main,
+  };
 };

--- a/src/components/EarnDetails/hooks.ts
+++ b/src/components/EarnDetails/hooks.ts
@@ -71,8 +71,7 @@ export const useApyAnalyticsChartConfig = (
 
 export const useBaseChartTheme = (): LineChartProps['theme'] => {
   const theme = useTheme();
-  const { mode } = useColorScheme();
-  const isLightTheme = mode === 'light';
+  const isLightTheme = useIsLightTheme();
 
   return {
     areaTopColor: isLightTheme
@@ -88,8 +87,7 @@ export const useBaseChartTheme = (): LineChartProps['theme'] => {
 
 export const useRewardChartTheme = (): StackedAreaChartProps['theme'] => {
   const theme = useTheme();
-  const { mode } = useColorScheme();
-  const isLightTheme = mode === 'light';
+  const isLightTheme = useIsLightTheme();
 
   return {
     baseLineColor: (theme.vars || theme).palette.accent2.main,
@@ -106,4 +104,23 @@ export const useRewardChartTheme = (): StackedAreaChartProps['theme'] => {
       : (theme.vars || theme).palette.bg.main,
     pointColor: (theme.vars || theme).palette.accent1.main,
   };
+};
+
+/**
+ * Resolve the color scheme the app should used, base on active theme, system mode, etc.
+ * @returns 'light' | 'dark'
+ */
+const useResolvedColorScheme = (): 'light' | 'dark' => {
+  const { mode, systemMode } = useColorScheme();
+
+  if (mode === 'system') {
+    return systemMode ?? 'light';
+  }
+
+  return mode ?? 'light';
+};
+
+const useIsLightTheme = (): boolean => {
+  const resolvedColorScheme = useResolvedColorScheme();
+  return resolvedColorScheme === 'light';
 };

--- a/src/components/composite/AssetOverviewCard/__snapshots__/AssetOverviewCard.snapshot.spec.tsx.snap
+++ b/src/components/composite/AssetOverviewCard/__snapshots__/AssetOverviewCard.snapshot.spec.tsx.snap
@@ -1217,7 +1217,7 @@ exports[`AssetOverviewCard Snapshots > NoDeFiPositions > should match snapshot f
             <span
               class="MuiTypography-root MuiTypography-titleMedium css-7anzin-MuiTypography-root"
             >
-              0
+              $0
             </span>
             <p
               class="MuiTypography-root MuiTypography-bodyXSmall css-1gwx9ao-MuiTypography-root"
@@ -1810,7 +1810,7 @@ exports[`AssetOverviewCard Snapshots > NoDeFiPositions > should match snapshot w
             <span
               class="MuiTypography-root MuiTypography-titleMedium css-7anzin-MuiTypography-root"
             >
-              0
+              $0
             </span>
             <p
               class="MuiTypography-root MuiTypography-bodyXSmall css-1gwx9ao-MuiTypography-root"
@@ -2321,7 +2321,7 @@ exports[`AssetOverviewCard Snapshots > NoTokens > should match snapshot for Toke
             <span
               class="MuiTypography-root MuiTypography-titleMedium css-7anzin-MuiTypography-root"
             >
-              0
+              $0
             </span>
             <p
               class="MuiTypography-root MuiTypography-bodyXSmall css-1gwx9ao-MuiTypography-root"
@@ -2464,7 +2464,7 @@ exports[`AssetOverviewCard Snapshots > NoTokens > should match snapshot with no 
             <span
               class="MuiTypography-root MuiTypography-titleMedium css-7anzin-MuiTypography-root"
             >
-              0
+              $0
             </span>
             <p
               class="MuiTypography-root MuiTypography-bodyXSmall css-1gwx9ao-MuiTypography-root"

--- a/src/components/core/charts/LineChart/LineChart.stories.tsx
+++ b/src/components/core/charts/LineChart/LineChart.stories.tsx
@@ -52,21 +52,7 @@ const DefaultRenderer = <
 
   return (
     <Box sx={{ height: 400 }}>
-      <LineChart
-        {...args}
-        theme={{ ...theme, ...args.theme }}
-        // theme={{
-        //   areaTopColor: isLightTheme
-        //     ? `#F2D9F6`
-        //     : (theme.vars || theme).palette.accent2Alt,
-        //   areaBottomColor: isLightTheme
-        //     ? (theme.vars || theme).palette.white.main
-        //     : (theme.vars || theme).palette.bg.main,
-        //   pointColor: (theme.vars || theme).palette.accent1.main,
-        //   lineColor: (theme.vars || theme).palette.accent2.main,
-        //   ...args.theme,
-        // }}
-      />
+      <LineChart {...args} theme={{ ...theme, ...args.theme }} />
     </Box>
   );
 };

--- a/src/components/core/charts/LineChart/LineChart.stories.tsx
+++ b/src/components/core/charts/LineChart/LineChart.stories.tsx
@@ -4,6 +4,7 @@ import { ChartDataPoint, LineChart, LineChartProps } from './LineChart';
 import { LineChartSkeleton } from './LineChartSkeleton';
 import Box from '@mui/material/Box';
 import { useColorScheme, useTheme } from '@mui/material/styles';
+import { useBaseChartTheme } from '@/components/EarnDetails/hooks';
 
 const data = [
   { date: '2023-01-01', value: 97.92 },
@@ -47,24 +48,24 @@ const DefaultRenderer = <
 >(
   args: LineChartProps<V, T>,
 ) => {
-  const theme = useTheme();
-  const { mode } = useColorScheme();
-  const isLightTheme = mode === 'light';
+  const theme = useBaseChartTheme();
+
   return (
     <Box sx={{ height: 400 }}>
       <LineChart
         {...args}
-        theme={{
-          areaTopColor: isLightTheme
-            ? `#F2D9F6`
-            : (theme.vars || theme).palette.accent2Alt,
-          areaBottomColor: isLightTheme
-            ? (theme.vars || theme).palette.white.main
-            : (theme.vars || theme).palette.bg.main,
-          pointColor: (theme.vars || theme).palette.accent1.main,
-          lineColor: (theme.vars || theme).palette.accent2.main,
-          ...args.theme,
-        }}
+        theme={{ ...theme, ...args.theme }}
+        // theme={{
+        //   areaTopColor: isLightTheme
+        //     ? `#F2D9F6`
+        //     : (theme.vars || theme).palette.accent2Alt,
+        //   areaBottomColor: isLightTheme
+        //     ? (theme.vars || theme).palette.white.main
+        //     : (theme.vars || theme).palette.bg.main,
+        //   pointColor: (theme.vars || theme).palette.accent1.main,
+        //   lineColor: (theme.vars || theme).palette.accent2.main,
+        //   ...args.theme,
+        // }}
       />
     </Box>
   );

--- a/src/components/core/charts/LineChart/LineChart.stories.tsx
+++ b/src/components/core/charts/LineChart/LineChart.stories.tsx
@@ -1,10 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
+import { useBaseChartTheme } from '@/components/EarnDetails/hooks';
+import Box from '@mui/material/Box';
 import { ChartDataPoint, LineChart, LineChartProps } from './LineChart';
 import { LineChartSkeleton } from './LineChartSkeleton';
-import Box from '@mui/material/Box';
-import { useColorScheme, useTheme } from '@mui/material/styles';
-import { useBaseChartTheme } from '@/components/EarnDetails/hooks';
 
 const data = [
   { date: '2023-01-01', value: 97.92 },

--- a/src/components/core/charts/StackedAreaChart/StackedAreaChart.stories.tsx
+++ b/src/components/core/charts/StackedAreaChart/StackedAreaChart.stories.tsx
@@ -1,0 +1,147 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { useRewardChartTheme } from '@/components/EarnDetails/hooks';
+import Box from '@mui/material/Box';
+import {
+  StackedAreaChart,
+  StackedAreaChartProps,
+  StackedChartDataPoint,
+} from './StackedAreaChart';
+
+const stackedApyData: StackedChartDataPoint[] = [
+  { date: '2023-01-01', base: 3.5, reward: 1.2 },
+  { date: '2023-01-02', base: 3.8, reward: 1.5 },
+  { date: '2023-01-03', base: 3.2, reward: 1.8 },
+  { date: '2023-01-04', base: 3.6, reward: 2.1 },
+  { date: '2023-01-05', base: 3.4, reward: 1.9 },
+  { date: '2023-01-07', base: 4.0, reward: 2.3 },
+  { date: '2023-01-08', base: 3.3, reward: 1.7 },
+  { date: '2023-01-09', base: 3.7, reward: 2.0 },
+  { date: '2023-01-10', base: 3.5, reward: 1.8 },
+  { date: '2023-01-11', base: 3.9, reward: 2.2 },
+  { date: '2023-01-12', base: 3.6, reward: 1.6 },
+  { date: '2023-01-13', base: 3.4, reward: 1.4 },
+  { date: '2023-01-15', base: 3.7, reward: 1.9 },
+  { date: '2023-01-16', base: 3.2, reward: 1.5 },
+  { date: '2023-01-17', base: 3.5, reward: 1.7 },
+  { date: '2023-01-18', base: 4.1, reward: 2.4 },
+  { date: '2023-01-20', base: 3.8, reward: 2.1 },
+  { date: '2023-01-21', base: 3.6, reward: 1.8 },
+  { date: '2023-01-22', base: 3.3, reward: 1.5 },
+  { date: '2023-01-23', base: 3.9, reward: 2.0 },
+];
+
+const meta = {
+  component: StackedAreaChart,
+  title: 'Core/Charts/StackedAreaChart',
+} satisfies Meta<typeof StackedAreaChart>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const DefaultRenderer = (args: StackedAreaChartProps) => {
+  const theme = useRewardChartTheme();
+
+  return (
+    <Box sx={{ height: 400 }}>
+      <StackedAreaChart {...args} theme={{ ...theme, ...args.theme }} />
+    </Box>
+  );
+};
+
+const commonArgs = {
+  data: stackedApyData,
+  theme: {},
+  dateFormat: 'dd MMM',
+};
+
+export const Default: Story = {
+  render: DefaultRenderer,
+  args: {
+    ...commonArgs,
+  },
+};
+
+export const RewardOnly: Story = {
+  render: DefaultRenderer,
+  args: {
+    ...commonArgs,
+    data: stackedApyData.map((d) => ({ ...d, base: 0 })),
+  },
+};
+
+export const BaseOnly: Story = {
+  render: DefaultRenderer,
+  args: {
+    ...commonArgs,
+    data: stackedApyData.map((d) => ({ ...d, reward: 0 })),
+  },
+};
+
+export const HighRewards: Story = {
+  render: DefaultRenderer,
+  args: {
+    ...commonArgs,
+    data: stackedApyData.map((d) => ({ ...d, reward: d.reward * 3 })),
+  },
+};
+
+export const VerySmallValues: Story = {
+  render: DefaultRenderer,
+  args: {
+    ...commonArgs,
+    data: stackedApyData.map((d) => ({
+      ...d,
+      base: d.base * 0.01,
+      reward: d.reward * 0.01,
+    })),
+  },
+};
+
+export const MonthlyView: Story = {
+  render: DefaultRenderer,
+  args: {
+    ...commonArgs,
+    dateFormat: 'MMM yyyy',
+    data: [
+      { date: '2025-01-01', base: 3.2, reward: 1.5 },
+      { date: '2025-02-01', base: 3.5, reward: 1.8 },
+      { date: '2025-03-01', base: 3.8, reward: 2.1 },
+      { date: '2025-04-01', base: 3.4, reward: 1.9 },
+      { date: '2025-05-01', base: 3.6, reward: 2.0 },
+      { date: '2025-06-01', base: 3.9, reward: 2.3 },
+      { date: '2025-07-01', base: 4.1, reward: 2.5 },
+      { date: '2025-08-01', base: 3.7, reward: 2.2 },
+      { date: '2025-09-01', base: 3.5, reward: 2.0 },
+      { date: '2025-10-01', base: 3.8, reward: 2.4 },
+      { date: '2025-11-01', base: 4.0, reward: 2.6 },
+      { date: '2025-12-01', base: 4.2, reward: 2.8 },
+    ],
+  },
+};
+
+export const OnlyWithBaseLayers: Story = {
+  render: DefaultRenderer,
+  args: {
+    ...commonArgs,
+    enableCrosshair: false,
+    enableGridY: false,
+    enableXAxis: false,
+    enableYAxis: false,
+    enableTooltip: false,
+  },
+};
+
+export const ZeroValues: Story = {
+  render: DefaultRenderer,
+  args: {
+    ...commonArgs,
+    data: [
+      { date: '2023-01-01', base: 0, reward: 0 },
+      { date: '2023-01-02', base: 0, reward: 0 },
+      { date: '2023-01-03', base: 0, reward: 0 },
+      { date: '2023-01-04', base: 0, reward: 0 },
+      { date: '2023-01-05', base: 0, reward: 0 },
+    ],
+  },
+};

--- a/src/components/core/charts/StackedAreaChart/StackedAreaChart.tsx
+++ b/src/components/core/charts/StackedAreaChart/StackedAreaChart.tsx
@@ -1,0 +1,349 @@
+import { styled, useTheme } from '@mui/material/styles';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  ResponsiveContainer,
+} from 'recharts';
+import { StackedAreaTooltip } from './StackedAreaTooltip';
+import {
+  formatValueWithConfig,
+  type ValueFormatConfig,
+} from 'src/utils/formatNumbers';
+import { formatDateLocalized } from 'src/utils/formatDateLocalized';
+import { LineChartSkeleton } from '../LineChart/LineChartSkeleton';
+import {
+  calculateTooltipPosition,
+  calculateEvenXAxisTicks,
+  calculateEvenYAxisTicks,
+} from '../LineChart/utils';
+import { useCallback, useId, useMemo, useRef, useState } from 'react';
+import type { HTMLAttributes } from 'react';
+import Box from '@mui/material/Box';
+import { AREA_CONFIG } from '../LineChart/constants';
+
+import type { ActiveDotProps } from 'recharts/types/util/types';
+
+const StyledResponsiveContainer = styled(ResponsiveContainer, {
+  shouldForwardProp: (prop) => prop !== 'enableCrosshair',
+})<{
+  enableCrosshair?: boolean;
+}>(({ enableCrosshair }) => ({
+  '& *': {
+    WebkitTapHighlightColor: 'transparent',
+  },
+  '& *:focus, & *:focus-visible, & *:focus-within': {
+    outline: 'none !important',
+    boxShadow: 'none !important',
+  },
+  '& .recharts-cartesian-grid, & .recharts-layer.recharts-area': {
+    cursor: enableCrosshair ? 'crosshair' : 'default',
+  },
+}));
+
+export interface StackedChartDataPoint {
+  date: string;
+  base: number;
+  reward: number;
+}
+
+export interface StackedAreaChartProps extends HTMLAttributes<HTMLDivElement> {
+  data: StackedChartDataPoint[];
+  theme: {
+    baseLineColor?: string;
+    baseAreaTopColor?: string;
+    baseAreaBottomColor?: string;
+    rewardLineColor?: string;
+    rewardAreaTopColor?: string;
+    rewardAreaBottomColor?: string;
+    pointColor?: string;
+  };
+  dateFormat?: string;
+  valueFormatConfig?: ValueFormatConfig;
+  isLoading?: boolean;
+  enableCrosshair?: boolean;
+  enableGridY?: boolean;
+  enableXAxis?: boolean;
+  enableYAxis?: boolean;
+  enableTooltip?: boolean;
+}
+
+const calculateStackedVisibleYRange = (data: StackedChartDataPoint[]) => {
+  if (data.length === 0) {
+    return {
+      minValue: 0,
+      maxValue: 1,
+      minValueWithOffset: 0,
+      maxValueWithOffset: 1,
+    };
+  }
+
+  const totals = data.map((d) => d.base + d.reward);
+  const dataMaxValue = Math.max(...totals);
+
+  const minValue = 0;
+  const maxValue = dataMaxValue > 0 ? dataMaxValue * 1.2 : 1;
+
+  return {
+    minValue,
+    maxValue,
+    minValueWithOffset: minValue,
+    maxValueWithOffset: maxValue,
+  };
+};
+
+export const StackedAreaChart = ({
+  data,
+  theme,
+  dateFormat,
+  valueFormatConfig,
+  enableCrosshair = true,
+  enableGridY = true,
+  enableXAxis = true,
+  enableYAxis = true,
+  enableTooltip = true,
+  isLoading,
+  ...props
+}: StackedAreaChartProps) => {
+  const muiTheme = useTheme();
+  const baseGradientId = useId();
+  const rewardGradientId = useId();
+  const chartContainerRef = useRef<HTMLDivElement>(null);
+  const [activeDot, setActiveDot] = useState<{
+    cx: number;
+    cy: number;
+    payload: StackedChartDataPoint;
+  } | null>(null);
+
+  const { minValue, maxValue, minValueWithOffset, maxValueWithOffset } =
+    calculateStackedVisibleYRange(data);
+
+  const dateFormatter = useCallback(
+    (date: string) => {
+      return formatDateLocalized(date ?? '', dateFormat ?? 'MMM yyyy');
+    },
+    [dateFormat],
+  );
+
+  const valueFormatter = useCallback(
+    (value: number) => {
+      if (!value || isNaN(value) || value === 0) {
+        return '0';
+      }
+
+      if (!valueFormatConfig) {
+        return value.toString();
+      }
+
+      return formatValueWithConfig(value, valueFormatConfig, {
+        includePrefixSuffix: true,
+      });
+    },
+    [valueFormatConfig],
+  );
+
+  const yAxisTickValues = useMemo(() => {
+    return calculateEvenYAxisTicks(minValue, maxValue);
+  }, [minValue, maxValue]);
+
+  const xAxisTicks = useMemo(() => {
+    // Adapt the data format for calculateEvenXAxisTicks
+    const adaptedData = data.map((d) => ({
+      date: d.date,
+      value: d.base + d.reward,
+    }));
+    return calculateEvenXAxisTicks(adaptedData, dateFormatter);
+  }, [data, dateFormatter]);
+
+  const handleMouseLeave = useCallback(() => {
+    setActiveDot(null);
+  }, []);
+
+  if (isLoading) {
+    return <LineChartSkeleton />;
+  }
+
+  const tooltipPosition = activeDot
+    ? calculateTooltipPosition(
+        activeDot.cx,
+        activeDot.cy,
+        chartContainerRef.current?.clientWidth ?? 0,
+        chartContainerRef.current?.clientHeight ?? 0,
+      )
+    : null;
+
+  const handleActiveDot = (props: ActiveDotProps) => {
+    const { cx, cy, payload } = props;
+
+    if (enableTooltip) {
+      setActiveDot((prev) => {
+        if (
+          prev?.payload.date === payload.date &&
+          prev?.payload.base === payload.base &&
+          prev?.payload.reward === payload.reward
+        ) {
+          return prev;
+        }
+        return {
+          cx: cx ?? 0,
+          cy: cy ?? 0,
+          payload,
+        };
+      });
+    }
+
+    return (
+      <g
+        style={{
+          cursor: 'crosshair',
+          transform: AREA_CONFIG.TRANSFORM,
+        }}
+      >
+        <circle cx={cx} cy={cy} r={4} strokeWidth={0} fill={theme.pointColor} />
+      </g>
+    );
+  };
+
+  return (
+    <Box sx={{ position: 'relative', width: '100%', height: '100%' }}>
+      <StyledResponsiveContainer
+        ref={chartContainerRef}
+        width="100%"
+        height="100%"
+        enableCrosshair={enableCrosshair}
+        {...props}
+      >
+        <AreaChart
+          data={data}
+          accessibilityLayer={false}
+          onMouseLeave={handleMouseLeave}
+        >
+          <defs>
+            <linearGradient id={baseGradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop
+                offset="0%"
+                stopColor={theme.baseAreaTopColor}
+                stopOpacity={1}
+              />
+              <stop
+                offset="100%"
+                stopColor={theme.baseAreaBottomColor}
+                stopOpacity={1}
+              />
+            </linearGradient>
+            <linearGradient id={rewardGradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop
+                offset="0%"
+                stopColor={theme.rewardAreaTopColor}
+                stopOpacity={1}
+              />
+              <stop
+                offset="100%"
+                stopColor={theme.rewardAreaBottomColor}
+                stopOpacity={1}
+              />
+            </linearGradient>
+          </defs>
+          {enableGridY && (
+            <CartesianGrid
+              vertical={false}
+              syncWithTicks={true}
+              strokeDasharray="0"
+              stroke={`color-mix(in srgb, ${
+                (muiTheme.vars || muiTheme).palette.alpha900.main
+              } 10%, transparent)`}
+              horizontalFill={['transparent']}
+            />
+          )}
+          {enableXAxis && (
+            <XAxis
+              dataKey="date"
+              axisLine={false}
+              tickLine={false}
+              ticks={xAxisTicks}
+              tickMargin={14}
+              tick={{
+                fill: (muiTheme.vars || muiTheme).palette.text.secondary,
+                fontSize: 10,
+                fontFamily: muiTheme.typography.bodyXXSmall.fontFamily,
+                fontWeight: muiTheme.typography.bodyXXSmall.fontWeight,
+              }}
+              tickFormatter={dateFormatter}
+            />
+          )}
+          {enableYAxis && (
+            <YAxis
+              axisLine={false}
+              tickLine={false}
+              ticks={yAxisTickValues}
+              tickMargin={8}
+              width={60}
+              domain={[minValueWithOffset, maxValueWithOffset]}
+              tick={{
+                fill: (muiTheme.vars || muiTheme).palette.text.secondary,
+                fontSize: 10,
+                fontFamily: muiTheme.typography.bodyXXSmall.fontFamily,
+                fontWeight: muiTheme.typography.bodyXXSmall.fontWeight,
+              }}
+              tickFormatter={valueFormatter}
+            />
+          )}
+          {/* Base area fill (bottom of stack, no stroke) */}
+          <Area
+            type="monotone"
+            dataKey="base"
+            stackId="apy"
+            stroke="transparent"
+            fillOpacity={1}
+            fill={`url(#${baseGradientId})`}
+            isAnimationActive
+            activeDot={false}
+            style={{
+              transform: AREA_CONFIG.TRANSFORM,
+            }}
+          />
+          {/* Reward area (stacked on top of base) - dot appears here */}
+          <Area
+            type="monotone"
+            dataKey="reward"
+            stackId="apy"
+            stroke={theme.rewardLineColor}
+            fillOpacity={1}
+            fill={`url(#${rewardGradientId})`}
+            isAnimationActive
+            activeDot={enableCrosshair ? handleActiveDot : false}
+            style={{
+              transform: AREA_CONFIG.TRANSFORM,
+            }}
+          />
+          {/* Base line rendered last (always on top in z-order) */}
+          <Area
+            type="monotone"
+            dataKey="base"
+            stroke={theme.baseLineColor}
+            fillOpacity={0}
+            fill="transparent"
+            isAnimationActive
+            activeDot={false}
+            style={{
+              transform: AREA_CONFIG.TRANSFORM,
+            }}
+          />
+        </AreaChart>
+      </StyledResponsiveContainer>
+      {enableTooltip && activeDot && tooltipPosition && (
+        <StackedAreaTooltip
+          active={true}
+          payload={activeDot.payload}
+          label={activeDot.payload.date}
+          x={tooltipPosition.x}
+          y={tooltipPosition.y}
+          transform={tooltipPosition.transform}
+          valueFormatConfig={valueFormatConfig}
+        />
+      )}
+    </Box>
+  );
+};

--- a/src/components/core/charts/StackedAreaChart/StackedAreaChart.tsx
+++ b/src/components/core/charts/StackedAreaChart/StackedAreaChart.tsx
@@ -18,6 +18,7 @@ import {
   calculateTooltipPosition,
   calculateEvenXAxisTicks,
   calculateEvenYAxisTicks,
+  calculateVisibleYRange,
 } from '../LineChart/utils';
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import type { HTMLAttributes } from 'react';
@@ -71,27 +72,12 @@ export interface StackedAreaChartProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 const calculateStackedVisibleYRange = (data: StackedChartDataPoint[]) => {
-  if (data.length === 0) {
-    return {
-      minValue: 0,
-      maxValue: 1,
-      minValueWithOffset: 0,
-      maxValueWithOffset: 1,
-    };
-  }
+  const points = data.map((d) => ({
+    date: d.date,
+    value: d.base + d.reward,
+  }));
 
-  const totals = data.map((d) => d.base + d.reward);
-  const dataMaxValue = Math.max(...totals);
-
-  const minValue = 0;
-  const maxValue = dataMaxValue > 0 ? dataMaxValue * 1.2 : 1;
-
-  return {
-    minValue,
-    maxValue,
-    minValueWithOffset: minValue,
-    maxValueWithOffset: maxValue,
-  };
+  return calculateVisibleYRange(points);
 };
 
 export const StackedAreaChart = ({

--- a/src/components/core/charts/StackedAreaChart/StackedAreaChart.tsx
+++ b/src/components/core/charts/StackedAreaChart/StackedAreaChart.tsx
@@ -129,7 +129,7 @@ export const StackedAreaChart = ({
 
   const valueFormatter = useCallback(
     (value: number) => {
-      if (!value || isNaN(value) || value === 0) {
+      if (isNaN(value)) {
         return '0';
       }
 

--- a/src/components/core/charts/StackedAreaChart/StackedAreaTooltip.tsx
+++ b/src/components/core/charts/StackedAreaChart/StackedAreaTooltip.tsx
@@ -1,0 +1,93 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { formatDateLocalized } from 'src/utils/formatDateLocalized';
+import type { FC } from 'react';
+import {
+  formatValueWithConfig,
+  type ValueFormatConfig,
+} from 'src/utils/formatNumbers';
+import type { StackedChartDataPoint } from './StackedAreaChart';
+
+interface StackedAreaTooltipProps {
+  active?: boolean;
+  payload: StackedChartDataPoint;
+  label: string;
+  valueFormatConfig?: ValueFormatConfig;
+  x: number;
+  y: number;
+  transform?: string;
+}
+
+export const StackedAreaTooltip: FC<StackedAreaTooltipProps> = ({
+  active,
+  payload,
+  label,
+  x,
+  y,
+  transform,
+  valueFormatConfig,
+}) => {
+  if (!active || !payload) {
+    return null;
+  }
+
+  const formatValue = (value: number) => {
+    if (valueFormatConfig) {
+      return formatValueWithConfig(value, valueFormatConfig);
+    }
+    return value.toFixed(2);
+  };
+
+  const total = payload.base + payload.reward;
+
+  return (
+    <Box
+      sx={(theme) => ({
+        background: (theme.vars || theme).palette.surface1.main,
+        color: (theme.vars || theme).palette.text.primary,
+        padding: theme.spacing(1.5),
+        display: 'inline-flex',
+        width: 'fit-content',
+        flexDirection: 'column',
+        gap: theme.spacing(0.5),
+        borderRadius: theme.spacing(2),
+        boxShadow: '0px 4px 24px 0px rgba(0, 0, 0, 0.08)',
+        whiteSpace: 'nowrap',
+        position: 'absolute',
+        left: x,
+        top: y,
+        pointerEvents: 'none',
+        zIndex: 1000,
+        transform,
+        willChange: 'transform',
+        backfaceVisibility: 'hidden',
+      })}
+    >
+      <Typography
+        variant="bodySmallStrong"
+        style={{ textTransform: 'capitalize' }}
+      >
+        {formatDateLocalized(label ?? '', 'PP @ HH:mm')}
+      </Typography>
+      <Typography variant="bodySmall">
+        Total: {formatValue(total)} <strong>APY</strong>
+      </Typography>
+      <Typography
+        variant="bodyXSmall"
+        sx={(theme) => ({
+          color: (theme.vars || theme).palette.text.secondary,
+        })}
+      >
+        Base: {formatValue(payload.base)}
+      </Typography>
+      <Typography
+        variant="bodyXSmall"
+        sx={(theme) => ({
+          color: (theme.vars || theme).palette.text.secondary,
+        })}
+      >
+        Reward: {formatValue(payload.reward)}
+      </Typography>
+    </Box>
+  );
+};

--- a/src/components/core/charts/StackedAreaChart/index.ts
+++ b/src/components/core/charts/StackedAreaChart/index.ts
@@ -1,0 +1,6 @@
+export { StackedAreaChart } from './StackedAreaChart';
+export type {
+  StackedAreaChartProps,
+  StackedChartDataPoint,
+} from './StackedAreaChart';
+export { StackedAreaTooltip } from './StackedAreaTooltip';

--- a/src/components/core/charts/StackedAreaChart/index.ts
+++ b/src/components/core/charts/StackedAreaChart/index.ts
@@ -1,6 +1,0 @@
-export { StackedAreaChart } from './StackedAreaChart';
-export type {
-  StackedAreaChartProps,
-  StackedChartDataPoint,
-} from './StackedAreaChart';
-export { StackedAreaTooltip } from './StackedAreaTooltip';

--- a/src/hooks/earn/useEarnApyAnalytics.ts
+++ b/src/hooks/earn/useEarnApyAnalytics.ts
@@ -1,0 +1,34 @@
+import type { ApyAnalyticsHistory } from '@/types/jumper-backend';
+import type { UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+import type { ApyAnalyticsRangeField } from 'src/app/lib/getOpportunityApyAnalytics';
+import { getOpportunityApyAnalytics } from 'src/app/lib/getOpportunityApyAnalytics';
+import { FIVE_MINUTES_MS } from 'src/const/time';
+
+export interface UseEarnApyAnalyticsProps {
+  slug: string;
+  range: ApyAnalyticsRangeField;
+}
+
+export type UseEarnApyAnalyticsResult = UseQueryResult<
+  ApyAnalyticsHistory,
+  unknown
+>;
+
+export const useEarnApyAnalytics = ({
+  slug,
+  range,
+}: UseEarnApyAnalyticsProps): UseEarnApyAnalyticsResult => {
+  return useQuery({
+    queryKey: ['earn-apy-analytics', slug, range],
+    queryFn: async () => {
+      const result = await getOpportunityApyAnalytics(slug, { range });
+      if (!result.ok) {
+        throw result.error;
+      }
+      // @ts-expect-error: see LF-15589 - we are transforming data in the backend
+      return result.data.data;
+    },
+    refetchInterval: FIVE_MINUTES_MS,
+  });
+};

--- a/src/utils/formatNumbers.spec.ts
+++ b/src/utils/formatNumbers.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { formatValueWithConfig } from './formatNumbers';
+import { APY_FORMAT_CONFIG } from './numbers/apy';
+
+describe('formatValueWithConfig', () => {
+  describe('with APY_FORMAT_CONFIG', () => {
+    it('should format 0.02 as 2%', () => {
+      expect(formatValueWithConfig(0.02, APY_FORMAT_CONFIG)).toBe('2%');
+    });
+
+    it('should format 0.1234 as 12.34%', () => {
+      expect(formatValueWithConfig(0.1234, APY_FORMAT_CONFIG)).toBe('12.34%');
+    });
+
+    it('should format 0.12345 with max 2 fraction digits as 12.35%', () => {
+      expect(formatValueWithConfig(0.12345, APY_FORMAT_CONFIG)).toBe('12.35%');
+    });
+
+    it('should format 0 as 0', () => {
+      expect(formatValueWithConfig(0, APY_FORMAT_CONFIG)).toBe('0%');
+    });
+
+    it('should format 1 as 100%', () => {
+      expect(formatValueWithConfig(1, APY_FORMAT_CONFIG)).toBe('100%');
+    });
+  });
+});

--- a/src/utils/formatNumbers.ts
+++ b/src/utils/formatNumbers.ts
@@ -82,12 +82,12 @@ export interface ValueFormatConfig {
 export const formatValueWithConfig = (
   value: number | string,
   config: ValueFormatConfig,
-  options?: { includePrefixSuffix?: boolean },
+  options?: { includePrefixSuffix?: boolean } & Intl.NumberFormatOptions,
 ): string => {
   const numValue = Number(value);
 
-  if (isNaN(numValue) || numValue === 0) {
-    return numValue === 0 ? '0' : value.toString();
+  if (isNaN(numValue)) {
+    return value.toString();
   }
 
   const includePrefixSuffix = options?.includePrefixSuffix ?? true;


### PR DESCRIPTION
Contributes to https://lifi.atlassian.net/browse/LF-17256

Sister PR: https://github.com/jumperexchange/jumper-backend/pull/674

- [x] Update API
- [x] Adds stacked chart (specialized on rewards for now) - [storybook](https://jumper-exchange-storybook-git-feat-diffe-9162e3-jumper-exchange.vercel.app/?path=/story/core-charts-stackedareachart--default)
- [x] Refactor how data and theme are moved around for consistency
- [x] Tweak format number, add test, and fix its type
- [x] Provide a hook to get currently active scheme

## Note

I'm adding `useResolvedColorScheme` to save on mistakes when we try to access the theme, and `useIsLightTheme` which we use a lot.

That'll prevent cases where we mix dark and light scheme because mode is actually system:

<img width="420" src="https://github.com/user-attachments/assets/e6d68ff4-e70e-40dc-9223-740ab454dd9e" />

## Test:

Visit opportunities, check the APY charts, the rewards should show up as a stacked chart (it might be 0%)
Examples with rewards:

http://localhost:3000/earn/moonwell-flagship-usdc-on-base
http://localhost:3000/earn/gauntlet-usdc-prime-on-base

<img width="420" src="https://github.com/user-attachments/assets/2067c8fa-095e-46ca-a0c1-3c90478e0e18" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added APY analytics visualization with configurable time ranges (daily, weekly, monthly, yearly)
  * Introduced enhanced charting capabilities to display APY and TVL analytics with improved visual clarity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->