### PR TITLE
fix: remove farcaster wallet in normal pages

### DIFF
--- a/src/providers/WalletProvider/EVMProvider.tsx
+++ b/src/providers/WalletProvider/EVMProvider.tsx
@@ -7,10 +7,15 @@ import {
   createDefaultWagmiConfig,
   useSyncWagmiConfig,
 } from '@lifi/wallet-management';
-import { type FC, type PropsWithChildren, useMemo, useState } from 'react';
+import {
+  type FC,
+  type PropsWithChildren,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { WagmiProvider } from 'wagmi';
 import { baseAccount } from 'wagmi/connectors';
-import { fa } from 'zod/v4/locales';
 import { baseMiniApp } from '@/app/lib/metadata';
 import { defaultCoinbaseConfig } from '@/config/coinbase';
 import envConfig from '@/config/env-config';
@@ -32,11 +37,15 @@ const { config, connectors: initialConnectors } = createDefaultWagmiConfig({
 
 export const EVMProvider: FC<PropsWithChildren> = ({ children }) => {
   const [useBaseMiniApp, setUseBaseMiniApp] = useState(false);
-  sdk.context.then((context) => {
-    if (context) {
-      setUseBaseMiniApp(true);
-    }
-  });
+
+  useEffect(() => {
+    sdk.context.then((context) => {
+      if (context) {
+        setUseBaseMiniApp(true);
+      }
+    });
+  }, []);
+
   const { chains } = useChains();
 
   const finalConnectors = useMemo(() => {

--- a/src/providers/WalletProvider/EVMProvider.tsx
+++ b/src/providers/WalletProvider/EVMProvider.tsx
@@ -1,14 +1,16 @@
 'use client';
 import { abstractWalletConnector } from '@abstract-foundation/agw-react/connectors';
+import { sdk } from '@farcaster/miniapp-sdk';
 import { farcasterMiniApp } from '@farcaster/miniapp-wagmi-connector';
 import type { ExtendedChain } from '@lifi/sdk';
 import {
   createDefaultWagmiConfig,
   useSyncWagmiConfig,
 } from '@lifi/wallet-management';
-import type { FC, PropsWithChildren } from 'react';
+import { type FC, type PropsWithChildren, useMemo, useState } from 'react';
 import { WagmiProvider } from 'wagmi';
 import { baseAccount } from 'wagmi/connectors';
+import { fa } from 'zod/v4/locales';
 import { baseMiniApp } from '@/app/lib/metadata';
 import { defaultCoinbaseConfig } from '@/config/coinbase';
 import envConfig from '@/config/env-config';
@@ -17,15 +19,8 @@ import { defaultWalletConnectConfig } from '@/config/walletConnect';
 import { useChains } from '@/hooks/useChains';
 
 const PUBLIC_URL = envConfig.NEXT_PUBLIC_SITE_URL as string;
-const { config, connectors } = createDefaultWagmiConfig({
-  connectors: [
-    farcasterMiniApp(),
-    baseAccount({
-      appName: baseMiniApp.miniAppName,
-      appLogoUrl: new URL(baseMiniApp.splashImageUrl, PUBLIC_URL).toString(),
-    }),
-    abstractWalletConnector(),
-  ],
+const { config, connectors: initialConnectors } = createDefaultWagmiConfig({
+  connectors: [abstractWalletConnector()],
   coinbase: defaultCoinbaseConfig,
   metaMask: defaultMetaMaskConfig,
   walletConnect: defaultWalletConnectConfig,
@@ -36,10 +31,32 @@ const { config, connectors } = createDefaultWagmiConfig({
 });
 
 export const EVMProvider: FC<PropsWithChildren> = ({ children }) => {
+  const [useBaseMiniApp, setUseBaseMiniApp] = useState(false);
+  sdk.context.then((context) => {
+    if (context) {
+      setUseBaseMiniApp(true);
+    }
+  });
   const { chains } = useChains();
 
-  useSyncWagmiConfig(config, connectors, chains as ExtendedChain[]);
+  const finalConnectors = useMemo(() => {
+    const allConnectors = [...initialConnectors];
+    if (useBaseMiniApp) {
+      allConnectors.unshift(farcasterMiniApp());
+      allConnectors.unshift(
+        baseAccount({
+          appName: baseMiniApp.miniAppName,
+          appLogoUrl: new URL(
+            baseMiniApp.splashImageUrl,
+            PUBLIC_URL,
+          ).toString(),
+        }),
+      );
+    }
+    return allConnectors;
+  }, [useBaseMiniApp]);
 
+  useSyncWagmiConfig(config, finalConnectors, chains as ExtendedChain[]);
   return (
     <WagmiProvider config={config} reconnectOnMount={false}>
       {children}


### PR DESCRIPTION
This allows removing the Farcaster wallet in normal pages and only allow it inside the base context.

# Which Jira task belongs to this PR?
https://lifi.atlassian.net/browse/JUM-256
# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated wallet connector initialization with conditional support for Base mini-app connectors and enhanced performance optimization through lazy loading configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->