### PR TITLE
fix: remove start end date filtering for quest

### DIFF
--- a/src/app/lib/getQuestsBy.ts
+++ b/src/app/lib/getQuestsBy.ts
@@ -6,8 +6,7 @@ import { getStrapiApiAccessToken } from 'src/utils/strapi/strapiHelper';
 export async function getQuestsBy(key: string, value: string) {
   const urlParams = new QuestStrapiApi()
     .filterBy(key, value)
-    .populateCampaign()
-    .filterByStartAndEndDate();
+    .populateCampaign();
   const apiUrl = urlParams.getApiUrl();
   const accessToken = getStrapiApiAccessToken();
 

--- a/src/app/ui/missions/MissionCard.tsx
+++ b/src/app/ui/missions/MissionCard.tsx
@@ -28,6 +28,8 @@ export const MissionCard: FC<MissionCardProps> = ({ mission }) => {
     mission.hasEnded,
   );
 
+  const isMissionDisabled = isDisabled || !missionDisplayData.href;
+
   const badge = useMemo(() => {
     if (!status) {
       return null;
@@ -64,13 +66,13 @@ export const MissionCard: FC<MissionCardProps> = ({ mission }) => {
       participants={missionDisplayData.participants}
       imageUrl={missionDisplayData.imageUrl}
       rewardGroups={missionDisplayData.rewardGroups}
-      onClick={!isDisabled ? handleClick : undefined}
+      onClick={!isMissionDisabled ? handleClick : undefined}
       fullWidth
       dataTestId={dataTestId}
     />
   );
 
-  return !isDisabled ? (
+  return !isMissionDisabled ? (
     <Link
       href={missionDisplayData.href}
       sx={{


### PR DESCRIPTION
# Which Jira task belongs to this PR?

https://linear.app/lifi-linear/issue/JUM-681/remove-start-end-date-filtering-for-quest-retrieval-by-slug

## Testing steps
1. Go to `/missions/test1234`
2. The mission page should be rendered
3. The `Ended` badge should be shown over the image from the mission card (left side)
4. Check in Strapi (staging) the Ended date is indeed in the past

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mission cards now properly disable when link information is unavailable, preventing unintended interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->