### PR TITLE
chore: add storage keys in the extend theme

### DIFF
--- a/src/app/[lng]/layout.tsx
+++ b/src/app/[lng]/layout.tsx
@@ -125,6 +125,12 @@ export default async function RootLayout({
       style={{ scrollBehavior: 'smooth' }}
     >
       <head>
+        <InitColorSchemeScript
+          attribute="class"
+          defaultMode="system"
+          modeStorageKey={THEME_MODE_STORAGE_KEY}
+          colorSchemeStorageKey={THEME_COLOR_SCHEME_STORAGE_KEY}
+        />
         <meta name="base:app_id" content={appId} />
         <style>
           {`
@@ -154,12 +160,6 @@ export default async function RootLayout({
           {`window._env_ = ${JSON.stringify(getPublicEnvVars())};`}
         </script>
         <link rel="icon" href="/favicon.ico" sizes="any" />
-        <InitColorSchemeScript
-          attribute="class"
-          defaultMode="system"
-          modeStorageKey={THEME_MODE_STORAGE_KEY}
-          colorSchemeStorageKey={THEME_COLOR_SCHEME_STORAGE_KEY}
-        />
         <Script
           strategy="lazyOnload"
           src={`https://www.googletagmanager.com/gtag/js?id=${config.NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID}`}

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -20,6 +20,10 @@ import { createPaletteLight } from './paletteLight';
 import { defaultShape } from './shape';
 import type { ThemeFonts } from './typography';
 import { createTypography, defaultFonts } from './typography';
+import {
+  THEME_MODE_STORAGE_KEY,
+  THEME_COLOR_SCHEME_STORAGE_KEY,
+} from '@/providers/ThemeProvider/constants';
 
 type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
@@ -99,6 +103,8 @@ export const createJumperTheme = (
     typography,
     palette,
     colorSchemes,
+    modeStorageKey: THEME_MODE_STORAGE_KEY,
+    colorSchemeStorageKey: THEME_COLOR_SCHEME_STORAGE_KEY,
   } as Parameters<typeof extendTheme>[0]);
 };
 


### PR DESCRIPTION
# Which Jira task belongs to this PR?
Contributes to https://linear.app/lifi-linear/issue/JUM-608/webapp-and-mobile-theme-flickering-on-page-refresh
Sync storage keys in extend theme

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated color-scheme initialization script to a single, earlier location in page head to avoid duplication.
  * Theme configuration now includes persistent storage keys so chosen theme mode and color scheme are reliably remembered across visits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->