### PR TITLE
fix: set config theme flag hasThemeModeSwitch to true if unset

### DIFF
--- a/src/components/ProfilePage/components/RankCard/RankCard.tsx
+++ b/src/components/ProfilePage/components/RankCard/RankCard.tsx
@@ -78,6 +78,7 @@ export const RankCard: FC<RankCardProps> = () => {
           <RankButtonContainer>
             <RankButton
               href={AppPaths.Leaderboard}
+              component={Link}
               data-testid="leaderboard-button"
             >
               {t('leaderboard.title')}

--- a/src/utils/formatTheme.ts
+++ b/src/utils/formatTheme.ts
@@ -90,7 +90,7 @@ export function formatConfig(
       ?.appearance as 'light' | 'dark',
     hasThemeModeSwitch:
       (theme.lightConfig || theme.darkConfig)?.customization
-        ?.hasThemeModeSwitch || false,
+        ?.hasThemeModeSwitch ?? true,
     hasBlurredNavigation:
       (theme.lightConfig || theme.darkConfig)?.customization
         ?.hasBlurredNavigation ?? false,


### PR DESCRIPTION
# Which Jira task belongs to this PR?

https://linear.app/lifi-linear/issue/JUM-565/theme-menu-option-disappears-after-404-on-scan-page

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Theme toggle now defaults to enabled when no setting is provided, restoring expected behavior.

* **UI Improvements**
  * Leaderboard button now renders as a navigational link while preserving its label and destination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->