### PR TITLE
feat: add order for learn articles sorting options

### DIFF
--- a/src/app/ui/learn/LearnPageArticlesSection/hooks.ts
+++ b/src/app/ui/learn/LearnPageArticlesSection/hooks.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import type { ParseKeys } from 'i18next';
 import { useLearnFiltering } from '@/providers/LearnProvider/filtering/LearnFilteringContext';
 import type {
   BlogArticlesFilterWithoutSortByAndOrder,
@@ -22,6 +23,41 @@ import type { NullableFields } from '@/types/internal';
 import { countBadge, datesBadge, readingDurationBadge } from './utils';
 import type { BlogArticlesPendingFilterValues } from './types';
 import { isEqual, startOfDay } from 'date-fns';
+
+type LearnArticlesSortByOption = {
+  value: `${SortByEnum}:${OrderEnum}`;
+  label: string;
+};
+
+const SORT_OPTIONS_CONFIG: Record<
+  SortByEnum,
+  {
+    label: ParseKeys<'translation'>;
+    order: Record<OrderEnum, ParseKeys<'translation'>>;
+  }
+> = {
+  [SortByOptions.LEVEL]: {
+    label: 'blog.sorting.level',
+    order: {
+      [OrderOptions.ASC]: 'blog.order.lowest',
+      [OrderOptions.DESC]: 'blog.order.highest',
+    },
+  },
+  [SortByOptions.DATE]: {
+    label: 'blog.sorting.publishDate',
+    order: {
+      [OrderOptions.ASC]: 'blog.order.oldest',
+      [OrderOptions.DESC]: 'blog.order.newest',
+    },
+  },
+  [SortByOptions.READING_TIME]: {
+    label: 'blog.sorting.readingTime',
+    order: {
+      [OrderOptions.ASC]: 'blog.order.lowest',
+      [OrderOptions.DESC]: 'blog.order.highest',
+    },
+  },
+};
 
 export const useLearnFilterBar = () => {
   const { t } = useTranslation();
@@ -97,36 +133,20 @@ export const useLearnFilterBar = () => {
   const readingDurationMax =
     filter?.maxReadingDuration ?? readingDurationRangeMax;
 
-  const sortByOptions = useMemo(
-    () =>
-      [
-        {
-          value: `${SortByOptions.LEVEL}:${OrderOptions.ASC}`,
-          label: `${t('blog.sorting.level')} ${t('blog.order.lowest')}`,
-        },
-        {
-          value: `${SortByOptions.LEVEL}:${OrderOptions.DESC}`,
-          label: `${t('blog.sorting.level')} ${t('blog.order.highest')}`,
-        },
-        {
-          value: `${SortByOptions.DATE}:${OrderOptions.ASC}`,
-          label: `${t('blog.sorting.publishDate')} ${t('blog.order.oldest')}`,
-        },
-        {
-          value: `${SortByOptions.DATE}:${OrderOptions.DESC}`,
-          label: `${t('blog.sorting.publishDate')} ${t('blog.order.newest')}`,
-        },
-        {
-          value: `${SortByOptions.READING_TIME}:${OrderOptions.ASC}`,
-          label: `${t('blog.sorting.readingTime')} ${t('blog.order.lowest')}`,
-        },
-        {
-          value: `${SortByOptions.READING_TIME}:${OrderOptions.DESC}`,
-          label: `${t('blog.sorting.readingTime')} ${t('blog.order.highest')}`,
-        },
-      ] as { value: `${SortByEnum}:${OrderEnum}`; label: string }[],
-    [t],
-  );
+  const sortByOptions = useMemo((): LearnArticlesSortByOption[] => {
+    const sortByValues = Object.values(SortByOptions) as SortByEnum[];
+    const orderValues = Object.values(OrderOptions) as OrderEnum[];
+
+    return sortByValues.flatMap((sortBy) =>
+      orderValues.map((order) => {
+        const config = SORT_OPTIONS_CONFIG[sortBy];
+        return {
+          value: `${sortBy}:${order}` as LearnArticlesSortByOption['value'],
+          label: `${t(config.label)} ${t(config.order[order])}`,
+        };
+      }),
+    );
+  }, [t]);
 
   const handleTagChange = (values: string[]) => {
     updateFilter({

--- a/src/app/ui/learn/LearnPageArticlesSection/hooks.ts
+++ b/src/app/ui/learn/LearnPageArticlesSection/hooks.ts
@@ -2,9 +2,13 @@ import { useMemo } from 'react';
 import { useLearnFiltering } from '@/providers/LearnProvider/filtering/LearnFilteringContext';
 import type {
   BlogArticlesFilterWithoutSortByAndOrder,
+  OrderEnum,
   SortByEnum,
 } from '@/providers/LearnProvider/filtering/types';
-import { SortByOptions } from '@/providers/LearnProvider/filtering/types';
+import {
+  OrderOptions,
+  SortByOptions,
+} from '@/providers/LearnProvider/filtering/types';
 import { sortSelectOptions } from '@/utils/sortSelectOptions';
 import { useTranslation } from 'react-i18next';
 import { usePendingFilters } from '@/components/composite/MultiLayer/hooks';
@@ -31,6 +35,8 @@ export const useLearnFilterBar = () => {
     clearFilters,
     sortBy,
     setSortBy,
+    order,
+    setOrder,
   } = useLearnFiltering();
 
   const tagOptions = useMemo(
@@ -92,14 +98,33 @@ export const useLearnFilterBar = () => {
     filter?.maxReadingDuration ?? readingDurationRangeMax;
 
   const sortByOptions = useMemo(
-    () => [
-      { value: SortByOptions.LEVEL, label: t('blog.sorting.level') },
-      { value: SortByOptions.DATE, label: t('blog.sorting.publishDate') },
-      {
-        value: SortByOptions.READING_TIME,
-        label: t('blog.sorting.readingTime'),
-      },
-    ],
+    () =>
+      [
+        {
+          value: `${SortByOptions.LEVEL}:${OrderOptions.ASC}`,
+          label: `${t('blog.sorting.level')} ${t('blog.order.lowest')}`,
+        },
+        {
+          value: `${SortByOptions.LEVEL}:${OrderOptions.DESC}`,
+          label: `${t('blog.sorting.level')} ${t('blog.order.highest')}`,
+        },
+        {
+          value: `${SortByOptions.DATE}:${OrderOptions.ASC}`,
+          label: `${t('blog.sorting.publishDate')} ${t('blog.order.oldest')}`,
+        },
+        {
+          value: `${SortByOptions.DATE}:${OrderOptions.DESC}`,
+          label: `${t('blog.sorting.publishDate')} ${t('blog.order.newest')}`,
+        },
+        {
+          value: `${SortByOptions.READING_TIME}:${OrderOptions.ASC}`,
+          label: `${t('blog.sorting.readingTime')} ${t('blog.order.lowest')}`,
+        },
+        {
+          value: `${SortByOptions.READING_TIME}:${OrderOptions.DESC}`,
+          label: `${t('blog.sorting.readingTime')} ${t('blog.order.highest')}`,
+        },
+      ] as { value: `${SortByEnum}:${OrderEnum}`; label: string }[],
     [t],
   );
 
@@ -147,6 +172,10 @@ export const useLearnFilterBar = () => {
     setSortBy(value as SortByEnum);
   };
 
+  const handleOrder = (value: string) => {
+    setOrder(value as OrderEnum);
+  };
+
   const optionsCount = [
     tagOptions.length,
     levelOptions.length,
@@ -187,6 +216,7 @@ export const useLearnFilterBar = () => {
     readingDurationRangeMax,
     sortByOptions,
     sortBy,
+    order,
     handleTagChange,
     handleLevelChange,
     handleDatesChange,
@@ -194,6 +224,7 @@ export const useLearnFilterBar = () => {
     handleClearAllFilters: clearFilters,
     handleApplyAllFilters,
     handleSortBy,
+    handleOrder,
   };
 };
 
@@ -214,9 +245,11 @@ export const useBlogArticlesFilteringCategories = () => {
     readingDurationRangeMax,
     sortByOptions,
     sortBy,
+    order,
     handleClearAllFilters,
     handleApplyAllFilters,
     handleSortBy,
+    handleOrder,
   } = useLearnFilterBar();
 
   const {
@@ -233,6 +266,7 @@ export const useBlogArticlesFilteringCategories = () => {
       dates: [dateMin, dateMax],
       readingDuration: [readingDurationMin, readingDurationMax],
       sortBy,
+      order,
     },
     onApply: (values) => {
       handleApplyAllFilters({
@@ -250,6 +284,7 @@ export const useBlogArticlesFilteringCategories = () => {
             : null,
       });
       handleSortBy(values.sortBy);
+      handleOrder(values.order);
     },
     onClear: handleClearAllFilters,
     isFilterApplied: (values) =>
@@ -261,7 +296,8 @@ export const useBlogArticlesFilteringCategories = () => {
       !isEqual(values.dates[1], dateRangeMax) ||
       values.readingDuration[0] !== readingDurationRangeMin ||
       values.readingDuration[1] !== readingDurationRangeMax ||
-      values.sortBy != sortBy,
+      values.sortBy != sortBy ||
+      values.order != order,
   });
 
   const usedMin = pendingValues.dates[0] ?? dateMin;
@@ -339,13 +375,21 @@ export const useBlogArticlesFilteringCategories = () => {
         })
       : null,
     sortByOptions.length > 1
-      ? createSingleSelectCategory<SortByEnum>({
+      ? createSingleSelectCategory<`${SortByEnum}:${OrderEnum}`>({
           id: 'sortBy',
           label: t('blog.sorting.sortBy'),
-          value: pendingValues.sortBy,
+          value: `${pendingValues.sortBy}:${pendingValues.order}`,
           onChange: (v) => {
-            if (v) {
-              setPendingValue('sortBy', v);
+            if (!v) {
+              return;
+            }
+            const [nextSortBy, nextOrder] = v.split(':') as [
+              SortByEnum,
+              OrderEnum,
+            ];
+            if (nextSortBy && nextOrder) {
+              setPendingValue('sortBy', nextSortBy);
+              setPendingValue('order', nextOrder);
             }
           },
           options: sortByOptions,

--- a/src/app/ui/learn/LearnPageArticlesSection/types.ts
+++ b/src/app/ui/learn/LearnPageArticlesSection/types.ts
@@ -1,5 +1,8 @@
 import type { DateRangeValue } from '@/components/composite/MultiLayer/MultiLayer.types';
-import type { SortByEnum } from '@/providers/LearnProvider/filtering/types';
+import type {
+  SortByEnum,
+  OrderEnum,
+} from '@/providers/LearnProvider/filtering/types';
 
 export interface BlogArticlesPendingFilterValues {
   tags: string[];
@@ -7,4 +10,5 @@ export interface BlogArticlesPendingFilterValues {
   dates: DateRangeValue;
   readingDuration: number[];
   sortBy: SortByEnum;
+  order: OrderEnum;
 }

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -42,6 +42,12 @@ interface Resources {
       minRead: '{{minRead}} min read';
       noPostsFound: 'No posts found for your search criteria.';
       openApp: 'Open app';
+      order: {
+        highest: '(highest)';
+        lowest: '(lowest)';
+        newest: '(newest)';
+        oldest: '(oldest)';
+      };
       popularPosts: 'Popular posts';
       recentPosts: 'Recent Posts';
       seeAllPosts: 'See all posts';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -131,6 +131,12 @@
       "publishDate": "Publish date",
       "readingTime": "Reading time"
     },
+    "order": {
+      "highest": "(highest)",
+      "lowest": "(lowest)",
+      "newest": "(newest)",
+      "oldest": "(oldest)"
+    },
     "tags": {
       "all": "All"
     },

--- a/src/providers/LearnProvider/filtering/LearnFilteringContext.tsx
+++ b/src/providers/LearnProvider/filtering/LearnFilteringContext.tsx
@@ -9,6 +9,7 @@ import type {
 import type {
   BlogArticlesFilterWithoutSortByAndOrder,
   LearnFilteringParams,
+  OrderEnum,
   SortByEnum,
 } from './types';
 import { OrderOptions, SortByOptions, TAG_ALL } from './types';
@@ -51,6 +52,8 @@ export const EMPTY_FILTERING_PARAMS: LearnFilteringParams = {
 export interface LearnFilteringContextType extends LearnFilteringParams {
   sortBy: SortByEnum;
   setSortBy: (sortBy: SortByEnum) => void;
+  order: OrderEnum;
+  setOrder: (order: OrderEnum) => void;
   filter: BlogArticlesFilterWithoutSortByAndOrder;
   updateFilter: (
     filter: NullableFields<BlogArticlesFilterWithoutSortByAndOrder>,
@@ -69,6 +72,8 @@ export const LearnFilteringContext = createContext<LearnFilteringContextType>({
   ...EMPTY_FILTERING_PARAMS,
   sortBy: SortByOptions.DATE,
   setSortBy: () => {},
+  order: OrderOptions.ASC,
+  setOrder: () => {},
   filter: {},
   updateFilter: () => {},
   clearFilters: () => {},
@@ -114,7 +119,12 @@ export const LearnFilteringProvider = ({
       history: 'replace',
     },
   );
-  const { sortBy: initialSortBy, tab, ...rest } = searchParamsState;
+  const {
+    sortBy: initialSortBy,
+    order: initialOrder,
+    tab,
+    ...rest
+  } = searchParamsState;
 
   const initialFilter = useMemo(() => {
     return removeNullValuesFromFilter(rest);
@@ -130,6 +140,7 @@ export const LearnFilteringProvider = ({
   }, [tab, setSearchParamsState]);
 
   const [sortBy, setSortBy] = useState<SortByEnum>(initialSortBy);
+  const [order, setOrder] = useState<OrderEnum>(initialOrder);
   const [filter, setFilter] =
     useState<BlogArticlesFilterWithoutSortByAndOrder>(initialFilter);
   const [page, setPage] = useState(0);
@@ -167,10 +178,10 @@ export const LearnFilteringProvider = ({
   const filteredSortedData = useMemo(() => {
     const filteredData = filterBlogArticles(unfilteredTabData, filter);
 
-    const sortedData = sortBlogArticles(filteredData, sortBy);
+    const sortedData = sortBlogArticles(filteredData, sortBy, order);
 
     return sortedData;
-  }, [unfilteredTabData, filter, sortBy]);
+  }, [unfilteredTabData, filter, sortBy, order]);
 
   const { data, pagination } = useMemo(() => {
     const total = filteredSortedData.length;
@@ -225,6 +236,15 @@ export const LearnFilteringProvider = ({
     [setSortBy, setSearchParamsState],
   );
 
+  const updateOrder = useCallback(
+    (newOrder: OrderEnum) => {
+      setPage(0);
+      setOrder(newOrder);
+      setSearchParamsState({ order: newOrder });
+    },
+    [setOrder, setSearchParamsState],
+  );
+
   const clearFilters = useCallback(() => {
     updateFilter({
       tags: null,
@@ -249,6 +269,8 @@ export const LearnFilteringProvider = ({
     return {
       sortBy,
       setSortBy: updateSortBy,
+      order,
+      setOrder: updateOrder,
       filter,
       updateFilter,
       clearFilters,
@@ -267,6 +289,8 @@ export const LearnFilteringProvider = ({
     changeTab,
     sortBy,
     updateSortBy,
+    order,
+    updateOrder,
     filter,
     updateFilter,
     data,


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-683/p2-learn-page-add-sorting-order-in-sortfilter-modaldrawer

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sort order selection to the Learn page articles filter and made the filter apply/remember both sort field and direction.

* **Localization**
  * Added translation keys for sort order labels (newest/oldest, highest/lowest).

* **Behavior**
  * Sorting now respects both selected field and order when displaying articles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->