### PR TITLE
feat: Simple necessary toAddress impl

### DIFF
--- a/src/components/Widgets/PrivateSwapModal/PrivateSwapModal.styles.ts
+++ b/src/components/Widgets/PrivateSwapModal/PrivateSwapModal.styles.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { Box } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+export const PrivateSwapModalCard = styled(Box)(({ theme }) => ({
+  width: 400,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(2),
+  padding: theme.spacing(3),
+  borderRadius: '16px',
+  background: (theme.vars || theme).palette.surface2.main,
+  boxShadow: (theme.vars || theme).shadows[1],
+  ...theme.applyStyles('light', {
+    background: (theme.vars || theme).palette.surface1.main,
+  }),
+}));

--- a/src/components/Widgets/PrivateSwapModal/PrivateSwapModal.styles.ts
+++ b/src/components/Widgets/PrivateSwapModal/PrivateSwapModal.styles.ts
@@ -4,7 +4,9 @@ import { Box } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
 export const PrivateSwapModalCard = styled(Box)(({ theme }) => ({
-  width: 400,
+  width: 'min(400px, calc(100vw - 32px))',
+  maxWidth: '100%',
+  boxSizing: 'border-box',
   display: 'flex',
   flexDirection: 'column',
   gap: theme.spacing(2),

--- a/src/components/Widgets/PrivateSwapModal/PrivateSwapModal.styles.ts
+++ b/src/components/Widgets/PrivateSwapModal/PrivateSwapModal.styles.ts
@@ -11,7 +11,7 @@ export const PrivateSwapModalCard = styled(Box)(({ theme }) => ({
   flexDirection: 'column',
   gap: theme.spacing(2),
   padding: theme.spacing(3),
-  borderRadius: '16px',
+  borderRadius: theme.shape.radius16,
   background: (theme.vars || theme).palette.surface2.main,
   boxShadow: (theme.vars || theme).shadows[1],
   ...theme.applyStyles('light', {

--- a/src/components/Widgets/PrivateSwapModal/PrivateSwapModal.tsx
+++ b/src/components/Widgets/PrivateSwapModal/PrivateSwapModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { FC } from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import Box from '@mui/material/Box';
@@ -33,6 +33,12 @@ export const PrivateSwapModal: FC<PrivateSwapModalProps> = ({
   const [address, setAddress] = useState(initialAddress);
   const [box1, setBox1] = useState(false);
   const [box2, setBox2] = useState(false);
+
+  useEffect(() => {
+    if (open && initialAddress !== undefined) {
+      setAddress(initialAddress);
+    }
+  }, [open, initialAddress]);
 
   const canConfirm = isValidAddress(address) && box1 && box2;
 

--- a/src/components/Widgets/PrivateSwapModal/PrivateSwapModal.tsx
+++ b/src/components/Widgets/PrivateSwapModal/PrivateSwapModal.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import type { FC } from 'react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import Box from '@mui/material/Box';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Typography from '@mui/material/Typography';
+
+import { Button } from 'src/components/Button/Button';
+import { FormInput } from 'src/components/Form/FormInput/FormInput';
+import { ModalContainer } from 'src/components/core/modals/ModalContainer/ModalContainer';
+import { isValidAddress } from 'src/utils/regex-patterns';
+
+import { PrivateSwapModalCard } from './PrivateSwapModal.styles';
+
+export interface PrivateSwapModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (address: string) => void;
+  initialAddress?: string;
+}
+
+export const PrivateSwapModal: FC<PrivateSwapModalProps> = ({
+  open,
+  onClose,
+  onConfirm,
+  initialAddress = '',
+}) => {
+  const { t } = useTranslation();
+  const [address, setAddress] = useState(initialAddress);
+  const [box1, setBox1] = useState(false);
+  const [box2, setBox2] = useState(false);
+
+  const canConfirm = isValidAddress(address) && box1 && box2;
+
+  const handlePaste = async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      setAddress(text);
+    } catch {
+      // clipboard access denied — no-op
+    }
+  };
+
+  const handleConfirm = () => {
+    if (canConfirm) {
+      onConfirm(address);
+    }
+  };
+
+  return (
+    <ModalContainer isOpen={open} onClose={onClose}>
+      <PrivateSwapModalCard>
+        <Typography variant="titleSmall" fontWeight={700}>
+          {t('modal.privateSwap.title')}
+        </Typography>
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Typography variant="bodyMedium">
+            {t('modal.privateSwap.subtitle')}
+          </Typography>
+        </Box>
+
+        <FormInput
+          id="private-swap-address"
+          name="private-swap-address"
+          value={address}
+          placeholder={t('modal.privateSwap.addressPlaceholder')}
+          onChange={(e) => setAddress(e.target.value)}
+          startAdornment={
+            <Button variant="secondary" size="small" onClick={handlePaste}>
+              {t('modal.privateSwap.paste')}
+            </Button>
+          }
+        />
+
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={box1}
+              onChange={(e) => setBox1(e.target.checked)}
+            />
+          }
+          label={
+            <Typography variant="bodySmall">
+              {t('modal.privateSwap.disclaimer1')}
+            </Typography>
+          }
+        />
+
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={box2}
+              onChange={(e) => setBox2(e.target.checked)}
+            />
+          }
+          label={
+            <Typography variant="bodySmall">
+              {t('modal.privateSwap.disclaimer2')}
+            </Typography>
+          }
+        />
+
+        <Button
+          variant="primary"
+          fullWidth
+          disabled={!canConfirm}
+          onClick={handleConfirm}
+        >
+          {t('modal.privateSwap.confirm')}
+        </Button>
+      </PrivateSwapModalCard>
+    </ModalContainer>
+  );
+};

--- a/src/components/Widgets/Widget.tsx
+++ b/src/components/Widgets/Widget.tsx
@@ -6,7 +6,7 @@ import { useAccount } from '@lifi/wallet-management';
 import type { FormState } from '@lifi/widget';
 import { PrefetchKind } from 'next/dist/client/components/router-reducer/router-reducer-types';
 import { usePathname, useRouter } from 'next/navigation';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useWelcomeScreen } from 'src/hooks/useWelcomeScreen';
 import { useBridgeConditions } from 'src/hooks/useBridgeConditions';
@@ -19,6 +19,7 @@ import { useFormParameters } from './hooks';
 import { AppPaths } from '@/const/urls';
 import { Widget as BaseWidget } from './variants/base/Widget';
 import FeeContribution from './FeeContribution/FeeContribution';
+import { PrivateSwapModal } from './PrivateSwapModal/PrivateSwapModal';
 
 export function Widget({
   starterVariant,
@@ -41,6 +42,12 @@ export function Widget({
     allowToChains,
     configThemeChains: configTheme?.chains,
   });
+  const [isPrivateSwapModalOpen, setIsPrivateSwapModalOpen] = useState(false);
+
+  useEffect(() => {
+    setIsPrivateSwapModalOpen(bridgeConditions.isPrivateSwapSelected);
+  }, [bridgeConditions.isPrivateSwapSelected]);
+
   const router = useRouter();
   const pathname = usePathname();
   const { t } = useTranslation();
@@ -148,6 +155,14 @@ export function Widget({
         formRef={formRef}
         feeConfig={{
           _vcComponent: () => <FeeContribution translationFn={t} />,
+        }}
+      />
+      <PrivateSwapModal
+        open={isPrivateSwapModalOpen}
+        onClose={() => setIsPrivateSwapModalOpen(false)}
+        onConfirm={(addr) => {
+          formRef.current?.setFieldValue('toAddress', addr);
+          setIsPrivateSwapModalOpen(false);
         }}
       />
     </WidgetWrapper>

--- a/src/components/Widgets/Widget.tsx
+++ b/src/components/Widgets/Widget.tsx
@@ -19,8 +19,13 @@ import { useFormParameters } from './hooks';
 import { AppPaths } from '@/const/urls';
 import { Widget as BaseWidget } from './variants/base/Widget';
 import FeeContribution from './FeeContribution/FeeContribution';
-import { PrivateSwapModal } from './PrivateSwapModal/PrivateSwapModal';
+import dynamic from 'next/dynamic';
 
+const PrivateSwapModal = dynamic(() =>
+  import('./PrivateSwapModal/PrivateSwapModal').then(
+    (mod) => mod.PrivateSwapModal,
+  ),
+);
 export function Widget({
   starterVariant,
   fromChain,

--- a/src/components/Widgets/Widget.tsx
+++ b/src/components/Widgets/Widget.tsx
@@ -159,6 +159,7 @@ export function Widget({
       />
       <PrivateSwapModal
         open={isPrivateSwapModalOpen}
+        initialAddress={bridgeConditions.toAddress}
         onClose={() => setIsPrivateSwapModalOpen(false)}
         onConfirm={(addr) => {
           formRef.current?.setFieldValue('toAddress', addr);

--- a/src/components/Widgets/Widget.tsx
+++ b/src/components/Widgets/Widget.tsx
@@ -162,15 +162,17 @@ export function Widget({
           _vcComponent: () => <FeeContribution translationFn={t} />,
         }}
       />
-      <PrivateSwapModal
-        open={isPrivateSwapModalOpen}
-        initialAddress={bridgeConditions.toAddress}
-        onClose={() => setIsPrivateSwapModalOpen(false)}
-        onConfirm={(addr) => {
-          formRef.current?.setFieldValue('toAddress', addr);
-          setIsPrivateSwapModalOpen(false);
-        }}
-      />
+      {isPrivateSwapModalOpen && (
+        <PrivateSwapModal
+          open={isPrivateSwapModalOpen}
+          initialAddress={bridgeConditions.toAddress}
+          onClose={() => setIsPrivateSwapModalOpen(false)}
+          onConfirm={(addr) => {
+            formRef.current?.setFieldValue('toAddress', addr);
+            setIsPrivateSwapModalOpen(false);
+          }}
+        />
+      )}
     </WidgetWrapper>
   );
 }

--- a/src/components/Widgets/variants/widgetConfig/types.ts
+++ b/src/components/Widgets/variants/widgetConfig/types.ts
@@ -67,6 +67,7 @@ export interface MainWidgetContext extends CommonWidgetContext {
     isAGWToNonABSChain?: boolean;
     isBridgeFromHypeToArbNativeUSDC?: boolean;
     isBridgeFromEvmToHype?: boolean;
+    isPrivateSwapSelected?: boolean;
   };
   isConnectedAGW?: boolean;
 }

--- a/src/components/Widgets/variants/widgetConfig/types.ts
+++ b/src/components/Widgets/variants/widgetConfig/types.ts
@@ -68,6 +68,7 @@ export interface MainWidgetContext extends CommonWidgetContext {
     isBridgeFromHypeToArbNativeUSDC?: boolean;
     isBridgeFromEvmToHype?: boolean;
     isPrivateSwapSelected?: boolean;
+    toAddress?: string;
   };
   isConnectedAGW?: boolean;
 }

--- a/src/components/Widgets/variants/widgetConfig/useMainWidgetConfig.ts
+++ b/src/components/Widgets/variants/widgetConfig/useMainWidgetConfig.ts
@@ -106,7 +106,10 @@ export function useMainWidgetConfig(
       ],
     };
 
-    if (context.bridgeConditions?.isAGWToNonABSChain) {
+    if (
+      context.bridgeConditions?.isAGWToNonABSChain ||
+      context.bridgeConditions?.isPrivateSwapSelected
+    ) {
       config.requiredUI = [...(config.requiredUI || []), RequiredUI.ToAddress];
     }
 

--- a/src/hooks/useBridgeConditions.ts
+++ b/src/hooks/useBridgeConditions.ts
@@ -49,9 +49,22 @@ export const useBridgeConditions = ({
       );
     };
 
+    const handleResetPrivateSwapSelected = () => {
+      setIsPrivateSwapSelected(false);
+    };
+
     widgetEvents.on(WidgetEvent.RouteSelected, handleSelectedRoute);
+    widgetEvents.on(
+      WidgetEvent.RouteExecutionStarted,
+      handleResetPrivateSwapSelected,
+    );
+
     return () => {
       widgetEvents.off(WidgetEvent.RouteSelected, handleSelectedRoute);
+      widgetEvents.off(
+        WidgetEvent.RouteExecutionStarted,
+        handleResetPrivateSwapSelected,
+      );
     };
   }, [widgetEvents]);
 

--- a/src/hooks/useBridgeConditions.ts
+++ b/src/hooks/useBridgeConditions.ts
@@ -7,6 +7,12 @@ import { ExtendedChainId } from 'src/components/Widgets/Widget.types';
 import { ARB_NATIVE_USDC } from 'src/config/tokens';
 import { useUrlParams } from './useUrlParams';
 import { useChains } from './useChains';
+import {
+  setupWidgetEvents,
+  teardownWidgetEvents,
+} from '@/components/Widgets/WidgetEventsManager';
+
+const PRIVATE_SWAP_TOOL_KEYS = ['houdini'];
 
 interface UseWidgetSelectionProps {
   formRef?: RefObject<FormState | null>;
@@ -50,7 +56,7 @@ export const useBridgeConditions = ({
   useEffect(() => {
     const handleSelectedRoute = ({ route }: { route: Route }) => {
       setIsPrivateSwapSelected(
-        route.steps.some((step) => step.tool === 'houdini'),
+        route.steps.some((step) => PRIVATE_SWAP_TOOL_KEYS.includes(step.tool)),
       );
     };
 
@@ -63,34 +69,21 @@ export const useBridgeConditions = ({
       }
     };
     const handleToAddressChange = (params: FormFieldChanged) => {
-      if (params?.fieldName === 'toAddress') {
+      if (params?.fieldName === 'toAddress' && params.newValue !== undefined) {
         setToAddress(params.newValue);
       }
     };
+    const widgetEventsConfig = {
+      routeSelected: handleSelectedRoute,
+      routeExecutionStarted: handleResetPrivateSwapSelected,
+      pageEntered: handleResetPrivateSwapSelectedForPageEntered,
+      formFieldChanged: handleToAddressChange,
+    };
 
-    widgetEvents.on(WidgetEvent.RouteSelected, handleSelectedRoute);
-    widgetEvents.on(
-      WidgetEvent.RouteExecutionStarted,
-      handleResetPrivateSwapSelected,
-    );
-    widgetEvents.on(
-      WidgetEvent.PageEntered,
-      handleResetPrivateSwapSelectedForPageEntered,
-    );
-    widgetEvents.on(WidgetEvent.FormFieldChanged, handleToAddressChange);
+    setupWidgetEvents(widgetEventsConfig, widgetEvents);
 
     return () => {
-      widgetEvents.off(WidgetEvent.RouteSelected, handleSelectedRoute);
-      widgetEvents.off(
-        WidgetEvent.RouteExecutionStarted,
-        handleResetPrivateSwapSelected,
-      );
-      widgetEvents.off(
-        WidgetEvent.PageEntered,
-        handleResetPrivateSwapSelectedForPageEntered,
-      );
-
-      widgetEvents.off(WidgetEvent.FormFieldChanged, handleToAddressChange);
+      teardownWidgetEvents(widgetEventsConfig, widgetEvents);
     };
   }, [widgetEvents]);
 

--- a/src/hooks/useBridgeConditions.ts
+++ b/src/hooks/useBridgeConditions.ts
@@ -1,7 +1,8 @@
-import { ChainId, ChainType } from '@lifi/sdk';
+import { ChainId, ChainType, type Route } from '@lifi/sdk';
 import { useAccount } from '@lifi/wallet-management';
 import type { FormState } from '@lifi/widget';
-import { RefObject, useEffect, useMemo } from 'react';
+import { useWidgetEvents, WidgetEvent } from '@lifi/widget';
+import { type RefObject, useEffect, useMemo, useState } from 'react';
 import { ExtendedChainId } from 'src/components/Widgets/Widget.types';
 import { ARB_NATIVE_USDC } from 'src/config/tokens';
 import { useUrlParams } from './useUrlParams';
@@ -25,6 +26,8 @@ export const useBridgeConditions = ({
   const { account } = useAccount();
   const isConnectedAGW = account?.connector?.name === 'Abstract';
   const { getChainById } = useChains();
+  const widgetEvents = useWidgetEvents();
+  const [isPrivateSwapSelected, setIsPrivateSwapSelected] = useState(false);
 
   const {
     sourceChainToken: sourceChainTokenParam,
@@ -38,6 +41,19 @@ export const useBridgeConditions = ({
     }
     return getChainById(sourceChainTokenParam.chainId)?.chainType;
   }, [sourceChainTokenParam?.chainId, getChainById]);
+
+  useEffect(() => {
+    const handleSelectedRoute = ({ route }: { route: Route }) => {
+      setIsPrivateSwapSelected(
+        route.steps.some((step) => step.tool === 'houdini'),
+      );
+    };
+
+    widgetEvents.on(WidgetEvent.RouteSelected, handleSelectedRoute);
+    return () => {
+      widgetEvents.off(WidgetEvent.RouteSelected, handleSelectedRoute);
+    };
+  }, [widgetEvents]);
 
   // // Handle initial URL parameter clearing
   useEffect(() => {
@@ -89,7 +105,9 @@ export const useBridgeConditions = ({
   ]);
 
   useEffect(() => {
-    if (!formRef?.current) return;
+    if (!formRef?.current) {
+      return;
+    }
 
     if (
       (isConnectedAGW && toAddress === account.address) ||
@@ -108,5 +126,5 @@ export const useBridgeConditions = ({
     isConnectedAGW,
   ]);
 
-  return bridgeConditions;
+  return { ...bridgeConditions, isPrivateSwapSelected };
 };

--- a/src/hooks/useBridgeConditions.ts
+++ b/src/hooks/useBridgeConditions.ts
@@ -52,11 +52,20 @@ export const useBridgeConditions = ({
     const handleResetPrivateSwapSelected = () => {
       setIsPrivateSwapSelected(false);
     };
+    const handleResetPrivateSwapSelectedForPageEntered = (route: string) => {
+      if (route === '/routes' || route === '/') {
+        setIsPrivateSwapSelected(false);
+      }
+    };
 
     widgetEvents.on(WidgetEvent.RouteSelected, handleSelectedRoute);
     widgetEvents.on(
       WidgetEvent.RouteExecutionStarted,
       handleResetPrivateSwapSelected,
+    );
+    widgetEvents.on(
+      WidgetEvent.PageEntered,
+      handleResetPrivateSwapSelectedForPageEntered,
     );
 
     return () => {
@@ -64,6 +73,10 @@ export const useBridgeConditions = ({
       widgetEvents.off(
         WidgetEvent.RouteExecutionStarted,
         handleResetPrivateSwapSelected,
+      );
+      widgetEvents.off(
+        WidgetEvent.PageEntered,
+        handleResetPrivateSwapSelectedForPageEntered,
       );
     };
   }, [widgetEvents]);
@@ -139,5 +152,5 @@ export const useBridgeConditions = ({
     isConnectedAGW,
   ]);
 
-  return { ...bridgeConditions, isPrivateSwapSelected };
+  return { ...bridgeConditions, isPrivateSwapSelected, toAddress };
 };

--- a/src/hooks/useBridgeConditions.ts
+++ b/src/hooks/useBridgeConditions.ts
@@ -52,8 +52,8 @@ export const useBridgeConditions = ({
     const handleResetPrivateSwapSelected = () => {
       setIsPrivateSwapSelected(false);
     };
-    const handleResetPrivateSwapSelectedForPageEntered = (route: string) => {
-      if (route === '/routes' || route === '/') {
+    const handleResetPrivateSwapSelectedForPageEntered = (path: string) => {
+      if (path === '/routes' || path === '/') {
         setIsPrivateSwapSelected(false);
       }
     };
@@ -121,6 +121,8 @@ export const useBridgeConditions = ({
       isBridgeFromHypeToArbNativeUSDC,
       isBridgeFromEvmToHype,
       isAGWToNonABSChain,
+      isPrivateSwapSelected,
+      toAddress,
     };
   }, [
     sourceChainTokenParam.chainId,
@@ -152,5 +154,5 @@ export const useBridgeConditions = ({
     isConnectedAGW,
   ]);
 
-  return { ...bridgeConditions, isPrivateSwapSelected, toAddress };
+  return bridgeConditions;
 };

--- a/src/hooks/useBridgeConditions.ts
+++ b/src/hooks/useBridgeConditions.ts
@@ -1,6 +1,6 @@
 import { ChainId, ChainType, type Route } from '@lifi/sdk';
 import { useAccount } from '@lifi/wallet-management';
-import type { FormState } from '@lifi/widget';
+import type { FormFieldChanged, FormState } from '@lifi/widget';
 import { useWidgetEvents, WidgetEvent } from '@lifi/widget';
 import { type RefObject, useEffect, useMemo, useState } from 'react';
 import { ExtendedChainId } from 'src/components/Widgets/Widget.types';
@@ -28,12 +28,17 @@ export const useBridgeConditions = ({
   const { getChainById } = useChains();
   const widgetEvents = useWidgetEvents();
   const [isPrivateSwapSelected, setIsPrivateSwapSelected] = useState(false);
+  const [toAddress, setToAddress] = useState<string | undefined>(undefined);
 
   const {
     sourceChainToken: sourceChainTokenParam,
     destinationChainToken: destinationChainTokenParam,
-    toAddress,
+    toAddress: toAddressUrlParams,
   } = useUrlParams();
+
+  useEffect(() => {
+    setToAddress(toAddressUrlParams);
+  }, [toAddressUrlParams]);
 
   const sourceChainType = useMemo(() => {
     if (!sourceChainTokenParam?.chainId) {
@@ -57,6 +62,11 @@ export const useBridgeConditions = ({
         setIsPrivateSwapSelected(false);
       }
     };
+    const handleToAddressChange = (params: FormFieldChanged) => {
+      if (params?.fieldName === 'toAddress') {
+        setToAddress(params.newValue);
+      }
+    };
 
     widgetEvents.on(WidgetEvent.RouteSelected, handleSelectedRoute);
     widgetEvents.on(
@@ -67,6 +77,7 @@ export const useBridgeConditions = ({
       WidgetEvent.PageEntered,
       handleResetPrivateSwapSelectedForPageEntered,
     );
+    widgetEvents.on(WidgetEvent.FormFieldChanged, handleToAddressChange);
 
     return () => {
       widgetEvents.off(WidgetEvent.RouteSelected, handleSelectedRoute);
@@ -78,6 +89,8 @@ export const useBridgeConditions = ({
         WidgetEvent.PageEntered,
         handleResetPrivateSwapSelectedForPageEntered,
       );
+
+      widgetEvents.off(WidgetEvent.FormFieldChanged, handleToAddressChange);
     };
   }, [widgetEvents]);
 
@@ -130,6 +143,8 @@ export const useBridgeConditions = ({
     destinationChainTokenParam.chainId,
     destinationChainTokenParam.token,
     isConnectedAGW,
+    isPrivateSwapSelected,
+    toAddress,
   ]);
 
   useEffect(() => {

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -370,6 +370,15 @@ interface Resources {
           title: 'Validation failed';
         };
       };
+      privateSwap: {
+        addressPlaceholder: 'Recipient address';
+        confirm: 'Confirm';
+        disclaimer1: "The address is correct and not an exchange wallet. Tokens sent to the wrong address can't be retrieved.";
+        disclaimer2: "This transaction is fulfilled by a centralized provider who might ask for KYC if it's flagged.";
+        paste: 'Paste';
+        subtitle: 'Set recipient address to keep it private.';
+        title: "You're going Incognito";
+      };
     };
     multisig: {
       connected: {

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -674,6 +674,15 @@
         "submit": "Verify wallet and claim perk",
         "submitting": "Waiting for verification"
       }
+    },
+    "privateSwap": {
+      "title": "You're going Incognito",
+      "subtitle": "Set recipient address to keep it private.",
+      "addressPlaceholder": "Recipient address",
+      "confirm": "Confirm",
+      "disclaimer1": "The address is correct and not an exchange wallet. Tokens sent to the wrong address can't be retrieved.",
+      "disclaimer2": "This transaction is fulfilled by a centralized provider who might ask for KYC if it's flagged.",
+      "paste": "Paste"
     }
   },
   "gatekeeper": {

--- a/tests/landingPage.spec.ts
+++ b/tests/landingPage.spec.ts
@@ -12,6 +12,7 @@ test.describe('Landing page and navigation', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
+    await page.waitForLoadState('load');
     await closeWelcomeScreen(page);
   });
 

--- a/tests/testData/landingPageFunctions.ts
+++ b/tests/testData/landingPageFunctions.ts
@@ -4,8 +4,11 @@ import { getElementByText } from './commonFunctions';
 /** Time for MUI Slide exit animation in WelcomeOverlayLayout (slideTimeout) */
 const WELCOME_SLIDE_TIMEOUT_MS = 2000;
 /** Extra time for slow CI: wait for button to appear and for overlay to close */
-const WELCOME_VISIBLE_TIMEOUT_MS = 10_000;
-const WELCOME_CLOSE_TIMEOUT_MS = WELCOME_SLIDE_TIMEOUT_MS + 5_000;
+const WELCOME_VISIBLE_TIMEOUT_MS = 30_000;
+const WELCOME_CLOSE_TIMEOUT_MS = WELCOME_SLIDE_TIMEOUT_MS + 15_000;
+
+/** Selector for the welcome overlay container (overlayClassName in App.tsx) */
+const WELCOME_OVERLAY_SELECTOR = '.welcome-screen-container';
 
 export async function closeWelcomeScreen(page: Page) {
   const getStartedButton = page.getByTestId('get-started-button');
@@ -14,7 +17,7 @@ export async function closeWelcomeScreen(page: Page) {
   });
   await getStartedButton.scrollIntoViewIfNeeded();
   await getStartedButton.click();
-  await expect(getStartedButton).not.toBeVisible({
+  await expect(page.locator(WELCOME_OVERLAY_SELECTOR)).not.toBeVisible({
     timeout: WELCOME_CLOSE_TIMEOUT_MS,
   });
 }

--- a/tests/testData/landingPageFunctions.ts
+++ b/tests/testData/landingPageFunctions.ts
@@ -2,15 +2,20 @@ import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { getElementByText } from './commonFunctions';
 /** Time for MUI Slide exit animation in WelcomeOverlayLayout (slideTimeout) */
-const WELCOME_SLIDE_TIMEOUT_MS = 500;
+const WELCOME_SLIDE_TIMEOUT_MS = 2000;
+/** Extra time for slow CI: wait for button to appear and for overlay to close */
+const WELCOME_VISIBLE_TIMEOUT_MS = 10_000;
+const WELCOME_CLOSE_TIMEOUT_MS = WELCOME_SLIDE_TIMEOUT_MS + 5_000;
 
 export async function closeWelcomeScreen(page: Page) {
   const getStartedButton = page.getByTestId('get-started-button');
-  await expect(getStartedButton).toBeVisible();
+  await expect(getStartedButton).toBeVisible({
+    timeout: WELCOME_VISIBLE_TIMEOUT_MS,
+  });
   await getStartedButton.scrollIntoViewIfNeeded();
   await getStartedButton.click();
   await expect(getStartedButton).not.toBeVisible({
-    timeout: WELCOME_SLIDE_TIMEOUT_MS + 5000,
+    timeout: WELCOME_CLOSE_TIMEOUT_MS,
   });
 }
 export async function itemInMenu(page, option: string) {


### PR DESCRIPTION
Sister PR
https://github.com/jumperexchange/jumper-backend/pull/756

Closes JUM-598
This PR aims at forcing explicit toAddress for Houdini Swaps (with a little modal for better UX)

# Which Jira task belongs to this PR?
Linear : JUM-598

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Private Swap modal for entering a swap address with a clipboard paste quick-fill, two disclosure checkboxes, and confirm gated by validation.
  * Modal adapts to light/dark themes and responsive layouts.

* **Integration**
  * Widget can open and control the Private Swap modal; confirming autofills the destination address and closes the modal.
  * Widget state now reflects a private-swap selection and syncs the destination address.

* **Localization**
  * Added UI text entries for the modal to support translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->