### PR TITLE
feat: add image interaction controls for image rich blocks renderer

### DIFF
--- a/src/components/Lightbox/Lightbox.style.ts
+++ b/src/components/Lightbox/Lightbox.style.ts
@@ -1,16 +1,16 @@
-import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Modal from '@mui/material/Modal';
+import { styled } from '@mui/material/styles';
 import Image from 'next/image';
 
-export const PreviewImage = styled(Image)(({ theme }) => ({
+export const PreviewImage = styled(Image)(() => ({
   borderRadius: '8px',
   width: '100%',
   height: '100%',
   '&:hover': { cursor: 'pointer' },
 }));
 
-export const LightboxModal = styled(Modal)(({ theme }) => ({
+export const LightboxModal = styled(Modal)(() => ({
   zIndex: 1500,
 }));
 
@@ -21,29 +21,53 @@ export const LightboxContainer = styled(Box)(({ theme }) => ({
   flexDirection: 'column',
   height: '100%',
   justifyContent: 'center',
+  outline: 'none',
+  '&:fullscreen': {
+    background: `color-mix(in srgb, ${theme.palette.black.main} 90%, transparent)`,
+  },
 }));
 
-export const LightboxImageContainer = styled('img')(({ theme }) => ({
+export const LightboxToolbarContainer = styled(Box)(({ theme }) => ({
   position: 'absolute',
-  left: '50%',
-  top: '50%',
-  transform: 'translate(-50%, -50%)',
-  width: '100%',
-  height: 'auto',
-  maxWidth: theme.breakpoints.values.md,
+  top: 0,
+  right: 0,
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(0.75),
+  padding: theme.spacing(2),
+  zIndex: 10,
+  backdropFilter: 'blur(24px)',
+  borderRadius: theme.shape.radius32,
 }));
 
-export const LightboxImage = styled('img')(({ theme }) => ({
-  maxWidth: '100%',
-  height: 'auto',
-  maxHeight: '90%',
-  objectFit: 'contain',
-  borderRadius: 8,
-  [theme.breakpoints.up('sm')]: {
-    maxWidth: 'calc( 100% - 32px)',
-    margin: theme.spacing(2),
-  },
-  [theme.breakpoints.up('xl')]: {
-    maxWidth: theme.breakpoints.values.lg,
-  },
-}));
+interface LightboxImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  scale?: number;
+  offsetX?: number;
+  offsetY?: number;
+  isDragging?: boolean;
+}
+
+export const LightboxImage = styled('img', {
+  shouldForwardProp: (prop) =>
+    !['scale', 'offsetX', 'offsetY', 'isDragging'].includes(prop as string),
+})<LightboxImageProps>(
+  ({ theme, scale = 1, offsetX = 0, offsetY = 0, isDragging = false }) => ({
+    maxWidth: '100%',
+    height: 'auto',
+    maxHeight: '90%',
+    objectFit: 'contain',
+    borderRadius: 8,
+    userSelect: 'none',
+    transition: isDragging ? 'none' : 'transform 0.2s ease',
+    transform: `translate(${offsetX}px, ${offsetY}px) scale(${scale})`,
+    transformOrigin: 'center center',
+    cursor: scale > 1 ? (isDragging ? 'grabbing' : 'grab') : 'default',
+    [theme.breakpoints.up('sm')]: {
+      maxWidth: 'calc(100% - 32px)',
+      margin: theme.spacing(2),
+    },
+    [theme.breakpoints.up('xl')]: {
+      maxWidth: theme.breakpoints.values.lg,
+    },
+  }),
+);

--- a/src/components/Lightbox/Lightbox.style.ts
+++ b/src/components/Lightbox/Lightbox.style.ts
@@ -29,15 +29,18 @@ export const LightboxContainer = styled(Box)(({ theme }) => ({
 
 export const LightboxToolbarContainer = styled(Box)(({ theme }) => ({
   position: 'absolute',
-  top: 0,
-  right: 0,
+  bottom: theme.spacing(1),
+  left: `50%`,
+  transform: `translateX(-50%)`,
   display: 'flex',
   alignItems: 'center',
   gap: theme.spacing(0.75),
   padding: theme.spacing(2),
   zIndex: 10,
   backdropFilter: 'blur(24px)',
+  background: (theme.vars || theme).palette.surface4.main,
   borderRadius: theme.shape.radius32,
+  boxShadow: theme.shadows[2],
 }));
 
 interface LightboxImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {

--- a/src/components/Lightbox/Lightbox.tsx
+++ b/src/components/Lightbox/Lightbox.tsx
@@ -1,65 +1,86 @@
 import type { StrapiMediaAttributes } from '@/types/strapi';
-import CloseIcon from '@mui/icons-material/Close';
-import type { Breakpoint } from '@mui/material';
-import { Fade, useTheme } from '@mui/material';
-import { useState } from 'react';
+import { Fade } from '@mui/material';
 import {
   LightboxContainer,
   LightboxImage,
   LightboxModal,
   PreviewImage,
-} from '.';
+} from './Lightbox.style';
+import { LightboxToolbar } from './LightboxToolbar';
+import { useLightbox } from './useLightbox';
+
 interface LightboxProps {
   baseUrl: string;
   imageData: StrapiMediaAttributes;
 }
 
 export const Lightbox = ({ baseUrl, imageData }: LightboxProps) => {
-  const [open, setOpen] = useState(false);
-  const theme = useTheme();
-  const handleClose = () => {
-    setOpen(false);
-  };
-
-  const handleImage = () => {
-    setOpen(true);
-  };
+  const {
+    open,
+    scale,
+    offset,
+    isFullscreen,
+    supportsFullscreen,
+    containerRef,
+    isDragging,
+    handleOpen,
+    handleClose,
+    zoomIn,
+    zoomOut,
+    handleWheel,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+    toggleFullscreen,
+  } = useLightbox();
 
   return (
     <>
       <PreviewImage
         src={imageData.url}
-        // read the following to understand why width and height are set to 0, https://github.com/vercel/next.js/discussions/18474#discussioncomment-5501724
         width={0}
         height={0}
         sizes="100vw"
-        // sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-        // fill
         alt={imageData.alternativeText ?? 'article-image'}
-        onClick={handleImage}
+        onClick={handleOpen}
       />
+
       <LightboxModal open={open} onClose={handleClose} closeAfterTransition>
         <Fade in={open} timeout={500}>
-          <LightboxContainer onClick={handleClose}>
-            <CloseIcon
-              onClick={handleClose}
-              sx={{
-                position: 'absolute',
-                top: 0,
-                cursor: 'pointer',
-                right: 0,
-                width: 32,
-                height: 32,
-                color: theme.palette.white.main,
-                margin: theme.spacing(2, 3),
-                [theme.breakpoints.up('sm' as Breakpoint)]: {
-                  margin: theme.spacing(3, 4),
-                },
-              }}
+          <LightboxContainer
+            ref={containerRef}
+            onClick={handleClose}
+            onWheel={handleWheel}
+          >
+            <LightboxToolbar
+              scale={scale}
+              isFullscreen={isFullscreen}
+              supportsFullscreen={supportsFullscreen}
+              onZoomIn={zoomIn}
+              onZoomOut={zoomOut}
+              onToggleFullscreen={toggleFullscreen}
+              onClose={handleClose}
             />
+
             <LightboxImage
               src={imageData.url}
               alt={imageData.alternativeText ?? 'article-image'}
+              scale={scale}
+              offsetX={offset.x}
+              offsetY={offset.y}
+              isDragging={isDragging.current}
+              onClick={(e) => e.stopPropagation()}
+              onMouseDown={handleMouseDown}
+              onMouseMove={handleMouseMove}
+              onMouseUp={handleMouseUp}
+              onMouseLeave={handleMouseUp}
+              onTouchStart={handleTouchStart}
+              onTouchMove={handleTouchMove}
+              onTouchEnd={handleTouchEnd}
+              draggable={false}
             />
           </LightboxContainer>
         </Fade>

--- a/src/components/Lightbox/LightboxToolbar.tsx
+++ b/src/components/Lightbox/LightboxToolbar.tsx
@@ -1,0 +1,96 @@
+import { Tooltip } from '@/components/core/Tooltip/Tooltip';
+import { IconButton } from '@/components/core/buttons/IconButton/IconButton';
+import { Size, Variant } from '@/components/core/buttons/types';
+import CloseIcon from '@mui/icons-material/Close';
+import FullscreenIcon from '@mui/icons-material/Fullscreen';
+import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
+import ZoomInIcon from '@mui/icons-material/ZoomIn';
+import ZoomOutIcon from '@mui/icons-material/ZoomOut';
+import Box from '@mui/material/Box';
+import type { FC } from 'react';
+import { LightboxToolbarContainer } from './Lightbox.style';
+import { MAX_SCALE, MIN_SCALE } from './useLightbox';
+import { useTranslation } from 'react-i18next';
+import Typography from '@mui/material/Typography';
+import { formatValueWithConfig } from '@/utils/formatNumbers';
+
+interface LightboxToolbarProps {
+  scale: number;
+  isFullscreen: boolean;
+  supportsFullscreen: boolean;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onToggleFullscreen: () => void;
+  onClose: () => void;
+}
+
+export const LightboxToolbar: FC<LightboxToolbarProps> = ({
+  scale,
+  isFullscreen,
+  supportsFullscreen,
+  onZoomIn,
+  onZoomOut,
+  onToggleFullscreen,
+  onClose,
+}) => {
+  const { t } = useTranslation();
+  return (
+    <LightboxToolbarContainer onClick={(e) => e.stopPropagation()}>
+      <Tooltip title={t('tooltips.zoomOut')}>
+        <Box component="span">
+          <IconButton
+            onClick={onZoomOut}
+            disabled={scale <= MIN_SCALE}
+            size={Size.LG}
+            variant={Variant.Borderless}
+          >
+            <ZoomOutIcon />
+          </IconButton>
+        </Box>
+      </Tooltip>
+
+      <Typography variant="bodyMedium" component="span">
+        {formatValueWithConfig(scale, { type: 'percentage' })}
+      </Typography>
+
+      <Tooltip title={t('tooltips.zoomIn')}>
+        <Box component="span">
+          <IconButton
+            onClick={onZoomIn}
+            disabled={scale >= MAX_SCALE}
+            size={Size.LG}
+            variant={Variant.Borderless}
+          >
+            <ZoomInIcon />
+          </IconButton>
+        </Box>
+      </Tooltip>
+
+      {supportsFullscreen && (
+        <Tooltip
+          title={t(
+            `tooltips.${isFullscreen ? 'exitFullscreen' : 'fullscreen'}`,
+          )}
+        >
+          <IconButton
+            onClick={onToggleFullscreen}
+            size={Size.LG}
+            variant={Variant.Borderless}
+          >
+            {isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
+          </IconButton>
+        </Tooltip>
+      )}
+
+      <Tooltip title={t('tooltips.close')}>
+        <IconButton
+          onClick={onClose}
+          size={Size.LG}
+          variant={Variant.Borderless}
+        >
+          <CloseIcon />
+        </IconButton>
+      </Tooltip>
+    </LightboxToolbarContainer>
+  );
+};

--- a/src/components/Lightbox/index.ts
+++ b/src/components/Lightbox/index.ts
@@ -1,2 +1,0 @@
-export * from './Lightbox';
-export * from './Lightbox.style';

--- a/src/components/Lightbox/useLightbox.ts
+++ b/src/components/Lightbox/useLightbox.ts
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export const MIN_SCALE = 1;
+export const MAX_SCALE = 4;
+const ZOOM_STEP = 0.25;
+
+const clampScale = (next: number) =>
+  Math.min(MAX_SCALE, Math.max(MIN_SCALE, next));
+
+const getTouchDistance = (touches: React.TouchList) => {
+  const dx = touches[0].clientX - touches[1].clientX;
+  const dy = touches[0].clientY - touches[1].clientY;
+  return Math.sqrt(dx * dx + dy * dy);
+};
+
+export const useLightbox = () => {
+  const [open, setOpen] = useState(false);
+  const [scale, setScale] = useState(1);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const isDragging = useRef(false);
+  const dragStart = useRef({ x: 0, y: 0 });
+  const offsetAtDragStart = useRef({ x: 0, y: 0 });
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const lastTouchDistance = useRef<number | null>(null);
+  const scaleAtTouchStart = useRef(1);
+
+  const resetState = useCallback(() => {
+    setScale(1);
+    setOffset({ x: 0, y: 0 });
+  }, []);
+
+  const handleClose = useCallback(() => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+    }
+    resetState();
+    setOpen(false);
+  }, [resetState]);
+
+  const handleOpen = useCallback(() => setOpen(true), []);
+
+  const zoomIn = useCallback(() => {
+    setScale((s) => clampScale(s + ZOOM_STEP));
+    setOffset({ x: 0, y: 0 });
+  }, []);
+
+  const zoomOut = useCallback(() => {
+    setScale((s) => clampScale(s - ZOOM_STEP));
+    setOffset({ x: 0, y: 0 });
+  }, []);
+
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    const delta = e.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP;
+    setScale((s) => clampScale(s + delta));
+    setOffset({ x: 0, y: 0 });
+  }, []);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (scale <= MIN_SCALE) {
+        return;
+      }
+      isDragging.current = true;
+      dragStart.current = { x: e.clientX, y: e.clientY };
+      offsetAtDragStart.current = offset;
+    },
+    [scale, offset],
+  );
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!isDragging.current) {
+      return;
+    }
+    setOffset({
+      x: offsetAtDragStart.current.x + (e.clientX - dragStart.current.x),
+      y: offsetAtDragStart.current.y + (e.clientY - dragStart.current.y),
+    });
+  }, []);
+
+  const handleMouseUp = useCallback(() => {
+    isDragging.current = false;
+  }, []);
+
+  const handleTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (e.touches.length === 2) {
+        lastTouchDistance.current = getTouchDistance(e.touches);
+        scaleAtTouchStart.current = scale;
+      } else if (e.touches.length === 1 && scale > MIN_SCALE) {
+        isDragging.current = true;
+        dragStart.current = {
+          x: e.touches[0].clientX,
+          y: e.touches[0].clientY,
+        };
+        offsetAtDragStart.current = offset;
+      }
+    },
+    [scale, offset],
+  );
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    e.preventDefault();
+    if (e.touches.length === 2 && lastTouchDistance.current !== null) {
+      const ratio = getTouchDistance(e.touches) / lastTouchDistance.current;
+      setScale(clampScale(scaleAtTouchStart.current * ratio));
+      setOffset({ x: 0, y: 0 });
+    } else if (e.touches.length === 1 && isDragging.current) {
+      setOffset({
+        x:
+          offsetAtDragStart.current.x +
+          (e.touches[0].clientX - dragStart.current.x),
+        y:
+          offsetAtDragStart.current.y +
+          (e.touches[0].clientY - dragStart.current.y),
+      });
+    }
+  }, []);
+
+  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+    if (e.touches.length < 2) {
+      lastTouchDistance.current = null;
+    }
+    if (e.touches.length === 0) {
+      isDragging.current = false;
+    }
+  }, []);
+
+  const toggleFullscreen = useCallback(async () => {
+    const el = containerRef.current;
+    if (!el) {
+      return;
+    }
+    if (!document.fullscreenElement) {
+      await el.requestFullscreen();
+    } else {
+      await document.exitFullscreen();
+    }
+  }, []);
+
+  useEffect(() => {
+    const onFsChange = () => setIsFullscreen(!!document.fullscreenElement);
+    document.addEventListener('fullscreenchange', onFsChange);
+    return () => document.removeEventListener('fullscreenchange', onFsChange);
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        handleClose();
+      }
+      if (e.key === '+' || e.key === '=') {
+        zoomIn();
+      }
+      if (e.key === '-') {
+        zoomOut();
+      }
+      if (e.key === 'f' || e.key === 'F') {
+        toggleFullscreen();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, handleClose, toggleFullscreen, zoomIn, zoomOut]);
+
+  const supportsFullscreen =
+    typeof document !== 'undefined' &&
+    !!document.documentElement.requestFullscreen;
+
+  return {
+    open,
+    scale,
+    offset,
+    isFullscreen,
+    supportsFullscreen,
+    containerRef,
+    isDragging,
+    handleOpen,
+    handleClose,
+    zoomIn,
+    zoomOut,
+    handleWheel,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+    toggleFullscreen,
+  };
+};

--- a/src/components/RichBlocks/blocks/ImageBlock.tsx
+++ b/src/components/RichBlocks/blocks/ImageBlock.tsx
@@ -6,7 +6,7 @@ import { RichBlocksVariant } from '../types';
 import dynamic from 'next/dynamic';
 
 const Lightbox = dynamic(() =>
-  import('src/components/Lightbox').then((mod) => mod.Lightbox),
+  import('src/components/Lightbox/Lightbox').then((mod) => mod.Lightbox),
 );
 
 interface ImageBlockProps extends ImageProps, CommonBlockProps {}

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -854,9 +854,12 @@ interface Resources {
       capInDollar: 'Available liquidity capacity of the market';
       chains_one: 'The chain you will earn from';
       chains_other: 'The chains you will earn from';
+      close: 'Close';
       deposit: 'The token on which the market is defined and yield accrues on.';
       depositDisabled: 'Deposit currently disabled for this opportunity. <0>Go to {{protocolName}}</0>';
       deposited: 'The token you have deposited into this market.';
+      exitFullscreen: 'Exit fullscreen';
+      fullscreen: 'Fullscreen';
       lockupPeriod: 'Once deposited, your position is subject to an {{formattedLockupPeriod}} lock-up period before you can withdraw the funds.';
       manageYourPosition: 'You can also manage your funds (withdraw, check PNL) on {{partnerName}} UI by clicking on this button';
       noPositionsToManage: 'You do not have any positions to manage';
@@ -864,6 +867,8 @@ interface Resources {
       rewardsApy: 'Expected yearly return rate distributed in reward token.';
       tvl: 'Total value of crypto assets deposited in this market.';
       withdrawDisabled: 'Withdraw currently disabled for this opportunity. <0>Go to {{protocolName}}</0>';
+      zoomIn: 'Zoom in';
+      zoomOut: 'Zoom out';
     };
     widget: {
       deposit: {

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -372,7 +372,12 @@
     "noPositionsToManage": "You do not have any positions to manage",
     "capInDollar": "Available liquidity capacity of the market",
     "depositDisabled": "Deposit currently disabled for this opportunity. <0>Go to {{protocolName}}</0>",
-    "withdrawDisabled": "Withdraw currently disabled for this opportunity. <0>Go to {{protocolName}}</0>"
+    "withdrawDisabled": "Withdraw currently disabled for this opportunity. <0>Go to {{protocolName}}</0>",
+    "zoomOut": "Zoom out",
+    "zoomIn": "Zoom in",
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "close": "Close"
   },
   "labels": {
     "apy": "APY",


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-642/p2-learn-details-page-add-image-zoom-functionality

## Testing steps
1. Go to `/learn/jump-into-boyco` for eg.
2. Click on any image in the article content
3. The image modal should show up and display zoomIn/out, fullscreen and close interaction controls
4. Open the same page in Safari
5. Check the controls behaviour


# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced image viewer with zoom controls (zoom in/out) and dynamic scale percentage display
  * Added drag-to-pan functionality for navigating zoomed images
  * Fullscreen viewing mode with toggle control
  * Touch support including pinch-zoom and single-finger drag panning
  * New interactive toolbar with close button and keyboard shortcuts (Escape to close, +/- to zoom, F for fullscreen)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->