### PR TITLE
feat: blog article popup and content scroll track

### DIFF
--- a/src/app/ui/newsletter/NewsletterPage.style.ts
+++ b/src/app/ui/newsletter/NewsletterPage.style.ts
@@ -36,75 +36,92 @@ export const NewsletterForm = styled(Box)(({ theme }) => ({
 }));
 
 export const NewsletterFormGroup = styled(FormGroup, {
-  shouldForwardProp: (prop) => prop !== 'error' && prop !== 'disabled',
-})<{ error?: boolean; disabled?: boolean }>(({ theme }) => ({
-  width: '100%',
-  boxShadow: theme.shadows[2],
-  verticalAlign: 'middle',
-  padding: theme.spacing(0.5, 0.5, 0.5, 2),
-  border: `1px solid`,
-  transition: 'border-color 0.2s ease-in-out',
-  borderRadius: theme.shape.buttonBorderRadius,
-  backgroundColor: (theme.vars || theme).palette.alphaLight100.main,
-  display: 'flex',
-  flexDirection: 'row',
-  flexWrap: 'nowrap',
-  ...theme.applyStyles?.('light', {
-    backgroundColor: (theme.vars || theme).palette.surface1.main,
-    border: getSurfaceBorder(theme, 'surface1'),
-  }),
-  '.MuiInputBase-root': {
-    ':before, :after': {
-      display: 'none',
-    },
-  },
-  '& input': {
-    ...theme.typography.bodyMedium,
-  },
-  '& input::placeholder': {
-    opacity: 1,
-    ...theme.typography.bodyMedium,
-    color: (theme.vars || theme).palette.textHint,
-  },
-  '& input:disabled': {
-    pointerEvents: 'none',
-    '&::placeholder': {
-      color: (theme.vars || theme).palette.textDisabled,
-    },
-  },
-  variants: [
-    {
-      props: { error: true },
-      style: {
-        borderColor: (theme.vars || theme).palette.borderError,
+  shouldForwardProp: (prop) =>
+    prop !== 'error' && prop !== 'disabled' && prop !== 'layout',
+})<{ error?: boolean; disabled?: boolean; layout?: 'inline' | 'stacked' }>(
+  ({ theme }) => ({
+    width: '100%',
+    boxShadow: theme.shadows[2],
+    verticalAlign: 'middle',
+    padding: theme.spacing(0.5, 0.5, 0.5, 2),
+    border: `1px solid`,
+    transition: 'border-color 0.2s ease-in-out',
+    borderRadius: theme.shape.buttonBorderRadius,
+    backgroundColor: (theme.vars || theme).palette.alphaLight100.main,
+    display: 'flex',
+    flexDirection: 'row',
+    flexWrap: 'nowrap',
+    alignItems: 'center',
+    ...theme.applyStyles?.('light', {
+      backgroundColor: (theme.vars || theme).palette.surface1.main,
+      border: getSurfaceBorder(theme, 'surface1'),
+    }),
+    '.MuiInputBase-root': {
+      ':before, :after': {
+        display: 'none',
       },
     },
-    {
-      props: { error: false },
-      style: {
-        borderColor: (theme.vars || theme).palette.grey[100],
-        '&:hover, &:active, &:focus, &:focus-visible, &:focus-within': {
-          borderColor: (theme.vars || theme).palette.borderActive,
+    '& input': {
+      ...theme.typography.bodyMedium,
+    },
+    '& input::placeholder': {
+      opacity: 1,
+      ...theme.typography.bodyMedium,
+      color: (theme.vars || theme).palette.textHint,
+    },
+    '& input:disabled': {
+      pointerEvents: 'none',
+      '&::placeholder': {
+        color: (theme.vars || theme).palette.textDisabled,
+      },
+    },
+    variants: [
+      {
+        props: { error: true },
+        style: {
+          borderColor: (theme.vars || theme).palette.borderError,
         },
       },
-    },
-    {
-      props: { disabled: true },
-      style: {
-        '&, &:hover, &:active, &:focus, &:focus-visible, &:focus-within': {
+      {
+        props: { error: false },
+        style: {
           borderColor: (theme.vars || theme).palette.grey[100],
-          backgroundColor: (theme.vars || theme).palette.buttonDisabledBg,
+          '&:hover, &:active, &:focus, &:focus-visible, &:focus-within': {
+            borderColor: (theme.vars || theme).palette.borderActive,
+          },
         },
       },
-    },
-  ],
-}));
+      {
+        props: { disabled: true },
+        style: {
+          '&, &:hover, &:active, &:focus, &:focus-visible, &:focus-within': {
+            borderColor: (theme.vars || theme).palette.grey[100],
+            backgroundColor: (theme.vars || theme).palette.buttonDisabledBg,
+          },
+        },
+      },
+      {
+        props: { layout: 'stacked' },
+        style: {
+          padding: theme.spacing(1.25, 2),
+          '& .MuiInputBase-root': {
+            width: '100%',
+          },
+        },
+      },
+    ],
+  }),
+);
 
 export const NewsletterFormButton = styled(ButtonPrimary)(({ theme }) => ({
   '&.MuiButtonBase-root.MuiButton-root': {
     ...theme.typography.bodySmallStrong,
     minWidth: 'fit-content',
     padding: theme.spacing(1.375, 2),
+    '&.MuiButton-fullWidth': {
+      minWidth: 'unset',
+      width: '100%',
+    },
     backgroundColor: (theme.vars || theme).palette.buttonPrimaryBg,
     color: (theme.vars || theme).palette.buttonPrimaryAction,
     '&:disabled': {

--- a/src/app/ui/newsletter/NewsletterSubscribeForm.tsx
+++ b/src/app/ui/newsletter/NewsletterSubscribeForm.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { TrackingAction, TrackingCategory } from '@/const/trackingKeys';
+import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
+import { useNewsletterSubscribe } from '@/hooks/useNewsletterSubscribe';
+import { useMenuStore } from '@/stores/menu';
+import { AppPaths, TERMS_CONDITIONS_URL } from '@/const/urls';
+import Input from '@mui/material/Input';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import type { FC } from 'react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next/TransWithoutContext';
+import {
+  NewsletterErrorMessage,
+  NewsletterForm,
+  NewsletterFormButton,
+  NewsletterFormGroup,
+  NewsletterLink,
+} from './NewsletterPage.style';
+import { getValidationSchema } from './utils';
+
+export type NewsletterSubscribeFormLayout = 'inline' | 'stacked';
+
+export interface NewsletterSubscribeFormProps {
+  utmCampaign?: string;
+  layout?: NewsletterSubscribeFormLayout;
+}
+
+export const NewsletterSubscribeForm: FC<NewsletterSubscribeFormProps> = ({
+  utmCampaign = 'newsletter-page',
+  layout = 'inline',
+}) => {
+  const { t } = useTranslation();
+  const { trackEvent } = useUserTracking();
+  const [email, setEmail] = useState<string>('');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const setSnackbarState = useMenuStore((state) => state.setSnackbarState);
+  const { mutate, isPending, isSuccess } = useNewsletterSubscribe();
+  const isStacked = layout === 'stacked';
+
+  useEffect(() => {
+    if (!isSuccess) {
+      return;
+    }
+    setEmail('');
+    setSnackbarState(true, t('newsletter.welcome.pending'), 'success');
+  }, [isSuccess, setSnackbarState, t]);
+
+  const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(event.target.value);
+    setErrorMessage(null);
+  };
+
+  const handleSubscribe = (event: React.FormEvent<HTMLDivElement>) => {
+    event.preventDefault();
+
+    const form = event.currentTarget as unknown as HTMLFormElement;
+    const formData = new FormData(form);
+    const values = Object.fromEntries(formData.entries());
+    const validationSchema = getValidationSchema(t);
+    const result = validationSchema.safeParse(values);
+    if (!result.success) {
+      setErrorMessage(
+        result.error.issues[0]?.message ||
+          t('newsletter.welcome.error.unknown'),
+      );
+      return;
+    }
+    trackEvent({
+      category: TrackingCategory.Newsletter,
+      action: TrackingAction.SubscribeToNewsletter,
+      label: `${utmCampaign}-open`,
+    });
+    mutate(
+      {
+        email: result.data.email,
+        utmSource: 'jumper-exchange',
+        utmMedium: 'website',
+        utmCampaign,
+        referringSite: window.location.href,
+      },
+      {
+        onError: (error) => {
+          setErrorMessage(error.message);
+        },
+      },
+    );
+  };
+
+  const emailField = (
+    <Input
+      name="email"
+      id="newsletter-subscribe-email"
+      placeholder={t('newsletter.welcome.emailPlaceholder')}
+      fullWidth
+      value={email}
+      disabled={isPending}
+      onChange={handleEmailChange}
+    />
+  );
+
+  const submitButton = (
+    <NewsletterFormButton
+      type="submit"
+      disabled={!email || isPending}
+      fullWidth={isStacked}
+      loading={isPending}
+      loadingPosition="start"
+    >
+      {t('newsletter.welcome.subscribe')}
+    </NewsletterFormButton>
+  );
+
+  const termsConditions = (
+    <Typography
+      variant="bodyXSmall"
+      color="text.secondary"
+      sx={{
+        maxWidth: isStacked ? '100%' : 402,
+        textAlign: 'left',
+      }}
+    >
+      <Trans
+        i18nKey={'newsletter.welcome.hint'}
+        components={[
+          <NewsletterLink
+            href={TERMS_CONDITIONS_URL}
+            target="_blank"
+            rel="noreferrer"
+          />,
+          <NewsletterLink
+            href={AppPaths.PrivacyPolicy}
+            target="_blank"
+            rel="noreferrer"
+          />,
+        ]}
+      />
+    </Typography>
+  );
+
+  return (
+    <>
+      <NewsletterForm
+        as="form"
+        onSubmit={handleSubscribe}
+        sx={isStacked ? { maxWidth: '100%' } : undefined}
+      >
+        {isStacked ? (
+          <Stack spacing={2} sx={{ width: '100%' }}>
+            <NewsletterFormGroup
+              error={!!errorMessage}
+              disabled={isPending}
+              layout="stacked"
+            >
+              {emailField}
+            </NewsletterFormGroup>
+            {errorMessage && (
+              <NewsletterErrorMessage variant="bodyMedium" sx={{ mt: 0 }}>
+                {errorMessage}
+              </NewsletterErrorMessage>
+            )}
+
+            {submitButton}
+
+            {termsConditions}
+          </Stack>
+        ) : (
+          <>
+            <NewsletterFormGroup error={!!errorMessage} disabled={isPending}>
+              {emailField}
+
+              {submitButton}
+            </NewsletterFormGroup>
+            {errorMessage && (
+              <NewsletterErrorMessage variant="bodyMedium">
+                {errorMessage}
+              </NewsletterErrorMessage>
+            )}
+          </>
+        )}
+      </NewsletterForm>
+      {!isStacked && termsConditions}
+    </>
+  );
+};

--- a/src/app/ui/newsletter/NewsletterSubscribeForm.tsx
+++ b/src/app/ui/newsletter/NewsletterSubscribeForm.tsx
@@ -95,6 +95,11 @@ export const NewsletterSubscribeForm: FC<NewsletterSubscribeFormProps> = ({
       id="newsletter-subscribe-email"
       placeholder={t('newsletter.welcome.emailPlaceholder')}
       fullWidth
+      type="email"
+      autoComplete="email"
+      inputProps={{
+        'aria-label': t('newsletter.welcome.emailPlaceholder'),
+      }}
       value={email}
       disabled={isPending}
       onChange={handleEmailChange}

--- a/src/app/ui/newsletter/NewsletterWelcomeScreen.tsx
+++ b/src/app/ui/newsletter/NewsletterWelcomeScreen.tsx
@@ -1,32 +1,21 @@
 'use client';
 
 import { CustomColor } from '@/components/CustomColorTypography.style';
-import { TrackingAction, TrackingCategory } from '@/const/trackingKeys';
-import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
-import type { FC } from 'react';
-import { useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { Trans } from 'react-i18next/TransWithoutContext';
 import {
   ContentWrapper,
   WelcomeContent,
   WelcomeScreenSubtitle,
 } from '@/components/WelcomeScreen/WelcomeScreen.style';
-import { AppPaths, TERMS_CONDITIONS_URL } from '@/const/urls';
-import Typography from '@mui/material/Typography';
-import {
-  NewsletterErrorMessage,
-  NewsletterLink,
-  NewsletterWelcomeContentContainer,
-  NewsletterFormGroup,
-  NewsletterWelcomeContentTitleContainer,
-  NewsletterForm,
-  NewsletterFormButton,
-} from './NewsletterPage.style';
-import { useNewsletterSubscribe } from '@/hooks/useNewsletterSubscribe';
-import Input from '@mui/material/Input';
-import { getValidationSchema } from './utils';
 import { useMenuStore } from '@/stores/menu';
+import type { FC } from 'react';
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next/TransWithoutContext';
+import {
+  NewsletterWelcomeContentContainer,
+  NewsletterWelcomeContentTitleContainer,
+} from './NewsletterPage.style';
+import { NewsletterSubscribeForm } from './NewsletterSubscribeForm';
 
 interface NewsletterWelcomeScreenProps {
   confirmSubscription?: boolean;
@@ -36,11 +25,7 @@ export const NewsletterWelcomeScreen: FC<NewsletterWelcomeScreenProps> = ({
   confirmSubscription = false,
 }) => {
   const { t } = useTranslation();
-  const { trackEvent } = useUserTracking();
-  const [email, setEmail] = useState<string>('');
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const setSnackbarState = useMenuStore((state) => state.setSnackbarState);
-  const { mutate, isPending, isSuccess } = useNewsletterSubscribe();
 
   useEffect(() => {
     if (!confirmSubscription) {
@@ -48,55 +33,6 @@ export const NewsletterWelcomeScreen: FC<NewsletterWelcomeScreenProps> = ({
     }
     setSnackbarState(true, t('newsletter.welcome.success'), 'success');
   }, [confirmSubscription, setSnackbarState, t]);
-
-  useEffect(() => {
-    if (!isSuccess) {
-      return;
-    }
-    setEmail('');
-    setSnackbarState(true, t('newsletter.welcome.pending'), 'success');
-  }, [isSuccess, setSnackbarState, t]);
-
-  const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setEmail(event.target.value);
-    setErrorMessage(null);
-  };
-
-  const handleSubscribe = (event: React.FormEvent<HTMLDivElement>) => {
-    event.preventDefault();
-
-    const form = event.currentTarget as unknown as HTMLFormElement;
-    const formData = new FormData(form);
-    const values = Object.fromEntries(formData.entries());
-    const validationSchema = getValidationSchema(t);
-    const result = validationSchema.safeParse(values);
-    if (!result.success) {
-      setErrorMessage(
-        result.error.issues[0]?.message ||
-          t('newsletter.welcome.error.unknown'),
-      );
-      return;
-    }
-    trackEvent({
-      category: TrackingCategory.Newsletter,
-      action: TrackingAction.SubscribeToNewsletter,
-      label: 'newsletter-page-open',
-    });
-    mutate(
-      {
-        email: result.data.email,
-        utmSource: 'jumper-exchange',
-        utmMedium: 'website',
-        utmCampaign: 'newsletter-page',
-        referringSite: window.location.href,
-      },
-      {
-        onError: (error) => {
-          setErrorMessage(error.message);
-        },
-      },
-    );
-  };
 
   return (
     <ContentWrapper>
@@ -110,53 +46,7 @@ export const NewsletterWelcomeScreen: FC<NewsletterWelcomeScreenProps> = ({
               <Trans i18nKey={'newsletter.welcome.subtitle'} />
             </WelcomeScreenSubtitle>
           </NewsletterWelcomeContentTitleContainer>
-          <NewsletterForm as="form" onSubmit={handleSubscribe}>
-            <NewsletterFormGroup error={!!errorMessage} disabled={isPending}>
-              <Input
-                name="email"
-                id="email"
-                placeholder={t('newsletter.welcome.emailPlaceholder')}
-                fullWidth
-                value={email}
-                disabled={isPending}
-                onChange={handleEmailChange}
-              />
-              <NewsletterFormButton
-                type="submit"
-                disabled={!email || isPending}
-                loading={isPending}
-                loadingPosition="start"
-              >
-                {t('newsletter.welcome.subscribe')}
-              </NewsletterFormButton>
-            </NewsletterFormGroup>
-            {errorMessage && (
-              <NewsletterErrorMessage variant="bodyMedium">
-                {errorMessage}
-              </NewsletterErrorMessage>
-            )}
-          </NewsletterForm>
-          <Typography
-            variant="bodyXSmall"
-            color="text.secondary"
-            sx={{ maxWidth: 402, textAlign: 'left' }}
-          >
-            <Trans
-              i18nKey={'newsletter.welcome.hint'}
-              components={[
-                <NewsletterLink
-                  href={TERMS_CONDITIONS_URL}
-                  target="_blank"
-                  rel="noreferrer"
-                />,
-                <NewsletterLink
-                  href={AppPaths.PrivacyPolicy}
-                  target="_blank"
-                  rel="noreferrer"
-                />,
-              ]}
-            />
-          </Typography>
+          <NewsletterSubscribeForm />
         </NewsletterWelcomeContentContainer>
       </WelcomeContent>
     </ContentWrapper>

--- a/src/components/Blog/BlogArticle/BlogArticle.tsx
+++ b/src/components/Blog/BlogArticle/BlogArticle.tsx
@@ -107,6 +107,7 @@ export const BlogArticle = ({ article }: BlogArticleProps) => {
           description: popup.Message,
           ctaLink: popup.CTALink,
           cta: popup.CTA,
+          isNewsletterSubscription: !!popup.IsNewsletterSubscription,
         });
       }
     },

--- a/src/components/Blog/BlogArticle/BlogArticle.tsx
+++ b/src/components/Blog/BlogArticle/BlogArticle.tsx
@@ -42,6 +42,7 @@ import {
 } from '@/const/trackingKeys';
 import { buildArticleSchema } from '@/utils/articles/buildArticleSchema';
 import Script from 'next/script';
+import { useBlogArticleTracking } from '@/hooks/userTracking/useBlogArticleTracking';
 
 const BlogArticleModal = dynamic(
   () => import('./BlogArticleModal').then((mod) => mod.BlogArticleModal),
@@ -71,7 +72,6 @@ export const BlogArticle = ({ article }: BlogArticleProps) => {
     author,
     publishedAt,
     createdAt,
-    updatedAt,
     tags,
     Image: image,
     faq_items,
@@ -80,6 +80,7 @@ export const BlogArticle = ({ article }: BlogArticleProps) => {
   const baseUrl = getStrapiBaseUrl();
   const minRead = readingTime(wordCount);
   const { t } = useTranslation();
+  const { trackBlogArticleOpenPopupEvent } = useBlogArticleTracking();
 
   const [isModalOpen, openModal] = useBlogArticleStore((s) => [
     s.isModalOpen,
@@ -99,6 +100,8 @@ export const BlogArticle = ({ article }: BlogArticleProps) => {
       }
 
       if (scrollProgress >= SCROLL_PROGRESS_OPEN_POPUP && !isModalOpen) {
+        trackBlogArticleOpenPopupEvent(id, title, popup.Title);
+
         openModal(documentId, {
           title: popup.Title,
           description: popup.Message,
@@ -107,14 +110,22 @@ export const BlogArticle = ({ article }: BlogArticleProps) => {
         });
       }
     },
-    [documentId, popup, isModalOpen, openModal],
+    [
+      documentId,
+      popup,
+      id,
+      title,
+      isModalOpen,
+      openModal,
+      trackBlogArticleOpenPopupEvent,
+    ],
   );
 
   const blogArticleSchema = buildArticleSchema(article);
 
   return (
     <>
-      {isModalOpen && <BlogArticleModal />}
+      {isModalOpen && <BlogArticleModal articleId={id} articleTitle={title} />}
       <BlogArticleContainer>
         <BlogArticleContentContainer sx={{ marginTop: 0 }}>
           <BlogArticleTopHeader>

--- a/src/components/Blog/BlogArticle/BlogArticle.tsx
+++ b/src/components/Blog/BlogArticle/BlogArticle.tsx
@@ -31,6 +31,8 @@ import { RichBlocksVariant } from '@/components/RichBlocks/types';
 import { BlogArticleAuthor } from './BlogArticleAuthor';
 import { WithSkeleton } from './WithSkeleton';
 import { AccordionFAQ } from '@/components/AccordionFAQ';
+import { ScrollProgress } from './ScrollProgress';
+import { useCallback } from 'react';
 import {
   TrackingCategory,
   TrackingAction,
@@ -43,6 +45,8 @@ interface BlogArticleProps {
   article: BlogArticleData;
   id?: number;
 }
+
+const IMAGE_HEIGHT = 640;
 
 export const BlogArticle = ({ article }: BlogArticleProps) => {
   const theme = useTheme();
@@ -66,6 +70,10 @@ export const BlogArticle = ({ article }: BlogArticleProps) => {
   const { t } = useTranslation();
 
   const mainTag = tags?.[0];
+
+  const handleScroll = useCallback((scrollProgress: number) => {
+    console.log(scrollProgress);
+  }, []);
 
   const blogArticleSchema = buildArticleSchema(article);
 
@@ -144,39 +152,46 @@ export const BlogArticle = ({ article }: BlogArticleProps) => {
             alt={image?.alternativeText ?? title}
             priority
             width={1200}
-            height={640}
+            height={IMAGE_HEIGHT}
           />
         </WithSkeleton>
       </BlogArticleImageContainer>
 
       <BlogArticleContainer>
         <BlogArticleContentContainer>
-          <WithSkeleton
-            show={!!content}
-            skeleton={<BlogArticleContentSkeleton variant="text" />}
+          <ScrollProgress
+            // @TODO enable this with JUM-640
+            // showProgress
+            onScroll={handleScroll}
+            topOffset={image ? `-${IMAGE_HEIGHT / 2}px` : 0}
           >
-            <RichBlocks
-              content={content!}
-              variant={RichBlocksVariant.BlogArticle}
-              blockSx={{
-                paragraph: (theme) => ({
-                  ...theme.typography.bodyLargeParagraph,
-                  fontWeight: 400,
-                }),
-              }}
-              trackingKeys={{
-                cta: {
-                  category: TrackingCategory.BlogArticle,
-                  action: TrackingAction.ClickBlogCTA,
-                  label: 'click-blog-cta',
-                  data: {
-                    [TrackingEventParameter.ArticleID]: String(id || ''),
-                    [TrackingEventParameter.ArticleTitle]: title || '',
+            <WithSkeleton
+              show={!!content}
+              skeleton={<BlogArticleContentSkeleton variant="text" />}
+            >
+              <RichBlocks
+                content={content!}
+                variant={RichBlocksVariant.BlogArticle}
+                blockSx={{
+                  paragraph: (theme) => ({
+                    ...theme.typography.bodyLargeParagraph,
+                    fontWeight: 400,
+                  }),
+                }}
+                trackingKeys={{
+                  cta: {
+                    category: TrackingCategory.BlogArticle,
+                    action: TrackingAction.ClickBlogCTA,
+                    label: 'click-blog-cta',
+                    data: {
+                      [TrackingEventParameter.ArticleID]: String(id || ''),
+                      [TrackingEventParameter.ArticleTitle]: title || '',
+                    },
                   },
-                },
-              }}
-            />
-          </WithSkeleton>
+                }}
+              />
+            </WithSkeleton>
+          </ScrollProgress>
           {faq_items?.length > 0 && (
             <AccordionFAQ
               accordionHeader={

--- a/src/components/Blog/BlogArticle/BlogArticle.tsx
+++ b/src/components/Blog/BlogArticle/BlogArticle.tsx
@@ -33,6 +33,8 @@ import { WithSkeleton } from './WithSkeleton';
 import { AccordionFAQ } from '@/components/AccordionFAQ';
 import { ScrollProgress } from './ScrollProgress';
 import { useCallback } from 'react';
+import { useBlogArticleStore } from '@/stores/learn/BlogArticleStore';
+import dynamic from 'next/dynamic';
 import {
   TrackingCategory,
   TrackingAction,
@@ -41,16 +43,26 @@ import {
 import { buildArticleSchema } from '@/utils/articles/buildArticleSchema';
 import Script from 'next/script';
 
+const BlogArticleModal = dynamic(
+  () => import('./BlogArticleModal').then((mod) => mod.BlogArticleModal),
+  {
+    ssr: false,
+  },
+);
+
 interface BlogArticleProps {
   article: BlogArticleData;
   id?: number;
 }
 
 const IMAGE_HEIGHT = 640;
+const SCROLL_PROGRESS_OPEN_POPUP = 0.3;
 
 export const BlogArticle = ({ article }: BlogArticleProps) => {
   const theme = useTheme();
   const {
+    id,
+    documentId,
     Subtitle: subtitle,
     Title: title,
     Content: content,
@@ -63,22 +75,46 @@ export const BlogArticle = ({ article }: BlogArticleProps) => {
     tags,
     Image: image,
     faq_items,
+    popup,
   } = article;
   const baseUrl = getStrapiBaseUrl();
-  const id = article.id;
   const minRead = readingTime(wordCount);
   const { t } = useTranslation();
 
+  const [isModalOpen, openModal] = useBlogArticleStore((s) => [
+    s.isModalOpen,
+    s.openModal,
+  ]);
+
+  const shouldOpenModal = useBlogArticleStore((s) =>
+    s.shouldOpenModalForArticle(documentId),
+  );
+
   const mainTag = tags?.[0];
 
-  const handleScroll = useCallback((scrollProgress: number) => {
-    console.log(scrollProgress);
-  }, []);
+  const handleScroll = useCallback(
+    (scrollProgress: number) => {
+      if (!popup) {
+        return;
+      }
+
+      if (scrollProgress >= SCROLL_PROGRESS_OPEN_POPUP && !isModalOpen) {
+        openModal(documentId, {
+          title: popup.Title,
+          description: popup.Message,
+          ctaLink: popup.CTALink,
+          cta: popup.CTA,
+        });
+      }
+    },
+    [documentId, popup, isModalOpen, openModal],
+  );
 
   const blogArticleSchema = buildArticleSchema(article);
 
   return (
     <>
+      {isModalOpen && <BlogArticleModal />}
       <BlogArticleContainer>
         <BlogArticleContentContainer sx={{ marginTop: 0 }}>
           <BlogArticleTopHeader>
@@ -162,7 +198,7 @@ export const BlogArticle = ({ article }: BlogArticleProps) => {
           <ScrollProgress
             // @TODO enable this with JUM-640
             // showProgress
-            onScroll={handleScroll}
+            onScroll={shouldOpenModal ? handleScroll : undefined}
             topOffset={image ? `-${IMAGE_HEIGHT / 2}px` : 0}
           >
             <WithSkeleton

--- a/src/components/Blog/BlogArticle/BlogArticleModal.tsx
+++ b/src/components/Blog/BlogArticle/BlogArticleModal.tsx
@@ -1,13 +1,25 @@
+import { NewsletterSubscribeForm } from '@/app/ui/newsletter/NewsletterSubscribeForm';
 import { SectionCardContainer } from '@/components/Cards/SectionCard/SectionCard.style';
 import { Button } from '@/components/core/buttons/Button/Button';
 import { Variant } from '@/components/core/buttons/types';
 import { ModalContainer } from '@/components/core/modals/ModalContainer/ModalContainer';
 import { ExternalLink } from '@/components/Link/ExternalLink';
+import { useBlogArticleTracking } from '@/hooks/userTracking/useBlogArticleTracking';
 import { useBlogArticleStore } from '@/stores/learn/BlogArticleStore';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+import type { FC } from 'react';
 
-export const BlogArticleModal = () => {
+interface BlogArticleModalProps {
+  articleId: number;
+  articleTitle: string;
+}
+
+export const BlogArticleModal: FC<BlogArticleModalProps> = ({
+  articleId,
+  articleTitle,
+}) => {
+  const { trackBlogArticleClosePopupEvent } = useBlogArticleTracking();
   const [isModalOpen, modalContent, closeModal] = useBlogArticleStore((s) => [
     s.isModalOpen,
     s.modalContent,
@@ -15,9 +27,17 @@ export const BlogArticleModal = () => {
   ]);
 
   const handleClick = () => {
-    // @Note: add tracking here
+    trackBlogArticleClosePopupEvent(
+      articleId,
+      articleTitle,
+      modalContent?.title,
+    );
+
     closeModal();
   };
+
+  // @Note: add prop in Strapi
+  const isSubscribeModal = !modalContent?.ctaLink || !modalContent?.cta;
 
   return (
     isModalOpen &&
@@ -25,6 +45,7 @@ export const BlogArticleModal = () => {
       <ModalContainer isOpen={isModalOpen} onClose={closeModal}>
         <SectionCardContainer
           sx={(theme) => ({
+            position: 'relative',
             maxHeight: 'calc(100vh - 6rem)',
             minWidth: '100%',
             maxWidth: 400,
@@ -35,9 +56,9 @@ export const BlogArticleModal = () => {
           })}
         >
           <Stack spacing={3}>
-            <Stack spacing={0.5}>
+            <Stack spacing={1}>
               {modalContent.title && (
-                <Typography variant="titleSmall">
+                <Typography variant="urbanistTitleMedium">
                   {modalContent.title}
                 </Typography>
               )}
@@ -45,15 +66,19 @@ export const BlogArticleModal = () => {
                 {modalContent.description}
               </Typography>
             </Stack>
-            <Button
-              variant={Variant.Primary}
-              fullWidth
-              href={modalContent.ctaLink}
-              component={modalContent.ctaLink ? ExternalLink : undefined}
-              onClick={handleClick}
-            >
-              {modalContent.cta ?? 'Close'}
-            </Button>
+            {isSubscribeModal ? (
+              <NewsletterSubscribeForm utmCampaign="blog-article" />
+            ) : (
+              <Button
+                variant={Variant.Primary}
+                fullWidth
+                href={modalContent.ctaLink}
+                component={modalContent.ctaLink ? ExternalLink : undefined}
+                onClick={handleClick}
+              >
+                {modalContent.cta}
+              </Button>
+            )}
           </Stack>
         </SectionCardContainer>
       </ModalContainer>

--- a/src/components/Blog/BlogArticle/BlogArticleModal.tsx
+++ b/src/components/Blog/BlogArticle/BlogArticleModal.tsx
@@ -1,0 +1,62 @@
+import { SectionCardContainer } from '@/components/Cards/SectionCard/SectionCard.style';
+import { Button } from '@/components/core/buttons/Button/Button';
+import { Variant } from '@/components/core/buttons/types';
+import { ModalContainer } from '@/components/core/modals/ModalContainer/ModalContainer';
+import { ExternalLink } from '@/components/Link/ExternalLink';
+import { useBlogArticleStore } from '@/stores/learn/BlogArticleStore';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+export const BlogArticleModal = () => {
+  const [isModalOpen, modalContent, closeModal] = useBlogArticleStore((s) => [
+    s.isModalOpen,
+    s.modalContent,
+    s.closeModal,
+  ]);
+
+  const handleClick = () => {
+    // @Note: add tracking here
+    closeModal();
+  };
+
+  return (
+    isModalOpen &&
+    modalContent && (
+      <ModalContainer isOpen={isModalOpen} onClose={closeModal}>
+        <SectionCardContainer
+          sx={(theme) => ({
+            maxHeight: 'calc(100vh - 6rem)',
+            minWidth: '100%',
+            maxWidth: 400,
+            borderRadius: `${theme.shape.cardBorderRadiusLarge}px`,
+            [theme.breakpoints.up('sm')]: {
+              minWidth: 400,
+            },
+          })}
+        >
+          <Stack spacing={3}>
+            <Stack spacing={0.5}>
+              {modalContent.title && (
+                <Typography variant="titleSmall">
+                  {modalContent.title}
+                </Typography>
+              )}
+              <Typography variant="bodyMediumParagraph">
+                {modalContent.description}
+              </Typography>
+            </Stack>
+            <Button
+              variant={Variant.Primary}
+              fullWidth
+              href={modalContent.ctaLink}
+              component={modalContent.ctaLink ? ExternalLink : undefined}
+              onClick={handleClick}
+            >
+              {modalContent.cta ?? 'Close'}
+            </Button>
+          </Stack>
+        </SectionCardContainer>
+      </ModalContainer>
+    )
+  );
+};

--- a/src/components/Blog/BlogArticle/BlogArticleModal.tsx
+++ b/src/components/Blog/BlogArticle/BlogArticleModal.tsx
@@ -9,6 +9,7 @@ import { useBlogArticleStore } from '@/stores/learn/BlogArticleStore';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface BlogArticleModalProps {
   articleId: number;
@@ -19,6 +20,7 @@ export const BlogArticleModal: FC<BlogArticleModalProps> = ({
   articleId,
   articleTitle,
 }) => {
+  const { t } = useTranslation();
   const { trackBlogArticleClosePopupEvent } = useBlogArticleTracking();
   const [isModalOpen, modalContent, closeModal] = useBlogArticleStore((s) => [
     s.isModalOpen,
@@ -35,9 +37,6 @@ export const BlogArticleModal: FC<BlogArticleModalProps> = ({
 
     closeModal();
   };
-
-  // @Note: add prop in Strapi
-  const isSubscribeModal = !modalContent?.ctaLink || !modalContent?.cta;
 
   return (
     isModalOpen &&
@@ -66,7 +65,7 @@ export const BlogArticleModal: FC<BlogArticleModalProps> = ({
                 {modalContent.description}
               </Typography>
             </Stack>
-            {isSubscribeModal ? (
+            {modalContent.isNewsletterSubscription ? (
               <NewsletterSubscribeForm utmCampaign="blog-article" />
             ) : (
               <Button
@@ -76,7 +75,7 @@ export const BlogArticleModal: FC<BlogArticleModalProps> = ({
                 component={modalContent.ctaLink ? ExternalLink : undefined}
                 onClick={handleClick}
               >
-                {modalContent.cta}
+                {modalContent.cta ?? t('buttons.close')}
               </Button>
             )}
           </Stack>

--- a/src/components/Blog/BlogArticle/ScrollProgress.tsx
+++ b/src/components/Blog/BlogArticle/ScrollProgress.tsx
@@ -1,0 +1,53 @@
+import { useTheme } from '@mui/material/styles';
+import type { UseScrollOptions } from 'motion/react';
+import { motion, useMotionValueEvent, useScroll } from 'motion/react';
+import type { FC, PropsWithChildren } from 'react';
+import { useRef } from 'react';
+
+type OffsetPoint = NonNullable<UseScrollOptions['offset']>[number];
+
+interface ScrollProgressProps extends PropsWithChildren {
+  topOffset?: OffsetPoint;
+  showProgress?: boolean;
+  onScroll?: (value: number) => void;
+}
+
+export const ScrollProgress: FC<ScrollProgressProps> = ({
+  children,
+  topOffset,
+  showProgress,
+  onScroll,
+}) => {
+  const theme = useTheme();
+  const contentRef = useRef(null);
+
+  const { scrollYProgress } = useScroll({
+    target: contentRef,
+    offset: [topOffset ?? 'start start', 'end end'],
+  });
+
+  useMotionValueEvent(scrollYProgress, 'change', (latest) => {
+    onScroll?.(latest);
+  });
+
+  return (
+    <div ref={contentRef}>
+      {showProgress && (
+        <motion.div
+          style={{
+            scaleX: scrollYProgress,
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 10,
+            originX: 0,
+            background: (theme.vars || theme).palette.primary.main,
+            zIndex: 1000,
+          }}
+        />
+      )}
+      {children}
+    </div>
+  );
+};

--- a/src/const/trackingKeys.ts
+++ b/src/const/trackingKeys.ts
@@ -121,6 +121,8 @@ export enum TrackingAction {
   ClickShareArticleLink = 'action_share_article_link',
   ClickAuthorsLinkedIn = 'action_click_author_linkedin',
   ClickAuthorsX = 'action_click_author_x',
+  OpenArticlePopup = 'action_open_article_popup',
+  CloseArticlePopup = 'action_close_article_popup',
 
   // Quests
   ClickQuestCard = 'action_click_quest_card',
@@ -304,6 +306,7 @@ export enum TrackingEventParameter {
   SwipeDirection = 'param_swipe_direction',
   ArticleTitle = 'param_article_title',
   ArticleID = 'param_article_id',
+  ArticlePopupTitle = 'param_article_popup_title',
 
   // Pagination
   Pagination = 'param_pagination',

--- a/src/hooks/userTracking/useBlogArticleTracking.ts
+++ b/src/hooks/userTracking/useBlogArticleTracking.ts
@@ -1,0 +1,48 @@
+import { useCallback } from 'react';
+import { useUserTracking } from './useUserTracking';
+import {
+  TrackingCategory,
+  TrackingAction,
+  TrackingEventParameter,
+} from '@/const/trackingKeys';
+
+export const useBlogArticleTracking = () => {
+  const { trackEvent } = useUserTracking();
+
+  const trackBlogArticleOpenPopupEvent = useCallback(
+    (articleId: number, articleTitle: string, popupTitle?: string) => {
+      trackEvent({
+        category: TrackingCategory.BlogArticle,
+        action: TrackingAction.OpenArticlePopup,
+        label: `blog-article-popup`,
+        data: {
+          [TrackingEventParameter.ArticleID]: articleId.toString(),
+          [TrackingEventParameter.ArticleTitle]: articleTitle,
+          [TrackingEventParameter.ArticlePopupTitle]: popupTitle || '',
+        },
+      });
+    },
+    [trackEvent],
+  );
+
+  const trackBlogArticleClosePopupEvent = useCallback(
+    (articleId: number, articleTitle: string, popupTitle?: string) => {
+      trackEvent({
+        category: TrackingCategory.BlogArticle,
+        action: TrackingAction.CloseArticlePopup,
+        label: `blog-article-popup`,
+        data: {
+          [TrackingEventParameter.ArticleID]: articleId.toString(),
+          [TrackingEventParameter.ArticleTitle]: articleTitle,
+          [TrackingEventParameter.ArticlePopupTitle]: popupTitle || '',
+        },
+      });
+    },
+    [trackEvent],
+  );
+
+  return {
+    trackBlogArticleOpenPopupEvent,
+    trackBlogArticleClosePopupEvent,
+  };
+};

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -61,6 +61,7 @@ interface Resources {
       okay: 'Okay';
     };
     buttons: {
+      close: 'Close';
       deposit: 'Deposit';
       depositButtonLabel: 'Quick deposit';
       depositNow: 'Deposit now';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -724,7 +724,8 @@
     "deposit": "Deposit",
     "depositNow": "Deposit now",
     "requestWithdraw": "Request withdraw",
-    "withdraw": "Withdraw"
+    "withdraw": "Withdraw",
+    "close": "Close"
   },
   "form": {
     "labels": {

--- a/src/stores/learn/BlogArticleStore.ts
+++ b/src/stores/learn/BlogArticleStore.ts
@@ -36,13 +36,13 @@ export const useBlogArticleStore = createWithEqualityFn(
       },
 
       openModal: (articleId: string, modalContent: ModalContent) => {
+        const currentIds = get().modalShownForArticlesIds ?? [];
         set({
           isModalOpen: true,
           modalContent,
-          modalShownForArticlesIds: [
-            ...(get().modalShownForArticlesIds ?? []),
-            articleId,
-          ],
+          modalShownForArticlesIds: currentIds.includes(articleId)
+            ? currentIds
+            : [...currentIds, articleId],
         });
       },
 

--- a/src/stores/learn/BlogArticleStore.ts
+++ b/src/stores/learn/BlogArticleStore.ts
@@ -1,0 +1,61 @@
+import { shallow } from 'zustand/shallow';
+import { createWithEqualityFn } from 'zustand/traditional';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+interface ModalContent {
+  title?: string;
+  description: string;
+  cta?: string;
+  ctaLink?: string;
+}
+
+interface BlogArticleState {
+  modalContent?: ModalContent;
+  modalShownForArticlesIds: string[];
+  isModalOpen: boolean;
+  shouldOpenModalForArticle: (articleId: string) => boolean;
+  openModal: (articleId: string, modalContent: ModalContent) => void;
+  closeModal: () => void;
+}
+
+export const useBlogArticleStore = createWithEqualityFn(
+  persist<BlogArticleState>(
+    (set, get) => ({
+      modalContent: undefined,
+      isModalOpen: false,
+      modalShownForArticlesIds: [],
+
+      shouldOpenModalForArticle: (articleId: string) => {
+        const modalShownForArticlesIds = get().modalShownForArticlesIds ?? [];
+        return !modalShownForArticlesIds.includes(articleId);
+      },
+
+      openModal: (articleId: string, modalContent: ModalContent) => {
+        set({
+          isModalOpen: true,
+          modalContent,
+          modalShownForArticlesIds: [
+            ...(get().modalShownForArticlesIds ?? []),
+            articleId,
+          ],
+        });
+      },
+
+      closeModal: () => {
+        set({
+          isModalOpen: false,
+          modalContent: undefined,
+        });
+      },
+    }),
+    {
+      name: 'blog-article-storage',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) =>
+        ({
+          modalShownForArticlesIds: state.modalShownForArticlesIds,
+        }) as unknown as BlogArticleState,
+    },
+  ),
+  shallow,
+);

--- a/src/stores/learn/BlogArticleStore.ts
+++ b/src/stores/learn/BlogArticleStore.ts
@@ -7,6 +7,7 @@ interface ModalContent {
   description: string;
   cta?: string;
   ctaLink?: string;
+  isNewsletterSubscription: boolean;
 }
 
 interface BlogArticleState {

--- a/src/stores/learn/BlogArticleStore.ts
+++ b/src/stores/learn/BlogArticleStore.ts
@@ -1,6 +1,10 @@
 import { shallow } from 'zustand/shallow';
 import { createWithEqualityFn } from 'zustand/traditional';
-import { persist, createJSONStorage } from 'zustand/middleware';
+import { persist } from 'zustand/middleware';
+import superjson from 'superjson';
+
+const getLocalStorage = () =>
+  typeof window === 'undefined' ? undefined : localStorage;
 
 interface ModalContent {
   title?: string;
@@ -50,8 +54,19 @@ export const useBlogArticleStore = createWithEqualityFn(
       },
     }),
     {
-      name: 'blog-article-storage',
-      storage: createJSONStorage(() => localStorage),
+      name: 'blog-article-store',
+      storage: {
+        getItem: (name) => {
+          const str = getLocalStorage()?.getItem(name);
+          return str ? superjson.parse(str) : null;
+        },
+        setItem: (name, value) => {
+          getLocalStorage()?.setItem(name, superjson.stringify(value));
+        },
+        removeItem: (name) => {
+          getLocalStorage()?.removeItem(name);
+        },
+      },
       partialize: (state) =>
         ({
           modalShownForArticlesIds: state.modalShownForArticlesIds,

--- a/src/stores/learn/BlogArticleStore.ts
+++ b/src/stores/learn/BlogArticleStore.ts
@@ -58,7 +58,15 @@ export const useBlogArticleStore = createWithEqualityFn(
       storage: {
         getItem: (name) => {
           const str = getLocalStorage()?.getItem(name);
-          return str ? superjson.parse(str) : null;
+          if (!str) {
+            return null;
+          }
+          try {
+            return superjson.parse(str);
+          } catch {
+            getLocalStorage()?.removeItem(name);
+            return null;
+          }
         },
         setItem: (name, value) => {
           getLocalStorage()?.setItem(name, superjson.stringify(value));

--- a/src/types/strapi.ts
+++ b/src/types/strapi.ts
@@ -218,6 +218,7 @@ export interface BlogArticlePopupAttributes {
   Message: string;
   CTA: string;
   CTALink?: string;
+  IsNewsletterSubscription?: boolean;
 }
 
 export interface SeoAttributes {

--- a/src/types/strapi.ts
+++ b/src/types/strapi.ts
@@ -207,6 +207,19 @@ export interface AvatarData extends StrapiMediaAttributes {
   // attributes: StrapiMediaAttributes;
 }
 
+export interface BlogArticlePopupData extends BlogArticlePopupAttributes {
+  id: number;
+  documentId: string;
+  // attributes: BlogArticleAttributes;
+}
+
+export interface BlogArticlePopupAttributes {
+  Title?: string;
+  Message: string;
+  CTA: string;
+  CTALink?: string;
+}
+
 export interface SeoAttributes {
   metaTitle: string;
   metaDescription: string;
@@ -249,6 +262,7 @@ export interface BlogArticleAttributes {
   tags: TagAttributes[];
   author: AuthorData;
   faq_items: FaqMeta[];
+  popup?: BlogArticlePopupData;
   publishedAt?: string;
   locale: string;
   RedirectURL?: string;

--- a/src/utils/strapi/StrapiApi.ts
+++ b/src/utils/strapi/StrapiApi.ts
@@ -124,6 +124,7 @@ class ArticleParams {
     'tags',
     'author.Avatar',
     'faq_items',
+    'popup',
     'seo',
     'seo.metaImage',
     'seo.openGraph',
@@ -487,7 +488,10 @@ class ArticleStrapiApi extends StrapiApi {
   } = {}) {
     super({ contentType: 'blog-articles' }); // Set content type to "blog-articles" automatically
     const articleParams = new ArticleParams(this.apiUrl);
-    this.apiUrl = articleParams.addParams({ includeFields, excludeFields });
+    this.apiUrl = articleParams.addParams({
+      includeFields,
+      excludeFields,
+    });
   }
 
   sort(order: SortOrder): this {


### PR DESCRIPTION
# Which Jira task belongs to this PR?

https://linear.app/lifi-linear/issue/JUM-633/p1-learn-details-page-newsletter-subscription

Sister PRs 

- https://github.com/jumperexchange/strapi-cms/pull/103
- https://github.com/jumperexchange/strapi-cms/pull/104

## Testing steps
1. Go to `/learn/3-reasons-bitcoin-altcoins-crashing`
2. Scroll past 1/3 of the article content (progress bar will follow up in a different PR)
3. Check the popup content is just showing the title, description and a button
4. Click on the button (should only close the popup)
5. Refresh the page
6. Scroll again past 1/3 of the article content
7. The popup should no longer show up
8. Go to `/learn/3-reasons-bitcoin-altcoins-crashing-ioana`
9. Scroll past 1/3 of the article content
10. Check the popup content is for the newsletter subscription
11. Go to `/learn/3-reasons-bitcoin-altcoins-crashing-link`
12. Scroll past 1/3 of the article content
13. Check the popup content is just showing the title, description and a button (this time with a link)
14. Click on the link
15. It should open https://jumper.xyz in a new page

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reusable newsletter subscribe form with inline/stacked layouts and modal newsletter option
  * Scroll-driven progress bar and scroll-triggered blog article popups; blog article modal UI
  * Persistent modal store and tracking hook for open/close events
* **Style**
  * Newsletter form vertical centering and full-width button support
* **Refactor**
  * Welcome screen simplified to use the reusable subscribe form
* **Chores**
  * Added "Close" translation and tracking keys/types for article popups
<!-- end of auto-generated comment: release notes by coderabbit.ai -->