### PR TITLE
fix: remove light bg override from select card

### DIFF
--- a/src/components/Cards/SelectCard/SelectCard.styles.ts
+++ b/src/components/Cards/SelectCard/SelectCard.styles.ts
@@ -45,9 +45,6 @@ export const SelectCardContainer = styled(Card, {
   flexDirection: 'column',
   gap: theme.spacing(1),
   cursor: isClickable ? 'pointer' : 'initial',
-  ...theme.applyStyles?.('light', {
-    background: (theme.vars || theme).palette.background.default,
-  }),
 }));
 
 export const SelectCardContentContainer = styled(Box)(({ theme }) => ({


### PR DESCRIPTION
# Which Jira task belongs to this PR?
Jira https://lifi.atlassian.net/browse/JUM-484

# Testing steps
1. Go to any earn opportunity
2. Check the `Your position` card amount bg
3. Switch between light/dark mode
4. Check the amount background remains the same as the whole card

# Why did I implement it this way?
The background color override was no longer needed for select card.

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified styling implementation by removing redundant conditional logic while preserving consistent visual appearance across themes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->