### PR TITLE
feat: widget theme based on selected theme

### DIFF
--- a/src/components/Widgets/variants/widgetConfig/useWidgetDependencies.ts
+++ b/src/components/Widgets/variants/widgetConfig/useWidgetDependencies.ts
@@ -3,7 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { useTheme } from '@mui/material/styles';
 import { useWalletMenu } from '@lifi/wallet-management';
 import { useThemeStore } from 'src/stores/theme/ThemeStore';
-import { HookDependencies } from './types';
+import { useGetPartnerWidgetTheme } from 'src/hooks/theme/useGetPartnerWidgetTheme';
+import type { HookDependencies } from './types';
 
 /**
  * Hook that provides all the React hook dependencies needed for widget configuration.
@@ -12,10 +13,8 @@ import { HookDependencies } from './types';
 export function useWidgetDependencies(): HookDependencies {
   const { i18n, t } = useTranslation();
   const muiTheme = useTheme();
-  const [widgetTheme, configTheme] = useThemeStore((state) => [
-    state.widgetTheme,
-    state.configTheme,
-  ]);
+  const configTheme = useThemeStore((state) => state.configTheme);
+  const widgetTheme = useGetPartnerWidgetTheme();
   const { openWalletMenu } = useWalletMenu();
 
   return useMemo(

--- a/src/hooks/theme/useGetPartnerWidgetTheme.ts
+++ b/src/hooks/theme/useGetPartnerWidgetTheme.ts
@@ -1,0 +1,19 @@
+import { useMemo } from 'react';
+import { useColorScheme } from '@mui/material/styles';
+import { useThemeStore } from 'src/stores/theme';
+import { getDefaultWidgetThemeV2 } from 'src/config/widgetConfig';
+import { useThemeConditionsMet } from './useThemeConditionsMet';
+
+export const useGetPartnerWidgetTheme = () => {
+  const widgetTheme = useThemeStore((state) => state.widgetTheme);
+  const { mode } = useColorScheme();
+  const { shouldShowForTheme, shouldShowForPath } = useThemeConditionsMet();
+
+  return useMemo(() => {
+    if (shouldShowForTheme && shouldShowForPath) {
+      return widgetTheme;
+    }
+    const currentMode = mode === 'system' || !mode ? 'light' : mode;
+    return getDefaultWidgetThemeV2(currentMode);
+  }, [shouldShowForTheme, shouldShowForPath, widgetTheme, mode]);
+};

--- a/src/providers/ThemeProvider/WalletManagementThemeProvider.tsx
+++ b/src/providers/ThemeProvider/WalletManagementThemeProvider.tsx
@@ -2,12 +2,12 @@
 import { ThemeProvider } from '@mui/material';
 import { useMemo } from 'react';
 import { createTheme } from '@lifi/widget';
-import { useThemeStore } from '@/stores/theme';
+import { useGetPartnerWidgetTheme } from '@/hooks/theme/useGetPartnerWidgetTheme';
 
 export const WalletManagementThemeProvider: React.FC<
   React.PropsWithChildren
 > = ({ children }) => {
-  const widgetTheme = useThemeStore((state) => state.widgetTheme);
+  const widgetTheme = useGetPartnerWidgetTheme();
 
   const theme = useMemo(
     () => createTheme(widgetTheme.config.theme),

--- a/src/providers/ThemeProvider/WalletManagementThemeProvider.tsx
+++ b/src/providers/ThemeProvider/WalletManagementThemeProvider.tsx
@@ -13,7 +13,7 @@ export const WalletManagementThemeProvider: React.FC<
   const theme = useMemo(() => {
     const _theme = createTheme(widgetTheme.config.theme);
     _theme.components = deepmerge(
-      _theme.components,
+      _theme.components ?? {},
       widgetTheme.config.theme?.components ?? {},
     );
     return _theme;

--- a/src/providers/ThemeProvider/WalletManagementThemeProvider.tsx
+++ b/src/providers/ThemeProvider/WalletManagementThemeProvider.tsx
@@ -3,16 +3,21 @@ import { ThemeProvider } from '@mui/material';
 import { useMemo } from 'react';
 import { createTheme } from '@lifi/widget';
 import { useGetPartnerWidgetTheme } from '@/hooks/theme/useGetPartnerWidgetTheme';
+import { deepmerge } from '@mui/utils';
 
 export const WalletManagementThemeProvider: React.FC<
   React.PropsWithChildren
 > = ({ children }) => {
   const widgetTheme = useGetPartnerWidgetTheme();
 
-  const theme = useMemo(
-    () => createTheme(widgetTheme.config.theme),
-    [widgetTheme.config.theme],
-  );
+  const theme = useMemo(() => {
+    const _theme = createTheme(widgetTheme.config.theme);
+    _theme.components = deepmerge(
+      _theme.components,
+      widgetTheme.config.theme?.components ?? {},
+    );
+    return _theme;
+  }, [widgetTheme.config.theme]);
 
   return (
     <ThemeProvider

--- a/src/stores/theme/createThemeStore.tsx
+++ b/src/stores/theme/createThemeStore.tsx
@@ -196,8 +196,8 @@ export const createThemeStore = (props: ThemeProps) =>
           const currentPartnerName = currentState.configTheme?.partnerName;
           const persistedPartnerName = persisted.configTheme?.partnerName;
           const partnerChanged =
-            !!currentPartnerName &&
-            !!persistedPartnerName &&
+            !currentPartnerName ||
+            !persistedPartnerName ||
             currentPartnerName !== persistedPartnerName;
 
           const baseConfigThemeStates = partnerChanged

--- a/src/stores/theme/createThemeStore.tsx
+++ b/src/stores/theme/createThemeStore.tsx
@@ -193,17 +193,26 @@ export const createThemeStore = (props: ThemeProps) =>
         merge: (persistedState, currentState) => {
           const persisted = (persistedState || {}) as PersistedThemeState;
 
-          const mergedConfigThemeStates = {
-            ...(persisted.configThemeStates ?? {}),
-            ...currentState.configThemeStates,
-          };
+          const currentPartnerName = currentState.configTheme?.partnerName;
+          const persistedPartnerName = persisted.configTheme?.partnerName;
+          const partnerChanged =
+            !!currentPartnerName &&
+            !!persistedPartnerName &&
+            currentPartnerName !== persistedPartnerName;
+
+          const baseConfigThemeStates = partnerChanged
+            ? {}
+            : {
+                ...(persisted.configThemeStates ?? {}),
+                ...currentState.configThemeStates,
+              };
 
           return {
             ...persisted,
             ...currentState,
             configThemeStates: initializeConfigThemeStates(
               currentState.configTheme,
-              mergedConfigThemeStates,
+              baseConfigThemeStates,
             ),
           };
         },


### PR DESCRIPTION
Contributes to: https://lifi.atlassian.net/browse/JUM-277

## Testing steps
1. Go to the main menu -> Theme sections
2. Select mega eth
3. Check the widget and wallet connection modal are properly styled (some updates will still be made in Strapi once design confirms)
4. Now select the light theme
5. Check the widget and wallet connection modal have the regular light theme
6. Repeat steps `4-5` for the dark theme

7. Now a small bug I've found while testing: if you already had a default partner theme stored in the `jumper-theme-store` local storage, with an expiration date set, the new theme will not be loaded. Eg. previously `monad`
8. You can test this is fixed by going to `jumper.exchange`
9. Open Dev tools -> Application -> Local Storage
10. Filter for the `jumper-theme-store` key and copy the entry

<img width="682" height="671" alt="Screenshot 2026-01-21 at 14 16 21" src="https://github.com/user-attachments/assets/9f67579c-f9f1-4ea3-a346-dfdd58385173" />

11. Come back to this preview and perform step 9.
12. Filter for `jumper-theme-store` and paste the value
13. Now refresh the page and megaeth should be visible/selected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reset theme configurations correctly when switching partners to avoid stale theme state.

* **Improvements**
  * More reliable partner-specific widget theming that respects color scheme selection.
  * Partner component overrides are now merged into the generated theme for more consistent wallet UI styling.
  * Refined widget theme sourcing to improve theme stability across the app.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->