### PR TITLE
chore: display 404 page instead of error on earn

### DIFF
--- a/src/app/ui/earn/EarnPage.tsx
+++ b/src/app/ui/earn/EarnPage.tsx
@@ -25,7 +25,11 @@ export const EarnPage: FC<EarnPageProps> = async ({ slug }) => {
   const [opportunity, relatedMarkets] = await Promise.all([
     getOpportunityBySlug(slug),
     getOpportunityRelatedMarket(slug),
-  ]);
+  ]).catch((error) => {
+    console.log('---error', error);
+    console.error(error);
+    return [{ error: true, data: null }];
+  });
 
   console.log('28. EarnPage opportunity', opportunity);
 
@@ -39,7 +43,7 @@ export const EarnPage: FC<EarnPageProps> = async ({ slug }) => {
   }
 
   const relatedMarketsData =
-    relatedMarkets.data.filter(Boolean).slice(0, 3) ?? [];
+    relatedMarkets.data?.filter(Boolean).slice(0, 3) ?? [];
 
   console.log('29. EarnPage relatedMarkets', relatedMarketsData);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling on the Earn page to gracefully manage market data fetch failures, ensuring the page remains responsive with fallback values when data retrieval encounters issues. Enhanced error logging for better debugging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->