### PR TITLE
feat: profile rewards section navigation and items sorting

### DIFF
--- a/src/components/ProfilePage/components/RewardsCarousel/RewardsCarousel.style.ts
+++ b/src/components/ProfilePage/components/RewardsCarousel/RewardsCarousel.style.ts
@@ -1,6 +1,48 @@
 import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 
+const blurEdge = (direction: 'left' | 'right', color: string) => ({
+  content: '""',
+  position: 'absolute',
+  top: 0,
+  [direction]: 0,
+  width: '80px',
+  height: '100%',
+  zIndex: 0,
+  pointerEvents: 'none',
+  opacity: 0,
+  transition: 'opacity 0.2s ease',
+  background: `linear-gradient(to ${direction === 'left' ? 'right' : 'left'}, ${color}, transparent)`,
+});
+
 export const RewardsCarouselContainer = styled(Box)(({ theme }) => ({
   width: '100%',
+  position: 'relative',
+}));
+
+export const RewardsCarouselNavigationContainer = styled(Box)(({ theme }) => ({
+  width: '100%',
+  height: '100%',
+  position: 'absolute',
+  right: 0,
+  top: 0,
+  zIndex: 10,
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  pointerEvents: 'none',
+
+  '&::before': {
+    ...blurEdge('left', (theme.vars || theme).palette.surface2.main),
+  },
+  '&::after': {
+    ...blurEdge('right', (theme.vars || theme).palette.surface2.main),
+  },
+
+  '&[data-show-left="true"]::before': {
+    opacity: 1,
+  },
+  '&[data-show-right="true"]::after': {
+    opacity: 1,
+  },
 }));

--- a/src/components/ProfilePage/components/RewardsCarousel/RewardsCarousel.style.ts
+++ b/src/components/ProfilePage/components/RewardsCarousel/RewardsCarousel.style.ts
@@ -18,6 +18,11 @@ const blurEdge = (direction: 'left' | 'right', color: string) => ({
 export const RewardsCarouselContainer = styled(Box)(({ theme }) => ({
   width: '100%',
   position: 'relative',
+  overflow: 'hidden',
+  marginBottom: theme.spacing(-2),
+  [theme.breakpoints.up('sm')]: {
+    margin: theme.spacing(0, -2, -2, -2),
+  },
 }));
 
 export const RewardsCarouselNavigationContainer = styled(Box)(({ theme }) => ({

--- a/src/components/ProfilePage/components/RewardsCarousel/RewardsCarousel.tsx
+++ b/src/components/ProfilePage/components/RewardsCarousel/RewardsCarousel.tsx
@@ -1,76 +1,62 @@
 'use client';
 import { useTheme } from '@mui/material/styles';
-import {
-  useCallback,
-  Children,
-  useState,
-  type FC,
-  type PropsWithChildren,
-} from 'react';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { Children, useEffect, type FC, type PropsWithChildren } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
-import type { Swiper as SwiperType } from 'swiper/types';
 import { FreeMode, Navigation } from 'swiper/modules';
 import 'swiper/css';
 import {
   RewardsCarouselContainer,
   RewardsCarouselNavigationContainer,
 } from './RewardsCarousel.style';
-import { useSwiperScopedClassNames } from '@/components/Carousel/hooks';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
-import { IconButton } from '@/components/core/buttons/IconButton/IconButton';
+import { useRewardsCarouselContext } from './RewardsCarouselContext';
+import { RewardsCarouselNavButtons } from './components/RewardsCarouselNavButtons';
 
-interface RewardsCarouselProps extends PropsWithChildren {}
-
-const updateNavState = (swiper: SwiperType) => ({
-  isBeginning: swiper.isBeginning,
-  isEnd: swiper.isEnd,
-});
-
-export const RewardsCarousel: FC<RewardsCarouselProps> = ({ children }) => {
+export const RewardsCarousel: FC<PropsWithChildren> = ({ children }) => {
   const theme = useTheme();
-  const [navState, setNavState] = useState({ isBeginning: true, isEnd: true });
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const { navState, classNames, swiperInstance, handleSwiper } =
+    useRewardsCarouselContext();
 
   const slides = Children.toArray(children);
-  const classNames = useSwiperScopedClassNames();
 
-  const handleSwiper = useCallback((swiper: SwiperType) => {
-    swiper.on('init', () => setNavState(updateNavState(swiper)));
-    swiper.on('update', () => setNavState(updateNavState(swiper)));
-    swiper.on('slideChange', () => setNavState(updateNavState(swiper)));
-    swiper.on('resize', () => setNavState(updateNavState(swiper)));
-  }, []);
+  useEffect(() => {
+    if (!swiperInstance) {
+      return;
+    }
+
+    const raf = requestAnimationFrame(() => {
+      swiperInstance.navigation.destroy();
+      swiperInstance.navigation.init();
+      swiperInstance.navigation.update();
+    });
+
+    return () => cancelAnimationFrame(raf);
+  }, [isMobile, swiperInstance]);
 
   return (
-    <RewardsCarouselContainer
-      sx={{
-        overflow: 'hidden',
-        margin: theme.spacing(0, -2, -2, -2),
-      }}
-    >
+    <RewardsCarouselContainer>
       <Swiper
+        key={isMobile ? 'mobile' : 'desktop'}
         onSwiper={handleSwiper}
         modules={[FreeMode, Navigation]}
-        slidesPerView="auto"
+        slidesPerView={isMobile ? 1 : 'auto'}
         spaceBetween={16}
-        freeMode={{
-          enabled: true,
-          sticky: true,
-          momentumRatio: 0.5,
-        }}
+        centeredSlides={isMobile}
+        centeredSlidesBounds={isMobile}
+        freeMode={{ enabled: true, sticky: true, momentumRatio: 0.5 }}
         className="carousel-swiper"
         grabCursor
         style={{
-          padding: theme.spacing(0, 1, 2, 1),
-          margin: theme.spacing(0, 1),
+          paddingRight: isMobile ? 0 : theme.spacing(1),
+          paddingLeft: isMobile ? 0 : theme.spacing(1),
+          paddingBottom: theme.spacing(2),
+          marginRight: isMobile ? 0 : theme.spacing(1),
+          marginLeft: isMobile ? 0 : theme.spacing(1),
         }}
         navigation={{
           prevEl: `.${classNames.navigationPrev}`,
           nextEl: `.${classNames.navigationNext}`,
-        }}
-        hashNavigation={{
-          replaceState: true,
         }}
       >
         {slides.map((child, index) => (
@@ -78,37 +64,14 @@ export const RewardsCarousel: FC<RewardsCarouselProps> = ({ children }) => {
             {child}
           </SwiperSlide>
         ))}
-        <RewardsCarouselNavigationContainer
-          data-show-left={!navState.isBeginning}
-          data-show-right={!navState.isEnd}
-        >
-          <IconButton
-            aria-label="previous"
-            className={classNames.navigationPrev}
-            sx={{
-              visibility: !navState.isBeginning ? 'visible' : 'hidden',
-              pointerEvents: !navState.isBeginning ? 'auto' : 'none',
-              zIndex: 10,
-              height: 'fit-content',
-              marginBottom: theme.spacing(1),
-            }}
+        {!isMobile && (
+          <RewardsCarouselNavigationContainer
+            data-show-left={!navState.isBeginning}
+            data-show-right={!navState.isEnd}
           >
-            <ArrowBackIcon sx={{ width: 20, height: 20 }} />
-          </IconButton>
-          <IconButton
-            aria-label="next"
-            className={classNames.navigationNext}
-            sx={{
-              visibility: !navState.isEnd ? 'visible' : 'hidden',
-              pointerEvents: !navState.isEnd ? 'auto' : 'none',
-              zIndex: 10,
-              height: 'fit-content',
-              marginBottom: theme.spacing(1),
-            }}
-          >
-            <ArrowForwardIcon sx={{ width: 20, height: 20 }} />
-          </IconButton>
-        </RewardsCarouselNavigationContainer>
+            <RewardsCarouselNavButtons />
+          </RewardsCarouselNavigationContainer>
+        )}
       </Swiper>
     </RewardsCarouselContainer>
   );

--- a/src/components/ProfilePage/components/RewardsCarousel/RewardsCarousel.tsx
+++ b/src/components/ProfilePage/components/RewardsCarousel/RewardsCarousel.tsx
@@ -1,30 +1,57 @@
 'use client';
 import { useTheme } from '@mui/material/styles';
-import { Children, type FC, type PropsWithChildren } from 'react';
+import {
+  useCallback,
+  Children,
+  useState,
+  type FC,
+  type PropsWithChildren,
+} from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
-import { FreeMode } from 'swiper/modules';
+import type { Swiper as SwiperType } from 'swiper/types';
+import { FreeMode, Navigation } from 'swiper/modules';
 import 'swiper/css';
-import { RewardsCarouselContainer } from './RewardsCarousel.style';
+import {
+  RewardsCarouselContainer,
+  RewardsCarouselNavigationContainer,
+} from './RewardsCarousel.style';
+import { useSwiperScopedClassNames } from '@/components/Carousel/hooks';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import { IconButton } from '@/components/core/buttons/IconButton/IconButton';
 
 interface RewardsCarouselProps extends PropsWithChildren {}
 
+const updateNavState = (swiper: SwiperType) => ({
+  isBeginning: swiper.isBeginning,
+  isEnd: swiper.isEnd,
+});
+
 export const RewardsCarousel: FC<RewardsCarouselProps> = ({ children }) => {
   const theme = useTheme();
+  const [navState, setNavState] = useState({ isBeginning: true, isEnd: true });
 
   const slides = Children.toArray(children);
+  const classNames = useSwiperScopedClassNames();
+
+  const handleSwiper = useCallback((swiper: SwiperType) => {
+    swiper.on('init', () => setNavState(updateNavState(swiper)));
+    swiper.on('update', () => setNavState(updateNavState(swiper)));
+    swiper.on('slideChange', () => setNavState(updateNavState(swiper)));
+    swiper.on('resize', () => setNavState(updateNavState(swiper)));
+  }, []);
 
   return (
     <RewardsCarouselContainer
       sx={{
         overflow: 'hidden',
-        margin: theme.spacing(2, -2, -2, -2),
-        [theme.breakpoints.up('md')]: {
-          marginTop: 0,
-        },
+        margin: theme.spacing(0, -2, -2, -2),
       }}
     >
       <Swiper
-        modules={[FreeMode]}
+        onSwiper={handleSwiper}
+        modules={[FreeMode, Navigation]}
         slidesPerView="auto"
         spaceBetween={16}
         freeMode={{
@@ -32,14 +59,56 @@ export const RewardsCarousel: FC<RewardsCarouselProps> = ({ children }) => {
           sticky: true,
           momentumRatio: 0.5,
         }}
+        className="carousel-swiper"
         grabCursor
-        style={{ overflow: 'visible', padding: theme.spacing(0, 2, 2, 2) }}
+        style={{
+          padding: theme.spacing(0, 1, 2, 1),
+          margin: theme.spacing(0, 1),
+        }}
+        navigation={{
+          prevEl: `.${classNames.navigationPrev}`,
+          nextEl: `.${classNames.navigationNext}`,
+        }}
+        hashNavigation={{
+          replaceState: true,
+        }}
       >
         {slides.map((child, index) => (
           <SwiperSlide key={index} style={{ width: 'auto' }}>
             {child}
           </SwiperSlide>
         ))}
+        <RewardsCarouselNavigationContainer
+          data-show-left={!navState.isBeginning}
+          data-show-right={!navState.isEnd}
+        >
+          <IconButton
+            aria-label="previous"
+            className={classNames.navigationPrev}
+            sx={{
+              visibility: !navState.isBeginning ? 'visible' : 'hidden',
+              pointerEvents: !navState.isBeginning ? 'auto' : 'none',
+              zIndex: 10,
+              height: 'fit-content',
+              marginBottom: theme.spacing(1),
+            }}
+          >
+            <ArrowBackIcon sx={{ width: 20, height: 20 }} />
+          </IconButton>
+          <IconButton
+            aria-label="next"
+            className={classNames.navigationNext}
+            sx={{
+              visibility: !navState.isEnd ? 'visible' : 'hidden',
+              pointerEvents: !navState.isEnd ? 'auto' : 'none',
+              zIndex: 10,
+              height: 'fit-content',
+              marginBottom: theme.spacing(1),
+            }}
+          >
+            <ArrowForwardIcon sx={{ width: 20, height: 20 }} />
+          </IconButton>
+        </RewardsCarouselNavigationContainer>
       </Swiper>
     </RewardsCarouselContainer>
   );

--- a/src/components/ProfilePage/components/RewardsCarousel/RewardsCarouselContext.tsx
+++ b/src/components/ProfilePage/components/RewardsCarousel/RewardsCarouselContext.tsx
@@ -1,0 +1,53 @@
+// RewardsCarousel.context.tsx
+'use client';
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  type ReactNode,
+} from 'react';
+import { useSwiperScopedClassNames } from '@/components/Carousel/hooks';
+import type { Swiper as SwiperType } from 'swiper/types';
+
+interface RewardsCarouselContextValue {
+  navState: { isBeginning: boolean; isEnd: boolean };
+  classNames: ReturnType<typeof useSwiperScopedClassNames>;
+  handleSwiper: (swiper: SwiperType) => void;
+  swiperInstance: SwiperType | null;
+}
+
+const RewardsCarouselContext =
+  createContext<RewardsCarouselContextValue | null>(null);
+
+export const useRewardsCarouselContext = () => {
+  const ctx = useContext(RewardsCarouselContext);
+  if (!ctx) {
+    throw new Error('Must be used within RewardsCarouselRoot');
+  }
+  return ctx;
+};
+
+export const RewardsCarouselRoot = ({ children }: { children: ReactNode }) => {
+  const [swiperInstance, setSwiperInstance] = useState<SwiperType | null>(null);
+  const [navState, setNavState] = useState({ isBeginning: true, isEnd: true });
+  const classNames = useSwiperScopedClassNames();
+
+  const handleSwiper = useCallback((swiper: SwiperType) => {
+    setSwiperInstance(swiper);
+    const update = () =>
+      setNavState({ isBeginning: swiper.isBeginning, isEnd: swiper.isEnd });
+    swiper.on('init', update);
+    swiper.on('update', update);
+    swiper.on('slideChange', update);
+    swiper.on('resize', update);
+  }, []);
+
+  return (
+    <RewardsCarouselContext.Provider
+      value={{ navState, classNames, handleSwiper, swiperInstance }}
+    >
+      {children}
+    </RewardsCarouselContext.Provider>
+  );
+};

--- a/src/components/ProfilePage/components/RewardsCarousel/RewardsCarouselContext.tsx
+++ b/src/components/ProfilePage/components/RewardsCarousel/RewardsCarouselContext.tsx
@@ -1,4 +1,3 @@
-// RewardsCarousel.context.tsx
 'use client';
 import {
   createContext,
@@ -41,6 +40,7 @@ export const RewardsCarouselRoot = ({ children }: { children: ReactNode }) => {
     swiper.on('update', update);
     swiper.on('slideChange', update);
     swiper.on('resize', update);
+    update();
   }, []);
 
   return (

--- a/src/components/ProfilePage/components/RewardsCarousel/components/RewardClaimCard.style.ts
+++ b/src/components/ProfilePage/components/RewardsCarousel/components/RewardClaimCard.style.ts
@@ -27,13 +27,17 @@ export const RewardCardContainer = styled(Box)(({ theme }) => ({
   borderRadius: theme.shape.cardBorderRadiusLarge,
   flexDirection: 'row',
   padding: theme.spacing(2),
-  width: theme.spacing(40),
-  maxWidth: theme.spacing(40),
+  width: '-webkit-fill-available',
   boxShadow: theme.shadows[2],
 
   ...theme.applyStyles('light', {
     backgroundColor: (theme.vars || theme).palette.white.main,
   }),
+
+  [theme.breakpoints.up('sm')]: {
+    width: theme.spacing(40),
+    maxWidth: theme.spacing(40),
+  },
 }));
 
 export const RewardCardActionsContainer = styled(Box)(({ theme }) => ({

--- a/src/components/ProfilePage/components/RewardsCarousel/components/RewardClaimCard.style.ts
+++ b/src/components/ProfilePage/components/RewardsCarousel/components/RewardClaimCard.style.ts
@@ -27,7 +27,7 @@ export const RewardCardContainer = styled(Box)(({ theme }) => ({
   borderRadius: theme.shape.cardBorderRadiusLarge,
   flexDirection: 'row',
   padding: theme.spacing(2),
-  width: '-webkit-fill-available',
+  width: 'stretch',
   boxShadow: theme.shadows[2],
 
   ...theme.applyStyles('light', {

--- a/src/components/ProfilePage/components/RewardsCarousel/components/RewardClaimCard.tsx
+++ b/src/components/ProfilePage/components/RewardsCarousel/components/RewardClaimCard.tsx
@@ -89,11 +89,12 @@ export const RewardClaimCard: FC<RewardClaimCardProps> = ({
 
     const amount = availableReward.amountToClaim;
     const amountUSD = amount * Number(priceUSD);
+    const amountStr = amount.toFixed(availableReward.tokenDecimals);
 
     return {
       token: _walletToken,
       amountUSD,
-      amount: toRawAmount(amount.toString(), availableReward.tokenDecimals),
+      amount: toRawAmount(amountStr, availableReward.tokenDecimals),
     };
   }, [availableReward, getToken, toRawAmount]);
 

--- a/src/components/ProfilePage/components/RewardsCarousel/components/RewardClaimCard.tsx
+++ b/src/components/ProfilePage/components/RewardsCarousel/components/RewardClaimCard.tsx
@@ -9,12 +9,14 @@ import {
   ExplorerLinkButton,
   RewardCardActionsContainer,
 } from './RewardClaimCard.style';
-import { TokenStackItem } from '@/components/composite/TokenListCard/TokenStackItem';
 import { useTokens } from '@/hooks/useTokens';
 import type { Address } from 'viem';
 import { useBlockchainExplorerURL } from '@/hooks/useBlockchainExplorerURL';
 import { REWARD_CLAIM_CARD_CONFIG } from './constants';
 import { useTranslation } from 'react-i18next';
+import { BalanceStackItem } from '@/components/composite/BalanceCard/components/BalanceStackItem';
+import { createWalletToken } from '@/types/tokens';
+import { useTokenAmountInput } from '@/hooks/tokens/useTokenAmountInput';
 
 interface RewardClaimCardProps {
   availableReward: BaseReward;
@@ -40,6 +42,7 @@ export const RewardClaimCard: FC<RewardClaimCardProps> = ({
   isPendingValidation = false,
 }) => {
   const { t } = useTranslation();
+  const { toRawAmount } = useTokenAmountInput();
   const theme = useTheme();
   const { getToken } = useTokens();
   const explorerLink = useBlockchainExplorerURL(
@@ -65,36 +68,40 @@ export const RewardClaimCard: FC<RewardClaimCardProps> = ({
     return t('profile_page.rewardsClaim.action.claim');
   }, [isLoading, isError, t]);
 
-  const token = useMemo(() => {
+  const balance = useMemo(() => {
     const _token = getToken(
       availableReward.chainId,
       availableReward.address as Address,
     );
-    const totalPriceUSD = _token?.priceUSD
-      ? Number(_token.priceUSD) * availableReward.amountToClaim
-      : 0;
-    return {
+
+    const priceUSD = _token?.priceUSD ?? '0';
+
+    const _walletToken = createWalletToken({
       address: availableReward.address,
-      logo: availableReward.logoURI,
+      logoURI: availableReward.logoURI,
       name: availableReward.symbol,
       symbol: availableReward.symbol,
       decimals: availableReward.tokenDecimals,
-      chain: {
-        chainId: availableReward.chainId,
-        chainKey: availableReward.chainId.toString(),
-      },
-      balance: availableReward.amountToClaim,
-      totalPriceUSD,
+      chainId: availableReward.chainId,
+      chainKey: availableReward.chainId.toString(),
+      priceUSD: priceUSD,
+    });
+
+    const amount = availableReward.amountToClaim;
+    const amountUSD = amount * Number(priceUSD);
+
+    return {
+      token: _walletToken,
+      amountUSD,
+      amount: toRawAmount(amount.toString(), availableReward.tokenDecimals),
     };
-  }, [availableReward, getToken]);
+  }, [availableReward, getToken, toRawAmount]);
 
   return (
     <RewardCardContainer gap={2}>
-      <TokenStackItem
-        token={token}
+      <BalanceStackItem
+        balance={balance}
         config={REWARD_CLAIM_CARD_CONFIG}
-        chainsLimit={1}
-        chainsSpacing={0}
         isClickable={false}
       />
 

--- a/src/components/ProfilePage/components/RewardsCarousel/components/RewardsCarouselNavButtons.tsx
+++ b/src/components/ProfilePage/components/RewardsCarousel/components/RewardsCarouselNavButtons.tsx
@@ -1,0 +1,44 @@
+'use client';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import { IconButton } from '@/components/core/buttons/IconButton/IconButton';
+import { useRewardsCarouselContext } from '../RewardsCarouselContext';
+
+export const RewardsCarouselNavButtons = () => {
+  const { navState, classNames } = useRewardsCarouselContext();
+
+  return (
+    <>
+      <IconButton
+        aria-label="previous"
+        className={classNames.navigationPrev}
+        disabled={navState.isBeginning}
+        sx={(theme) => ({
+          pointerEvents: navState.isBeginning ? 'none' : 'auto',
+          zIndex: 1,
+          [theme.breakpoints.up('sm')]: {
+            marginBottom: theme.spacing(1.5),
+            visibility: navState.isBeginning ? 'hidden' : 'visible',
+          },
+        })}
+      >
+        <ArrowBackIcon sx={{ width: 20, height: 20 }} />
+      </IconButton>
+      <IconButton
+        aria-label="next"
+        className={classNames.navigationNext}
+        disabled={navState.isEnd}
+        sx={(theme) => ({
+          pointerEvents: navState.isEnd ? 'none' : 'auto',
+          zIndex: 1,
+          [theme.breakpoints.up('sm')]: {
+            marginBottom: theme.spacing(1.5),
+            visibility: navState.isEnd ? 'hidden' : 'visible',
+          },
+        })}
+      >
+        <ArrowForwardIcon sx={{ width: 20, height: 20 }} />
+      </IconButton>
+    </>
+  );
+};

--- a/src/components/ProfilePage/components/RewardsCarousel/components/constants.ts
+++ b/src/components/ProfilePage/components/RewardsCarousel/components/constants.ts
@@ -8,6 +8,7 @@ export const REWARD_CLAIM_CARD_CONFIG = {
   infoContainerGap: 0,
   itemSx: {
     borderRadius: 0,
+    alignSelf: 'stretch',
     '&:not(:has([data-hint-hover-active]))': {
       '&:hover, &:focus-visible, &:focus': {
         backgroundColor: 'transparent',

--- a/src/components/ProfilePage/sections/RewardsSection.tsx
+++ b/src/components/ProfilePage/sections/RewardsSection.tsx
@@ -12,10 +12,12 @@ import { ProfileContext } from 'src/providers/ProfileProvider';
 import { RewardsCarousel } from '../components/RewardsCarousel/RewardsCarousel';
 import { RewardClaimCardSkeleton } from '../components/RewardsCarousel/components/RewardClaimCardSkeleton';
 import type { MerklRewardsData } from 'src/types/strapi';
+import type { RewardItem } from '@/types/rewards';
 import { MerklRewardClaim } from '../components/RewardsCarousel/components/MerklRewardClaim';
 import { DefiReacherRewardClaim } from '../components/RewardsCarousel/components/DefiReacherRewardClaim';
 import { useDeFiReacherRewards } from '@/hooks/rewards/useDeFiReacherRewards';
 import { fromMerklRewardsData } from '@/utils/rewards/rewardFilterAdapters';
+import { orderBy } from 'lodash';
 
 export const RewardsSection = ({
   merklRewards,
@@ -46,17 +48,27 @@ export const RewardsSection = ({
     isLoading: isDeFiReacherLoading,
   } = useDeFiReacherRewards({ userAddress: address, filterCriteria });
 
-  const merklRewardsWithAmount = merklAvailableRewards.filter(
-    (reward) => reward.amountToClaim > 0,
-  );
+  const rewards = useMemo((): RewardItem[] => {
+    const _merkl: RewardItem[] = merklAvailableRewards.map((reward) => ({
+      type: 'merkl',
+      reward,
+    }));
 
-  const deFiReacherRewardsWithAmount = deFiReacherAvailableRewards.filter(
-    (reward) => reward.amountToClaim > 0,
-  );
+    const _defiReacher: RewardItem[] = deFiReacherAvailableRewards.map(
+      (reward) => ({
+        type: 'defi-reacher',
+        reward,
+      }),
+    );
+
+    const combined: RewardItem[] = [..._merkl, ..._defiReacher];
+    return orderBy(combined, 'reward.amountToClaim', 'desc').filter(
+      (r) => r.reward.amountToClaim > 0,
+    );
+  }, [merklAvailableRewards, deFiReacherAvailableRewards]);
 
   const isLoading = isMerklLoading || isDeFiReacherLoading;
-  const hasNoRewards =
-    !merklRewardsWithAmount.length && !deFiReacherRewardsWithAmount.length;
+  const hasNoRewards = !rewards.length;
   const isSuccess = isMerklSuccess || isDeFiReacherSuccess;
 
   if (hasNoRewards || !isSuccess) {
@@ -75,19 +87,19 @@ export const RewardsSection = ({
               <RewardClaimCardSkeleton key={index} />
             ))}
           {!isLoading &&
-            merklRewardsWithAmount.map((reward, i) => (
-              <MerklRewardClaim
-                key={`merkl-${i}-${reward.address}`}
-                availableReward={reward}
-              />
-            ))}
-          {!isLoading &&
-            deFiReacherRewardsWithAmount.map((reward, i) => (
-              <DefiReacherRewardClaim
-                key={`defireacher-${i}-${reward.address}`}
-                availableReward={reward}
-              />
-            ))}
+            rewards.map((r, i) =>
+              r.type === 'merkl' ? (
+                <MerklRewardClaim
+                  key={`merkl-${i}-${r.reward.address}`}
+                  availableReward={r.reward}
+                />
+              ) : (
+                <DefiReacherRewardClaim
+                  key={`defireacher-${i}-${r.reward.address}`}
+                  availableReward={r.reward}
+                />
+              ),
+            )}
         </RewardsCarousel>
       </RewardsSectionContentContainer>
     </RewardsSectionContainer>

--- a/src/components/ProfilePage/sections/RewardsSection.tsx
+++ b/src/components/ProfilePage/sections/RewardsSection.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import {
   RewardsSectionContentContainer,
   RewardsSectionContainer,
+  RewardsSectionHeaderContainer,
 } from './Section.style';
 import Typography from '@mui/material/Typography';
 import { useContext, useMemo } from 'react';
@@ -18,6 +19,10 @@ import { DefiReacherRewardClaim } from '../components/RewardsCarousel/components
 import { useDeFiReacherRewards } from '@/hooks/rewards/useDeFiReacherRewards';
 import { fromMerklRewardsData } from '@/utils/rewards/rewardFilterAdapters';
 import { orderBy } from 'lodash';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { RewardsCarouselNavButtons } from '../components/RewardsCarousel/components/RewardsCarouselNavButtons';
+import Box from '@mui/material/Box';
+import { RewardsCarouselRoot } from '../components/RewardsCarousel/RewardsCarouselContext';
 
 export const RewardsSection = ({
   merklRewards,
@@ -25,6 +30,7 @@ export const RewardsSection = ({
   merklRewards: MerklRewardsData[] | undefined;
 }) => {
   const { t } = useTranslation();
+  const isMobile = useMediaQuery((theme) => theme.breakpoints.down('sm'));
   const { walletAddress: address } = useContext(ProfileContext);
 
   const filterCriteria = useMemo(
@@ -76,32 +82,41 @@ export const RewardsSection = ({
   }
 
   return (
-    <RewardsSectionContainer>
-      <RewardsSectionContentContainer>
-        <Typography variant="titleXSmall" sx={{ flexShrink: 0 }}>
-          {t('profile_page.availableRewards')}
-        </Typography>
-        <RewardsCarousel>
-          {isLoading &&
-            Array.from({ length: 2 }).map((_, index) => (
-              <RewardClaimCardSkeleton key={index} />
-            ))}
-          {!isLoading &&
-            rewards.map((r, i) =>
-              r.type === 'merkl' ? (
-                <MerklRewardClaim
-                  key={`merkl-${i}-${r.reward.address}`}
-                  availableReward={r.reward}
-                />
-              ) : (
-                <DefiReacherRewardClaim
-                  key={`defireacher-${i}-${r.reward.address}`}
-                  availableReward={r.reward}
-                />
-              ),
+    <RewardsCarouselRoot>
+      <RewardsSectionContainer>
+        <RewardsSectionContentContainer>
+          <RewardsSectionHeaderContainer>
+            <Typography variant="titleXSmall" sx={{ flexShrink: 0 }}>
+              {t('profile_page.availableRewards')}
+            </Typography>
+            {isMobile && (
+              <Box sx={{ display: 'flex', gap: 0.5 }}>
+                <RewardsCarouselNavButtons />
+              </Box>
             )}
-        </RewardsCarousel>
-      </RewardsSectionContentContainer>
-    </RewardsSectionContainer>
+          </RewardsSectionHeaderContainer>
+          <RewardsCarousel>
+            {isLoading &&
+              Array.from({ length: 2 }).map((_, index) => (
+                <RewardClaimCardSkeleton key={index} />
+              ))}
+            {!isLoading &&
+              rewards.map((r, i) =>
+                r.type === 'merkl' ? (
+                  <MerklRewardClaim
+                    key={`merkl-${i}-${r.reward.address}`}
+                    availableReward={r.reward}
+                  />
+                ) : (
+                  <DefiReacherRewardClaim
+                    key={`defireacher-${i}-${r.reward.address}`}
+                    availableReward={r.reward}
+                  />
+                ),
+              )}
+          </RewardsCarousel>
+        </RewardsSectionContentContainer>
+      </RewardsSectionContainer>
+    </RewardsCarouselRoot>
   );
 };

--- a/src/components/ProfilePage/sections/Section.style.ts
+++ b/src/components/ProfilePage/sections/Section.style.ts
@@ -23,7 +23,10 @@ export const RewardsSectionContainer = styled(SectionCardContainer)(
 
 export const RewardsSectionContentContainer = styled(Box)(({ theme }) => ({
   display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
+  flexDirection: 'column',
   gap: theme.spacing(2),
+  [theme.breakpoints.up('sm')]: {
+    alignItems: 'center',
+    flexDirection: 'row',
+  },
 }));

--- a/src/components/ProfilePage/sections/Section.style.ts
+++ b/src/components/ProfilePage/sections/Section.style.ts
@@ -30,3 +30,12 @@ export const RewardsSectionContentContainer = styled(Box)(({ theme }) => ({
     flexDirection: 'row',
   },
 }));
+
+export const RewardsSectionHeaderContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexShrink: 0,
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: theme.spacing(2),
+}));

--- a/src/components/composite/BalanceCard/types.ts
+++ b/src/components/composite/BalanceCard/types.ts
@@ -20,7 +20,7 @@ export interface BalanceStackItemProps {
   balance: PortfolioBalance<WalletToken>;
   config: BalanceStackConfig;
   isClickable: boolean;
-  onClick: () => void;
+  onClick?: () => void;
   compact?: boolean;
 }
 

--- a/src/types/rewards.ts
+++ b/src/types/rewards.ts
@@ -23,3 +23,10 @@ export interface DeFiReacherReward extends BaseReward {
   campaignId: string;
   contractAddress: string;
 }
+
+export type MerklRewardItem = { type: 'merkl'; reward: MerklReward };
+export type DeFiReacherRewardItem = {
+  type: 'defi-reacher';
+  reward: DeFiReacherReward;
+};
+export type RewardItem = MerklRewardItem | DeFiReacherRewardItem;


### PR DESCRIPTION
# Which Jira task belongs to this PR?
Jira: https://lifi.atlassian.net/browse/JUM-555

## Testing steps
1. Go to `/profile`
2. Connect a wallet that has rewards
3. Check the rewards are sorted `desc` based on the amount in USD
4. Also, if there is an array of rewards the navigation buttons should show up on desktop
5. Try navigating and check the buttons show up/are hidden
6. On mobile, the navigation buttons should be next to the title
7. Again, check pressing them navigates properly

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile-responsive rewards carousel with intuitive previous/next navigation buttons and improved touch behavior
  * Consolidated rewards list combining multiple sources into a single, sorted view
  * Rewards display now shows USD values and balance-driven visuals for clearer claim info

* **Refactor**
  * Carousel now provides internal navigation state via a contextual provider for more reliable controls

* **Style**
  * Updated responsive layout and spacing for reward cards and section headers

* **Types**
  * Introduced explicit reward item union types and made a balance item click handler optional
<!-- end of auto-generated comment: release notes by coderabbit.ai -->