### PR TITLE
feat: instant apy LF-17257

### DIFF
--- a/src/app/lib/getOpportunityApyAnalytics.ts
+++ b/src/app/lib/getOpportunityApyAnalytics.ts
@@ -10,7 +10,7 @@ export type GetOpportunityApyAnalyticsResult = HttpResponse<
 
 export async function getOpportunityApyAnalytics(
   slug: string,
-  query: { range: ApyAnalyticsRangeField },
+  query: { range: ApyAnalyticsRangeField; instant?: boolean },
 ): Promise<GetOpportunityApyAnalyticsResult> {
   const client = makeClient();
   return client.v1.earnControllerGetApyAnalyticsV1(slug, query);

--- a/src/components/EarnDetails/EarnDetails.styles.ts
+++ b/src/components/EarnDetails/EarnDetails.styles.ts
@@ -41,10 +41,11 @@ export const EarnDetailsAnalyticsButtonsContainer = styled(Stack)(
 
 interface EarnDetailsAnalyticsButtonProps extends Omit<ButtonProps, 'variant'> {
   isActive: boolean;
+  isDisabled?: boolean;
 }
 
 export const EarnDetailsAnalyticsButton = styled(ButtonPrimary, {
-  shouldForwardProp: (prop) => prop !== 'isActive',
+  shouldForwardProp: (prop) => prop !== 'isActive' && prop !== 'isDisabled',
 })<EarnDetailsAnalyticsButtonProps>(({ theme }) => ({
   ...theme.typography.bodyXSmallStrong,
   padding: theme.spacing(1),
@@ -66,6 +67,14 @@ export const EarnDetailsAnalyticsButton = styled(ButtonPrimary, {
       props: { isActive: true },
       style: {
         cursor: 'default',
+        pointerEvents: 'none',
+      },
+    },
+    {
+      props: { isDisabled: true },
+      style: {
+        opacity: 0.5,
+        cursor: 'not-allowed',
         pointerEvents: 'none',
       },
     },

--- a/src/components/EarnDetails/EarnDetailsAnalytics.tsx
+++ b/src/components/EarnDetails/EarnDetailsAnalytics.tsx
@@ -13,6 +13,16 @@ import { EarnDetailsTvlChart } from './EarnDetailsTvlChart';
 import { AnalyticsRangeFieldEnum, AnalyticsValueFieldEnum } from './types';
 import { capitalizeString } from 'src/utils/capitalizeString';
 
+const INSTANT_APY_ALLOWED_RANGES: AnalyticsRangeFieldEnum[] = [
+  AnalyticsRangeFieldEnum.WEEK,
+];
+
+const VALUE_LABELS: Record<AnalyticsValueFieldEnum, string> = {
+  [AnalyticsValueFieldEnum.APY]: 'APY',
+  [AnalyticsValueFieldEnum.INSTANT_APY]: 'Instant APY',
+  [AnalyticsValueFieldEnum.TVL]: 'TVL',
+};
+
 interface EarnDetailsAnalyticsProps {
   slug: string;
 }
@@ -27,7 +37,20 @@ export const EarnDetailsAnalytics: React.FC<EarnDetailsAnalyticsProps> = ({
     AnalyticsRangeFieldEnum.WEEK,
   );
 
-  const isApy = value === AnalyticsValueFieldEnum.APY;
+  const isInstantApy = value === AnalyticsValueFieldEnum.INSTANT_APY;
+  const isApy = value === AnalyticsValueFieldEnum.APY || isInstantApy;
+
+  const handleValueChange = (newValue: AnalyticsValueFieldEnum) => {
+    setValue(newValue);
+    if (newValue === AnalyticsValueFieldEnum.INSTANT_APY) {
+      if (!INSTANT_APY_ALLOWED_RANGES.includes(range)) {
+        setRange(AnalyticsRangeFieldEnum.WEEK);
+      }
+    }
+  };
+
+  const isRangeDisabled = (rangeItem: AnalyticsRangeFieldEnum) =>
+    isInstantApy && !INSTANT_APY_ALLOWED_RANGES.includes(rangeItem);
 
   return (
     <EarnDetailsAnalyticsContainer>
@@ -37,6 +60,7 @@ export const EarnDetailsAnalytics: React.FC<EarnDetailsAnalyticsProps> = ({
             <EarnDetailsAnalyticsButton
               key={rangeItem}
               isActive={rangeItem === range}
+              isDisabled={isRangeDisabled(rangeItem)}
               onClick={() => setRange(rangeItem as AnalyticsRangeFieldEnum)}
               size="small"
               data-testid={`analytics-range-${rangeItem}`}
@@ -50,18 +74,22 @@ export const EarnDetailsAnalytics: React.FC<EarnDetailsAnalyticsProps> = ({
             <EarnDetailsAnalyticsButton
               key={valueItem}
               isActive={valueItem === value}
-              onClick={() => setValue(valueItem as AnalyticsValueFieldEnum)}
+              onClick={() => handleValueChange(valueItem)}
               size="small"
               data-testid={`analytics-value-${valueItem}`}
             >
-              {valueItem.toUpperCase()}
+              {VALUE_LABELS[valueItem]}
             </EarnDetailsAnalyticsButton>
           ))}
         </EarnDetailsAnalyticsButtonsContainer>
       </EarnDetailsAnalyticsHeaderContainer>
       <EarnDetailsAnalyticsLineChartContainer>
         {isApy ? (
-          <EarnDetailsApyChart slug={slug} range={range} />
+          <EarnDetailsApyChart
+            slug={slug}
+            range={range}
+            instant={isInstantApy}
+          />
         ) : (
           <EarnDetailsTvlChart slug={slug} range={range} />
         )}

--- a/src/components/EarnDetails/EarnDetailsApyChart.tsx
+++ b/src/components/EarnDetails/EarnDetailsApyChart.tsx
@@ -8,13 +8,19 @@ import type { AnalyticsRangeFieldEnum } from './types';
 interface EarnDetailsApyChartProps {
   slug: string;
   range: AnalyticsRangeFieldEnum;
+  instant?: boolean;
 }
 
 export const EarnDetailsApyChart: React.FC<EarnDetailsApyChartProps> = ({
   slug,
   range,
+  instant,
 }) => {
-  const { isLoading, data: rawData } = useEarnApyAnalytics({ slug, range });
+  const { isLoading, data: rawData } = useEarnApyAnalytics({
+    slug,
+    range,
+    instant,
+  });
   const config = useApyAnalyticsChartConfig(rawData, range);
 
   return (

--- a/src/components/EarnDetails/types.ts
+++ b/src/components/EarnDetails/types.ts
@@ -1,4 +1,5 @@
 export enum AnalyticsValueFieldEnum {
+  INSTANT_APY = 'instant-apy',
   APY = 'apy',
   TVL = 'tvl',
 }

--- a/src/hooks/earn/useEarnApyAnalytics.ts
+++ b/src/hooks/earn/useEarnApyAnalytics.ts
@@ -8,6 +8,7 @@ import { FIVE_MINUTES_MS } from 'src/const/time';
 export interface UseEarnApyAnalyticsProps {
   slug: string;
   range: ApyAnalyticsRangeField;
+  instant?: boolean;
 }
 
 export type UseEarnApyAnalyticsResult = UseQueryResult<
@@ -18,11 +19,12 @@ export type UseEarnApyAnalyticsResult = UseQueryResult<
 export const useEarnApyAnalytics = ({
   slug,
   range,
+  instant,
 }: UseEarnApyAnalyticsProps): UseEarnApyAnalyticsResult => {
   return useQuery({
-    queryKey: ['earn-apy-analytics', slug, range],
+    queryKey: ['earn-apy-analytics', slug, range, instant],
     queryFn: async () => {
-      const result = await getOpportunityApyAnalytics(slug, { range });
+      const result = await getOpportunityApyAnalytics(slug, { range, instant });
       if (!result.ok) {
         throw result.error;
       }

--- a/src/types/jumper-backend.ts
+++ b/src/types/jumper-backend.ts
@@ -1690,6 +1690,11 @@ export class JumperBackend<
          * @example "day"
          */
         range: 'day' | 'week' | 'month' | 'year';
+        /**
+         * Use instant (1-day) APY instead of 7-day rolling APY
+         * @example true
+         */
+        instant?: boolean;
       },
       params: RequestParams = {},
     ) =>


### PR DESCRIPTION
Contributes to https://lifi.atlassian.net/browse/LF-17257

⚠️  builds on https://github.com/jumperexchange/jumper-exchange/pull/2620

- [x] Introduce Instant APY option in the charts
- [x] Ensure only week can be selected with instant APY
- [x] Checkin with Octave on how it looks

![CleanShot 2026-01-19 at 16 10 36](https://github.com/user-attachments/assets/44152011-1df8-4fab-849d-0aca260d5c27)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Instant APY (1-day) option for earnings analytics alongside traditional range-based views
  * Range selection automatically constrains available options when Instant APY is selected

* **UI/UX Improvements**
  * Added visual feedback for disabled time range options

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->