### PR TITLE
feat: add app source to positions LF-17246

### DIFF
--- a/src/app/ui/portfolio/PortfolioDeFiPositionsFilteringContext.tsx
+++ b/src/app/ui/portfolio/PortfolioDeFiPositionsFilteringContext.tsx
@@ -12,7 +12,7 @@ import { useQueryStates } from 'nuqs';
 import { useConnectedEvmAddresses } from '@/hooks/useConnectedEvmAddresses';
 import { usePortfolioDeFiPositions } from 'src/hooks/portfolio/usePortfolioDeFiPositions';
 import { isEqual } from 'lodash';
-import type { DefiPosition } from '@/types/jumper-backend';
+import type { DefiPosition } from '@/utils/positions/type-guards';
 import type {
   OrderEnum,
   PortfolioDeFiPositionsFilter,

--- a/src/app/ui/portfolio/PortfolioDeFiProtocolsList.tsx
+++ b/src/app/ui/portfolio/PortfolioDeFiProtocolsList.tsx
@@ -3,6 +3,7 @@ import { DeFiPositionCard } from '@/components/composite/DeFiPositionCard/DeFiPo
 import { DepositFlowModal } from '@/components/composite/DepositFlow/DepositFlow';
 import { useFormatDisplayDeFiPositions } from '@/hooks/portfolio/useFormatDisplayDeFiPositions';
 import { usePortfolioDeFiPositionsFiltering } from './PortfolioDeFiPositionsFilteringContext';
+import { getPositionGroupKey } from '@/utils/positions/type-guards';
 import { PortfolioEmptyList } from './PortfolioEmptyList';
 import { PortfolioAssetsListContainer } from './PortfolioPage.styles';
 import { WithdrawFlowModal } from '@/components/composite/WithdrawFlow/WithdrawFlow';
@@ -19,7 +20,7 @@ export const PortfolioDeFiProtocolsList = () => {
 
   const protocolGroups = useFormatDisplayDeFiPositions(
     data,
-    (position) => `${position.protocol.name}-${position.chain.chainId}`,
+    getPositionGroupKey,
     { sortBy, order },
   );
 
@@ -35,7 +36,7 @@ export const PortfolioDeFiProtocolsList = () => {
     if (protocolGroups.length > 0) {
       return protocolGroups.map((positions, index) => (
         <PortfolioAnimatedAssetContainer
-          key={`${positions[0].protocol.name}-${positions[0].chain.chainId}-${index}`}
+          key={`${getPositionGroupKey(positions[0])}-${index}`}
         >
           <DeFiPositionCard defiPositions={positions} isLoading={isLoading} />
         </PortfolioAnimatedAssetContainer>

--- a/src/app/ui/portfolio/PortfolioDeFiProtocolsList.tsx
+++ b/src/app/ui/portfolio/PortfolioDeFiProtocolsList.tsx
@@ -36,7 +36,7 @@ export const PortfolioDeFiProtocolsList = () => {
     if (protocolGroups.length > 0) {
       return protocolGroups.map((positions, index) => (
         <PortfolioAnimatedAssetContainer
-          key={`${getPositionGroupKey(positions[0])}-${index}`}
+          key={getPositionGroupKey(positions[0])}
         >
           <DeFiPositionCard defiPositions={positions} isLoading={isLoading} />
         </PortfolioAnimatedAssetContainer>

--- a/src/app/ui/portfolio/utils.ts
+++ b/src/app/ui/portfolio/utils.ts
@@ -17,9 +17,13 @@ import type {
   OrderEnum,
 } from './types';
 import type { Account } from '@lifi/wallet-management';
-import type { DefiPosition, WalletPositions } from '@/types/jumper-backend';
+import type { WalletPositions } from '@/types/jumper-backend';
 import { OrderOptions, SortByOptions } from './types';
 import { DEFAULT_DEFI_POSITIONS_MIN_VALUE } from './constants';
+import {
+  isChainDefiPosition,
+  type DefiPosition,
+} from '@/utils/positions/type-guards';
 
 export type SortAccessors<T> = Partial<
   Record<SortByEnum, (item: T) => string | number>
@@ -60,7 +64,13 @@ export const tokenSortAccessors: SortAccessors<PortfolioToken> = {
 export const defiGroupSortAccessors: SortAccessors<DefiPosition[]> = {
   [SortByOptions.VALUE]: (group) =>
     sumBy(group, (pos) => pos.netUsd || pos.assetUsd || 0),
-  [SortByOptions.CHAIN]: (group) => group[0]?.chain?.chainKey ?? '',
+  [SortByOptions.CHAIN]: (group) => {
+    const pos = group[0];
+    if (!pos) {
+      return '';
+    }
+    return isChainDefiPosition(pos) ? pos.chain.chainKey : pos.app.key;
+  },
   [SortByOptions.ASSET]: (group) => group[0]?.protocol?.name ?? '',
 };
 
@@ -247,10 +257,11 @@ export const deFiPositionsSearchParamsParsers = {
 export const extractDeFiPositionsFilteringParams = (
   wallet: WalletPositions,
 ): PortfolioDeFiPositionsFilteringParams => {
-  const allPositions = wallet.data;
+  const allPositions: DefiPosition[] = wallet.data;
+  const chainPositions = allPositions.filter(isChainDefiPosition);
 
   const allChains = uniqBy(
-    map(allPositions, (position) => position.chain).filter(Boolean),
+    chainPositions.map((position) => position.chain),
     'chainId',
   );
 
@@ -261,7 +272,7 @@ export const extractDeFiPositionsFilteringParams = (
 
   const allTypes = uniq(map(allPositions, 'type').filter(Boolean));
 
-  const allTokens = flatMap(allPositions, (position) => [
+  const allTokens = flatMap(chainPositions, (position) => [
     ...(position.supplyTokens || []),
     ...(position.assetTokens || []),
     ...(position.collateralTokens || []),

--- a/src/components/composite/AssetOverviewCard/AssetOverviewCard.types.ts
+++ b/src/components/composite/AssetOverviewCard/AssetOverviewCard.types.ts
@@ -1,4 +1,5 @@
-import type { DefiPosition, Protocol } from 'src/types/jumper-backend';
+import type { Protocol } from 'src/types/jumper-backend';
+import type { DefiPosition } from '@/utils/positions/type-guards';
 import type { PortfolioToken } from 'src/types/tokens';
 
 export enum AssetOverviewCardView {

--- a/src/components/composite/AssetOverviewCard/fixtures.ts
+++ b/src/components/composite/AssetOverviewCard/fixtures.ts
@@ -1,4 +1,4 @@
-import type { DefiPosition } from 'src/types/jumper-backend';
+import type { DefiPosition } from '@/utils/positions/type-guards';
 import type { PortfolioToken } from 'src/types/tokens';
 
 const ethereumChain = {
@@ -81,6 +81,7 @@ export const tokens: PortfolioToken[] = [
 
 export const aavePositions: DefiPosition[] = [
   {
+    source: 'chain',
     name: 'Aave V3',
     assetUsd: 1.0017831783178317,
     debtUsd: 0,
@@ -130,6 +131,7 @@ export const aavePositions: DefiPosition[] = [
     rewardTokens: [],
   },
   {
+    source: 'chain',
     name: 'Aave V3',
     assetUsd: 7.04781961968e-9,
     debtUsd: 1,
@@ -198,6 +200,7 @@ export const aavePositions: DefiPosition[] = [
 
 export const morphoPositions: DefiPosition[] = [
   {
+    source: 'chain',
     name: 'Morpho',
     assetUsd: 0.33359629049812184,
     debtUsd: 0,
@@ -248,6 +251,7 @@ export const morphoPositions: DefiPosition[] = [
     rewardTokens: [],
   },
   {
+    source: 'chain',
     name: 'Morpho',
     assetUsd: 5.931475,
     debtUsd: 0,
@@ -297,6 +301,7 @@ export const morphoPositions: DefiPosition[] = [
     rewardTokens: [],
   },
   {
+    source: 'chain',
     name: 'Morpho',
     assetUsd: 119.705551,
     debtUsd: 0,
@@ -347,6 +352,7 @@ export const morphoPositions: DefiPosition[] = [
     rewardTokens: [],
   },
   {
+    source: 'chain',
     name: 'Morpho',
     assetUsd: 10.65361505075361,
     debtUsd: 0,
@@ -399,6 +405,7 @@ export const morphoPositions: DefiPosition[] = [
 
 export const hyperwavePositions: DefiPosition[] = [
   {
+    source: 'chain',
     name: 'Hyperwave',
     assetUsd: 17.148273267639563,
     debtUsd: 0,
@@ -440,6 +447,7 @@ export const hyperwavePositions: DefiPosition[] = [
 
 export const merklPositions: DefiPosition[] = [
   {
+    source: 'chain',
     name: 'Merkl',
     assetUsd: 0.03301631879858625,
     debtUsd: 0,
@@ -522,6 +530,7 @@ export const merklPositions: DefiPosition[] = [
 
 export const eulerPositions: DefiPosition[] = [
   {
+    source: 'chain',
     name: 'Euler',
     assetUsd: 12.020139013901389,
     debtUsd: 0,

--- a/src/components/composite/AssetOverviewCard/utils.ts
+++ b/src/components/composite/AssetOverviewCard/utils.ts
@@ -1,4 +1,5 @@
-import type { DefiPosition, Protocol } from 'src/types/jumper-backend';
+import type { Protocol } from 'src/types/jumper-backend';
+import type { DefiPosition } from '@/utils/positions/type-guards';
 import { orderBy } from 'lodash';
 import type { ProtocolGroupData } from './AssetOverviewCard.types';
 

--- a/src/components/composite/DeFiPositionCard/DeFiPositionCard.tsx
+++ b/src/components/composite/DeFiPositionCard/DeFiPositionCard.tsx
@@ -202,7 +202,9 @@ export const DeFiPositionCard: FC<DeFiPositionCardProps> = ({
                     {!!description && (
                       <DeFiPositionOverview
                         icon={<NotesRoundedIcon sx={ICON_STYLES} />}
-                        header=""
+                        header={t(
+                          'portfolio.defiPositionCard.overview.details',
+                        )}
                         description={description}
                       />
                     )}

--- a/src/components/composite/DeFiPositionCard/DeFiPositionCard.tsx
+++ b/src/components/composite/DeFiPositionCard/DeFiPositionCard.tsx
@@ -40,6 +40,7 @@ import { openInNewTab } from '@/utils/openInNewTab';
 import { AppPaths } from '@/const/urls';
 import { useRouter } from 'next/navigation';
 import { DeFiPositionOverviewButton } from './components/DeFiPositionOverviewButton';
+import { isChainDefiPosition } from '@/utils/positions/type-guards';
 
 export const DeFiPositionCard: FC<DeFiPositionCardProps> = ({
   defiPositions,
@@ -105,7 +106,9 @@ export const DeFiPositionCard: FC<DeFiPositionCardProps> = ({
             }
             protocol={firstPosition.protocol}
             protocolSize={AvatarSize.XXL}
-            chains={[firstPosition.chain]}
+            chains={
+              isChainDefiPosition(firstPosition) ? [firstPosition.chain] : []
+            }
             content={{
               title: firstPosition.protocol.name,
               titleVariant: TYPOGRAPHY_VARIANTS.title,
@@ -166,11 +169,15 @@ export const DeFiPositionCard: FC<DeFiPositionCardProps> = ({
       <StyledAccordionDetails>
         <StyledDetailsContainer>
           {positionGroups.map((positionGroup, index) => {
-            const earn = positionGroup.position.earn;
-            const openedAt = positionGroup.position.openedAt;
-            const unlockAt = positionGroup.position.unlockAt;
+            const { position } = positionGroup;
+            const earn = position.earn;
+            const openedAt = position.openedAt;
+            const unlockAt = position.unlockAt;
+            const chainId = isChainDefiPosition(position)
+              ? position.chain.chainId
+              : undefined;
             return (
-              <Fragment key={positionGroup.position.address}>
+              <Fragment key={position.address}>
                 <StyledSectionDivider
                   sx={{ marginTop: index === 0 ? 1.5 : 0 }}
                 />
@@ -191,20 +198,22 @@ export const DeFiPositionCard: FC<DeFiPositionCardProps> = ({
                       />
                     )}
                     <StyledOverviewActions>
-                      <DeFiPositionOverviewButton
-                        tooltip={t(
-                          'portfolio.defiPositionCard.overview.tooltip.address',
-                        )}
-                        onClick={() =>
-                          handleAddressExplorerClick(
-                            positionGroup.position.chain.chainId,
-                            positionGroup.position.address,
-                          )
-                        }
-                        slots={{
-                          icon: CodeRoundedIcon,
-                        }}
-                      />
+                      {chainId !== undefined && (
+                        <DeFiPositionOverviewButton
+                          tooltip={t(
+                            'portfolio.defiPositionCard.overview.tooltip.address',
+                          )}
+                          onClick={() =>
+                            handleAddressExplorerClick(
+                              chainId,
+                              position.address,
+                            )
+                          }
+                          slots={{
+                            icon: CodeRoundedIcon,
+                          }}
+                        />
+                      )}
                       {!!earn && (
                         <DeFiPositionOverviewButton
                           tooltip={t(

--- a/src/components/composite/DeFiPositionCard/DeFiPositionCard.tsx
+++ b/src/components/composite/DeFiPositionCard/DeFiPositionCard.tsx
@@ -1,5 +1,6 @@
 import CalendarMonthRoundedIcon from '@mui/icons-material/CalendarMonthRounded';
 import LockOutlineRoundedIcon from '@mui/icons-material/LockOutlineRounded';
+import NotesRoundedIcon from '@mui/icons-material/NotesRounded';
 import type { FC } from 'react';
 import { Fragment, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -173,6 +174,7 @@ export const DeFiPositionCard: FC<DeFiPositionCardProps> = ({
             const earn = position.earn;
             const openedAt = position.openedAt;
             const unlockAt = position.unlockAt;
+            const description = position.description;
             const chainId = isChainDefiPosition(position)
               ? position.chain.chainId
               : undefined;
@@ -195,6 +197,13 @@ export const DeFiPositionCard: FC<DeFiPositionCardProps> = ({
                         icon={<LockOutlineRoundedIcon sx={ICON_STYLES} />}
                         header={t('portfolio.defiPositionCard.overview.lockup')}
                         description={formatTimeDifference(unlockAt, t)}
+                      />
+                    )}
+                    {!!description && (
+                      <DeFiPositionOverview
+                        icon={<NotesRoundedIcon sx={ICON_STYLES} />}
+                        header=""
+                        description={description}
                       />
                     )}
                     <StyledOverviewActions>

--- a/src/components/composite/DeFiPositionCard/DeFiPositionCard.types.ts
+++ b/src/components/composite/DeFiPositionCard/DeFiPositionCard.types.ts
@@ -1,7 +1,8 @@
 import type { TypographyProps } from '@mui/material/Typography';
 import type { TFunction } from 'i18next';
 import type { ColumnDefinition } from 'src/components/core/ColumnTable/ColumnTable.types';
-import type { DefiPosition, DefiToken } from 'src/types/jumper-backend';
+import type { AppToken, DefiToken } from 'src/types/jumper-backend';
+import type { DefiPosition } from '@/utils/positions/type-guards';
 
 export interface DeFiPositionCardProps {
   defiPositions?: DefiPosition[];
@@ -25,7 +26,7 @@ export interface TableSection<T> {
   showHeader: boolean;
 }
 
-export type EnhancedDefiTokenWithPositionData = DefiToken &
+export type EnhancedDefiTokenWithPositionData = (DefiToken | AppToken) &
   Pick<DefiPosition, 'latest' | 'earn' | 'protocol' | 'earnInteractionFlags'>;
 
 export type SupplySection = TableSection<EnhancedDefiTokenWithPositionData>;

--- a/src/components/composite/DeFiPositionCard/fixtures.ts
+++ b/src/components/composite/DeFiPositionCard/fixtures.ts
@@ -1,7 +1,9 @@
-import type { DefiPosition } from '@/types/jumper-backend';
+import type { AppDefiPosition } from '@/types/jumper-backend';
+import type { DefiPosition } from '@/utils/positions/type-guards';
 
 export const aavePositions: DefiPosition[] = [
   {
+    source: 'chain',
     name: 'Aave V3',
     assetUsd: 1.0017831783178317,
     debtUsd: 0,
@@ -51,6 +53,7 @@ export const aavePositions: DefiPosition[] = [
     rewardTokens: [],
   },
   {
+    source: 'chain',
     name: 'Aave V3',
     assetUsd: 7.04781961968e-9,
     debtUsd: 1,
@@ -119,6 +122,7 @@ export const aavePositions: DefiPosition[] = [
 
 export const morphoPositions: DefiPosition[] = [
   {
+    source: 'chain',
     name: 'Morpho',
     assetUsd: 0.33359629049812184,
     debtUsd: 0,
@@ -169,6 +173,7 @@ export const morphoPositions: DefiPosition[] = [
     rewardTokens: [],
   },
   {
+    source: 'chain',
     name: 'Morpho',
     assetUsd: 5.931475,
     debtUsd: 0,
@@ -218,6 +223,7 @@ export const morphoPositions: DefiPosition[] = [
     rewardTokens: [],
   },
   {
+    source: 'chain',
     name: 'Morpho',
     assetUsd: 119.705551,
     debtUsd: 0,
@@ -268,6 +274,7 @@ export const morphoPositions: DefiPosition[] = [
     rewardTokens: [],
   },
   {
+    source: 'chain',
     name: 'Morpho',
     assetUsd: 10.65361505075361,
     debtUsd: 0,
@@ -320,6 +327,7 @@ export const morphoPositions: DefiPosition[] = [
 
 export const gauntletPositions: DefiPosition[] = [
   {
+    source: 'chain',
     name: 'Gauntlet USDC Prime',
     assetUsd: 1.5076017601760177,
     debtUsd: 0,
@@ -374,6 +382,7 @@ export const gauntletPositions: DefiPosition[] = [
 
 export const merklPositions: DefiPosition[] = [
   {
+    source: 'chain',
     name: 'Merkl',
     assetUsd: 0.03301631879858625,
     debtUsd: 0,
@@ -447,6 +456,87 @@ export const merklPositions: DefiPosition[] = [
         priceUSD: 3023.72,
       },
     ],
+    borrowTokens: [],
+    assetTokens: [],
+    collateralTokens: [],
+    rewardTokens: [],
+  },
+];
+
+export const hyperliquidPositions: ({ source: 'app' } & AppDefiPosition)[] = [
+  {
+    source: 'app',
+    name: 'Hyperliquid',
+    description: 'Main-Account Spot',
+    assetUsd: 101.45,
+    debtUsd: 0,
+    netUsd: 101.45,
+    address: '0x1234567890abcdef1234567890abcdef12345678',
+    type: 'Deposit',
+    protocol: {
+      name: 'Hyperliquid',
+      logo: 'https://static.debank.com/image/project/logo_url/hyperliquid/hyperliquid.png',
+      url: 'https://app.hyperliquid.xyz',
+    },
+    app: {
+      key: 'hyperliquid',
+      logo: 'https://static.debank.com/image/project/logo_url/hyperliquid/hyperliquid.png',
+      url: 'https://app.hyperliquid.xyz',
+    },
+    supplyTokens: [
+      {
+        chainType: 'EVM',
+        amount: '101451288',
+        amountUSD: 101.45,
+        name: 'USDC',
+        symbol: 'USDC',
+        decimals: 8,
+        logo: 'https://static.debank.com/image/coin/logo_url/usdc/usdc.png',
+        address: 'cbc85c2463806ead7328a5da06425a2b',
+        priceUSD: 1,
+        app: {
+          key: 'hyperliquid',
+          logo: 'https://static.debank.com/image/project/logo_url/hyperliquid/hyperliquid.png',
+          url: 'https://app.hyperliquid.xyz',
+        },
+      },
+    ],
+    borrowTokens: [],
+    assetTokens: [],
+    collateralTokens: [],
+    rewardTokens: [],
+  },
+];
+
+export const polymarketPositions: ({ source: 'app' } & AppDefiPosition)[] = [
+  {
+    source: 'app',
+    name: 'Polymarket',
+    assetUsd: 399.99,
+    debtUsd: 0,
+    netUsd: 399.99,
+    address: '0xabcdef1234567890abcdef1234567890abcdef12',
+    type: 'Prediction',
+    protocol: {
+      name: 'Polymarket',
+      logo: 'https://static.debank.com/image/project/logo_url/polymarket/polymarket.png',
+      url: 'https://polymarket.com/',
+    },
+    app: {
+      key: 'polymarket',
+      logo: 'https://static.debank.com/image/project/logo_url/polymarket/polymarket.png',
+      url: 'https://polymarket.com/',
+    },
+    predictionDetails: {
+      name: 'Ethereum Up or Down - January 3',
+      side: 'Up',
+      amount: 399.9865,
+      price: 1,
+      claimable: true,
+      eventEndAt: null,
+      isMarketClosed: false,
+    },
+    supplyTokens: [],
     borrowTokens: [],
     assetTokens: [],
     collateralTokens: [],

--- a/src/components/composite/DeFiPositionCard/hooks.ts
+++ b/src/components/composite/DeFiPositionCard/hooks.ts
@@ -4,7 +4,8 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ColumnDefinition } from 'src/components/core/ColumnTable/ColumnTable.types';
 import { createEmptyColumn } from 'src/components/core/ColumnTable/utils';
-import type { DefiPosition, DefiToken } from 'src/types/jumper-backend';
+import type { DefiToken } from 'src/types/jumper-backend';
+import type { DefiPosition } from '@/utils/positions/type-guards';
 import {
   createEnhancedToken,
   renderApyCell,

--- a/src/components/composite/DeFiPositionCard/utils.tsx
+++ b/src/components/composite/DeFiPositionCard/utils.tsx
@@ -21,7 +21,12 @@ import type { TFunction } from 'i18next';
 import { WithdrawFlowOnDemandButton } from '../WithdrawFlow/WithdrawFlow';
 import { formatUnits } from 'viem';
 import { formatApy } from '@/utils/numbers/apy';
-import type { DefiPosition, DefiToken } from '@/types/jumper-backend';
+import type { AppToken, DefiToken, Token } from '@/types/jumper-backend';
+import type { DefiPosition } from '@/utils/positions/type-guards';
+
+const isTokenWithChain = (
+  token: DefiToken | AppToken,
+): token is DefiToken & Token => 'chain' in token && token.chain !== undefined;
 
 export const formatTimeDifference = (date: string, t: TFunction) => {
   const now = new Date();
@@ -72,7 +77,7 @@ export const formatTimeDifference = (date: string, t: TFunction) => {
 };
 
 export const createEnhancedToken = (
-  token: DefiToken,
+  token: DefiToken | AppToken,
   position: DefiPosition,
 ): EnhancedDefiTokenWithPositionData => ({
   ...token,
@@ -86,22 +91,46 @@ export const renderEntityCell = ({
   item,
   titleVariant,
   descriptionVariant,
-}: RenderCellProps<EnhancedDefiTokenWithPositionData>) => (
-  <EntityChainStack
-    variant={EntityChainStackVariant.Tokens}
-    tokens={[item]}
-    tokensSize={AvatarSize.XL}
-    content={{
-      title: item.name,
-      titleVariant,
-      descriptionVariant,
-    }}
-    spacing={{
-      chains: COLUMN_SPACING.chains,
-      infoContainerGap: COLUMN_SPACING.infoContainerGap,
-    }}
-  />
-);
+}: RenderCellProps<EnhancedDefiTokenWithPositionData>) => {
+  if (isTokenWithChain(item)) {
+    return (
+      <EntityChainStack
+        variant={EntityChainStackVariant.Tokens}
+        tokens={[item]}
+        tokensSize={AvatarSize.XL}
+        content={{
+          title: item.name,
+          titleVariant,
+          descriptionVariant,
+        }}
+        spacing={{
+          chains: COLUMN_SPACING.chains,
+          infoContainerGap: COLUMN_SPACING.infoContainerGap,
+        }}
+      />
+    );
+  }
+
+  return (
+    <EntityChainStack
+      variant={EntityChainStackVariant.Protocol}
+      protocol={{
+        name: item.name,
+        logo: item.logo,
+      }}
+      protocolSize={AvatarSize.XL}
+      content={{
+        title: item.name,
+        titleVariant,
+        descriptionVariant,
+      }}
+      spacing={{
+        chains: COLUMN_SPACING.chains,
+        infoContainerGap: COLUMN_SPACING.infoContainerGap,
+      }}
+    />
+  );
+};
 
 export const renderValueCell = ({
   item,

--- a/src/hooks/portfolio/useFormatDisplayDeFiPositions.ts
+++ b/src/hooks/portfolio/useFormatDisplayDeFiPositions.ts
@@ -1,4 +1,4 @@
-import type { DefiPosition } from '@/types/jumper-backend';
+import type { DefiPosition } from '@/utils/positions/type-guards';
 import { groupBy } from 'lodash';
 import { useMemo } from 'react';
 import type { OrderEnum, SortByEnum } from '@/app/ui/portfolio/types';

--- a/src/hooks/portfolio/usePortfolioDeFiPositions.ts
+++ b/src/hooks/portfolio/usePortfolioDeFiPositions.ts
@@ -5,7 +5,8 @@ import { ONE_HOUR_MS } from 'src/const/time';
 import type { Address, Hex } from 'viem';
 import type { PortfolioPositionsQuery } from '@/app/lib/getPositionsForAddress';
 import { getPositionsForAddress } from '@/app/lib/getPositionsForAddress';
-import type { DefiPosition, WalletPositions } from '@/types/jumper-backend';
+import type { WalletPositions } from '@/types/jumper-backend';
+import type { DefiPosition } from '@/utils/positions/type-guards';
 import type { GetTokenUSDPrice } from '@/utils/positions/update-price';
 import { updateWalletPositionsPrice } from '@/utils/positions/update-price';
 import { useTokens } from '../useTokens';
@@ -65,7 +66,7 @@ export const usePortfolioDeFiPositions = ({
           evm: address,
           ...filter,
         });
-        const positions = result.data;
+        const positions = result.data.data as unknown as WalletPositions;
         return updateWalletPositionsPrice(positions, getTokenUSDPrice);
       },
       enabled: !!address && !isLoadingTokens,

--- a/src/hooks/portfolio/usePortfolioDeFiPositions.ts
+++ b/src/hooks/portfolio/usePortfolioDeFiPositions.ts
@@ -66,7 +66,7 @@ export const usePortfolioDeFiPositions = ({
           evm: address,
           ...filter,
         });
-        const positions = result.data.data as unknown as WalletPositions;
+        const positions = result.data;
         return updateWalletPositionsPrice(positions, getTokenUSDPrice);
       },
       enabled: !!address && !isLoadingTokens,

--- a/src/hooks/portfolio/useTokensWithoutLpPositions.ts
+++ b/src/hooks/portfolio/useTokensWithoutLpPositions.ts
@@ -3,6 +3,7 @@ import { differenceWith } from 'lodash';
 import { useConnectedEvmAddresses } from '@/hooks/useConnectedEvmAddresses';
 import { usePortfolioDeFiPositions } from '@/hooks/portfolio/usePortfolioDeFiPositions';
 import type { PortfolioToken } from 'src/types/tokens';
+import { isChainDefiPosition } from '@/utils/positions/type-guards';
 
 const getTokenKey = (address: string, chainId: number) =>
   `${address.toLowerCase()}-${chainId}`;
@@ -45,6 +46,7 @@ export const useLpPositions = () => {
       return [];
     }
     return positions
+      .filter(isChainDefiPosition)
       .filter((p) => p.lpToken?.address && p.lpToken?.chain.chainId)
       .map((p) => ({
         address: p.lpToken!.address,

--- a/src/hooks/userTracking/usePortfolioTracking.ts
+++ b/src/hooks/userTracking/usePortfolioTracking.ts
@@ -8,7 +8,7 @@ import {
   TrackingAction,
   TrackingEventParameter,
 } from '@/const/trackingKeys';
-import type { DefiPosition } from '@/types/jumper-backend';
+import type { DefiPosition } from '@/utils/positions/type-guards';
 import type { PortfolioToken } from '@/types/tokens';
 import { zeroAddress } from 'viem';
 import type { ChainId } from '@lifi/sdk';

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -134,7 +134,7 @@ interface Resources {
         updated: 'Updated {{time}} ago';
       };
       position: {
-        disabled: 'Actions are currently disabled for this opportunity. <link>Go to {{protocolName}}</link>';
+        disabled: 'Actions are currently disabled for this opportunity. <0>Go to {{protocolName}}</0>';
         label: 'Your position';
       };
       relatedMarkets: {
@@ -514,6 +514,7 @@ interface Resources {
           value: 'Value';
         };
         overview: {
+          details: 'Details';
           lockup: 'Lockup';
           lockupPeriod: {
             days_one: '{{count}} day ago';
@@ -634,7 +635,7 @@ interface Resources {
       chains_one: 'The chain you will earn from';
       chains_other: 'The chains you will earn from';
       deposit: 'The token on which the market is defined and yield accrues on.';
-      depositDisabled: 'Deposit currently disabled for this opportunity';
+      depositDisabled: 'Deposit currently disabled for this opportunity. <0>Go to {{protocolName}}</0>';
       deposited: 'The token you have deposited into this market.';
       lockupPeriod: 'Once deposited, your position is subject to an {{formattedLockupPeriod}} lock-up period before you can withdraw the funds.';
       manageYourPosition: 'You can also manage your funds (withdraw, check PNL) on {{partnerName}} UI by clicking on this button';
@@ -642,7 +643,7 @@ interface Resources {
       protocol: 'The protocol you will earn from';
       rewardsApy: 'Expected yearly return rate of the rewards tokens invested.';
       tvl: 'Total value of crypto assets deposited in this market.';
-      withdrawDisabled: 'Withdraw currently disabled for this opportunity';
+      withdrawDisabled: 'Withdraw currently disabled for this opportunity. <0>Go to {{protocolName}}</0>';
     };
     widget: {
       depositCard: {

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -477,6 +477,7 @@
       "overview": {
         "opened": "Opened",
         "lockup": "Lockup",
+        "details": "Details",
         "lockupPeriod": {
           "lessThanOneMinute": "<1 minute ago",
           "minutes_one": "{{count}} minute ago",

--- a/src/types/jumper-backend.ts
+++ b/src/types/jumper-backend.ts
@@ -952,7 +952,7 @@ export interface DefiToken {
 }
 
 export interface ChainDefiPosition {
-  source: string;
+  source: 'chain';
   name: string;
   /** Additional context about the position */
   description?: string;
@@ -1013,7 +1013,7 @@ export interface PredictionDetails {
 }
 
 export interface AppDefiPosition {
-  source: string;
+  source: 'app';
   name: string;
   /** Additional context about the position */
   description?: string;

--- a/src/types/jumper-backend.ts
+++ b/src/types/jumper-backend.ts
@@ -937,11 +937,6 @@ export interface TokenBalances {
   updatedAt: string;
 }
 
-export interface MetadataWithUpdatedAt {
-  /** @format date-time */
-  updatedAt: string;
-}
-
 export interface DefiToken {
   name: string;
   symbol: string;
@@ -956,13 +951,15 @@ export interface DefiToken {
   priceUSD: number;
 }
 
-export interface DefiPosition {
+export interface ChainDefiPosition {
+  source: string;
   name: string;
+  /** Additional context about the position */
+  description?: string;
   assetUsd: number;
   debtUsd: number;
   netUsd: number;
   address: string;
-  chain: Chain;
   earn?: string;
   earnInteractionFlags?: EarnInteractionFlags;
   latest?: EarnOpportunityHistoryItem;
@@ -972,6 +969,7 @@ export interface DefiPosition {
   openedAt?: string;
   type: string;
   protocol: Protocol;
+  chain: Chain;
   supplyTokens: DefiToken[];
   borrowTokens: DefiToken[];
   assetTokens: DefiToken[];
@@ -980,9 +978,82 @@ export interface DefiPosition {
   lpToken?: Token;
 }
 
+export interface App {
+  /** Unique identifier for the app, e.g., "hyperliquid", "polymarket" */
+  key: string;
+  /** URL to app logo */
+  logo?: string;
+  /** App website URL */
+  url: string;
+}
+
+export interface AppToken {
+  chainType: string;
+  /** The amount of the token in the native currency */
+  amount: string;
+  amountUSD: number;
+  name: string;
+  symbol: string;
+  decimals: number;
+  /** URL to token logo */
+  logo?: string;
+  address: string;
+  app: App;
+  priceUSD: number;
+}
+
+export interface PredictionDetails {
+  name: string;
+  side: string;
+  amount: number;
+  price: number;
+  claimable: boolean;
+  eventEndAt?: number | null;
+  isMarketClosed: boolean;
+}
+
+export interface AppDefiPosition {
+  source: string;
+  name: string;
+  /** Additional context about the position */
+  description?: string;
+  assetUsd: number;
+  debtUsd: number;
+  netUsd: number;
+  address: string;
+  earn?: string;
+  earnInteractionFlags?: EarnInteractionFlags;
+  latest?: EarnOpportunityHistoryItem;
+  /** @format date-time */
+  unlockAt?: string;
+  /** @format date-time */
+  openedAt?: string;
+  type: string;
+  protocol: Protocol;
+  app: App;
+  supplyTokens: AppToken[];
+  borrowTokens: AppToken[];
+  assetTokens: AppToken[];
+  collateralTokens: AppToken[];
+  rewardTokens: AppToken[];
+  predictionDetails?: PredictionDetails;
+}
+
+export interface MetadataWithUpdatedAt {
+  /** @format date-time */
+  updatedAt: string;
+}
+
 export interface WalletPositions {
   meta: MetadataWithUpdatedAt;
-  data: DefiPosition[];
+  data: (
+    | ({
+        source: 'chain';
+      } & ChainDefiPosition)
+    | ({
+        source: 'app';
+      } & AppDefiPosition)
+  )[];
 }
 
 export interface TaskVerificationDto {

--- a/src/utils/positions/type-guards.ts
+++ b/src/utils/positions/type-guards.ts
@@ -1,0 +1,24 @@
+import type {
+  ChainDefiPosition,
+  AppDefiPosition,
+} from '@/types/jumper-backend';
+
+export type DefiPosition =
+  | ({ source: 'chain' } & ChainDefiPosition)
+  | ({ source: 'app' } & AppDefiPosition);
+
+export const isChainDefiPosition = (
+  position: DefiPosition,
+): position is { source: 'chain' } & ChainDefiPosition =>
+  position.source === 'chain';
+
+export const isAppDefiPosition = (
+  position: DefiPosition,
+): position is { source: 'app' } & AppDefiPosition => position.source === 'app';
+
+export const getPositionGroupKey = (position: DefiPosition): string => {
+  if (isChainDefiPosition(position)) {
+    return `${position.protocol.name}-${position.chain.chainId}`;
+  }
+  return `${position.protocol.name}-app-${position.app.key}`;
+};

--- a/src/utils/positions/type-guards.ts
+++ b/src/utils/positions/type-guards.ts
@@ -1,20 +1,18 @@
 import type {
   ChainDefiPosition,
   AppDefiPosition,
+  WalletPositions,
 } from '@/types/jumper-backend';
 
-export type DefiPosition =
-  | ({ source: 'chain' } & ChainDefiPosition)
-  | ({ source: 'app' } & AppDefiPosition);
+export type DefiPosition = WalletPositions['data'][number];
 
 export const isChainDefiPosition = (
   position: DefiPosition,
-): position is { source: 'chain' } & ChainDefiPosition =>
-  position.source === 'chain';
+): position is ChainDefiPosition => position.source === 'chain';
 
 export const isAppDefiPosition = (
   position: DefiPosition,
-): position is { source: 'app' } & AppDefiPosition => position.source === 'app';
+): position is AppDefiPosition => position.source === 'app';
 
 export const getPositionGroupKey = (position: DefiPosition): string => {
   if (isChainDefiPosition(position)) {

--- a/src/utils/positions/update-price.spec.ts
+++ b/src/utils/positions/update-price.spec.ts
@@ -1,9 +1,10 @@
-import type { DefiPosition } from '@/types/jumper-backend';
+import type { DefiPosition } from '@/utils/positions/type-guards';
 import { describe, expect, it, vi } from 'vitest';
 import { updatePositionPrice } from './update-price';
 
 // Generated from http://localhost:3001/v1/portfolio/positions?evm=0xb29601eB52a052042FB6c68C69a442BD0AE90082 on 2025-12-10
 const ASSET_FIXTURE: DefiPosition = {
+  source: 'chain',
   name: 'Aave V3',
   assetUsd: 0.115107514249528,
   debtUsd: 0,

--- a/src/utils/positions/update-price.ts
+++ b/src/utils/positions/update-price.ts
@@ -1,10 +1,7 @@
-import type {
-  DefiPosition,
-  DefiToken,
-  WalletPositions,
-} from '@/types/jumper-backend';
+import type { DefiToken, WalletPositions } from '@/types/jumper-backend';
 import { formatTokenPrice } from '@lifi/widget';
 import { sumBy } from 'lodash';
+import { isAppDefiPosition, type DefiPosition } from './type-guards';
 
 export type GetTokenUSDPrice = (token: {
   chainId: number;
@@ -50,6 +47,10 @@ export const updatePositionPrice = async (
   position: DefiPosition,
   getTokenUSDPrice: GetTokenUSDPrice,
 ): Promise<DefiPosition> => {
+  if (isAppDefiPosition(position)) {
+    return position;
+  }
+
   const [
     supplyTokens,
     borrowTokens,
@@ -89,12 +90,15 @@ export const updateWalletPositionsPrice = async (
   wallet: WalletPositions,
   getTokenUSDPrice: GetTokenUSDPrice,
 ): Promise<WalletPositions> => {
+  const positions = wallet.data as DefiPosition[];
+  const updatedPositions = await Promise.all(
+    positions.map((position) =>
+      updatePositionPrice(position, getTokenUSDPrice),
+    ),
+  );
+
   return {
     ...wallet,
-    data: await Promise.all(
-      wallet.data.map((position) =>
-        updatePositionPrice(position, getTokenUSDPrice),
-      ),
-    ),
+    data: updatedPositions as WalletPositions['data'],
   };
 };

--- a/src/utils/positions/update-price.ts
+++ b/src/utils/positions/update-price.ts
@@ -90,7 +90,7 @@ export const updateWalletPositionsPrice = async (
   wallet: WalletPositions,
   getTokenUSDPrice: GetTokenUSDPrice,
 ): Promise<WalletPositions> => {
-  const positions = wallet.data as DefiPosition[];
+  const positions = wallet.data;
   const updatedPositions = await Promise.all(
     positions.map((position) =>
       updatePositionPrice(position, getTokenUSDPrice),
@@ -99,6 +99,6 @@ export const updateWalletPositionsPrice = async (
 
   return {
     ...wallet,
-    data: updatedPositions as WalletPositions['data'],
+    data: updatedPositions,
   };
 };

--- a/src/utils/tracking/portfolio.ts
+++ b/src/utils/tracking/portfolio.ts
@@ -3,10 +3,13 @@ import {
   mapPositionGroupsToProtocolData,
   sortAssetsByPrice,
 } from '@/components/composite/AssetOverviewCard/utils';
-import type { DefiPosition } from '@/types/jumper-backend';
 import type { PortfolioToken } from '@/types/tokens';
 import type { ChainId } from '@lifi/widget';
 import { TrackingEventParameter } from 'src/const/trackingKeys';
+import {
+  isChainDefiPosition,
+  type DefiPosition,
+} from '@/utils/positions/type-guards';
 
 const FLEXIBLE_STABLE_COINS_REGEX =
   /^.*(USD|EUR|XAU|YEN|IDR|CHF|CAD|CNH|MXN).*$/;
@@ -96,7 +99,9 @@ export const parseEarnPortfolioDataToTrackingData = (
 
   for (const positionGroup of defiPositionGroups) {
     for (const position of positionGroup) {
-      chainIds.add(position.chain.chainId);
+      if (isChainDefiPosition(position)) {
+        chainIds.add(position.chain.chainId);
+      }
     }
   }
 


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Contributes to https://lifi.atlassian.net/browse/LF-17246

Requires https://github.com/jumperexchange/jumper-backend/pull/680

# Why did I implement it this way?

The API now return object that are either AppPosition (no chain info) or DefiPosition (with chain, tokens, etc).

hyperliquid and lighter in that screenshot:

<img width="300" src="https://github.com/user-attachments/assets/7cf0962b-2848-4a31-924e-5a53e6a49f61" />

It also adds the description / details field to differentiate opportunities (spots, perps, etc).
<img width="300" src="https://github.com/user-attachments/assets/ecd7519c-1304-435b-88c0-98ed97154263" />

## Tests

Visit the portfolio using acounts that own things like perpertuals and polymarkets.
Example: 0xb29601eB52a052042FB6c68C69a442BD0AE90082

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [x] If this changed the API, I have updated the documentation
- [x] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [x] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds app-backed DeFi positions alongside chain-backed ones.
  * Shows position descriptions/details and a new "Details" label in the UI.
  * Address explorer and position overview options appear conditionally when available.

* **Bug Fixes**
  * Improved grouping and filtering so mixed (app vs chain) positions display and aggregate correctly.

* **Refactor**
  * Centralized position handling for more consistent rendering and safer type handling across the portfolio.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->