### PR TITLE
feat: add tests for deposit and withdraw button on DeFI tab

### DIFF
--- a/tests/pages/PortfolioPage.ts
+++ b/tests/pages/PortfolioPage.ts
@@ -22,6 +22,12 @@ export class PortfolioPage {
   private readonly portfolioHeaderOverviewElement: Locator;
   private readonly tokensOverviewElement: Locator;
   private readonly defiPositionsOverviewElement: Locator;
+  public readonly depositButton: Locator;
+  public readonly withdrawButton: Locator;
+  private readonly gearBoxPositionCard: Locator;
+  private readonly depositModalTitle: Locator;
+  private readonly withdrawModalTitle: Locator;
+  public readonly closeModalButton: Locator;
 
   constructor(private readonly page: Page) {
     this.getStartedButton = this.page.locator('#portfolio-get-started-button');
@@ -53,6 +59,14 @@ export class PortfolioPage {
     this.filterBarSkeleton = this.page.getByTestId(
       'portfolio-filter-bar-skeleton',
     );
+    this.depositModalTitle = this.page.locator(
+      'xpath=//p[normalize-space(text())="Quick deposit"]',
+    );
+    this.closeModalButton = this.page.getByTestId('CloseIcon');
+    this.withdrawModalTitle = this.page.locator(
+      'xpath=//p[normalize-space(text())="Withdraw"]',
+    );
+
     this.tokensFilterLocators = [
       this.walletSelectFilter,
       this.chainSelectFilter,
@@ -81,7 +95,17 @@ export class PortfolioPage {
     this.defiPositionsOverviewElement = this.page.getByTestId(
       'asset-overview-card-defi-positions',
     );
+    this.depositButton = this.page
+      .getByTestId('portfolio-deposit-button')
+      .first();
+    this.withdrawButton = this.page
+      .getByTestId('portfolio-withdraw-button')
+      .first();
+    this.gearBoxPositionCard = this.page.locator(
+      'xpath=//div[@aria-label="Position card for gearbox protocol"]',
+    );
   }
+
   async clickGetStartedButton(): Promise<void> {
     await this.getStartedButton.click();
   }
@@ -221,5 +245,26 @@ export class PortfolioPage {
         `Total value does not equal sum of individual values. Difference: ${difference}`,
       );
     }
+  }
+
+  async expandSparkPositionCard(): Promise<void> {
+    await this.gearBoxPositionCard.click();
+  }
+
+  async verifyDepositButtonIsVisibleOnDeFiPositionsTab(): Promise<void> {
+    await this.page.waitForLoadState('domcontentloaded');
+    await expect(this.depositButton).toBeVisible({ timeout: 30000 });
+  }
+
+  async verifyDepositModalIsVisible(): Promise<void> {
+    await this.page.waitForLoadState('domcontentloaded');
+    await expect(this.depositModalTitle).toBeVisible();
+  }
+
+  async verifyWithdrawButtonIsVisibleOnDeFiPositionsTab(): Promise<void> {
+    await expect(this.withdrawButton).toBeVisible();
+  }
+  async verifyWithdrawModalIsVisible(): Promise<void> {
+    await expect(this.withdrawModalTitle).toBeVisible();
   }
 }

--- a/tests/portfolioPage.spec.ts
+++ b/tests/portfolioPage.spec.ts
@@ -81,5 +81,32 @@ test.describe('Portfolio page', () => {
         await portfolioPage.verifyMainTotalValueEqualsSumOfIndividualValues();
       });
     });
+    test('verify that deposit and withdraw buttons are visible on DeFI positions tab', async ({
+      page,
+    }) => {
+      const portfolioPage = new PortfolioPage(page);
+      await portfolioPage.verifyGetStartedButtonIsVisible();
+      await portfolioPage.clickGetStartedButton();
+
+      await test.step('verify deposit and withdraw buttons are visible on defi positions tab', async () => {
+        await portfolioPage.clickDefiProtocolsTab();
+        await portfolioPage.expandSparkPositionCard();
+        await portfolioPage.verifyDepositButtonIsVisibleOnDeFiPositionsTab();
+        await portfolioPage.verifyWithdrawButtonIsVisibleOnDeFiPositionsTab();
+      });
+      await test.step('click deposit button', async () => {
+        await portfolioPage.depositButton.click();
+      });
+      await test.step('verify deposit modal is visible', async () => {
+        await portfolioPage.verifyDepositModalIsVisible();
+        await portfolioPage.closeModalButton.click();
+      });
+      await test.step('click withdraw button', async () => {
+        await portfolioPage.withdrawButton.click();
+      });
+      await test.step('verify withdraw modal is visible', async () => {
+        await portfolioPage.verifyWithdrawModalIsVisible();
+      });
+    });
   });
 });


### PR DESCRIPTION
# Which Jira task belongs to this PR?
https://lifi.atlassian.net/browse/LF-17569 

### ** Why did I implement it this way?**
Page object (PortfolioPage):
 - Added locators for the first deposit/withdraw buttons (getByTestId(...).first()) because there are many position cards with the same test ids; we only need to interact with the first visible one in this flow.
 - Used a dedicated position card locator (Gearbox) to expand a DeFi position before asserting and clicking deposit/withdraw, so the test runs against a concrete card state.
 - Modal checks use text-based locators for “Quick deposit” and “Withdraw” because those titles are rendered inside the LiFi widget and don’t have data-testids we can set.
 - Close button uses getByTestId('CloseIcon') to close the modal after verifying the deposit modal.
**Spec flow:**
 - The test goes through: open portfolio → close welcome → switch to DeFi Protocols tab → expand a position card → assert deposit/withdraw buttons are visible → click deposit → assert deposit modal → close modal → click withdraw → assert withdraw modal. This covers the main happy path for DeFi deposit/withdraw from the portfolio page.

### **# Checklist before requesting a review**

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for deposit and withdraw functionality on the DeFi positions tab, including validation of modal interactions and button visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->