### PR TITLE
fix: balance range filter progressively update

### DIFF
--- a/src/providers/PortfolioProvider/filtering/BalancesFilteringContext.tsx
+++ b/src/providers/PortfolioProvider/filtering/BalancesFilteringContext.tsx
@@ -101,12 +101,27 @@ export const BalancesFilteringProvider = ({ children }: PropsWithChildren) => {
   const prevStatsRef = useRef<BalancesFilteringParams>(
     EMPTY_BALANCES_FILTERING_PARAMS,
   );
+  /**
+   * If an initial filter range is provided, preserve those values
+   * and clamp them to the available data once loading completes.
+   *
+   * If no initial range exists, dynamically update the minimum
+   * filter value based on the currently loaded statistics.
+   */
+  const hasInitialFilterRangeRef = useRef<boolean | null>(null);
+  if (hasInitialFilterRangeRef.current === null) {
+    hasInitialFilterRangeRef.current =
+      balancesMinValue != null || balancesMaxValue !== null;
+  }
 
   const balancesState = usePortfolioBalances();
   const orchestrationState = usePortfolioState();
   const balancesSourceState = orchestrationState.sources.balances;
 
   const isEmpty = balancesSourceState.isEmpty;
+
+  const isAllDataLoading =
+    balancesSourceState.isLoading || balancesSourceState.isRefreshing;
 
   const stats = useMemo((): BalancesFilteringParams => {
     if (isEmpty) {
@@ -126,14 +141,25 @@ export const BalancesFilteringProvider = ({ children }: PropsWithChildren) => {
       return;
     }
 
-    prevStatsRef.current = stats;
+    if (!isAllDataLoading) {
+      prevStatsRef.current = stats;
+    }
 
-    const sanitized = sanitizeBalancesFilter(filter, stats);
+    const shouldClampRangeFilter =
+      !!hasInitialFilterRangeRef.current && !isAllDataLoading;
+
+    const sanitized = sanitizeBalancesFilter(
+      filter,
+      stats,
+      shouldClampRangeFilter,
+    );
     const effectiveValueRange = getEffectiveValueRange(stats.allValueRange);
 
     const withDefaults = {
       ...sanitized,
-      minValue: sanitized.minValue ?? effectiveValueRange.min,
+      minValue: hasInitialFilterRangeRef.current
+        ? sanitized.minValue
+        : effectiveValueRange.min,
     };
 
     if (!isEqual(withDefaults, filter)) {
@@ -146,7 +172,7 @@ export const BalancesFilteringProvider = ({ children }: PropsWithChildren) => {
         balancesMaxValue: withDefaults.maxValue,
       });
     }
-  }, [stats, setSearchParamsState, setFilter, filter]);
+  }, [stats, setSearchParamsState, setFilter, isAllDataLoading, filter]);
 
   const sortedData = useMemo(() => {
     return filterSortBalancesData(

--- a/src/providers/PortfolioProvider/filtering/utils.ts
+++ b/src/providers/PortfolioProvider/filtering/utils.ts
@@ -111,6 +111,7 @@ export const removeNullValuesFromFilter = <T>(filter: Nullable<T>): T => {
 export const sanitizeBalancesFilter = (
   filter: BalancesFilter,
   stats: BalancesFilteringParams,
+  shouldClampRangeFilter?: boolean,
 ): Nullable<BalancesFilter> => {
   if (
     !stats.allWallets.length ||
@@ -132,11 +133,15 @@ export const sanitizeBalancesFilter = (
     assets: filter.assets?.filter((a) => validAssets.has(a)) ?? null,
     minValue:
       filter.minValue !== undefined
-        ? Math.max(Math.min(filter.minValue, valueMax), valueMin)
+        ? shouldClampRangeFilter
+          ? Math.max(Math.min(filter.minValue, valueMax), valueMin)
+          : filter.minValue
         : null,
     maxValue:
       filter.maxValue !== undefined
-        ? Math.max(Math.min(filter.maxValue, valueMax), valueMin)
+        ? shouldClampRangeFilter
+          ? Math.max(Math.min(filter.maxValue, valueMax), valueMin)
+          : filter.maxValue
         : null,
   };
 };

--- a/src/providers/PortfolioProvider/lib/fetchBalancesForAddresses.ts
+++ b/src/providers/PortfolioProvider/lib/fetchBalancesForAddresses.ts
@@ -100,6 +100,5 @@ export const fetchBalancesForAddress = async ({
   );
 
   await results;
-  console.log(balances);
   return { balances, address };
 };


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Contributes to https://lifi.atlassian.net/browse/LF-17199

## Testing steps

1. Connect a wallet with small balances (below $1 would be ideal), notice the the balanceMinValue
2. Connect another wallet type with a very large balance, go to /profile (or just remove all filtering params and refresh the page)
3. Notice how the balanceMinValue progressively updates
4. Now disconnect the wallet with large balance, the balanceMinValue should be updated to match the other wallet balances

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged
