### PR TITLE
Removed duplicate remotePatterns in next.config.mjs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -37,36 +37,6 @@ const nextConfig = {
       },
       {
         protocol: 'https',
-        hostname: 'raw.githubusercontent.com',
-        port: '',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'assets.coingecko.com',
-        port: '',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 's2.coinmarketcap.com',
-        port: '',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'cdn.sei.io',
-        port: '',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'static.debank.com',
-        port: '',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
         hostname: 'strapi-staging.jumper.xyz',
         port: '',
         pathname: '/uploads/**',
@@ -95,12 +65,6 @@ const nextConfig = {
       //   port: '',
       //   pathname: '/**',
       // },
-      {
-        protocol: 'https',
-        hostname: '*.etherscan.io',
-        port: '',
-        pathname: '/token/images/**',
-      },
       {
         protocol: 'https',
         hostname: 'resolve.mercle.xyz',


### PR DESCRIPTION
Removed duplicate entries in `remotePatterns`:
- `assets.coingecko.com`
- `s2.coinmarketcap.com`
- `static.debank.com`
- `cdn.sei.io`
- `*.etherscan.io`

`raw.githubusercontent.com` содержал разные уровни ограничений:

Full access:
```
      {
        protocol: 'https',
        hostname: 'raw.githubusercontent.com',
        port: '',
        pathname: '/**',
      },
```
and more restrictive path:
```
      {
        protocol: 'https',
        hostname: 'raw.githubusercontent.com', // TODO: this one can be dangerous
        port: '',
        pathname: '/lifinance/types/main/src/assets/**',
      },
```

I kept the more restrictive path because it provides better security by limiting access to only the necessary assets.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted external image source permissions to enhance security policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->