### PR TITLE
feat: handle null values in analytics charts LF-16533

### DIFF
--- a/src/components/EarnDetails/hooks.ts
+++ b/src/components/EarnDetails/hooks.ts
@@ -9,6 +9,15 @@ import type { LineChartProps } from '../core/charts/LineChart/LineChart';
 import type { StackedAreaChartProps } from '../core/charts/StackedAreaChart/StackedAreaChart';
 import { AnalyticsRangeFieldEnum } from './types';
 
+/**
+ * Trims leading entries from an array where the predicate returns false.
+ * Returns the array starting from the first element where hasValue returns true.
+ */
+function trimLeadingNulls<T>(data: T[], hasValue: (item: T) => boolean): T[] {
+  const firstValidIndex = data.findIndex(hasValue);
+  return firstValidIndex === -1 ? [] : data.slice(firstValidIndex);
+}
+
 const useDefaultDateFormat = (range: AnalyticsRangeFieldEnum) => {
   return range === AnalyticsRangeFieldEnum.WEEK ||
     range === AnalyticsRangeFieldEnum.MONTH
@@ -21,12 +30,12 @@ export const useSimpleAnalyticsChartConfig = (
   range: AnalyticsRangeFieldEnum,
 ): LineChartProps => {
   const data = useMemo(() => {
-    return (
+    const mapped =
       rawData?.points.map((point) => ({
         date: new Date(point.t).toISOString(),
         value: point.v,
-      })) ?? []
-    );
+      })) ?? [];
+    return trimLeadingNulls(mapped, (item) => item.value != null);
   }, [rawData]);
 
   const dateFormat = useDefaultDateFormat(range);
@@ -46,13 +55,20 @@ export const useApyAnalyticsChartConfig = (
   range: AnalyticsRangeFieldEnum,
 ): StackedAreaChartProps => {
   const data = useMemo(() => {
-    return (
+    const mapped =
       rawData?.points.map((point) => ({
         date: new Date(point.t).toISOString(),
         base: point.base,
         reward: point.reward,
-      })) ?? []
-    );
+        total:
+          point.base != null && point.reward != null
+            ? point.base + point.reward
+            : null,
+      })) ?? [];
+    return trimLeadingNulls(
+      mapped,
+      (item) => item.total != null,
+    ) as StackedAreaChartProps['data'];
   }, [rawData]);
 
   const theme = useRewardChartTheme();

--- a/src/components/EarnDetails/hooks.ts
+++ b/src/components/EarnDetails/hooks.ts
@@ -33,7 +33,8 @@ export const useSimpleAnalyticsChartConfig = (
     const mapped =
       rawData?.points.map((point) => ({
         date: new Date(point.t).toISOString(),
-        value: point.v,
+        // Normalize potential nulls to undefined to match chart value typings
+        value: point.v ?? undefined,
       })) ?? [];
     return trimLeadingNulls(mapped, (item) => item.value != null);
   }, [rawData]);
@@ -65,10 +66,7 @@ export const useApyAnalyticsChartConfig = (
             ? point.base + point.reward
             : null,
       })) ?? [];
-    return trimLeadingNulls(
-      mapped,
-      (item) => item.total != null,
-    ) as StackedAreaChartProps['data'];
+    return trimLeadingNulls(mapped, (item) => item.total != null);
   }, [rawData]);
 
   const theme = useRewardChartTheme();

--- a/src/components/core/charts/LineChart/CustomTooltip.tsx
+++ b/src/components/core/charts/LineChart/CustomTooltip.tsx
@@ -68,9 +68,11 @@ export const CustomTooltip: FC<CustomTooltipProps> = ({
         {formatDateLocalized(label ?? '', 'PP @ HH:mm')}
       </Typography>
       <Typography variant="bodySmall">
-        {valueFormatConfig
-          ? formatValueWithConfig(data.value, valueFormatConfig)
-          : data.value}{' '}
+        {data.value == null
+          ? 'NULL'
+          : valueFormatConfig
+            ? formatValueWithConfig(data.value, valueFormatConfig)
+            : data.value}{' '}
         <strong>{dataSetId?.toString().toUpperCase()}</strong>
       </Typography>
     </Box>

--- a/src/components/core/charts/LineChart/LineChart.tsx
+++ b/src/components/core/charts/LineChart/LineChart.tsx
@@ -234,10 +234,16 @@ export const LineChart = <
             type="monotone"
             dataKey="value"
             stroke={theme.lineColor}
+            connectNulls={true}
             activeDot={
               enableCrosshair
                 ? (props: ActiveDotProps) => {
                     const { cx, cy, payload } = props;
+
+                    // Skip null values - no dot, no tooltip
+                    if (payload.value == null) {
+                      return null;
+                    }
 
                     if (enableTooltip) {
                       setActiveDot((prev) => {

--- a/src/components/core/charts/LineChart/LineChart.tsx
+++ b/src/components/core/charts/LineChart/LineChart.tsx
@@ -45,7 +45,9 @@ const StyledResponsiveContainer = styled(ResponsiveContainer, {
   },
 }));
 
-export interface ChartDataPoint<V extends number | string = number | string> {
+export interface ChartDataPoint<
+  V extends number | string | undefined = number | string | undefined,
+> {
   date: string;
   value: V;
 }
@@ -242,6 +244,9 @@ export const LineChart = <
 
                     // Skip null values - no dot, no tooltip
                     if (payload.value == null) {
+                      if (enableTooltip) {
+                        setActiveDot(null);
+                      }
                       return null;
                     }
 

--- a/src/components/core/charts/StackedAreaChart/StackedAreaChart.stories.tsx
+++ b/src/components/core/charts/StackedAreaChart/StackedAreaChart.stories.tsx
@@ -84,8 +84,8 @@ export const HighRewards: Story = {
     ...commonArgs,
     data: stackedApyData.map((d) => ({
       ...d,
-      reward: d.reward * 3,
-      total: d.base + d.reward * 3,
+      reward: d.reward! * 3,
+      total: d.base! + d.reward! * 3,
     })),
   },
 };
@@ -96,9 +96,9 @@ export const VerySmallValues: Story = {
     ...commonArgs,
     data: stackedApyData.map((d) => ({
       ...d,
-      base: d.base * 0.01,
-      reward: d.reward * 0.01,
-      total: (d.base + d.reward) * 0.01,
+      base: d.base! * 0.01,
+      reward: d.reward! * 0.01,
+      total: (d.base! + d.reward!) * 0.01,
     })),
   },
 };

--- a/src/components/core/charts/StackedAreaChart/StackedAreaChart.stories.tsx
+++ b/src/components/core/charts/StackedAreaChart/StackedAreaChart.stories.tsx
@@ -9,26 +9,26 @@ import {
 } from './StackedAreaChart';
 
 const stackedApyData: StackedChartDataPoint[] = [
-  { date: '2023-01-01', base: 3.5, reward: 1.2 },
-  { date: '2023-01-02', base: 3.8, reward: 1.5 },
-  { date: '2023-01-03', base: 3.2, reward: 1.8 },
-  { date: '2023-01-04', base: 3.6, reward: 2.1 },
-  { date: '2023-01-05', base: 3.4, reward: 1.9 },
-  { date: '2023-01-07', base: 4.0, reward: 2.3 },
-  { date: '2023-01-08', base: 3.3, reward: 1.7 },
-  { date: '2023-01-09', base: 3.7, reward: 2.0 },
-  { date: '2023-01-10', base: 3.5, reward: 1.8 },
-  { date: '2023-01-11', base: 3.9, reward: 2.2 },
-  { date: '2023-01-12', base: 3.6, reward: 1.6 },
-  { date: '2023-01-13', base: 3.4, reward: 1.4 },
-  { date: '2023-01-15', base: 3.7, reward: 1.9 },
-  { date: '2023-01-16', base: 3.2, reward: 1.5 },
-  { date: '2023-01-17', base: 3.5, reward: 1.7 },
-  { date: '2023-01-18', base: 4.1, reward: 2.4 },
-  { date: '2023-01-20', base: 3.8, reward: 2.1 },
-  { date: '2023-01-21', base: 3.6, reward: 1.8 },
-  { date: '2023-01-22', base: 3.3, reward: 1.5 },
-  { date: '2023-01-23', base: 3.9, reward: 2.0 },
+  { date: '2023-01-01', base: 3.5, reward: 1.2, total: 4.7 },
+  { date: '2023-01-02', base: 3.8, reward: 1.5, total: 5.3 },
+  { date: '2023-01-03', base: 3.2, reward: 1.8, total: 5.0 },
+  { date: '2023-01-04', base: 3.6, reward: 2.1, total: 5.7 },
+  { date: '2023-01-05', base: 3.4, reward: 1.9, total: 5.3 },
+  { date: '2023-01-07', base: 4.0, reward: 2.3, total: 6.3 },
+  { date: '2023-01-08', base: 3.3, reward: 1.7, total: 5.0 },
+  { date: '2023-01-09', base: 3.7, reward: 2.0, total: 5.7 },
+  { date: '2023-01-10', base: 3.5, reward: 1.8, total: 5.3 },
+  { date: '2023-01-11', base: 3.9, reward: 2.2, total: 6.1 },
+  { date: '2023-01-12', base: 3.6, reward: 1.6, total: 5.2 },
+  { date: '2023-01-13', base: 3.4, reward: 1.4, total: 4.8 },
+  { date: '2023-01-15', base: 3.7, reward: 1.9, total: 5.6 },
+  { date: '2023-01-16', base: 3.2, reward: 1.5, total: 4.7 },
+  { date: '2023-01-17', base: 3.5, reward: 1.7, total: 5.2 },
+  { date: '2023-01-18', base: 4.1, reward: 2.4, total: 6.5 },
+  { date: '2023-01-20', base: 3.8, reward: 2.1, total: 5.9 },
+  { date: '2023-01-21', base: 3.6, reward: 1.8, total: 5.4 },
+  { date: '2023-01-22', base: 3.3, reward: 1.5, total: 4.8 },
+  { date: '2023-01-23', base: 3.9, reward: 2.0, total: 5.9 },
 ];
 
 const meta = {
@@ -66,7 +66,7 @@ export const RewardOnly: Story = {
   render: DefaultRenderer,
   args: {
     ...commonArgs,
-    data: stackedApyData.map((d) => ({ ...d, base: 0 })),
+    data: stackedApyData.map((d) => ({ ...d, base: 0, total: d.reward })),
   },
 };
 
@@ -74,7 +74,7 @@ export const BaseOnly: Story = {
   render: DefaultRenderer,
   args: {
     ...commonArgs,
-    data: stackedApyData.map((d) => ({ ...d, reward: 0 })),
+    data: stackedApyData.map((d) => ({ ...d, reward: 0, total: d.base })),
   },
 };
 
@@ -82,7 +82,11 @@ export const HighRewards: Story = {
   render: DefaultRenderer,
   args: {
     ...commonArgs,
-    data: stackedApyData.map((d) => ({ ...d, reward: d.reward * 3 })),
+    data: stackedApyData.map((d) => ({
+      ...d,
+      reward: d.reward * 3,
+      total: d.base + d.reward * 3,
+    })),
   },
 };
 
@@ -94,6 +98,7 @@ export const VerySmallValues: Story = {
       ...d,
       base: d.base * 0.01,
       reward: d.reward * 0.01,
+      total: (d.base + d.reward) * 0.01,
     })),
   },
 };
@@ -104,18 +109,18 @@ export const MonthlyView: Story = {
     ...commonArgs,
     dateFormat: 'MMM yyyy',
     data: [
-      { date: '2025-01-01', base: 3.2, reward: 1.5 },
-      { date: '2025-02-01', base: 3.5, reward: 1.8 },
-      { date: '2025-03-01', base: 3.8, reward: 2.1 },
-      { date: '2025-04-01', base: 3.4, reward: 1.9 },
-      { date: '2025-05-01', base: 3.6, reward: 2.0 },
-      { date: '2025-06-01', base: 3.9, reward: 2.3 },
-      { date: '2025-07-01', base: 4.1, reward: 2.5 },
-      { date: '2025-08-01', base: 3.7, reward: 2.2 },
-      { date: '2025-09-01', base: 3.5, reward: 2.0 },
-      { date: '2025-10-01', base: 3.8, reward: 2.4 },
-      { date: '2025-11-01', base: 4.0, reward: 2.6 },
-      { date: '2025-12-01', base: 4.2, reward: 2.8 },
+      { date: '2025-01-01', base: 3.2, reward: 1.5, total: 4.7 },
+      { date: '2025-02-01', base: 3.5, reward: 1.8, total: 5.3 },
+      { date: '2025-03-01', base: 3.8, reward: 2.1, total: 5.9 },
+      { date: '2025-04-01', base: 3.4, reward: 1.9, total: 5.3 },
+      { date: '2025-05-01', base: 3.6, reward: 2.0, total: 5.6 },
+      { date: '2025-06-01', base: 3.9, reward: 2.3, total: 6.2 },
+      { date: '2025-07-01', base: 4.1, reward: 2.5, total: 6.6 },
+      { date: '2025-08-01', base: 3.7, reward: 2.2, total: 5.9 },
+      { date: '2025-09-01', base: 3.5, reward: 2.0, total: 5.5 },
+      { date: '2025-10-01', base: 3.8, reward: 2.4, total: 6.2 },
+      { date: '2025-11-01', base: 4.0, reward: 2.6, total: 6.6 },
+      { date: '2025-12-01', base: 4.2, reward: 2.8, total: 7.0 },
     ],
   },
 };
@@ -137,11 +142,11 @@ export const ZeroValues: Story = {
   args: {
     ...commonArgs,
     data: [
-      { date: '2023-01-01', base: 0, reward: 0 },
-      { date: '2023-01-02', base: 0, reward: 0 },
-      { date: '2023-01-03', base: 0, reward: 0 },
-      { date: '2023-01-04', base: 0, reward: 0 },
-      { date: '2023-01-05', base: 0, reward: 0 },
+      { date: '2023-01-01', base: 0, reward: 0, total: 0 },
+      { date: '2023-01-02', base: 0, reward: 0, total: 0 },
+      { date: '2023-01-03', base: 0, reward: 0, total: 0 },
+      { date: '2023-01-04', base: 0, reward: 0, total: 0 },
+      { date: '2023-01-05', base: 0, reward: 0, total: 0 },
     ],
   },
 };

--- a/src/components/core/charts/StackedAreaChart/StackedAreaChart.tsx
+++ b/src/components/core/charts/StackedAreaChart/StackedAreaChart.tsx
@@ -46,9 +46,9 @@ const StyledResponsiveContainer = styled(ResponsiveContainer, {
 
 export interface StackedChartDataPoint {
   date: string;
-  base: number;
-  reward: number;
-  total: number;
+  base: number | null;
+  reward: number | null;
+  total: number | null;
 }
 
 export interface StackedAreaChartProps extends HTMLAttributes<HTMLDivElement> {
@@ -74,7 +74,9 @@ export interface StackedAreaChartProps extends HTMLAttributes<HTMLDivElement> {
 
 const calculateStackedVisibleYRange = (data: StackedChartDataPoint[]) => {
   const points = data
-    .filter((d) => d.total != null)
+    .filter(
+      (d): d is StackedChartDataPoint & { total: number } => d.total != null,
+    )
     .map((d) => ({
       date: d.date,
       value: d.total,
@@ -140,7 +142,9 @@ export const StackedAreaChart = ({
   const xAxisTicks = useMemo(() => {
     // Adapt the data format for calculateEvenXAxisTicks
     const adaptedData = data
-      .filter((d) => d.total != null)
+      .filter(
+        (d): d is StackedChartDataPoint & { total: number } => d.total != null,
+      )
       .map((d) => ({
         date: d.date,
         value: d.total,
@@ -169,6 +173,9 @@ export const StackedAreaChart = ({
     const { cx, cy, payload } = props;
 
     if (payload.total == null) {
+      if (enableTooltip) {
+        setActiveDot(null);
+      }
       return null;
     }
 

--- a/src/components/core/charts/StackedAreaChart/StackedAreaChart.tsx
+++ b/src/components/core/charts/StackedAreaChart/StackedAreaChart.tsx
@@ -48,6 +48,7 @@ export interface StackedChartDataPoint {
   date: string;
   base: number;
   reward: number;
+  total: number;
 }
 
 export interface StackedAreaChartProps extends HTMLAttributes<HTMLDivElement> {
@@ -72,10 +73,12 @@ export interface StackedAreaChartProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 const calculateStackedVisibleYRange = (data: StackedChartDataPoint[]) => {
-  const points = data.map((d) => ({
-    date: d.date,
-    value: d.base + d.reward,
-  }));
+  const points = data
+    .filter((d) => d.total != null)
+    .map((d) => ({
+      date: d.date,
+      value: d.total,
+    }));
 
   return calculateVisibleYRange(points);
 };
@@ -136,10 +139,12 @@ export const StackedAreaChart = ({
 
   const xAxisTicks = useMemo(() => {
     // Adapt the data format for calculateEvenXAxisTicks
-    const adaptedData = data.map((d) => ({
-      date: d.date,
-      value: d.base + d.reward,
-    }));
+    const adaptedData = data
+      .filter((d) => d.total != null)
+      .map((d) => ({
+        date: d.date,
+        value: d.total,
+      }));
     return calculateEvenXAxisTicks(adaptedData, dateFormatter);
   }, [data, dateFormatter]);
 
@@ -162,6 +167,10 @@ export const StackedAreaChart = ({
 
   const handleActiveDot = (props: ActiveDotProps) => {
     const { cx, cy, payload } = props;
+
+    if (payload.total == null) {
+      return null;
+    }
 
     if (enableTooltip) {
       setActiveDot((prev) => {
@@ -276,26 +285,12 @@ export const StackedAreaChart = ({
               tickFormatter={valueFormatter}
             />
           )}
-          {/* Base area fill (bottom of stack, no stroke) */}
+          {/* Total area (reward gradient) - rendered first as background */}
           <Area
             type="monotone"
-            dataKey="base"
-            stackId="apy"
-            stroke="transparent"
-            fillOpacity={1}
-            fill={`url(#${baseGradientId})`}
-            isAnimationActive
-            activeDot={false}
-            style={{
-              transform: AREA_CONFIG.TRANSFORM,
-            }}
-          />
-          {/* Reward area (stacked on top of base) - dot appears here */}
-          <Area
-            type="monotone"
-            dataKey="reward"
-            stackId="apy"
+            dataKey="total"
             stroke={theme.rewardLineColor}
+            connectNulls={true}
             fillOpacity={1}
             fill={`url(#${rewardGradientId})`}
             isAnimationActive
@@ -304,11 +299,26 @@ export const StackedAreaChart = ({
               transform: AREA_CONFIG.TRANSFORM,
             }}
           />
-          {/* Base line rendered last (always on top in z-order) */}
+          {/* Base area - overlays bottom portion */}
+          <Area
+            type="monotone"
+            dataKey="base"
+            stroke="transparent"
+            connectNulls={true}
+            fillOpacity={1}
+            fill={`url(#${baseGradientId})`}
+            isAnimationActive
+            activeDot={false}
+            style={{
+              transform: AREA_CONFIG.TRANSFORM,
+            }}
+          />
+          {/* Base line (divider between base and reward) */}
           <Area
             type="monotone"
             dataKey="base"
             stroke={theme.baseLineColor}
+            connectNulls={true}
             fillOpacity={0}
             fill="transparent"
             isAnimationActive

--- a/src/components/core/charts/StackedAreaChart/StackedAreaTooltip.tsx
+++ b/src/components/core/charts/StackedAreaChart/StackedAreaTooltip.tsx
@@ -42,9 +42,11 @@ export const StackedAreaTooltip: FC<StackedAreaTooltipProps> = ({
   };
 
   const total =
-    payload.base != null && payload.reward != null
-      ? payload.base + payload.reward
-      : null;
+    payload.total != null
+      ? payload.total
+      : payload.base != null && payload.reward != null
+        ? payload.base + payload.reward
+        : null;
 
   return (
     <Box

--- a/src/components/core/charts/StackedAreaChart/StackedAreaTooltip.tsx
+++ b/src/components/core/charts/StackedAreaChart/StackedAreaTooltip.tsx
@@ -31,14 +31,20 @@ export const StackedAreaTooltip: FC<StackedAreaTooltipProps> = ({
     return null;
   }
 
-  const formatValue = (value: number) => {
+  const formatValue = (value: number | null | undefined) => {
+    if (value == null) {
+      return 'NULL';
+    }
     if (valueFormatConfig) {
       return formatValueWithConfig(value, valueFormatConfig);
     }
     return value.toFixed(2);
   };
 
-  const total = payload.base + payload.reward;
+  const total =
+    payload.base != null && payload.reward != null
+      ? payload.base + payload.reward
+      : null;
 
   return (
     <Box


### PR DESCRIPTION
## Summary

Contributes to https://lifi.atlassian.net/browse/LF-16533
Depends on https://github.com/jumperexchange/jumper-backend/pull/688

Frontend changes to properly handle null values returned by the analytics API when data points are missing.

### Changes

- **Trim leading nulls**: Charts now start from the first valid data point instead of showing empty space
- **Fix stacked area chart**: Replaced `stackId` approach with overlapping areas to work around Recharts [connectNulls bug with stacked charts](https://github.com/recharts/recharts/issues/2316)
- **Null checks in tooltips**: Added null value checks to prevent tooltips from appearing on null data points
- **Debug visibility**: Tooltips display "NULL" when value is null for debugging purposes

## Test

Visit opportunities with base + rewards and missing data, check that the diagram still make sense. Example: http://localhost:3000/fr/earn/fluid-gho-on-mainnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lines in charts now connect across null values.
  * Stacked area charts and stories include and propagate a total field.
  * Charts drop leading empty data points so plots start at first valid value.

* **Bug Fixes**
  * Improved handling and normalization of null/undefined chart values.
  * Tooltips display "NULL" for missing values.
  * Active dots and tooltip interaction are suppressed for null data points.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->