### PR TITLE
fix: wrap scan and campaign pages content with suspense for not found

### DIFF
--- a/src/app/[lng]/campaign/[slug]/layout.tsx
+++ b/src/app/[lng]/campaign/[slug]/layout.tsx
@@ -1,23 +1,5 @@
-import type { Metadata } from 'next';
 import type { PropsWithChildren } from 'react';
 import { Layout } from 'src/Layout';
-
-type Params = Promise<{ slug: string }>;
-
-export async function generateMetadata({
-  params,
-}: {
-  params: Params;
-}): Promise<Metadata> {
-  const { slug } = await params;
-
-  return {
-    title: `Jumper Campaign - ${slug}`, // Example: Dynamic title
-    other: {
-      'partner-theme': slug,
-    },
-  };
-}
 
 export default async function CampaignLayout({ children }: PropsWithChildren) {
   return <Layout>{children}</Layout>;

--- a/src/app/[lng]/campaign/[slug]/page.tsx
+++ b/src/app/[lng]/campaign/[slug]/page.tsx
@@ -1,13 +1,11 @@
+import { getCampaigns } from '@/app/lib/getCampaigns';
 import type { Metadata } from 'next';
-import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
-import { getCampaigns } from 'src/app/lib/getCampaigns';
 import { getCampaignBySlug } from 'src/app/lib/getCampaignsBySlug';
 import { siteName } from 'src/app/lib/metadata';
-import { CampaignPage } from 'src/components/Campaign/CampaignPage';
+import { CampaignPage } from '@/components/Campaign/CampaignPage';
 import { CampaignPageSkeleton } from 'src/components/Campaign/CampaignPageSkeleton';
 import { getSiteUrl } from 'src/const/urls';
-import { fetchQuestOpportunitiesByRewardsIds } from 'src/utils/merkl/fetchQuestOpportunities';
 import { sliceStrToXChar } from 'src/utils/splitStringToXChar';
 
 // Add generateStaticParams function
@@ -31,7 +29,7 @@ export async function generateMetadata({
   params,
 }: {
   params: Promise<{ slug: string }>;
-}): Promise<Metadata> {
+}) {
   const { slug } = await params;
 
   try {
@@ -57,11 +55,14 @@ export async function generateMetadata({
       alternates: {
         canonical: `${getSiteUrl()}/campaign/${slug}`,
       },
+      other: {
+        'partner-theme': slug,
+      },
       twitter: openGraph,
       openGraph,
     };
   } catch (err) {
-    notFound();
+    return {};
   }
 }
 
@@ -69,19 +70,10 @@ type Params = Promise<{ slug: string }>;
 
 export default async function Page({ params }: { params: Params }) {
   const { slug } = await params;
-  const campaign = await getCampaignBySlug(slug);
-
-  if (!campaign || !campaign.data || campaign.data.length === 0) {
-    notFound();
-  }
-
-  const extendedQuests = await fetchQuestOpportunitiesByRewardsIds(
-    campaign.data[0].quests,
-  );
 
   return (
     <Suspense fallback={<CampaignPageSkeleton />}>
-      <CampaignPage campaign={campaign.data[0]} quests={extendedQuests} />
+      <CampaignPage slug={slug} />
     </Suspense>
   );
 }

--- a/src/app/[lng]/scan/[[...segments]]/page.tsx
+++ b/src/app/[lng]/scan/[[...segments]]/page.tsx
@@ -3,7 +3,7 @@ import ScanPage from '@/app/ui/scan/ScanPage';
 import { getSiteUrl } from '@/const/urls';
 import { scanParamsSchema } from '@/utils/validation-schemas';
 import type { Metadata } from 'next';
-import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
 
 type MetadataParams = Promise<{ segments: string[] }>;
 
@@ -76,12 +76,10 @@ export default async function Page({
   params: Params;
 }) {
   const { lng, segments } = await params;
-  // Validate segments
-  const result = scanParamsSchema.safeParse({ segments: segments });
 
-  if (!result.success) {
-    return notFound();
-  }
-
-  return <ScanPage lng={lng} />;
+  return (
+    <Suspense>
+      <ScanPage lng={lng} segments={segments} />
+    </Suspense>
+  );
 }

--- a/src/app/ui/scan/ScanPage.tsx
+++ b/src/app/ui/scan/ScanPage.tsx
@@ -1,88 +1,18 @@
-'use client';
+import { scanParamsSchema } from '@/utils/validation-schemas';
+import { notFound } from 'next/navigation';
+import ScanPageContent from './ScanPageContent';
 
-import { ClientOnly } from '@/components/ClientOnly';
-import config from '@/config/env-config';
-import { JUMPER_SCAN_PATH } from '@/const/urls';
-import getApiUrl from '@/utils/getApiUrl';
-import { LiFiExplorer, type LiFiExplorerConfig } from '@lifi/explorer';
-import Box from '@mui/material/Box';
-import { useTheme } from '@mui/material/styles';
-import { useMemo, useRef } from 'react';
-import { getSurfaceBorder } from '@/theme/utils/getSurfaceBorder';
-import { usePathname } from 'next/navigation';
+interface ScanPageProps {
+  lng: string;
+  segments: string[];
+}
 
-export default function ScanPage({ lng }: { lng: string }) {
-  const theme = useTheme();
-  const pathname = usePathname();
-  const basePath = pathname.split(JUMPER_SCAN_PATH)[0];
+export default function ScanPage({ lng, segments }: ScanPageProps) {
+  const result = scanParamsSchema.safeParse({ segments });
 
-  const defaultSuccessPalette = useMemo(
-    () => ({
-      success: {
-        main: '#d6ffe7',
-        dark: '#00b849',
-      },
-      warning: {
-        main: '#FFCC00',
-        dark: '#000000',
-      },
-    }),
-    [],
-  );
-  const configRef = useRef<LiFiExplorerConfig | null>(null);
-  if (!configRef.current) {
-    configRef.current = {
-      apiUrl: getApiUrl(),
-      // appearance: 'light' as PaletteMode, // This controls light and dark mode
-      integrator: config.NEXT_PUBLIC_WIDGET_INTEGRATOR, // TODO: change as needed
-      base: `${basePath}${JUMPER_SCAN_PATH}`, // Important for the routing and having everything served under /scan. Do not remove!
-      theme: {
-        // These colors and values correspond to the figma design
-        shape: {
-          borderRadiusSecondary: (theme.vars || theme).shape
-            .scanBorderRadiusSecondary,
-          borderRadiusTertiary: (theme.vars || theme).shape
-            .scanBorderRadiusTertiary,
-          borderRadius: (theme.vars || theme).shape.scanBorderRadius,
-        },
-        colorSchemes: {
-          light: {
-            palette: {
-              ...theme.colorSchemes.light?.palette,
-              ...defaultSuccessPalette,
-            },
-          },
-          dark: {
-            palette: {
-              ...theme.colorSchemes.dark?.palette,
-              ...defaultSuccessPalette,
-            },
-          },
-        },
-      },
-    } as LiFiExplorerConfig;
+  if (!result.success) {
+    notFound();
   }
 
-  return (
-    <ClientOnly>
-      <Box
-        sx={{
-          p: 4,
-          paddingBottom: {
-            xs: 12,
-            md: 8,
-          },
-          '& .MuiPaper-root': {
-            backgroundImage: 'none',
-            border: getSurfaceBorder(theme, 'surface2'),
-          },
-          '& .MuiList-root > .MuiGrid-root.MuiGrid-container': {
-            border: getSurfaceBorder(theme, 'surface1'),
-          },
-        }}
-      >
-        <LiFiExplorer config={configRef.current} />
-      </Box>
-    </ClientOnly>
-  );
+  return <ScanPageContent lng={lng} />;
 }

--- a/src/app/ui/scan/ScanPageContent.tsx
+++ b/src/app/ui/scan/ScanPageContent.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { ClientOnly } from '@/components/ClientOnly';
+import config from '@/config/env-config';
+import { JUMPER_SCAN_PATH } from '@/const/urls';
+import getApiUrl from '@/utils/getApiUrl';
+import { LiFiExplorer, type LiFiExplorerConfig } from '@lifi/explorer';
+import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
+import { useMemo, useRef } from 'react';
+import { getSurfaceBorder } from '@/theme/utils/getSurfaceBorder';
+import { usePathname } from 'next/navigation';
+
+export default function ScanPageContent({ lng }: { lng: string }) {
+  const theme = useTheme();
+  const pathname = usePathname();
+  const basePath = pathname.split(JUMPER_SCAN_PATH)[0];
+
+  const defaultSuccessPalette = useMemo(
+    () => ({
+      success: {
+        main: '#d6ffe7',
+        dark: '#00b849',
+      },
+      warning: {
+        main: '#FFCC00',
+        dark: '#000000',
+      },
+    }),
+    [],
+  );
+  const configRef = useRef<LiFiExplorerConfig | null>(null);
+  if (!configRef.current) {
+    configRef.current = {
+      apiUrl: getApiUrl(),
+      // appearance: 'light' as PaletteMode, // This controls light and dark mode
+      integrator: config.NEXT_PUBLIC_WIDGET_INTEGRATOR, // TODO: change as needed
+      base: `${basePath}${JUMPER_SCAN_PATH}`, // Important for the routing and having everything served under /scan. Do not remove!
+      theme: {
+        // These colors and values correspond to the figma design
+        shape: {
+          borderRadiusSecondary: (theme.vars || theme).shape
+            .scanBorderRadiusSecondary,
+          borderRadiusTertiary: (theme.vars || theme).shape
+            .scanBorderRadiusTertiary,
+          borderRadius: (theme.vars || theme).shape.scanBorderRadius,
+        },
+        colorSchemes: {
+          light: {
+            palette: {
+              ...theme.colorSchemes.light?.palette,
+              ...defaultSuccessPalette,
+            },
+          },
+          dark: {
+            palette: {
+              ...theme.colorSchemes.dark?.palette,
+              ...defaultSuccessPalette,
+            },
+          },
+        },
+      },
+    } as LiFiExplorerConfig;
+  }
+
+  return (
+    <ClientOnly>
+      <Box
+        sx={{
+          p: 4,
+          paddingBottom: {
+            xs: 12,
+            md: 8,
+          },
+          '& .MuiPaper-root': {
+            backgroundImage: 'none',
+            border: getSurfaceBorder(theme, 'surface2'),
+          },
+          '& .MuiList-root > .MuiGrid-root.MuiGrid-container': {
+            border: getSurfaceBorder(theme, 'surface1'),
+          },
+        }}
+      >
+        <LiFiExplorer config={configRef.current} />
+      </Box>
+    </ClientOnly>
+  );
+}

--- a/src/components/Campaign/CampaignPage.tsx
+++ b/src/components/Campaign/CampaignPage.tsx
@@ -1,28 +1,24 @@
-import { QuestDataExtended } from 'src/types/merkl';
-import { CampaignData } from 'src/types/strapi';
-import { CampaignHero } from './CampaignHero/CampaignHero';
-import { MissionsSection } from './MissionsSection/MissionsSection';
-import { MissionsList } from './MissionsSection/MissionsList';
-import { GridContainer } from '../Containers/GridContainer';
-import { PageContainer } from '../Containers/PageContainer';
+import { notFound } from 'next/navigation';
+import { getCampaignBySlug } from 'src/app/lib/getCampaignsBySlug';
+import { fetchQuestOpportunitiesByRewardsIds } from 'src/utils/merkl/fetchQuestOpportunities';
+import { CampaignPageContent } from './CampaignPageContent';
 
 interface CampaignPageProps {
-  campaign: CampaignData;
-  quests: QuestDataExtended[];
+  slug: string;
 }
 
-export const CampaignPage = ({ campaign, quests }: CampaignPageProps) => {
-  return (
-    <PageContainer>
-      <CampaignHero campaign={campaign} />
+export async function CampaignPage({ slug }: CampaignPageProps) {
+  const campaign = await getCampaignBySlug(slug);
 
-      {!!quests.length && (
-        <MissionsSection>
-          <GridContainer>
-            <MissionsList missions={quests} />
-          </GridContainer>
-        </MissionsSection>
-      )}
-    </PageContainer>
+  if (!campaign || !campaign.data || campaign.data.length === 0) {
+    notFound();
+  }
+
+  const extendedQuests = await fetchQuestOpportunitiesByRewardsIds(
+    campaign.data[0].quests,
   );
-};
+
+  return (
+    <CampaignPageContent campaign={campaign.data[0]} quests={extendedQuests} />
+  );
+}

--- a/src/components/Campaign/CampaignPageContent.tsx
+++ b/src/components/Campaign/CampaignPageContent.tsx
@@ -1,0 +1,31 @@
+import type { QuestDataExtended } from 'src/types/merkl';
+import type { CampaignData } from 'src/types/strapi';
+import { CampaignHero } from './CampaignHero/CampaignHero';
+import { MissionsSection } from './MissionsSection/MissionsSection';
+import { MissionsList } from './MissionsSection/MissionsList';
+import { GridContainer } from '../Containers/GridContainer';
+import { PageContainer } from '../Containers/PageContainer';
+
+interface CampaignPageContentProps {
+  campaign: CampaignData;
+  quests: QuestDataExtended[];
+}
+
+export const CampaignPageContent = ({
+  campaign,
+  quests,
+}: CampaignPageContentProps) => {
+  return (
+    <PageContainer>
+      <CampaignHero campaign={campaign} />
+
+      {!!quests.length && (
+        <MissionsSection>
+          <GridContainer>
+            <MissionsList missions={quests} />
+          </GridContainer>
+        </MissionsSection>
+      )}
+    </PageContainer>
+  );
+};


### PR DESCRIPTION
# Which Jira task belongs to this PR?
https://linear.app/lifi-linear/issue/JUM-605/blank-page-is-shown-when-a-user-enters-random-text-into-scan-url 

## Testing steps
1. Try to open `/campaign/123456abcd`
2. The not found page should be rendered
3. Try to open `/scan/1234`
4. Again the  not found page should be rendered
5. Try to open an invalid tx under `/scan/tx/invalid-tx-here`
6. Of course try opening some existing txs or campaigns - the correct content should be rendered

# Why did I implement it this way?

Couldn't find the exact docs that specify we need to wrap the page content with suspense for the `notFound()` call to properly work and not just throw the `NEXT_HTTP_ERROR_FALLBACK` as per https://nextjs.org/docs/app/api-reference/functions/not-found#notfound - but seems this approach helped solve the issue on these pages

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Campaign pages now use static generation for faster loads and more consistent performance.
  * Metadata generation is more resilient and fails gracefully when campaign data is unavailable.

* **New Features**
  * Scan experience updated: lazy-loading improves perceived load time and input validation provides clearer 404 handling.
  * A refreshed in-page scan explorer UI delivers an embedded, themed scanning experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->