### PR TITLE
chore: remove earn opportunity disabled state if wrong wallet connected

### DIFF
--- a/src/components/Cards/EarnCard/EarnCard.styles.ts
+++ b/src/components/Cards/EarnCard/EarnCard.styles.ts
@@ -10,14 +10,12 @@ import { getSurfaceBorder } from '@/theme/utils/getSurfaceBorder';
 
 interface EarnCardContainerProps {
   hasLink?: boolean;
-  isConnected?: boolean;
 }
 
 const EarnCardContainer = styled(Box, {
-  shouldForwardProp: (prop) => prop !== 'hasLink' && prop !== 'isConnected',
-})<EarnCardContainerProps>(({ theme, hasLink, isConnected = true }) => ({
+  shouldForwardProp: (prop) => prop !== 'hasLink',
+})<EarnCardContainerProps>(({ theme, hasLink }) => ({
   backgroundColor: (theme.vars || theme).palette.surface1.main,
-  opacity: isConnected ? 1 : 0.5,
   border: getSurfaceBorder(theme, 'surface1'),
   borderRadius: theme.shape.cardBorderRadius,
   boxShadow: theme.shadows[2],

--- a/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
+++ b/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EarnCard snapshot > compact card matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-n606gh"
+    class="MuiBox-root css-1tyjne1"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -346,7 +346,7 @@ exports[`EarnCard snapshot > compact card matches snapshot 1`] = `
 exports[`EarnCard snapshot > compact card with cap in dollar matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-n606gh"
+    class="MuiBox-root css-1tyjne1"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -667,7 +667,7 @@ exports[`EarnCard snapshot > compact card with href matches snapshot 1`] = `
     href="/earn/moonwell-flagship-usdc-on-base"
   >
     <div
-      class="MuiBox-root css-f7oo3y"
+      class="MuiBox-root css-43o07u"
     >
       <div
         class="MuiBox-root css-ohw5b5"
@@ -985,7 +985,7 @@ exports[`EarnCard snapshot > compact card with href matches snapshot 1`] = `
 exports[`EarnCard snapshot > compact card with loading matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1ctq8zw"
+    class="MuiBox-root css-1tyjne1"
   >
     <div
       class="MuiBox-root css-1wj7dar"
@@ -1042,7 +1042,7 @@ exports[`EarnCard snapshot > compact card with loading matches snapshot 1`] = `
 exports[`EarnCard snapshot > compact card with lockup months and cap in dollar matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-n606gh"
+    class="MuiBox-root css-1tyjne1"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -1359,7 +1359,7 @@ exports[`EarnCard snapshot > compact card with lockup months and cap in dollar m
 exports[`EarnCard snapshot > compact card with lockup months matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-n606gh"
+    class="MuiBox-root css-1tyjne1"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -1676,7 +1676,7 @@ exports[`EarnCard snapshot > compact card with lockup months matches snapshot 1`
 exports[`EarnCard snapshot > compact card with no recommendation matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-n606gh"
+    class="MuiBox-root css-1tyjne1"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -1988,7 +1988,7 @@ exports[`EarnCard snapshot > compact card with no recommendation matches snapsho
 exports[`EarnCard snapshot > compact card with single asset matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-n606gh"
+    class="MuiBox-root css-1tyjne1"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -2331,7 +2331,7 @@ exports[`EarnCard snapshot > compact card with single asset matches snapshot 1`]
 exports[`EarnCard snapshot > compact card with two items matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-n606gh"
+    class="MuiBox-root css-1tyjne1"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -2602,7 +2602,7 @@ exports[`EarnCard snapshot > compact card with two items matches snapshot 1`] = 
 exports[`EarnCard snapshot > list item card matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-u0qpbt"
+    class="MuiBox-root css-nhh3oc"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -2831,7 +2831,7 @@ exports[`EarnCard snapshot > list item card matches snapshot 1`] = `
 exports[`EarnCard snapshot > list item card with cap in dollar matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-u0qpbt"
+    class="MuiBox-root css-nhh3oc"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -3038,7 +3038,7 @@ exports[`EarnCard snapshot > list item card with href matches snapshot 1`] = `
     href="/earn/moonwell-flagship-usdc-on-base"
   >
     <div
-      class="MuiBox-root css-1wzwj6u"
+      class="MuiBox-root css-1c0785"
     >
       <div
         class="MuiBox-root css-ohw5b5"
@@ -3242,7 +3242,7 @@ exports[`EarnCard snapshot > list item card with href matches snapshot 1`] = `
 exports[`EarnCard snapshot > list item card with loading matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-ofsn0k"
+    class="MuiBox-root css-nhh3oc"
   >
     <div
       class="MuiBox-root css-1wj7dar"
@@ -3304,7 +3304,7 @@ exports[`EarnCard snapshot > list item card with loading matches snapshot 1`] = 
 exports[`EarnCard snapshot > list item card with lockup months and cap in dollar matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-u0qpbt"
+    class="MuiBox-root css-nhh3oc"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -3507,7 +3507,7 @@ exports[`EarnCard snapshot > list item card with lockup months and cap in dollar
 exports[`EarnCard snapshot > list item card with lockup months matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-u0qpbt"
+    class="MuiBox-root css-nhh3oc"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -3710,7 +3710,7 @@ exports[`EarnCard snapshot > list item card with lockup months matches snapshot 
 exports[`EarnCard snapshot > list item card with no recommendation matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-u0qpbt"
+    class="MuiBox-root css-nhh3oc"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -3908,7 +3908,7 @@ exports[`EarnCard snapshot > list item card with no recommendation matches snaps
 exports[`EarnCard snapshot > list item card with single asset matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-u0qpbt"
+    class="MuiBox-root css-nhh3oc"
   >
     <div
       class="MuiBox-root css-ohw5b5"
@@ -4111,7 +4111,7 @@ exports[`EarnCard snapshot > list item card with single asset matches snapshot 1
 exports[`EarnCard snapshot > overview card matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1k8mh22"
+    class="MuiBox-root css-4gp3vo"
   >
     <div
       class="MuiStack-root css-h345r2-MuiStack-root"
@@ -4480,7 +4480,7 @@ exports[`EarnCard snapshot > overview card matches snapshot 1`] = `
 exports[`EarnCard snapshot > overview card with badge matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1k8mh22"
+    class="MuiBox-root css-4gp3vo"
   >
     <div
       class="MuiStack-root css-h345r2-MuiStack-root"
@@ -4852,7 +4852,7 @@ exports[`EarnCard snapshot > overview card with badge matches snapshot 1`] = `
 exports[`EarnCard snapshot > overview card with cap in dollar matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1k8mh22"
+    class="MuiBox-root css-4gp3vo"
   >
     <div
       class="MuiStack-root css-h345r2-MuiStack-root"
@@ -5221,7 +5221,7 @@ exports[`EarnCard snapshot > overview card with cap in dollar matches snapshot 1
 exports[`EarnCard snapshot > overview card with loading matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1k8mh22"
+    class="MuiBox-root css-4gp3vo"
   >
     <div
       class="MuiStack-root css-h345r2-MuiStack-root"
@@ -5255,7 +5255,7 @@ exports[`EarnCard snapshot > overview card with loading matches snapshot 1`] = `
 exports[`EarnCard snapshot > overview card with lockup months and cap in dollar matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1k8mh22"
+    class="MuiBox-root css-4gp3vo"
   >
     <div
       class="MuiStack-root css-h345r2-MuiStack-root"
@@ -5624,7 +5624,7 @@ exports[`EarnCard snapshot > overview card with lockup months and cap in dollar 
 exports[`EarnCard snapshot > overview card with lockup months matches snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1k8mh22"
+    class="MuiBox-root css-4gp3vo"
   >
     <div
       class="MuiStack-root css-h345r2-MuiStack-root"

--- a/src/components/Cards/EarnCard/variants/CompactEarnCard.tsx
+++ b/src/components/Cards/EarnCard/variants/CompactEarnCard.tsx
@@ -19,7 +19,6 @@ import { CompactEarnCardSkeleton } from './CompactEarnCardSkeleton';
 import { useFormatDisplayEarnOpportunityData } from 'src/hooks/earn/useFormatDisplayEarnOpportunityData';
 import { ConditionalLink } from 'src/components/Link/ConditionalLink';
 import { CompactEarnCardMissingPosition } from './CompactEarnCardMissingPosition';
-import { useChainTypeData } from '@/hooks/chains/useChainTypeData';
 
 export const CompactEarnCard: FC<Omit<EarnCardProps, 'variant'>> = ({
   primaryAction,
@@ -30,8 +29,6 @@ export const CompactEarnCard: FC<Omit<EarnCardProps, 'variant'>> = ({
 }) => {
   // Note: later we might want to keep rendering the card if it's loading but already has data (on ttl for examples).
   const isEmpty = !data || isLoading;
-
-  const chainTypeData = useChainTypeData(data?.lpToken?.chain.chainId);
 
   const { overviewItems, chains } = useFormatDisplayEarnOpportunityData(
     data,
@@ -69,10 +66,7 @@ export const CompactEarnCard: FC<Omit<EarnCardProps, 'variant'>> = ({
 
   return (
     <ConditionalLink href={href}>
-      <CompactEarnCardContainer
-        hasLink={!!href}
-        isConnected={chainTypeData.isAccountConnected}
-      >
+      <CompactEarnCardContainer hasLink={!!href}>
         <CompactEarnCardBody hasHintHoverActive>
           <CompactEarnCardHeaderContainer direction="row">
             <CompactEarnCardTagContainer direction="row">

--- a/src/components/Cards/EarnCard/variants/ListItemEarnCard.tsx
+++ b/src/components/Cards/EarnCard/variants/ListItemEarnCard.tsx
@@ -18,7 +18,6 @@ import { ListItemTooltipBadge } from './ListItemTooltipBadge';
 import { useFormatDisplayEarnOpportunityData } from 'src/hooks/earn/useFormatDisplayEarnOpportunityData';
 import { ConditionalLink } from 'src/components/Link/ConditionalLink';
 import { ListItemEarnCardMissingPosition } from './ListItemEarnCardMissingPosition';
-import { useChainTypeData } from '@/hooks/chains/useChainTypeData';
 
 export const ListItemEarnCard: FC<Omit<EarnCardProps, 'variant'>> = ({
   data,
@@ -31,8 +30,6 @@ export const ListItemEarnCard: FC<Omit<EarnCardProps, 'variant'>> = ({
   const isEmpty = data === null || isLoading;
 
   const isMobile = useMediaQuery((theme) => theme.breakpoints.down('sm'));
-
-  const chainTypeData = useChainTypeData(data?.lpToken?.chain.chainId);
 
   const { overviewItems, chains } = useFormatDisplayEarnOpportunityData(
     data,
@@ -65,10 +62,7 @@ export const ListItemEarnCard: FC<Omit<EarnCardProps, 'variant'>> = ({
 
   return (
     <ConditionalLink href={href}>
-      <ListItemEarnCardContainer
-        hasLink={!!href}
-        isConnected={chainTypeData.isAccountConnected}
-      >
+      <ListItemEarnCardContainer hasLink={!!href}>
         <ListItemEarnCardBody hasHintHoverActive>
           <ListItemEarnContentWrapper direction="row" flexWrap="wrap">
             <EntityChainStack


### PR DESCRIPTION
# Which Jira task belongs to this PR?
https://linear.app/lifi-linear/issue/JUM-677/remove-fade-out-effect-from-earn-opportunity-cards-if-wrong-wallet-is

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged
