### PR TITLE
fix: migration to jumper.xyz for local dev

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -67,7 +67,7 @@ const nextConfig = {
       },
       {
         protocol: 'https',
-        hostname: 'strapi-staging.jumper.exchange',
+        hostname: 'strapi-staging.jumper.xyz',
         port: '',
         pathname: '/uploads/**',
       },


### PR DESCRIPTION
# Which Jira task belongs to this PR?

None, fixes:

```
Error: Invalid src prop (https://strapi-staging.jumper.xyz/uploads/megaeth_f8f2a5f7b4.png) on `next/image`, hostname "strapi-staging.jumper.xyz" is not configured under images in your `next.config.js`
See more info: https://nextjs.org/docs/messages/next-image-unconfigured-host
```

When work on dev

# Why did I implement it this way?

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] ~I have added tests that cover the functionality / test the bug~
- [ ] ~If this changed the API, I have updated the documentation~
- [ ] ~I have provided QA instructions for the feature / fix implemented in this PR (if applicable)~
- [ ] ~I have provided instructions for any environment / deployment changes that this PR needs when merged~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated image source configuration for staging environment to use new domain.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->