### PR TITLE
fix: Error alert when balances not available

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -100,6 +100,9 @@ jobs:
           else
             echo "summary=❌ Some snapshot tests failed. Check the logs for details." >> "$GITHUB_OUTPUT"
           fi
+      - name: Fail if snapshot tests failed
+        if: steps.test.outcome == 'failure'
+        run: exit 1
 
   post-snapshot-comment:
     needs: [test-snapshots]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -92,4 +92,4 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: Snapshot Tests Summary
-          message: ${{ steps.test.outcome == 'success' && '✅ All snapshot tests passed' || '❌ Some snapshot tests failed. Check the logs for details' }}
+          message: ${{ steps.test.outcome == 'success' && '✅ All snapshot tests passed' || '❌ Some snapshot tests failed. Check the logs for details.' }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -79,8 +79,6 @@ jobs:
 
   test-snapshots:
     runs-on: ubuntu-latest
-    outputs:
-      summary: ${{ steps.results.outputs.summary }}
     steps:
       - *checkout
       - *pnpm-setup
@@ -100,18 +98,12 @@ jobs:
           else
             echo "summary=❌ Some snapshot tests failed. Check the logs for details." >> "$GITHUB_OUTPUT"
           fi
+      - name: Post snapshot comment
+        if: always() && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: Snapshot Tests Summary
+          message: ${{ steps.results.outputs.summary }}
       - name: Fail if snapshot tests failed
         if: steps.test.outcome == 'failure'
         run: exit 1
-
-  post-snapshot-comment:
-    needs: [test-snapshots]
-    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
-        env:
-          SUMMARY: ${{ needs.test-snapshots.outputs.summary }}
-        with:
-          header: Snapshot Tests Summary
-          message: ${{ env.SUMMARY }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -87,23 +87,9 @@ jobs:
       - name: Run tests
         id: test
         run: pnpm test:snapshots
-        continue-on-error: true
-      - name: Get test results
-        id: results
-        env:
-          TEST_OUTCOME: ${{ steps.test.outcome }}
-        run: |
-          if [ "$TEST_OUTCOME" = 'success' ]; then
-            echo "summary=✅ All snapshot tests passed" >> "$GITHUB_OUTPUT"
-          else
-            echo "summary=❌ Some snapshot tests failed. Check the logs for details." >> "$GITHUB_OUTPUT"
-          fi
       - name: Post snapshot comment
         if: always() && github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: Snapshot Tests Summary
-          message: ${{ steps.results.outputs.summary }}
-      - name: Fail if snapshot tests failed
-        if: steps.test.outcome == 'failure'
-        run: exit 1
+          message: ${{ steps.test.outcome == 'success' && '✅ All snapshot tests passed' || '❌ Some snapshot tests failed. Check the logs for details' }}

--- a/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
+++ b/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
@@ -104,13 +104,13 @@ exports[`EarnCard snapshot > compact card matches snapshot 1`] = `
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1we4ia9-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-a67k74-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -125,13 +125,13 @@ exports[`EarnCard snapshot > compact card matches snapshot 1`] = `
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-5ylplk-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1lynvi0-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-6y1h1j-MuiSkeleton-root"
@@ -311,13 +311,13 @@ exports[`EarnCard snapshot > compact card matches snapshot 1`] = `
                 class="MuiBox-root css-1xdhyk6"
               >
                 <div
-                  class="MuiStack-root css-5s31b2-MuiStack-root"
+                  class="MuiStack-root css-k9cukr-MuiStack-root"
                 >
                   <div
                     class="MuiStack-root css-k0vgmj-MuiStack-root"
                   >
                     <div
-                      class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                      class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                     >
                       <img
                         alt="USD Coin"
@@ -421,13 +421,13 @@ exports[`EarnCard snapshot > compact card with cap in dollar matches snapshot 1`
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1we4ia9-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-a67k74-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -442,13 +442,13 @@ exports[`EarnCard snapshot > compact card with cap in dollar matches snapshot 1`
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-5ylplk-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1lynvi0-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-6y1h1j-MuiSkeleton-root"
@@ -628,13 +628,13 @@ exports[`EarnCard snapshot > compact card with cap in dollar matches snapshot 1`
                 class="MuiBox-root css-1xdhyk6"
               >
                 <div
-                  class="MuiStack-root css-5s31b2-MuiStack-root"
+                  class="MuiStack-root css-k9cukr-MuiStack-root"
                 >
                   <div
                     class="MuiStack-root css-k0vgmj-MuiStack-root"
                   >
                     <div
-                      class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                      class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                     >
                       <img
                         alt="USD Coin"
@@ -742,13 +742,13 @@ exports[`EarnCard snapshot > compact card with href matches snapshot 1`] = `
               class="MuiBox-root css-wioyy2"
             >
               <div
-                class="MuiStack-root css-5s31b2-MuiStack-root"
+                class="MuiStack-root css-k9cukr-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-k0vgmj-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular css-1we4ia9-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular css-a67k74-MuiAvatar-root"
                   >
                     <img
                       alt="morpho"
@@ -763,13 +763,13 @@ exports[`EarnCard snapshot > compact card with href matches snapshot 1`] = `
                 class="MuiBox-root css-k8f1u5"
               >
                 <div
-                  class="MuiStack-root css-1g44ov9-MuiStack-root"
+                  class="MuiStack-root css-8lrfwp-MuiStack-root"
                 >
                   <div
                     class="MuiStack-root css-1x5pyaa-MuiStack-root"
                   >
                     <div
-                      class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-5ylplk-MuiAvatar-root"
+                      class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1lynvi0-MuiAvatar-root"
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-6y1h1j-MuiSkeleton-root"
@@ -949,13 +949,13 @@ exports[`EarnCard snapshot > compact card with href matches snapshot 1`] = `
                   class="MuiBox-root css-1xdhyk6"
                 >
                   <div
-                    class="MuiStack-root css-5s31b2-MuiStack-root"
+                    class="MuiStack-root css-k9cukr-MuiStack-root"
                   >
                     <div
                       class="MuiStack-root css-k0vgmj-MuiStack-root"
                     >
                       <div
-                        class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                        class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                       >
                         <img
                           alt="USD Coin"
@@ -1117,13 +1117,13 @@ exports[`EarnCard snapshot > compact card with lockup months and cap in dollar m
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1we4ia9-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-a67k74-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -1138,13 +1138,13 @@ exports[`EarnCard snapshot > compact card with lockup months and cap in dollar m
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-5ylplk-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1lynvi0-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-6y1h1j-MuiSkeleton-root"
@@ -1324,13 +1324,13 @@ exports[`EarnCard snapshot > compact card with lockup months and cap in dollar m
                 class="MuiBox-root css-1xdhyk6"
               >
                 <div
-                  class="MuiStack-root css-5s31b2-MuiStack-root"
+                  class="MuiStack-root css-k9cukr-MuiStack-root"
                 >
                   <div
                     class="MuiStack-root css-k0vgmj-MuiStack-root"
                   >
                     <div
-                      class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                      class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                     >
                       <img
                         alt="USD Coin"
@@ -1434,13 +1434,13 @@ exports[`EarnCard snapshot > compact card with lockup months matches snapshot 1`
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1we4ia9-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-a67k74-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -1455,13 +1455,13 @@ exports[`EarnCard snapshot > compact card with lockup months matches snapshot 1`
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-5ylplk-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1lynvi0-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-6y1h1j-MuiSkeleton-root"
@@ -1641,13 +1641,13 @@ exports[`EarnCard snapshot > compact card with lockup months matches snapshot 1`
                 class="MuiBox-root css-1xdhyk6"
               >
                 <div
-                  class="MuiStack-root css-5s31b2-MuiStack-root"
+                  class="MuiStack-root css-k9cukr-MuiStack-root"
                 >
                   <div
                     class="MuiStack-root css-k0vgmj-MuiStack-root"
                   >
                     <div
-                      class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                      class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                     >
                       <img
                         alt="USD Coin"
@@ -1746,13 +1746,13 @@ exports[`EarnCard snapshot > compact card with no recommendation matches snapsho
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1we4ia9-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-a67k74-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -1767,13 +1767,13 @@ exports[`EarnCard snapshot > compact card with no recommendation matches snapsho
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-5ylplk-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1lynvi0-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-6y1h1j-MuiSkeleton-root"
@@ -1953,13 +1953,13 @@ exports[`EarnCard snapshot > compact card with no recommendation matches snapsho
                 class="MuiBox-root css-1xdhyk6"
               >
                 <div
-                  class="MuiStack-root css-5s31b2-MuiStack-root"
+                  class="MuiStack-root css-k9cukr-MuiStack-root"
                 >
                   <div
                     class="MuiStack-root css-k0vgmj-MuiStack-root"
                   >
                     <div
-                      class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                      class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                     >
                       <img
                         alt="USD Coin"
@@ -2089,13 +2089,13 @@ exports[`EarnCard snapshot > compact card with single asset matches snapshot 1`]
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1we4ia9-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-a67k74-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -2110,13 +2110,13 @@ exports[`EarnCard snapshot > compact card with single asset matches snapshot 1`]
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-5ylplk-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1lynvi0-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-6y1h1j-MuiSkeleton-root"
@@ -2296,13 +2296,13 @@ exports[`EarnCard snapshot > compact card with single asset matches snapshot 1`]
                 class="MuiBox-root css-1xdhyk6"
               >
                 <div
-                  class="MuiStack-root css-5s31b2-MuiStack-root"
+                  class="MuiStack-root css-k9cukr-MuiStack-root"
                 >
                   <div
                     class="MuiStack-root css-k0vgmj-MuiStack-root"
                   >
                     <div
-                      class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                      class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                     >
                       <img
                         alt="USD Coin"
@@ -2432,13 +2432,13 @@ exports[`EarnCard snapshot > compact card with two items matches snapshot 1`] = 
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1we4ia9-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-a67k74-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -2453,13 +2453,13 @@ exports[`EarnCard snapshot > compact card with two items matches snapshot 1`] = 
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-5ylplk-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1lynvi0-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-6y1h1j-MuiSkeleton-root"
@@ -2567,13 +2567,13 @@ exports[`EarnCard snapshot > compact card with two items matches snapshot 1`] = 
                 class="MuiBox-root css-1xdhyk6"
               >
                 <div
-                  class="MuiStack-root css-5s31b2-MuiStack-root"
+                  class="MuiStack-root css-k9cukr-MuiStack-root"
                 >
                   <div
                     class="MuiStack-root css-k0vgmj-MuiStack-root"
                   >
                     <div
-                      class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                      class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                     >
                       <img
                         alt="USD Coin"
@@ -2618,13 +2618,13 @@ exports[`EarnCard snapshot > list item card matches snapshot 1`] = `
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1vh1zud-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-guu055-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -2639,13 +2639,13 @@ exports[`EarnCard snapshot > list item card matches snapshot 1`] = `
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ksgy38-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-d2d7y6-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-gn4zsg-MuiSkeleton-root"
@@ -2771,13 +2771,13 @@ exports[`EarnCard snapshot > list item card matches snapshot 1`] = `
             data-mui-internal-clone-element="true"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                 >
                   <img
                     alt="USD Coin"
@@ -2847,13 +2847,13 @@ exports[`EarnCard snapshot > list item card with cap in dollar matches snapshot 
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1vh1zud-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-guu055-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -2868,13 +2868,13 @@ exports[`EarnCard snapshot > list item card with cap in dollar matches snapshot 
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ksgy38-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-d2d7y6-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-gn4zsg-MuiSkeleton-root"
@@ -3000,13 +3000,13 @@ exports[`EarnCard snapshot > list item card with cap in dollar matches snapshot 
             data-mui-internal-clone-element="true"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                 >
                   <img
                     alt="USD Coin"
@@ -3054,13 +3054,13 @@ exports[`EarnCard snapshot > list item card with href matches snapshot 1`] = `
               class="MuiBox-root css-wioyy2"
             >
               <div
-                class="MuiStack-root css-5s31b2-MuiStack-root"
+                class="MuiStack-root css-k9cukr-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-k0vgmj-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular css-1vh1zud-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular css-guu055-MuiAvatar-root"
                   >
                     <img
                       alt="morpho"
@@ -3075,13 +3075,13 @@ exports[`EarnCard snapshot > list item card with href matches snapshot 1`] = `
                 class="MuiBox-root css-k8f1u5"
               >
                 <div
-                  class="MuiStack-root css-1g44ov9-MuiStack-root"
+                  class="MuiStack-root css-8lrfwp-MuiStack-root"
                 >
                   <div
                     class="MuiStack-root css-1x5pyaa-MuiStack-root"
                   >
                     <div
-                      class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ksgy38-MuiAvatar-root"
+                      class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-d2d7y6-MuiAvatar-root"
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-gn4zsg-MuiSkeleton-root"
@@ -3207,13 +3207,13 @@ exports[`EarnCard snapshot > list item card with href matches snapshot 1`] = `
               data-mui-internal-clone-element="true"
             >
               <div
-                class="MuiStack-root css-5s31b2-MuiStack-root"
+                class="MuiStack-root css-k9cukr-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-k0vgmj-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                   >
                     <img
                       alt="USD Coin"
@@ -3320,13 +3320,13 @@ exports[`EarnCard snapshot > list item card with lockup months and cap in dollar
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1vh1zud-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-guu055-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -3341,13 +3341,13 @@ exports[`EarnCard snapshot > list item card with lockup months and cap in dollar
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ksgy38-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-d2d7y6-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-gn4zsg-MuiSkeleton-root"
@@ -3473,13 +3473,13 @@ exports[`EarnCard snapshot > list item card with lockup months and cap in dollar
             data-mui-internal-clone-element="true"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                 >
                   <img
                     alt="USD Coin"
@@ -3523,13 +3523,13 @@ exports[`EarnCard snapshot > list item card with lockup months matches snapshot 
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1vh1zud-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-guu055-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -3544,13 +3544,13 @@ exports[`EarnCard snapshot > list item card with lockup months matches snapshot 
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ksgy38-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-d2d7y6-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-gn4zsg-MuiSkeleton-root"
@@ -3676,13 +3676,13 @@ exports[`EarnCard snapshot > list item card with lockup months matches snapshot 
             data-mui-internal-clone-element="true"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                 >
                   <img
                     alt="USD Coin"
@@ -3726,13 +3726,13 @@ exports[`EarnCard snapshot > list item card with no recommendation matches snaps
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1vh1zud-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-guu055-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -3747,13 +3747,13 @@ exports[`EarnCard snapshot > list item card with no recommendation matches snaps
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ksgy38-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-d2d7y6-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-gn4zsg-MuiSkeleton-root"
@@ -3848,13 +3848,13 @@ exports[`EarnCard snapshot > list item card with no recommendation matches snaps
             data-mui-internal-clone-element="true"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                 >
                   <img
                     alt="USD Coin"
@@ -3924,13 +3924,13 @@ exports[`EarnCard snapshot > list item card with single asset matches snapshot 1
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1vh1zud-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-guu055-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -3945,13 +3945,13 @@ exports[`EarnCard snapshot > list item card with single asset matches snapshot 1
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ksgy38-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-d2d7y6-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-gn4zsg-MuiSkeleton-root"
@@ -4077,13 +4077,13 @@ exports[`EarnCard snapshot > list item card with single asset matches snapshot 1
             data-mui-internal-clone-element="true"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                 >
                   <img
                     alt="USD Coin"
@@ -4280,13 +4280,13 @@ exports[`EarnCard snapshot > overview card matches snapshot 1`] = `
                   class="MuiBox-root css-wioyy2"
                 >
                   <div
-                    class="MuiStack-root css-5s31b2-MuiStack-root"
+                    class="MuiStack-root css-k9cukr-MuiStack-root"
                   >
                     <div
                       class="MuiStack-root css-k0vgmj-MuiStack-root"
                     >
                       <div
-                        class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                        class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                       >
                         <img
                           alt="USD Coin"
@@ -4301,13 +4301,13 @@ exports[`EarnCard snapshot > overview card matches snapshot 1`] = `
                     class="MuiBox-root css-k8f1u5"
                   >
                     <div
-                      class="MuiStack-root css-1g44ov9-MuiStack-root"
+                      class="MuiStack-root css-8lrfwp-MuiStack-root"
                     >
                       <div
                         class="MuiStack-root css-1x5pyaa-MuiStack-root"
                       >
                         <div
-                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1itdt8o-MuiAvatar-root"
+                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-gchynv-MuiAvatar-root"
                         >
                           <span
                             class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-1esbst0-MuiSkeleton-root"
@@ -4363,13 +4363,13 @@ exports[`EarnCard snapshot > overview card matches snapshot 1`] = `
               class="MuiBox-root css-1xdhyk6"
             >
               <div
-                class="MuiStack-root css-5s31b2-MuiStack-root"
+                class="MuiStack-root css-k9cukr-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-k0vgmj-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-14hx8vr-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-2ek4cj-MuiSkeleton-root"
@@ -4425,13 +4425,13 @@ exports[`EarnCard snapshot > overview card matches snapshot 1`] = `
                   class="MuiBox-root css-wioyy2"
                 >
                   <div
-                    class="MuiStack-root css-5s31b2-MuiStack-root"
+                    class="MuiStack-root css-k9cukr-MuiStack-root"
                   >
                     <div
                       class="MuiStack-root css-k0vgmj-MuiStack-root"
                     >
                       <div
-                        class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                        class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                       >
                         <img
                           alt="morpho"
@@ -4446,13 +4446,13 @@ exports[`EarnCard snapshot > overview card matches snapshot 1`] = `
                     class="MuiBox-root css-k8f1u5"
                   >
                     <div
-                      class="MuiStack-root css-1g44ov9-MuiStack-root"
+                      class="MuiStack-root css-8lrfwp-MuiStack-root"
                     >
                       <div
                         class="MuiStack-root css-1x5pyaa-MuiStack-root"
                       >
                         <div
-                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1itdt8o-MuiAvatar-root"
+                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-gchynv-MuiAvatar-root"
                         >
                           <span
                             class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-1esbst0-MuiSkeleton-root"
@@ -4652,13 +4652,13 @@ exports[`EarnCard snapshot > overview card with badge matches snapshot 1`] = `
                   class="MuiBox-root css-wioyy2"
                 >
                   <div
-                    class="MuiStack-root css-5s31b2-MuiStack-root"
+                    class="MuiStack-root css-k9cukr-MuiStack-root"
                   >
                     <div
                       class="MuiStack-root css-k0vgmj-MuiStack-root"
                     >
                       <div
-                        class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                        class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                       >
                         <img
                           alt="USD Coin"
@@ -4673,13 +4673,13 @@ exports[`EarnCard snapshot > overview card with badge matches snapshot 1`] = `
                     class="MuiBox-root css-k8f1u5"
                   >
                     <div
-                      class="MuiStack-root css-1g44ov9-MuiStack-root"
+                      class="MuiStack-root css-8lrfwp-MuiStack-root"
                     >
                       <div
                         class="MuiStack-root css-1x5pyaa-MuiStack-root"
                       >
                         <div
-                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1itdt8o-MuiAvatar-root"
+                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-gchynv-MuiAvatar-root"
                         >
                           <span
                             class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-1esbst0-MuiSkeleton-root"
@@ -4735,13 +4735,13 @@ exports[`EarnCard snapshot > overview card with badge matches snapshot 1`] = `
               class="MuiBox-root css-1xdhyk6"
             >
               <div
-                class="MuiStack-root css-5s31b2-MuiStack-root"
+                class="MuiStack-root css-k9cukr-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-k0vgmj-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-14hx8vr-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-2ek4cj-MuiSkeleton-root"
@@ -4797,13 +4797,13 @@ exports[`EarnCard snapshot > overview card with badge matches snapshot 1`] = `
                   class="MuiBox-root css-wioyy2"
                 >
                   <div
-                    class="MuiStack-root css-5s31b2-MuiStack-root"
+                    class="MuiStack-root css-k9cukr-MuiStack-root"
                   >
                     <div
                       class="MuiStack-root css-k0vgmj-MuiStack-root"
                     >
                       <div
-                        class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                        class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                       >
                         <img
                           alt="morpho"
@@ -4818,13 +4818,13 @@ exports[`EarnCard snapshot > overview card with badge matches snapshot 1`] = `
                     class="MuiBox-root css-k8f1u5"
                   >
                     <div
-                      class="MuiStack-root css-1g44ov9-MuiStack-root"
+                      class="MuiStack-root css-8lrfwp-MuiStack-root"
                     >
                       <div
                         class="MuiStack-root css-1x5pyaa-MuiStack-root"
                       >
                         <div
-                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1itdt8o-MuiAvatar-root"
+                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-gchynv-MuiAvatar-root"
                         >
                           <span
                             class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-1esbst0-MuiSkeleton-root"
@@ -5021,13 +5021,13 @@ exports[`EarnCard snapshot > overview card with cap in dollar matches snapshot 1
                   class="MuiBox-root css-wioyy2"
                 >
                   <div
-                    class="MuiStack-root css-5s31b2-MuiStack-root"
+                    class="MuiStack-root css-k9cukr-MuiStack-root"
                   >
                     <div
                       class="MuiStack-root css-k0vgmj-MuiStack-root"
                     >
                       <div
-                        class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                        class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                       >
                         <img
                           alt="USD Coin"
@@ -5042,13 +5042,13 @@ exports[`EarnCard snapshot > overview card with cap in dollar matches snapshot 1
                     class="MuiBox-root css-k8f1u5"
                   >
                     <div
-                      class="MuiStack-root css-1g44ov9-MuiStack-root"
+                      class="MuiStack-root css-8lrfwp-MuiStack-root"
                     >
                       <div
                         class="MuiStack-root css-1x5pyaa-MuiStack-root"
                       >
                         <div
-                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1itdt8o-MuiAvatar-root"
+                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-gchynv-MuiAvatar-root"
                         >
                           <span
                             class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-1esbst0-MuiSkeleton-root"
@@ -5104,13 +5104,13 @@ exports[`EarnCard snapshot > overview card with cap in dollar matches snapshot 1
               class="MuiBox-root css-1xdhyk6"
             >
               <div
-                class="MuiStack-root css-5s31b2-MuiStack-root"
+                class="MuiStack-root css-k9cukr-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-k0vgmj-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-14hx8vr-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-2ek4cj-MuiSkeleton-root"
@@ -5166,13 +5166,13 @@ exports[`EarnCard snapshot > overview card with cap in dollar matches snapshot 1
                   class="MuiBox-root css-wioyy2"
                 >
                   <div
-                    class="MuiStack-root css-5s31b2-MuiStack-root"
+                    class="MuiStack-root css-k9cukr-MuiStack-root"
                   >
                     <div
                       class="MuiStack-root css-k0vgmj-MuiStack-root"
                     >
                       <div
-                        class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                        class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                       >
                         <img
                           alt="morpho"
@@ -5187,13 +5187,13 @@ exports[`EarnCard snapshot > overview card with cap in dollar matches snapshot 1
                     class="MuiBox-root css-k8f1u5"
                   >
                     <div
-                      class="MuiStack-root css-1g44ov9-MuiStack-root"
+                      class="MuiStack-root css-8lrfwp-MuiStack-root"
                     >
                       <div
                         class="MuiStack-root css-1x5pyaa-MuiStack-root"
                       >
                         <div
-                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1itdt8o-MuiAvatar-root"
+                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-gchynv-MuiAvatar-root"
                         >
                           <span
                             class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-1esbst0-MuiSkeleton-root"
@@ -5424,13 +5424,13 @@ exports[`EarnCard snapshot > overview card with lockup months and cap in dollar 
                   class="MuiBox-root css-wioyy2"
                 >
                   <div
-                    class="MuiStack-root css-5s31b2-MuiStack-root"
+                    class="MuiStack-root css-k9cukr-MuiStack-root"
                   >
                     <div
                       class="MuiStack-root css-k0vgmj-MuiStack-root"
                     >
                       <div
-                        class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                        class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                       >
                         <img
                           alt="USD Coin"
@@ -5445,13 +5445,13 @@ exports[`EarnCard snapshot > overview card with lockup months and cap in dollar 
                     class="MuiBox-root css-k8f1u5"
                   >
                     <div
-                      class="MuiStack-root css-1g44ov9-MuiStack-root"
+                      class="MuiStack-root css-8lrfwp-MuiStack-root"
                     >
                       <div
                         class="MuiStack-root css-1x5pyaa-MuiStack-root"
                       >
                         <div
-                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1itdt8o-MuiAvatar-root"
+                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-gchynv-MuiAvatar-root"
                         >
                           <span
                             class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-1esbst0-MuiSkeleton-root"
@@ -5507,13 +5507,13 @@ exports[`EarnCard snapshot > overview card with lockup months and cap in dollar 
               class="MuiBox-root css-1xdhyk6"
             >
               <div
-                class="MuiStack-root css-5s31b2-MuiStack-root"
+                class="MuiStack-root css-k9cukr-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-k0vgmj-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-14hx8vr-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-2ek4cj-MuiSkeleton-root"
@@ -5569,13 +5569,13 @@ exports[`EarnCard snapshot > overview card with lockup months and cap in dollar 
                   class="MuiBox-root css-wioyy2"
                 >
                   <div
-                    class="MuiStack-root css-5s31b2-MuiStack-root"
+                    class="MuiStack-root css-k9cukr-MuiStack-root"
                   >
                     <div
                       class="MuiStack-root css-k0vgmj-MuiStack-root"
                     >
                       <div
-                        class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                        class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                       >
                         <img
                           alt="morpho"
@@ -5590,13 +5590,13 @@ exports[`EarnCard snapshot > overview card with lockup months and cap in dollar 
                     class="MuiBox-root css-k8f1u5"
                   >
                     <div
-                      class="MuiStack-root css-1g44ov9-MuiStack-root"
+                      class="MuiStack-root css-8lrfwp-MuiStack-root"
                     >
                       <div
                         class="MuiStack-root css-1x5pyaa-MuiStack-root"
                       >
                         <div
-                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1itdt8o-MuiAvatar-root"
+                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-gchynv-MuiAvatar-root"
                         >
                           <span
                             class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-1esbst0-MuiSkeleton-root"
@@ -5793,13 +5793,13 @@ exports[`EarnCard snapshot > overview card with lockup months matches snapshot 1
                   class="MuiBox-root css-wioyy2"
                 >
                   <div
-                    class="MuiStack-root css-5s31b2-MuiStack-root"
+                    class="MuiStack-root css-k9cukr-MuiStack-root"
                   >
                     <div
                       class="MuiStack-root css-k0vgmj-MuiStack-root"
                     >
                       <div
-                        class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                        class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                       >
                         <img
                           alt="USD Coin"
@@ -5814,13 +5814,13 @@ exports[`EarnCard snapshot > overview card with lockup months matches snapshot 1
                     class="MuiBox-root css-k8f1u5"
                   >
                     <div
-                      class="MuiStack-root css-1g44ov9-MuiStack-root"
+                      class="MuiStack-root css-8lrfwp-MuiStack-root"
                     >
                       <div
                         class="MuiStack-root css-1x5pyaa-MuiStack-root"
                       >
                         <div
-                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1itdt8o-MuiAvatar-root"
+                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-gchynv-MuiAvatar-root"
                         >
                           <span
                             class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-1esbst0-MuiSkeleton-root"
@@ -5876,13 +5876,13 @@ exports[`EarnCard snapshot > overview card with lockup months matches snapshot 1
               class="MuiBox-root css-1xdhyk6"
             >
               <div
-                class="MuiStack-root css-5s31b2-MuiStack-root"
+                class="MuiStack-root css-k9cukr-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-k0vgmj-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-ed36ue-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-14hx8vr-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-2ek4cj-MuiSkeleton-root"
@@ -5938,13 +5938,13 @@ exports[`EarnCard snapshot > overview card with lockup months matches snapshot 1
                   class="MuiBox-root css-wioyy2"
                 >
                   <div
-                    class="MuiStack-root css-5s31b2-MuiStack-root"
+                    class="MuiStack-root css-k9cukr-MuiStack-root"
                   >
                     <div
                       class="MuiStack-root css-k0vgmj-MuiStack-root"
                     >
                       <div
-                        class="MuiAvatar-root MuiAvatar-circular css-1luopuh-MuiAvatar-root"
+                        class="MuiAvatar-root MuiAvatar-circular css-1mqs5nj-MuiAvatar-root"
                       >
                         <img
                           alt="morpho"
@@ -5959,13 +5959,13 @@ exports[`EarnCard snapshot > overview card with lockup months matches snapshot 1
                     class="MuiBox-root css-k8f1u5"
                   >
                     <div
-                      class="MuiStack-root css-1g44ov9-MuiStack-root"
+                      class="MuiStack-root css-8lrfwp-MuiStack-root"
                     >
                       <div
                         class="MuiStack-root css-1x5pyaa-MuiStack-root"
                       >
                         <div
-                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1itdt8o-MuiAvatar-root"
+                          class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-gchynv-MuiAvatar-root"
                         >
                           <span
                             class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-1esbst0-MuiSkeleton-root"

--- a/src/components/Cards/HeroEarnCard/__snapshots__/HeroEarnCard.snapshot.spec.tsx.snap
+++ b/src/components/Cards/HeroEarnCard/__snapshots__/HeroEarnCard.snapshot.spec.tsx.snap
@@ -77,13 +77,13 @@ exports[`HeroEarnCard snapshot > hero card matches snapshot 1`] = `
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1vh1zud-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-guu055-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -98,13 +98,13 @@ exports[`HeroEarnCard snapshot > hero card matches snapshot 1`] = `
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ksgy38-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-d2d7y6-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-gn4zsg-MuiSkeleton-root"
@@ -219,13 +219,13 @@ exports[`HeroEarnCard snapshot > hero card with EARN_UP_TO copy matches snapshot
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1vh1zud-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-guu055-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -240,13 +240,13 @@ exports[`HeroEarnCard snapshot > hero card with EARN_UP_TO copy matches snapshot
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ksgy38-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-d2d7y6-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-gn4zsg-MuiSkeleton-root"
@@ -361,13 +361,13 @@ exports[`HeroEarnCard snapshot > hero card with MAKE_THE_JUMP copy matches snaps
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1vh1zud-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-guu055-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -382,13 +382,13 @@ exports[`HeroEarnCard snapshot > hero card with MAKE_THE_JUMP copy matches snaps
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ksgy38-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-d2d7y6-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-gn4zsg-MuiSkeleton-root"
@@ -503,13 +503,13 @@ exports[`HeroEarnCard snapshot > hero card with MAXIMIZE_YOUR_REVENUE copy match
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1vh1zud-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-guu055-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -524,13 +524,13 @@ exports[`HeroEarnCard snapshot > hero card with MAXIMIZE_YOUR_REVENUE copy match
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ksgy38-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-d2d7y6-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-gn4zsg-MuiSkeleton-root"
@@ -649,13 +649,13 @@ exports[`HeroEarnCard snapshot > hero card with link matches snapshot 1`] = `
               class="MuiBox-root css-wioyy2"
             >
               <div
-                class="MuiStack-root css-5s31b2-MuiStack-root"
+                class="MuiStack-root css-k9cukr-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-k0vgmj-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular css-1vh1zud-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular css-guu055-MuiAvatar-root"
                   >
                     <img
                       alt="morpho"
@@ -670,13 +670,13 @@ exports[`HeroEarnCard snapshot > hero card with link matches snapshot 1`] = `
                 class="MuiBox-root css-k8f1u5"
               >
                 <div
-                  class="MuiStack-root css-1g44ov9-MuiStack-root"
+                  class="MuiStack-root css-8lrfwp-MuiStack-root"
                 >
                   <div
                     class="MuiStack-root css-1x5pyaa-MuiStack-root"
                   >
                     <div
-                      class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ksgy38-MuiAvatar-root"
+                      class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-d2d7y6-MuiAvatar-root"
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-gn4zsg-MuiSkeleton-root"
@@ -835,13 +835,13 @@ exports[`HeroEarnCard snapshot > hero card with single asset matches snapshot 1`
             class="MuiBox-root css-wioyy2"
           >
             <div
-              class="MuiStack-root css-5s31b2-MuiStack-root"
+              class="MuiStack-root css-k9cukr-MuiStack-root"
             >
               <div
                 class="MuiStack-root css-k0vgmj-MuiStack-root"
               >
                 <div
-                  class="MuiAvatar-root MuiAvatar-circular css-1vh1zud-MuiAvatar-root"
+                  class="MuiAvatar-root MuiAvatar-circular css-guu055-MuiAvatar-root"
                 >
                   <img
                     alt="morpho"
@@ -856,13 +856,13 @@ exports[`HeroEarnCard snapshot > hero card with single asset matches snapshot 1`
               class="MuiBox-root css-k8f1u5"
             >
               <div
-                class="MuiStack-root css-1g44ov9-MuiStack-root"
+                class="MuiStack-root css-8lrfwp-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-1x5pyaa-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ksgy38-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-d2d7y6-MuiAvatar-root"
                   >
                     <span
                       class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-gn4zsg-MuiSkeleton-root"

--- a/src/components/Menus/WalletMenu/WalletMenu.tsx
+++ b/src/components/Menus/WalletMenu/WalletMenu.tsx
@@ -110,28 +110,32 @@ export const WalletMenu = () => {
           </Typography>
         </WalletButton>
       </Stack>
-      {Object.entries(balancesByAddress).map(
-        ([walletAddress, balanceByAddress]) => {
-          const balanceStateByAddress =
-            sources.balancesByAddress[walletAddress] ?? {};
+      {accounts.map((account) => {
+        const walletAddress = account.address;
+        if (!walletAddress) {
+          return null;
+        }
+        const balanceByAddress = balancesByAddress[walletAddress];
+        const balanceStateByAddress =
+          sources.balancesByAddress[walletAddress] ?? {};
 
-          return (
-            <WalletBalanceCard
-              key={walletAddress}
-              data-testid="wallet-balance-card"
-              walletAddress={walletAddress}
-              refetch={() => refreshByAddress(walletAddress)}
-              isFetching={
-                balanceStateByAddress.isLoading ||
-                balanceStateByAddress.isRefreshing
-              }
-              isSuccess={balanceStateByAddress.isSuccess}
-              updatedAt={balanceStateByAddress.updatedAt ?? Date.now()}
-              data={balanceByAddress ?? {}}
-            />
-          );
-        },
-      )}
+        return (
+          <WalletBalanceCard
+            key={walletAddress}
+            data-testid="wallet-balance-card"
+            walletAddress={walletAddress}
+            refetch={() => refreshByAddress(walletAddress)}
+            isFetching={
+              balanceStateByAddress.isLoading ||
+              balanceStateByAddress.isRefreshing
+            }
+            isSuccess={balanceStateByAddress.isSuccess}
+            updatedAt={balanceStateByAddress.updatedAt ?? Date.now()}
+            data={balanceByAddress ?? {}}
+            error={balanceStateByAddress.error}
+          />
+        );
+      })}
     </CustomDrawer>
   );
 };

--- a/src/components/composite/WalletBalanceCard/WalletBalanceCard.snapshot.spec.tsx
+++ b/src/components/composite/WalletBalanceCard/WalletBalanceCard.snapshot.spec.tsx
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '../../../../vitest.setup';
+import { WalletBalanceCard } from './WalletBalanceCard';
+import { walletBalanceCardFixture } from './fixtures';
+
+const MOCK_WALLET_ADDRESS = '0x1234567890123456789012345678901234567890';
+
+vi.mock('@lifi/wallet-management', () => ({
+  useAccount: () => ({
+    accounts: [
+      {
+        address: MOCK_WALLET_ADDRESS,
+        chainId: 1,
+        isConnected: true,
+        connector: undefined,
+      },
+    ],
+  }),
+  useAccountDisconnect: () => vi.fn(),
+  getConnectorIcon: () => undefined,
+}));
+
+vi.mock('src/hooks/useMainPaths', () => ({
+  useMainPaths: () => ({ isMainPaths: true }),
+}));
+
+vi.mock('src/stores/menu', () => ({
+  useMenuStore: (selector: (state: any) => any) =>
+    selector({
+      setWalletMenuState: vi.fn(),
+      closeAllMenus: vi.fn(),
+      setSnackbarState: vi.fn(),
+    }),
+}));
+
+vi.mock('@/stores/menu', () => ({
+  useMenuStore: (selector: (state: any) => any) =>
+    selector({
+      setWalletMenuState: vi.fn(),
+      closeAllMenus: vi.fn(),
+      setSnackbarState: vi.fn(),
+    }),
+}));
+
+vi.mock('src/stores/widgetCache', () => ({
+  useWidgetCacheStore: (selector: (state: any) => any) =>
+    selector({ setFrom: vi.fn() }),
+}));
+
+vi.mock('@/stores/settings', () => ({
+  useSettingsStore: (selector: (state: any) => any) =>
+    selector({ setWelcomeScreenClosed: vi.fn() }),
+}));
+
+vi.mock('@/stores/settings/SettingsStore', () => ({
+  useSettingsStore: (selector: (state: any) => any) =>
+    selector({ setWelcomeScreenClosed: vi.fn() }),
+}));
+
+vi.mock('@/stores/portfolio', () => ({
+  usePortfolioStore: (selector: (state: any) => any) =>
+    selector({ deleteCacheTokenAddress: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useChains', () => ({
+  useChains: () => ({ chains: [], getChainById: () => undefined }),
+}));
+
+vi.mock('@/hooks/useMultisig', () => ({
+  useMultisig: () => ({ isSafe: false }),
+}));
+
+vi.mock('@/hooks/userTracking/useUserTracking', () => ({
+  useUserTracking: () => ({ trackEvent: vi.fn() }),
+}));
+
+vi.mock('@/hooks/images/useGetColorsFromImage', () => ({
+  useDominantColorFromImage: () => null,
+}));
+
+vi.mock('@/hooks/tokens/usePortfolioFormatters', () => ({
+  usePortfolioFormatters: () => ({
+    toAggregatedAmount: () => '0',
+    toAggregatedAmountUSD: () => 0,
+    toDisplayAggregatedAmountUSD: () => '$0.00',
+    toDisplayAggregatedAmount: () => '0',
+  }),
+}));
+
+vi.mock('src/hooks/useTokens', () => ({
+  useTokens: () => ({
+    data: undefined,
+    getToken: () => undefined,
+    getTokenByAddressAndChain: () => undefined,
+    isSuccess: false,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('react-animated-counter', () => ({
+  AnimatedCounter: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+describe('WalletBalanceCard snapshot', () => {
+  it('with error renders alert', async () => {
+    const { container } = render(
+      <WalletBalanceCard
+        {...walletBalanceCardFixture}
+        data={{}}
+        error={new Error('Failed to load balances')}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('without error renders normally', async () => {
+    const { container } = render(
+      <WalletBalanceCard {...walletBalanceCardFixture} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/composite/WalletBalanceCard/WalletBalanceCard.stories.tsx
+++ b/src/components/composite/WalletBalanceCard/WalletBalanceCard.stories.tsx
@@ -50,3 +50,15 @@ export const Default: Story = {
     ...walletBalanceCardFixture,
   },
 };
+
+export const WithError: Story = {
+  args: {
+    walletAddress: '0x1234567890123456789012345678901234567890',
+    updatedAt: 12345,
+    refetch: () => {},
+    isFetching: false,
+    isSuccess: false,
+    data: {},
+    error: new Error('Failed to load balances'),
+  },
+};

--- a/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
+++ b/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
@@ -135,22 +135,26 @@ export const WalletBalanceCard: FC<WalletBalanceCardProps> = ({
             />
             <Stack>
               {error && <Alert severity="error">{error.message}</Alert>}
-              {!isSuccess &&
-                balanceGroups.length == 0 &&
-                Array.from({ length: 8 }).map(() => (
-                  <BalanceCardSkeleton size={BalanceCardSize.SM} />
-                ))}
-              {balanceGroups.map(([symbol, balances], index) => (
-                <BalanceCard
-                  balances={balances}
-                  size={BalanceCardSize.SM}
-                  key={symbol}
-                  onSelect={handleSelectToken}
-                  shouldShowExpandedEndDivider={
-                    index !== balanceGroups.length - 1
-                  }
-                />
-              ))}
+              {!error && (
+                <>
+                  {!isSuccess &&
+                    balanceGroups.length == 0 &&
+                    Array.from({ length: 8 }).map(() => (
+                      <BalanceCardSkeleton size={BalanceCardSize.SM} />
+                    ))}
+                  {balanceGroups.map(([symbol, balances], index) => (
+                    <BalanceCard
+                      balances={balances}
+                      size={BalanceCardSize.SM}
+                      key={symbol}
+                      onSelect={handleSelectToken}
+                      shouldShowExpandedEndDivider={
+                        index !== balanceGroups.length - 1
+                      }
+                    />
+                  ))}
+                </>
+              )}
             </Stack>
           </WalletBalanceCardContentContainer>
         </StyledAccordionDetails>

--- a/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
+++ b/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
@@ -14,6 +14,7 @@ import {
   WalletBalanceCardContainer,
   WalletBalanceCardContentContainer,
 } from './WalletBalanceCard.styles';
+import Alert from '@mui/material/Alert';
 import Stack from '@mui/material/Stack';
 import type { PortfolioBalance, WalletToken } from 'src/types/tokens';
 import { WalletTotalBalance } from './components/WalletTotalBalance';
@@ -35,6 +36,7 @@ export const WalletBalanceCard: FC<WalletBalanceCardProps> = ({
   isFetching,
   isSuccess,
   updatedAt,
+  error,
   data,
   'data-testid': dataTestId,
 }) => {
@@ -132,6 +134,7 @@ export const WalletBalanceCard: FC<WalletBalanceCardProps> = ({
               })}
             />
             <Stack>
+              {error && <Alert severity="error">{error.message}</Alert>}
               {!isSuccess &&
                 balanceGroups.length == 0 &&
                 Array.from({ length: 8 }).map(() => (

--- a/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
+++ b/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
@@ -29,6 +29,8 @@ import {
   balanceGroupSortAccessors,
   sortPortfolioItems,
 } from '@/providers/PortfolioProvider/filtering/utils';
+import { BaseAlert } from '@/components/Alerts/BaseAlert/BaseAlert';
+import { BaseAlertVariant } from '@/components/Alerts/BaseAlert/BaseAlert.styles';
 
 export const WalletBalanceCard: FC<WalletBalanceCardProps> = ({
   walletAddress,
@@ -134,7 +136,12 @@ export const WalletBalanceCard: FC<WalletBalanceCardProps> = ({
               })}
             />
             <Stack>
-              {error && <Alert severity="error">{error.message}</Alert>}
+              {error && (
+                <BaseAlert
+                  variant={BaseAlertVariant.Error}
+                  description={error.message}
+                />
+              )}
               {!error && (
                 <>
                   {!isSuccess &&

--- a/src/components/composite/WalletBalanceCard/WalletBalanceCard.types.ts
+++ b/src/components/composite/WalletBalanceCard/WalletBalanceCard.types.ts
@@ -7,5 +7,6 @@ export interface WalletBalanceCardProps {
   isSuccess: boolean;
   updatedAt: number;
   data: Record<string, PortfolioBalance<WalletToken>[]>;
+  error: Error | null;
   ['data-testid']?: string;
 }

--- a/src/components/composite/WalletBalanceCard/__snapshots__/WalletBalanceCard.snapshot.spec.tsx.snap
+++ b/src/components/composite/WalletBalanceCard/__snapshots__/WalletBalanceCard.snapshot.spec.tsx.snap
@@ -1,0 +1,758 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`WalletBalanceCard snapshot > with error renders alert 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-wul4wz"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters css-8lc9nw-MuiPaper-root-MuiAccordion-root"
+      style="--Paper-shadow: var(--jumper-shadows-1); --Paper-overlay: var(--jumper-overlays-1);"
+    >
+      <h3
+        class="MuiAccordion-heading css-cy7rkm-MuiAccordion-heading"
+      >
+        <div
+          aria-expanded="true"
+          class="MuiAccordionSummary-root Mui-expanded MuiAccordionSummary-gutters css-usb5t6"
+          focusvisibleclassname="Mui-focusVisible"
+        >
+          <span
+            class="MuiAccordionSummary-content Mui-expanded MuiAccordionSummary-contentGutters css-yfrx4k-MuiAccordionSummary-content"
+          >
+            <div
+              class="MuiBox-root css-dcu3ri"
+            >
+              <div
+                class="MuiContainer-root MuiContainer-maxWidthLg MuiContainer-disableGutters css-s4bmt1-MuiContainer-root"
+              >
+                <div
+                  class="MuiBox-root css-1vocpx"
+                >
+                  <span
+                    class="MuiBadge-root css-vo210k-MuiBadge-root"
+                  >
+                    <div
+                      class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-4ydead-MuiAvatar-root"
+                    >
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-piyikp-MuiSkeleton-root"
+                        style="width: 40px; height: 40px;"
+                      />
+                    </div>
+                    <span
+                      class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-33pqtt-MuiBadge-badge"
+                    />
+                  </span>
+                  <button
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-1ol01mw-MuiButtonBase-root-MuiButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-bodyMediumStrong css-1isabjp-MuiTypography-root"
+                    >
+                      0x12345...67890
+                    </p>
+                  </button>
+                </div>
+                <div
+                  class="MuiStack-root css-kh907h-MuiStack-root"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-wf63va-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1d0ztq2-MuiSvgIcon-root"
+                      data-testid="OpenInNewIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-wf63va-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1d0ztq2-MuiSvgIcon-root"
+                      data-testid="ReceiptLongIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19.5 3.5 18 2l-1.5 1.5L15 2l-1.5 1.5L12 2l-1.5 1.5L9 2 7.5 3.5 6 2v14H3v3c0 1.66 1.34 3 3 3h12c1.66 0 3-1.34 3-3V2zM19 19c0 .55-.45 1-1 1s-1-.45-1-1v-3H8V5h11z"
+                      />
+                      <path
+                        d="M9 7h6v2H9zm7 0h2v2h-2zm-7 3h6v2H9zm7 0h2v2h-2z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1f8ih3t-MuiButtonBase-root-MuiIconButton-root"
+                    id="disconnect-wallet-button"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1d0ztq2-MuiSvgIcon-root"
+                      data-testid="PowerSettingsNewIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M13 3h-2v10h2zm4.83 2.17-1.42 1.42C17.99 7.86 19 9.81 19 12c0 3.87-3.13 7-7 7s-7-3.13-7-7c0-2.19 1.01-4.14 2.58-5.42L6.17 5.17C4.23 6.82 3 9.26 3 12c0 4.97 4.03 9 9 9s9-4.03 9-9c0-2.74-1.23-5.18-3.17-6.83"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="MuiContainer-root MuiContainer-maxWidthLg MuiContainer-disableGutters css-s4bmt1-MuiContainer-root"
+              >
+                <div
+                  class="MuiStack-root css-16ml5pn-MuiStack-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-bodyXSmallStrong css-1o3lrdt-MuiTypography-root"
+                  >
+                    navbar.walletMenu.walletBalance
+                  </p>
+                  <div
+                    class="MuiStack-root css-18tjum2-MuiStack-root"
+                  >
+                    <div
+                      class="MuiStack-root css-1gu36qu-MuiStack-root"
+                    >
+                      <div
+                        class="css-1l8j7hy"
+                      >
+                        <span>
+                          0
+                        </span>
+                      </div>
+                      <button
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1ca0mjw-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <div
+                          aria-label="navbar.walletMenu.totalBalanceRefresh"
+                          class="MuiBox-root css-r2eaa2"
+                          data-mui-internal-clone-element="true"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-w1g9nl-MuiSvgIcon-root"
+                            data-testid="RefreshIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4z"
+                            />
+                          </svg>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </span>
+        </div>
+      </h3>
+      <div
+        class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-qr6njo-MuiCollapse-root"
+        style="min-height: 0px;"
+      >
+        <div
+          class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
+        >
+          <div
+            class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
+          >
+            <div
+              class="MuiAccordion-region css-at4ued-MuiAccordion-region"
+              role="region"
+            >
+              <div
+                class="MuiAccordionDetails-root css-1dwkzq1-MuiAccordionDetails-root"
+              >
+                <div
+                  class="MuiBox-root css-dcu3ri"
+                >
+                  <hr
+                    class="MuiDivider-root MuiDivider-fullWidth css-4lfm89-MuiDivider-root"
+                  />
+                  <div
+                    class="MuiStack-root css-nen11g-MuiStack-root"
+                  >
+                    <div
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorError MuiAlert-standardError MuiAlert-standard css-57oh4c-MuiPaper-root-MuiAlert-root"
+                      role="alert"
+                      style="--Paper-shadow: var(--jumper-shadows-0); --Paper-overlay: var(--jumper-overlays-0);"
+                    >
+                      <div
+                        class="MuiAlert-icon css-vab54s-MuiAlert-icon"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-8hoymy-MuiSvgIcon-root"
+                          data-testid="ErrorOutlineIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="MuiAlert-message css-zioonp-MuiAlert-message"
+                      >
+                        Failed to load balances
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`WalletBalanceCard snapshot > without error renders normally 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-wul4wz"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded Mui-expanded MuiAccordion-gutters css-8lc9nw-MuiPaper-root-MuiAccordion-root"
+      style="--Paper-shadow: var(--jumper-shadows-1); --Paper-overlay: var(--jumper-overlays-1);"
+    >
+      <h3
+        class="MuiAccordion-heading css-cy7rkm-MuiAccordion-heading"
+      >
+        <div
+          aria-expanded="true"
+          class="MuiAccordionSummary-root Mui-expanded MuiAccordionSummary-gutters css-usb5t6"
+          focusvisibleclassname="Mui-focusVisible"
+        >
+          <span
+            class="MuiAccordionSummary-content Mui-expanded MuiAccordionSummary-contentGutters css-yfrx4k-MuiAccordionSummary-content"
+          >
+            <div
+              class="MuiBox-root css-dcu3ri"
+            >
+              <div
+                class="MuiContainer-root MuiContainer-maxWidthLg MuiContainer-disableGutters css-s4bmt1-MuiContainer-root"
+              >
+                <div
+                  class="MuiBox-root css-1vocpx"
+                >
+                  <span
+                    class="MuiBadge-root css-vo210k-MuiBadge-root"
+                  >
+                    <div
+                      class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-4ydead-MuiAvatar-root"
+                    >
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-piyikp-MuiSkeleton-root"
+                        style="width: 40px; height: 40px;"
+                      />
+                    </div>
+                    <span
+                      class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-33pqtt-MuiBadge-badge"
+                    />
+                  </span>
+                  <button
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-1ol01mw-MuiButtonBase-root-MuiButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-bodyMediumStrong css-1isabjp-MuiTypography-root"
+                    >
+                      0x12345...67890
+                    </p>
+                  </button>
+                </div>
+                <div
+                  class="MuiStack-root css-kh907h-MuiStack-root"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-wf63va-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1d0ztq2-MuiSvgIcon-root"
+                      data-testid="OpenInNewIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-wf63va-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1d0ztq2-MuiSvgIcon-root"
+                      data-testid="ReceiptLongIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19.5 3.5 18 2l-1.5 1.5L15 2l-1.5 1.5L12 2l-1.5 1.5L9 2 7.5 3.5 6 2v14H3v3c0 1.66 1.34 3 3 3h12c1.66 0 3-1.34 3-3V2zM19 19c0 .55-.45 1-1 1s-1-.45-1-1v-3H8V5h11z"
+                      />
+                      <path
+                        d="M9 7h6v2H9zm7 0h2v2h-2zm-7 3h6v2H9zm7 0h2v2h-2z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1f8ih3t-MuiButtonBase-root-MuiIconButton-root"
+                    id="disconnect-wallet-button"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1d0ztq2-MuiSvgIcon-root"
+                      data-testid="PowerSettingsNewIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M13 3h-2v10h2zm4.83 2.17-1.42 1.42C17.99 7.86 19 9.81 19 12c0 3.87-3.13 7-7 7s-7-3.13-7-7c0-2.19 1.01-4.14 2.58-5.42L6.17 5.17C4.23 6.82 3 9.26 3 12c0 4.97 4.03 9 9 9s9-4.03 9-9c0-2.74-1.23-5.18-3.17-6.83"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="MuiContainer-root MuiContainer-maxWidthLg MuiContainer-disableGutters css-s4bmt1-MuiContainer-root"
+              >
+                <div
+                  class="MuiStack-root css-16ml5pn-MuiStack-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-bodyXSmallStrong css-1o3lrdt-MuiTypography-root"
+                  >
+                    navbar.walletMenu.walletBalance
+                  </p>
+                  <div
+                    class="MuiStack-root css-18tjum2-MuiStack-root"
+                  >
+                    <div
+                      class="MuiStack-root css-1gu36qu-MuiStack-root"
+                    >
+                      <div
+                        class="css-1l8j7hy"
+                      >
+                        <span>
+                          0
+                        </span>
+                      </div>
+                      <button
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1ca0mjw-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <div
+                          aria-label="navbar.walletMenu.totalBalanceRefresh"
+                          class="MuiBox-root css-r2eaa2"
+                          data-mui-internal-clone-element="true"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-w1g9nl-MuiSvgIcon-root"
+                            data-testid="RefreshIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4z"
+                            />
+                          </svg>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </span>
+        </div>
+      </h3>
+      <div
+        class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-qr6njo-MuiCollapse-root"
+        style="min-height: 0px;"
+      >
+        <div
+          class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
+        >
+          <div
+            class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
+          >
+            <div
+              class="MuiAccordion-region css-at4ued-MuiAccordion-region"
+              role="region"
+            >
+              <div
+                class="MuiAccordionDetails-root css-1dwkzq1-MuiAccordionDetails-root"
+              >
+                <div
+                  class="MuiBox-root css-dcu3ri"
+                >
+                  <hr
+                    class="MuiDivider-root MuiDivider-fullWidth css-4lfm89-MuiDivider-root"
+                  />
+                  <div
+                    class="MuiStack-root css-nen11g-MuiStack-root"
+                  >
+                    <div
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded css-lkocyo-MuiPaper-root-MuiAccordion-root"
+                      style="--Paper-shadow: var(--jumper-shadows-1); --Paper-overlay: var(--jumper-overlays-1);"
+                    >
+                      <h3
+                        class="MuiAccordion-heading css-cy7rkm-MuiAccordion-heading"
+                      >
+                        <button
+                          aria-expanded="false"
+                          class="MuiButtonBase-root MuiAccordionSummary-root css-406cw6-MuiButtonBase-root-MuiAccordionSummary-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <span
+                            class="MuiAccordionSummary-content css-18x5eyn-MuiAccordionSummary-content"
+                          >
+                            <div
+                              class="MuiStack-root css-4ghnc3-MuiStack-root"
+                            >
+                              <div
+                                class="MuiBox-root css-dffkzv"
+                              >
+                                <div
+                                  class="MuiBox-root css-wioyy2"
+                                >
+                                  <div
+                                    class="MuiBox-root css-1xdhyk6"
+                                  >
+                                    <div
+                                      class="MuiStack-root css-8lrfwp-MuiStack-root"
+                                    >
+                                      <div
+                                        class="MuiStack-root css-54t7xt-MuiStack-root"
+                                      >
+                                        <div
+                                          class="MuiAvatar-root MuiAvatar-circular css-1xcstal-MuiAvatar-root"
+                                        >
+                                          <img
+                                            alt="USD Coin"
+                                            class="MuiAvatar-img css-i4dfdj-MuiAvatar-img"
+                                            loading="lazy"
+                                            src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                                          />
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                                <div
+                                  class="MuiBox-root css-fxacz8"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-bodySmallStrong css-ck7yql-MuiTypography-root"
+                                    data-testid="entity-stack-title"
+                                  >
+                                    USDC
+                                  </p>
+                                  <div
+                                    class="MuiStack-root css-8lrfwp-MuiStack-root"
+                                  >
+                                    <div
+                                      class="MuiStack-root css-dnapf8-MuiStack-root"
+                                    >
+                                      <div
+                                        class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1furbft-MuiAvatar-root"
+                                      >
+                                        <p
+                                          class="MuiTypography-root MuiTypography-body1 css-1rcwuno-MuiTypography-root"
+                                        >
+                                          P
+                                        </p>
+                                      </div>
+                                      <div
+                                        class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1furbft-MuiAvatar-root"
+                                      >
+                                        <p
+                                          class="MuiTypography-root MuiTypography-body1 css-1rcwuno-MuiTypography-root"
+                                        >
+                                          E
+                                        </p>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div
+                                class="MuiBox-root css-19josn"
+                              >
+                                <p
+                                  class="MuiTypography-root MuiTypography-bodySmallStrong css-ck7yql-MuiTypography-root"
+                                >
+                                  $0.00
+                                </p>
+                                <p
+                                  class="MuiTypography-root MuiTypography-bodyXXSmall css-1l48hti-MuiTypography-root"
+                                >
+                                  0
+                                </p>
+                              </div>
+                            </div>
+                          </span>
+                        </button>
+                      </h3>
+                      <div
+                        class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
+                        style="min-height: 0px;"
+                      >
+                        <div
+                          class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
+                        >
+                          <div
+                            class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
+                          >
+                            <div
+                              class="MuiAccordion-region css-at4ued-MuiAccordion-region"
+                              role="region"
+                            >
+                              <div
+                                class="MuiAccordionDetails-root css-1dwkzq1-MuiAccordionDetails-root"
+                              >
+                                <div
+                                  class="MuiStack-root css-nen11g-MuiStack-root"
+                                >
+                                  <hr
+                                    class="MuiDivider-root MuiDivider-fullWidth css-1pk5x0u-MuiDivider-root"
+                                  />
+                                  <div
+                                    class="MuiStack-root css-1n0yfix-MuiStack-root"
+                                  >
+                                    <div
+                                      class="MuiBox-root css-dffkzv"
+                                    >
+                                      <div
+                                        class="MuiBox-root css-wioyy2"
+                                      >
+                                        <div
+                                          class="MuiBox-root css-1jlu52p"
+                                        >
+                                          <div
+                                            class="MuiStack-root css-8lrfwp-MuiStack-root"
+                                          >
+                                            <div
+                                              class="MuiStack-root css-54t7xt-MuiStack-root"
+                                            >
+                                              <div
+                                                class="MuiAvatar-root MuiAvatar-circular css-o8tmub-MuiAvatar-root"
+                                              >
+                                                <img
+                                                  alt="USD Coin"
+                                                  class="MuiAvatar-img css-i4dfdj-MuiAvatar-img"
+                                                  loading="lazy"
+                                                  src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                                                />
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="MuiBox-root css-nosxnw"
+                                        >
+                                          <div
+                                            class="MuiStack-root css-8lrfwp-MuiStack-root"
+                                          >
+                                            <div
+                                              class="MuiStack-root css-1x5pyaa-MuiStack-root"
+                                            >
+                                              <div
+                                                class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1nj5o1p-MuiAvatar-root"
+                                              >
+                                                <p
+                                                  class="MuiTypography-root MuiTypography-body1 css-1rcwuno-MuiTypography-root"
+                                                >
+                                                  E
+                                                </p>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="MuiBox-root css-vtfvnu"
+                                      >
+                                        <p
+                                          class="MuiTypography-root MuiTypography-bodySmallStrong css-ck7yql-MuiTypography-root"
+                                          data-testid="entity-stack-title"
+                                        >
+                                          USDC
+                                        </p>
+                                        <div
+                                          class="MuiBox-root css-sq6w4p"
+                                        >
+                                          <p
+                                            class="MuiTypography-root MuiTypography-bodyXXSmall css-1l48hti-MuiTypography-root"
+                                            data-testid="entity-stack-hint"
+                                            style="position: absolute; -webkit-transform: none; transform: none; transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"
+                                          >
+                                            Eth
+                                          </p>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="MuiBox-root css-1wwrdzw"
+                                    >
+                                      <p
+                                        class="MuiTypography-root MuiTypography-bodySmallStrong css-ck7yql-MuiTypography-root"
+                                      >
+                                        format.currency
+                                      </p>
+                                      <p
+                                        class="MuiTypography-root MuiTypography-bodyXXSmall css-1l48hti-MuiTypography-root"
+                                      >
+                                        format.decimal USDC
+                                      </p>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="MuiStack-root css-1n0yfix-MuiStack-root"
+                                  >
+                                    <div
+                                      class="MuiBox-root css-dffkzv"
+                                    >
+                                      <div
+                                        class="MuiBox-root css-wioyy2"
+                                      >
+                                        <div
+                                          class="MuiBox-root css-1jlu52p"
+                                        >
+                                          <div
+                                            class="MuiStack-root css-8lrfwp-MuiStack-root"
+                                          >
+                                            <div
+                                              class="MuiStack-root css-54t7xt-MuiStack-root"
+                                            >
+                                              <div
+                                                class="MuiAvatar-root MuiAvatar-circular css-o8tmub-MuiAvatar-root"
+                                              >
+                                                <img
+                                                  alt="USD Coin"
+                                                  class="MuiAvatar-img css-i4dfdj-MuiAvatar-img"
+                                                  loading="lazy"
+                                                  src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+                                                />
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="MuiBox-root css-nosxnw"
+                                        >
+                                          <div
+                                            class="MuiStack-root css-8lrfwp-MuiStack-root"
+                                          >
+                                            <div
+                                              class="MuiStack-root css-1x5pyaa-MuiStack-root"
+                                            >
+                                              <div
+                                                class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1nj5o1p-MuiAvatar-root"
+                                              >
+                                                <p
+                                                  class="MuiTypography-root MuiTypography-body1 css-1rcwuno-MuiTypography-root"
+                                                >
+                                                  P
+                                                </p>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="MuiBox-root css-vtfvnu"
+                                      >
+                                        <p
+                                          class="MuiTypography-root MuiTypography-bodySmallStrong css-ck7yql-MuiTypography-root"
+                                          data-testid="entity-stack-title"
+                                        >
+                                          USDC
+                                        </p>
+                                        <div
+                                          class="MuiBox-root css-sq6w4p"
+                                        >
+                                          <p
+                                            class="MuiTypography-root MuiTypography-bodyXXSmall css-1l48hti-MuiTypography-root"
+                                            data-testid="entity-stack-hint"
+                                            style="position: absolute; -webkit-transform: none; transform: none; transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"
+                                          >
+                                            Pol
+                                          </p>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="MuiBox-root css-1wwrdzw"
+                                    >
+                                      <p
+                                        class="MuiTypography-root MuiTypography-bodySmallStrong css-ck7yql-MuiTypography-root"
+                                      >
+                                        format.currency
+                                      </p>
+                                      <p
+                                        class="MuiTypography-root MuiTypography-bodyXXSmall css-1l48hti-MuiTypography-root"
+                                      >
+                                        format.decimal USDC
+                                      </p>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/composite/WalletBalanceCard/__snapshots__/WalletBalanceCard.snapshot.spec.tsx.snap
+++ b/src/components/composite/WalletBalanceCard/__snapshots__/WalletBalanceCard.snapshot.spec.tsx.snap
@@ -198,29 +198,27 @@ exports[`WalletBalanceCard snapshot > with error renders alert 1`] = `
                     class="MuiStack-root css-nen11g-MuiStack-root"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorError MuiAlert-standardError MuiAlert-standard css-57oh4c-MuiPaper-root-MuiAlert-root"
-                      role="alert"
-                      style="--Paper-shadow: var(--jumper-shadows-0); --Paper-overlay: var(--jumper-overlays-0);"
+                      class="MuiBox-root css-5gjva7"
                     >
                       <div
-                        class="MuiAlert-icon css-vab54s-MuiAlert-icon"
+                        class="MuiBox-root css-zgl2zz"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-8hoymy-MuiSvgIcon-root"
-                          data-testid="ErrorOutlineIcon"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1lldh1y-MuiSvgIcon-root"
+                          data-testid="ErrorRoundedIcon"
                           focusable="false"
                           viewBox="0 0 24 24"
                         >
                           <path
-                            d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 11c-.55 0-1-.45-1-1V8c0-.55.45-1 1-1s1 .45 1 1v4c0 .55-.45 1-1 1m1 4h-2v-2h2z"
                           />
                         </svg>
-                      </div>
-                      <div
-                        class="MuiAlert-message css-zioonp-MuiAlert-message"
-                      >
-                        Failed to load balances
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-lvvsd-MuiTypography-root"
+                        >
+                          Failed to load balances
+                        </p>
                       </div>
                     </div>
                   </div>

--- a/src/components/composite/WalletBalanceCard/fixtures.ts
+++ b/src/components/composite/WalletBalanceCard/fixtures.ts
@@ -9,4 +9,5 @@ export const walletBalanceCardFixture = {
   data: {
     USDC: mockMultiChainUsdcBalances,
   },
+  error: null,
 };

--- a/src/components/composite/cards/ProcessingTransactionCard/__snapshots__/ProcessingTransactionCard.snapshot.spec.tsx.snap
+++ b/src/components/composite/cards/ProcessingTransactionCard/__snapshots__/ProcessingTransactionCard.snapshot.spec.tsx.snap
@@ -46,13 +46,13 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot 1`] = `
               class="MuiBox-root css-wioyy2"
             >
               <div
-                class="MuiStack-root css-5s31b2-MuiStack-root"
+                class="MuiStack-root css-k9cukr-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-k0vgmj-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1c4ud6y-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-xczvr5-MuiAvatar-root"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-8stpht-MuiTypography-root"
@@ -66,13 +66,13 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot 1`] = `
                 class="MuiBox-root css-k8f1u5"
               >
                 <div
-                  class="MuiStack-root css-1g44ov9-MuiStack-root"
+                  class="MuiStack-root css-8lrfwp-MuiStack-root"
                 >
                   <div
                     class="MuiStack-root css-1x5pyaa-MuiStack-root"
                   >
                     <div
-                      class="MuiAvatar-root MuiAvatar-circular css-1tqea6q-MuiAvatar-root"
+                      class="MuiAvatar-root MuiAvatar-circular css-lzt2y3-MuiAvatar-root"
                     >
                       <img
                         alt="Ethereum"
@@ -98,13 +98,13 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot 1`] = `
               class="MuiBox-root css-wioyy2"
             >
               <div
-                class="MuiStack-root css-5s31b2-MuiStack-root"
+                class="MuiStack-root css-k9cukr-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-k0vgmj-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1c4ud6y-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-xczvr5-MuiAvatar-root"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-8stpht-MuiTypography-root"
@@ -118,13 +118,13 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot 1`] = `
                 class="MuiBox-root css-k8f1u5"
               >
                 <div
-                  class="MuiStack-root css-1g44ov9-MuiStack-root"
+                  class="MuiStack-root css-8lrfwp-MuiStack-root"
                 >
                   <div
                     class="MuiStack-root css-1x5pyaa-MuiStack-root"
                   >
                     <div
-                      class="MuiAvatar-root MuiAvatar-circular css-1tqea6q-MuiAvatar-root"
+                      class="MuiAvatar-root MuiAvatar-circular css-lzt2y3-MuiAvatar-root"
                     >
                       <img
                         alt="Ethereum"
@@ -225,13 +225,13 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot with status faile
               class="MuiBox-root css-wioyy2"
             >
               <div
-                class="MuiStack-root css-5s31b2-MuiStack-root"
+                class="MuiStack-root css-k9cukr-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-k0vgmj-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1c4ud6y-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-xczvr5-MuiAvatar-root"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-8stpht-MuiTypography-root"
@@ -245,13 +245,13 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot with status faile
                 class="MuiBox-root css-k8f1u5"
               >
                 <div
-                  class="MuiStack-root css-1g44ov9-MuiStack-root"
+                  class="MuiStack-root css-8lrfwp-MuiStack-root"
                 >
                   <div
                     class="MuiStack-root css-1x5pyaa-MuiStack-root"
                   >
                     <div
-                      class="MuiAvatar-root MuiAvatar-circular css-1tqea6q-MuiAvatar-root"
+                      class="MuiAvatar-root MuiAvatar-circular css-lzt2y3-MuiAvatar-root"
                     >
                       <img
                         alt="Ethereum"
@@ -277,13 +277,13 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot with status faile
               class="MuiBox-root css-wioyy2"
             >
               <div
-                class="MuiStack-root css-5s31b2-MuiStack-root"
+                class="MuiStack-root css-k9cukr-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-k0vgmj-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1c4ud6y-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-xczvr5-MuiAvatar-root"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-8stpht-MuiTypography-root"
@@ -297,13 +297,13 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot with status faile
                 class="MuiBox-root css-k8f1u5"
               >
                 <div
-                  class="MuiStack-root css-1g44ov9-MuiStack-root"
+                  class="MuiStack-root css-8lrfwp-MuiStack-root"
                 >
                   <div
                     class="MuiStack-root css-1x5pyaa-MuiStack-root"
                   >
                     <div
-                      class="MuiAvatar-root MuiAvatar-circular css-1tqea6q-MuiAvatar-root"
+                      class="MuiAvatar-root MuiAvatar-circular css-lzt2y3-MuiAvatar-root"
                     >
                       <img
                         alt="Ethereum"
@@ -404,13 +404,13 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot with status succe
               class="MuiBox-root css-wioyy2"
             >
               <div
-                class="MuiStack-root css-5s31b2-MuiStack-root"
+                class="MuiStack-root css-k9cukr-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-k0vgmj-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1c4ud6y-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-xczvr5-MuiAvatar-root"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-8stpht-MuiTypography-root"
@@ -424,13 +424,13 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot with status succe
                 class="MuiBox-root css-k8f1u5"
               >
                 <div
-                  class="MuiStack-root css-1g44ov9-MuiStack-root"
+                  class="MuiStack-root css-8lrfwp-MuiStack-root"
                 >
                   <div
                     class="MuiStack-root css-1x5pyaa-MuiStack-root"
                   >
                     <div
-                      class="MuiAvatar-root MuiAvatar-circular css-1tqea6q-MuiAvatar-root"
+                      class="MuiAvatar-root MuiAvatar-circular css-lzt2y3-MuiAvatar-root"
                     >
                       <img
                         alt="Ethereum"
@@ -456,13 +456,13 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot with status succe
               class="MuiBox-root css-wioyy2"
             >
               <div
-                class="MuiStack-root css-5s31b2-MuiStack-root"
+                class="MuiStack-root css-k9cukr-MuiStack-root"
               >
                 <div
                   class="MuiStack-root css-k0vgmj-MuiStack-root"
                 >
                   <div
-                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1c4ud6y-MuiAvatar-root"
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-xczvr5-MuiAvatar-root"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1 css-8stpht-MuiTypography-root"
@@ -476,13 +476,13 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot with status succe
                 class="MuiBox-root css-k8f1u5"
               >
                 <div
-                  class="MuiStack-root css-1g44ov9-MuiStack-root"
+                  class="MuiStack-root css-8lrfwp-MuiStack-root"
                 >
                   <div
                     class="MuiStack-root css-1x5pyaa-MuiStack-root"
                   >
                     <div
-                      class="MuiAvatar-root MuiAvatar-circular css-1tqea6q-MuiAvatar-root"
+                      class="MuiAvatar-root MuiAvatar-circular css-lzt2y3-MuiAvatar-root"
                     >
                       <img
                         alt="Ethereum"

--- a/src/providers/PortfolioProvider/PortfolioContext.ts
+++ b/src/providers/PortfolioProvider/PortfolioContext.ts
@@ -79,6 +79,7 @@ const defaultSourceState: SourceState = {
   isRefreshing: false,
   isStale: false,
   updatedAt: null,
+  error: null,
 };
 
 const defaultOrchestrationState: OrchestrationState = {

--- a/src/providers/PortfolioProvider/hooks/useBalancesData.ts
+++ b/src/providers/PortfolioProvider/hooks/useBalancesData.ts
@@ -14,6 +14,7 @@ export interface ResultState {
   isSuccess: boolean;
   isPlaceholderData: boolean;
   updatedAt: number | null;
+  error: Error | null;
 }
 
 export interface UseTokensDataResult extends ResultState {
@@ -181,6 +182,7 @@ export const useBalancesData = (): UseTokensDataResult => {
             isSuccess: query.isSuccess,
             isPlaceholderData: query.isPlaceholderData,
             updatedAt: query.data?.updatedAt ?? null,
+            error: query.error ?? null,
           };
         }
 

--- a/src/providers/PortfolioProvider/hooks/useBalancesData.ts
+++ b/src/providers/PortfolioProvider/hooks/useBalancesData.ts
@@ -182,7 +182,7 @@ export const useBalancesData = (): UseTokensDataResult => {
             isSuccess: query.isSuccess,
             isPlaceholderData: query.isPlaceholderData,
             updatedAt: query.data?.updatedAt ?? null,
-            error: query.error ?? null,
+            error: query.error,
           };
         }
 

--- a/src/providers/PortfolioProvider/hooks/useOrchestrationState.ts
+++ b/src/providers/PortfolioProvider/hooks/useOrchestrationState.ts
@@ -18,6 +18,7 @@ export const useOrchestrationState = (
       isStale: balances.isPlaceholderData,
       isSuccess: balances.isSuccess,
       updatedAt: balances.updatedAt,
+      error: balances.error,
     }),
     [
       balances.accounts,
@@ -27,6 +28,7 @@ export const useOrchestrationState = (
       balances.isSuccess,
       balances.isPlaceholderData,
       balances.updatedAt,
+      balances.error,
     ],
   );
 
@@ -41,6 +43,7 @@ export const useOrchestrationState = (
           isStale: state.isPlaceholderData,
           isSuccess: state.isSuccess,
           updatedAt: state.updatedAt,
+          error: state.error,
         },
       ]),
     );
@@ -54,6 +57,7 @@ export const useOrchestrationState = (
       isStale: positions.isPlaceholderData,
       isSuccess: positions.isSuccess,
       updatedAt: positions.updatedAt,
+      error: positions.error,
     }),
     [
       positions.accounts,
@@ -63,6 +67,7 @@ export const useOrchestrationState = (
       positions.isSuccess,
       positions.isPlaceholderData,
       positions.updatedAt,
+      positions.error,
     ],
   );
 
@@ -74,8 +79,14 @@ export const useOrchestrationState = (
       isStale: !pricesData.hasFreshPrices,
       isSuccess: pricesData.hasFreshPrices && !pricesData.isLoading,
       updatedAt: pricesData.updatedAt ?? null,
+      error: pricesData.error,
     }),
-    [pricesData.hasFreshPrices, pricesData.isLoading, pricesData.updatedAt],
+    [
+      pricesData.error,
+      pricesData.hasFreshPrices,
+      pricesData.isLoading,
+      pricesData.updatedAt,
+    ],
   );
 
   const isEmpty = balances.isEmpty && positions.isEmpty;

--- a/src/providers/PortfolioProvider/hooks/usePriceLookup.ts
+++ b/src/providers/PortfolioProvider/hooks/usePriceLookup.ts
@@ -6,6 +6,7 @@ export interface UsePriceLookupResult {
   isLoading: boolean;
   hasFreshPrices: boolean;
   updatedAt: number | undefined;
+  error: Error | null;
 }
 
 /**
@@ -19,6 +20,7 @@ export const usePriceLookup = (): UsePriceLookupResult => {
     isLoading,
     isSuccess: hasFreshPrices,
     updatedAt,
+    error,
   } = useTokens();
 
   const getPrice = useMemo(() => {
@@ -38,5 +40,6 @@ export const usePriceLookup = (): UsePriceLookupResult => {
     isLoading,
     hasFreshPrices,
     updatedAt,
+    error,
   };
 };

--- a/src/providers/PortfolioProvider/types.ts
+++ b/src/providers/PortfolioProvider/types.ts
@@ -89,6 +89,7 @@ export interface SourceState {
   isStale: boolean;
   isSuccess: boolean;
   updatedAt: number | null;
+  error: Error | null;
 }
 
 /**


### PR DESCRIPTION
Also changing the action for snapshot tests, so that the tests fails when the snapshot tests fail :)
<img width="399" height="381" alt="Capture d’écran 2026-03-04 à 18 10 39" src="https://github.com/user-attachments/assets/b65d138f-59c4-477c-b391-972556a0459f" />

# Which Jira task belongs to this PR?
Closes JUM-285

# Why did I implement it this way?

I just want the errors to be propagated if needed to be consumed by components.

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-account balance cards now show explicit error alerts when balance/price/source data fail to load.
* **Tests**
  * Added snapshot tests covering balance card with and without error states.
* **Documentation**
  * Added a story demonstrating the balance card error state.
* **Chores**
  * CI snapshot post-comment flow simplified to always run and report results inline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->