### PR TITLE
chore: remove page entered event from widget tracking

### DIFF
--- a/src/components/Widgets/Widgets.tsx
+++ b/src/components/Widgets/Widgets.tsx
@@ -85,7 +85,6 @@ export function Widgets({ widgetVariant }: WidgetsProps) {
           routeHighValueLoss: TrackingAction.OnRouteHighValueLoss,
           lowAddressActivityConfirmed:
             TrackingAction.OnLowAddressActivityConfirmed,
-          pageEntered: TrackingAction.OnPageEntered,
           sendToWalletToggled: TrackingAction.OnSendToWalletToggled,
           formFieldChanged: TrackingAction.OnFormFieldChanged,
         }}

--- a/src/const/trackingKeys.ts
+++ b/src/const/trackingKeys.ts
@@ -39,7 +39,6 @@ export enum TrackingAction {
   ContributeImpression = 'action_contribute_impression',
   ContributeSuccess = 'action_contribute_success',
   OnChainPinned = 'action_on_chain_pinned',
-  OnPageEntered = 'action_on_page_entered',
   OnSendToWalletToggled = 'action_on_send_to_wallet_toggled',
   OnFormFieldChanged = 'action_on_form_field_changed',
 

--- a/src/providers/WidgetTrackingProvider.tsx
+++ b/src/providers/WidgetTrackingProvider.tsx
@@ -72,7 +72,6 @@ interface WidgetTrackingProviderProps extends PropsWithChildren {
     routeExecutionUpdated?: TrackingAction;
     routeHighValueLoss?: TrackingAction;
     lowAddressActivityConfirmed?: TrackingAction;
-    pageEntered?: TrackingAction;
     sendToWalletToggled?: TrackingAction;
     formFieldChanged?: TrackingAction;
   };
@@ -97,7 +96,6 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
     routeExecutionUpdated: '',
     routeHighValueLoss: '',
     lowAddressActivityConfirmed: '',
-    pageEntered: '',
     sendToWalletToggled: '',
     formFieldChanged: '',
   },
@@ -398,24 +396,6 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
     [trackEvent, trackingActionKeys.lowAddressActivityConfirmed],
   );
 
-  const pageEntered = useCallback(
-    (page: string) => {
-      if (!trackingActionKeys.pageEntered) {
-        return;
-      }
-      trackEvent({
-        category: TrackingCategory.WidgetEvent,
-        action: trackingActionKeys.pageEntered,
-        label: `page_entered`,
-        data: {
-          [TrackingEventParameter.Page]: page,
-        },
-        enableAddressable: true,
-      });
-    },
-    [trackEvent, trackingActionKeys.pageEntered],
-  );
-
   const sendToWalletToggled = useCallback(
     (sendToWallet: boolean) => {
       if (!trackingActionKeys.sendToWalletToggled) {
@@ -499,7 +479,6 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
       settingUpdated,
       routeHighValueLoss,
       lowAddressActivityConfirmed,
-      pageEntered,
       sendToWalletToggled,
       formFieldChanged,
       routeSelected: posthogTracker.onRouteSelected,
@@ -523,7 +502,6 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
     destinationChainTokenSelected,
     routeHighValueLoss,
     lowAddressActivityConfirmed,
-    pageEntered,
     sendToWalletToggled,
     formFieldChanged,
     posthogTracker.onRouteSelected,


### PR DESCRIPTION
# Which Jira task belongs to this PR?

https://lifi.atlassian.net/browse/JUM-478

# Testing steps
1. Go to `/` page
2. On the widget, toggle the toAddress
3. Go to the toAddress page on the widget
4. Check no event with action `action_on_page_entered` is sent
5. Now insert values in the other widget fields and select a route for execution
6. Perform check from `4`
7. Now open the settings and check number `4`

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed page entry tracking events from the widget tracking provider, including associated action definitions and event configuration that were monitoring page navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->