### PR TITLE
Remove duplicate `Advertiser` interface

### DIFF
--- a/src/types/spindl.ts
+++ b/src/types/spindl.ts
@@ -75,11 +75,6 @@ export interface SpindlFetchData {
   debug: DebugInfo;
 }
 
-interface Advertiser {
-  name: string;
-  imageUrl: string;
-}
-
 export interface SpindlInfos {
   impressionId: string;
   advertiserId: string;


### PR DESCRIPTION
- Deleted the duplicate `Advertiser` interface to clean up the code.
- The original `Advertiser` interface is kept and referenced in `SpindlItem`.
- No functional changes; this only removes redundancy and potential confusion.

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the Advertiser interface from the public API. Applications that directly depend on this type definition will require updates to continue functioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->