### PR TITLE
fix: position balance for non-evm address

### DIFF
--- a/src/components/EarnDetails/EarnDetailsActions.tsx
+++ b/src/components/EarnDetails/EarnDetailsActions.tsx
@@ -1,10 +1,8 @@
-import { useAccount } from '@lifi/wallet-management';
 import Typography from '@mui/material/Typography';
 import { useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import type { EarnOpportunityExtended } from 'src/stores/depositFlow/DepositFlowStore';
 import type { Hex } from 'viem';
-import { useAccountAddress } from '@/hooks/earn/useAccountAddress';
 import { useIsEarnUIFeatureDisabled } from '@/hooks/earn/useDisabledEarnUIFeatures';
 import { usePortfolioDeFiPositions } from '@/hooks/portfolio/usePortfolioDeFiPositions';
 import { useGetZapInPoolBalance } from '@/hooks/zaps/useGetZapInPoolBalance';
@@ -22,6 +20,7 @@ import {
   EarnDetailsActionsContainer,
 } from './EarnDetails.styles';
 import { EarnDetailsActionsPosition } from './EarnDetailsActionsPosition';
+import { useChainTypeData } from '@/hooks/chains/useChainTypeData';
 
 interface EarnDetailsActionsProps {
   earnOpportunity: EarnOpportunityExtended;
@@ -31,10 +30,9 @@ export const EarnDetailsActions = ({
   earnOpportunity,
 }: EarnDetailsActionsProps) => {
   const { t } = useTranslation();
-  const { account } = useAccount();
-  const accountAddress = useAccountAddress();
-
-  const isConnected = !!account?.address;
+  const { account, isAccountConnected: isConnected } = useChainTypeData(
+    earnOpportunity.lpToken.chain.chainId,
+  );
 
   const {
     isDisabled: isDepositFeatureDisabled,
@@ -56,7 +54,7 @@ export const EarnDetailsActions = ({
     isLoading: isLoadingPositions,
     refetch: refetchPositions,
   } = usePortfolioDeFiPositions({
-    addresses: accountAddress ? [accountAddress] : [],
+    accounts: account ? [account] : [],
     filter: {
       earn: earnOpportunity.slug,
     },
@@ -67,7 +65,7 @@ export const EarnDetailsActions = ({
     refetchDepositToken: refetchDepositAmount,
     isLoadingDepositTokenData: isLoadingDepositTokenData,
   } = useGetZapInPoolBalance(
-    accountAddress,
+    account?.address,
     earnOpportunity.lpToken.address as Hex,
     earnOpportunity.lpToken.chain.chainId,
   );

--- a/src/hooks/portfolio/usePortfolioDeFiPositions.ts
+++ b/src/hooks/portfolio/usePortfolioDeFiPositions.ts
@@ -10,9 +10,11 @@ import type { DefiPosition } from '@/utils/positions/type-guards';
 import type { GetTokenUSDPrice } from '@/utils/positions/update-price';
 import { updateWalletPositionsPrice } from '@/utils/positions/update-price';
 import { useTokens } from '../useTokens';
+import type { Account } from '@lifi/wallet-management';
+import { ChainType } from '@lifi/sdk';
 
 export interface Props {
-  addresses: Hex[];
+  accounts: Account[];
   filter?: Omit<PortfolioPositionsQuery, 'evm'>;
 }
 
@@ -25,7 +27,7 @@ export interface Result {
 }
 
 export const usePortfolioDeFiPositions = ({
-  addresses,
+  accounts,
   filter,
 }: Props): Result => {
   const { getToken, isLoading: isLoadingTokens, updatedAt } = useTokens();
@@ -59,17 +61,27 @@ export const usePortfolioDeFiPositions = ({
   );
 
   const queries = useQueries({
-    queries: addresses.map((address) => ({
-      queryKey: ['portfolio-defi-positions', address, filter, updatedAt],
+    queries: accounts.map((account) => ({
+      queryKey: [
+        'portfolio-defi-positions',
+        account.address,
+        filter,
+        updatedAt,
+      ],
       queryFn: async () => {
+        // @TODO JUM-624 handle svm address as query param
+        if (account.chainType !== ChainType.EVM) {
+          return;
+        }
+
         const result = await getPositionsForAddress({
-          evm: address,
+          evm: account.address as Hex,
           ...filter,
         });
         const positions = result.data;
         return updateWalletPositionsPrice(positions, getTokenUSDPrice);
       },
-      enabled: !!address && !isLoadingTokens,
+      enabled: !!account.address && account.isConnected && !isLoadingTokens,
       refetchInterval: ONE_HOUR_MS,
     })),
   });

--- a/src/hooks/zaps/useGetZapInPoolBalance.ts
+++ b/src/hooks/zaps/useGetZapInPoolBalance.ts
@@ -1,64 +1,133 @@
 import { useMemo } from 'react';
 import { useReadContracts } from 'wagmi';
-import type { Hex } from 'viem';
+import { useQuery } from '@tanstack/react-query';
+import { getToken, getTokenBalances } from '@lifi/sdk';
+import { type Hex, type Address, isAddress } from 'viem';
+
+const BALANCE_OF_ABI = [
+  {
+    inputs: [{ name: 'owner', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const;
+
+const DECIMALS_ABI = [
+  {
+    inputs: [],
+    name: 'decimals',
+    outputs: [{ name: '', type: 'uint8' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const;
+
+export const tokenBalanceQueryKeys = {
+  all: ['tokenBalance'] as const,
+  lifi: (chainId: number, tokenAddress: string, walletAddress: string) =>
+    [
+      ...tokenBalanceQueryKeys.all,
+      'lifi',
+      chainId,
+      tokenAddress,
+      walletAddress,
+    ] as const,
+} as const;
+
+interface TokenBalanceResult {
+  depositTokenData: bigint | number | undefined;
+  depositTokenDecimals: bigint | number | undefined;
+  isLoadingDepositTokenData: boolean;
+  refetchDepositToken: () => void;
+}
 
 export const useGetZapInPoolBalance = (
-  walletAddress: Hex | undefined,
+  walletAddress: string | undefined,
   tokenAddress: Hex,
   chainId: number,
-) => {
-  const contractsConfig = useMemo(() => {
-    return [
+): TokenBalanceResult => {
+  const isEvmWallet = !!walletAddress && isAddress(walletAddress);
+  const isNonEvmWallet = !!walletAddress && !isEvmWallet;
+
+  const contractsConfig = useMemo(
+    () => [
       {
-        abi: [
-          {
-            inputs: [{ name: 'owner', type: 'address' }],
-            name: 'balanceOf',
-            outputs: [{ name: '', type: 'uint256' }],
-            stateMutability: 'view',
-            type: 'function',
-          },
-        ] as const,
+        abi: BALANCE_OF_ABI,
         address: tokenAddress,
         chainId,
-        functionName: 'balanceOf',
-        args: [walletAddress],
+        functionName: 'balanceOf' as const,
+        args: [walletAddress as Address],
       },
       {
-        abi: [
-          {
-            inputs: [],
-            name: 'decimals',
-            outputs: [{ name: '', type: 'uint8' }],
-            stateMutability: 'view',
-            type: 'function',
-          },
-        ] as const,
+        abi: DECIMALS_ABI,
         address: tokenAddress,
-        chainId: chainId,
-        functionName: 'decimals',
+        chainId,
+        functionName: 'decimals' as const,
       },
-    ];
-  }, [walletAddress, tokenAddress, chainId]);
+    ],
+    [walletAddress, tokenAddress, chainId],
+  );
 
   const {
-    data: [
-      { result: depositTokenData } = {},
-      { result: depositTokenDecimals } = {},
-    ] = [],
-    isLoading: isLoadingDepositTokenData,
-    refetch: refetchDepositToken,
+    data: evmData,
+    isLoading: isEvmLoading,
+    refetch: refetchEvm,
   } = useReadContracts({
     contracts: contractsConfig,
-    query: {
-      enabled: !!walletAddress,
-    },
+    query: { enabled: isEvmWallet },
   });
 
-  return {
-    depositTokenData,
-    depositTokenDecimals,
-    isLoadingDepositTokenData,
-    refetchDepositToken,
-  };
+  const {
+    data: lifiData,
+    isLoading: isLifiLoading,
+    refetch: refetchLifi,
+  } = useQuery({
+    queryKey: tokenBalanceQueryKeys.lifi(
+      chainId,
+      tokenAddress,
+      walletAddress ?? '',
+    ),
+    queryFn: async () => {
+      const token = await getToken(chainId, tokenAddress);
+      const [balance] = await getTokenBalances(walletAddress!, [token]);
+      return balance ?? null;
+    },
+    enabled: isNonEvmWallet,
+    staleTime: 30_000,
+    gcTime: 60_000,
+  });
+
+  return useMemo<TokenBalanceResult>(() => {
+    if (isEvmWallet) {
+      const [
+        { result: depositTokenData } = {},
+        { result: depositTokenDecimals } = {},
+      ] = evmData ?? [];
+
+      return {
+        depositTokenData,
+        depositTokenDecimals,
+        isLoadingDepositTokenData: isEvmLoading,
+        refetchDepositToken: refetchEvm,
+      };
+    }
+
+    return {
+      depositTokenData:
+        lifiData?.amount !== undefined ? BigInt(lifiData.amount) : undefined,
+      depositTokenDecimals: lifiData?.decimals,
+      isLoadingDepositTokenData: isLifiLoading,
+      refetchDepositToken: refetchLifi,
+    };
+  }, [
+    isEvmWallet,
+    evmData,
+    isEvmLoading,
+    refetchEvm,
+    lifiData,
+    isLifiLoading,
+    refetchLifi,
+  ]);
 };


### PR DESCRIPTION
# Which Jira task belongs to this PR?

https://linear.app/lifi-linear/issue/JUM-579/earn-position-are-showing-0-in-the-earn-page-despite-having-value-in

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for non-EVM blockchain networks in wallet connectivity and portfolio tracking.

* **Improvements**
  * Enhanced multi-chain awareness for wallet account data retrieval and synchronization.
  * Improved token balance fetching with support for both EVM and non-EVM wallet types.
  * Optimized portfolio position data handling across different blockchain networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->