### PR TITLE
Fix type check in filterByTag

### DIFF
--- a/src/utils/strapi/StrapiApi.ts
+++ b/src/utils/strapi/StrapiApi.ts
@@ -486,7 +486,7 @@ class ArticleStrapiApi extends StrapiApi {
   }
 
   filterByTag(tags: number | number[]): this {
-    if (typeof tags === 'string') {
+    if (typeof tags === 'number') {
       this.apiUrl.searchParams.set('filters[tags][id][$eq]', tags);
     } else if (Array.isArray(tags)) {
       tags.forEach((tag, index) => {


### PR DESCRIPTION
The `filterByTag` method was incorrectly checking `typeof tags === 'string'`, but the parameter is typed as `number | number[]`.
Changed the check to `typeof tags === 'number'` to correctly handle single tag filtering, ensuring the API query is set properly.

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tag filtering functionality to properly handle numeric tag identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->