### PR TITLE
fix: add path guard for positions fetching

### DIFF
--- a/src/providers/PortfolioProvider/hooks/usePositionsData.ts
+++ b/src/providers/PortfolioProvider/hooks/usePositionsData.ts
@@ -10,7 +10,7 @@ import type { EVMAccount } from '@lifi/wallet-management';
 import { useAccount } from '@lifi/wallet-management';
 import { usePortfolioCacheStore } from '@/stores/portfolio/PortfolioCacheStore';
 import { usePathnameWithoutLocale } from '@/hooks/routing/usePathnameWithoutLocale';
-import { isAllowedPositionPath } from '../utils';
+import { isCurrentPageUsingPositionData } from '../utils';
 
 export interface UsePositionsDataProps {
   filter?: Omit<PortfolioPositionsQuery, 'evm'>;
@@ -53,7 +53,7 @@ export const usePositionsData = ({
   filter,
 }: UsePositionsDataProps): UsePositionsDataResult => {
   const pathname = usePathnameWithoutLocale();
-  const isPathEnabled = isAllowedPositionPath(pathname);
+  const isEnabled = isCurrentPageUsingPositionData(pathname);
   const { accounts } = useAccount();
   const connectedAccounts = useMemo(
     () =>
@@ -93,7 +93,7 @@ export const usePositionsData = ({
         });
         return { ...result.data, address };
       },
-      enabled: !!address && isPathEnabled,
+      enabled: !!address && isEnabled,
       refetchInterval: ONE_HOUR_MS,
       placeholderData: shouldUseCache
         ? (): QueryData | undefined => {

--- a/src/providers/PortfolioProvider/hooks/usePositionsData.ts
+++ b/src/providers/PortfolioProvider/hooks/usePositionsData.ts
@@ -9,6 +9,8 @@ import type { DefiPosition } from '@/utils/positions/type-guards';
 import type { EVMAccount } from '@lifi/wallet-management';
 import { useAccount } from '@lifi/wallet-management';
 import { usePortfolioCacheStore } from '@/stores/portfolio/PortfolioCacheStore';
+import { usePathnameWithoutLocale } from '@/hooks/routing/usePathnameWithoutLocale';
+import { isAllowedPositionPath } from '../utils';
 
 export interface UsePositionsDataProps {
   filter?: Omit<PortfolioPositionsQuery, 'evm'>;
@@ -50,6 +52,8 @@ interface QueryData {
 export const usePositionsData = ({
   filter,
 }: UsePositionsDataProps): UsePositionsDataResult => {
+  const pathname = usePathnameWithoutLocale();
+  const isPathEnabled = isAllowedPositionPath(pathname);
   const { accounts } = useAccount();
   const connectedAccounts = useMemo(
     () =>
@@ -89,7 +93,7 @@ export const usePositionsData = ({
         });
         return { ...result.data, address };
       },
-      enabled: !!address,
+      enabled: !!address && isPathEnabled,
       refetchInterval: ONE_HOUR_MS,
       placeholderData: shouldUseCache
         ? (): QueryData | undefined => {

--- a/src/providers/PortfolioProvider/utils.ts
+++ b/src/providers/PortfolioProvider/utils.ts
@@ -24,6 +24,7 @@ import type {
 } from './types';
 import type { ExtendedChain } from '@lifi/sdk';
 import { uniqBy } from 'lodash';
+import { AppPaths } from '@/const/urls';
 
 type GetPrice = (chainId: number, address: string) => number | undefined;
 
@@ -291,3 +292,6 @@ export const positionAccessors = {
     return `${p.protocol.name}-unknown`;
   },
 };
+
+export const isAllowedPositionPath = (pathname: string) =>
+  [AppPaths.Portfolio].some((allowedPath) => pathname.startsWith(allowedPath));

--- a/src/providers/PortfolioProvider/utils.ts
+++ b/src/providers/PortfolioProvider/utils.ts
@@ -294,4 +294,7 @@ export const positionAccessors = {
 };
 
 export const isAllowedPositionPath = (pathname: string) =>
-  [AppPaths.Portfolio].some((allowedPath) => pathname.startsWith(allowedPath));
+  [AppPaths.Portfolio].some(
+    (allowedPath) =>
+      pathname === allowedPath || pathname.startsWith(allowedPath + '/'),
+  );

--- a/src/providers/PortfolioProvider/utils.ts
+++ b/src/providers/PortfolioProvider/utils.ts
@@ -293,7 +293,7 @@ export const positionAccessors = {
   },
 };
 
-export const isAllowedPositionPath = (pathname: string) =>
+export const isCurrentPageUsingPositionData = (pathname: string) =>
   [AppPaths.Portfolio].some(
     (allowedPath) =>
       pathname === allowedPath || pathname.startsWith(allowedPath + '/'),


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-618/disable-positions-query-when-not-on-portfolio-page

## Testing steps
1. Go to `/`
2. Open the network tab and filter for `/positions`
3. Connect your wallet
4. Check no call to `/positions` endpoint is made
5. Open the wallet management drawer
6. Check again no call to `/positions` endpoint is made
7. Now go to `/portfolio`
8. Check a call to `/positions` is indeed made
9. Now disconnect your wallet
10. Refresh the page
11. Check no call to `/positions` endpoint is made
12. Connect your wallet
13. Call to `/positions` endpoint is made

# Why did I implement it this way?

In order to decrease the number of requests made to `/positions` endpoint, we're going to fetch this data only upon navigating to `/portfolio`. If we'll need this data elsewhere in the future we might change this condition

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Portfolio position queries are now limited to portfolio routes, so address-based position lookups only run when viewing portfolio-related pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->