### PR TITLE
feat: use framer motion for blog articles carousel

### DIFF
--- a/src/app/ui/learn/LearnArticlePage.tsx
+++ b/src/app/ui/learn/LearnArticlePage.tsx
@@ -30,11 +30,7 @@ const LearnArticlePage = ({ article, articles }: LearnArticlePageProps) => {
       <BlogArticleSection>
         <Box component={Background} sx={{ position: 'absolute' }} />
         {articles.length > 2 && (
-          <BlogCarousel
-            title={t('blog.similarPosts')}
-            showAllButton={true}
-            data={articles}
-          />
+          <BlogCarousel title={t('blog.similarPosts')} data={articles} />
         )}
         <JoinDiscordBanner />
       </BlogArticleSection>

--- a/src/components/Blog/BlogCarousel/BlogCarousel.style.ts
+++ b/src/components/Blog/BlogCarousel/BlogCarousel.style.ts
@@ -1,7 +1,26 @@
 'use client';
+
 import { getSurfaceBorder } from '@/theme/utils/getSurfaceBorder';
 import { Container as MuiContainer } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import { motion } from 'motion/react';
+
+export const CARD_GAP = 24;
+export const FALLBACK_CARD_WIDTH = 416;
+export const FALLBACK_CARD_HEIGHT = 416;
+export const FALLBACK_SLOT = FALLBACK_CARD_WIDTH + CARD_GAP;
+export const STACK_PEEK_PX = 14;
+
+export const NAV_SPRING = {
+  type: 'spring',
+  stiffness: 300,
+  damping: 32,
+} as const;
+export const SPREAD_SPRING = {
+  type: 'spring',
+  stiffness: 200,
+  damping: 30,
+} as const;
 
 export const BlogCarouselContainer = styled(MuiContainer)(({ theme }) => ({
   position: 'relative',
@@ -26,3 +45,18 @@ export const BlogCarouselContainer = styled(MuiContainer)(({ theme }) => ({
     paddingBottom: theme.spacing(5.25),
   },
 }));
+
+export const CarouselViewport = styled('div')({
+  position: 'relative',
+  width: '100%',
+  overflow: 'hidden',
+  padding: '16px 0 32px',
+});
+
+export const DraggableRow = styled(motion.div)({
+  display: 'flex',
+  alignItems: 'start',
+  cursor: 'grab',
+  '&:active': { cursor: 'grabbing' },
+  userSelect: 'none',
+});

--- a/src/components/Blog/BlogCarousel/BlogCarousel.tsx
+++ b/src/components/Blog/BlogCarousel/BlogCarousel.tsx
@@ -16,7 +16,6 @@ import {
   CarouselViewport,
   DraggableRow,
   CARD_GAP,
-  FALLBACK_CARD_WIDTH,
   SPREAD_SPRING,
   FALLBACK_CARD_HEIGHT,
 } from './BlogCarousel.style';
@@ -39,8 +38,8 @@ export const BlogCarousel = ({ data, title }: BlogCarouselProps) => {
   const total = data?.length ?? 0;
 
   const isInView = useInView(sectionRef, {
-    amount: 'all',
-    margin: `${FALLBACK_CARD_HEIGHT}px 100px 100px 0px`,
+    amount: 0.5,
+    margin: `${FALLBACK_CARD_HEIGHT / 2}px 100px 0px 0px`,
     once: false,
   });
 

--- a/src/components/Blog/BlogCarousel/BlogCarousel.tsx
+++ b/src/components/Blog/BlogCarousel/BlogCarousel.tsx
@@ -48,6 +48,8 @@ export const BlogCarousel = ({ data, title }: BlogCarouselProps) => {
 
   const {
     displayIndex,
+    isDragging,
+    carouselSessionActiveRef,
     handlePointerCancel,
     handlePointerDown,
     handlePointerMove,
@@ -102,6 +104,7 @@ export const BlogCarousel = ({ data, title }: BlogCarouselProps) => {
           }}
         >
           <DraggableRow
+            onDragStart={(e) => e.preventDefault()}
             onPointerCancel={handlePointerCancel}
             onPointerDown={handlePointerDown}
             onPointerMove={handlePointerMove}
@@ -126,6 +129,8 @@ export const BlogCarousel = ({ data, title }: BlogCarouselProps) => {
                 cardSlot={cardSlot}
                 total={total}
                 isSpread={isSpread}
+                isDragging={isDragging}
+                carouselSessionActiveRef={carouselSessionActiveRef}
                 measureRef={index === 0 ? firstCardRef : undefined}
               />
             ))}

--- a/src/components/Blog/BlogCarousel/BlogCarousel.tsx
+++ b/src/components/Blog/BlogCarousel/BlogCarousel.tsx
@@ -113,7 +113,7 @@ export const BlogCarousel = ({ data, title }: BlogCarouselProps) => {
               left: 0,
               top: 0,
               cursor: isSpread ? 'grab' : 'default',
-              touchAction: isSpread ? 'none' : 'auto',
+              touchAction: isSpread ? 'pan-y' : 'auto',
             }}
           >
             {data.map((article, index) => (

--- a/src/components/Blog/BlogCarousel/BlogCarousel.tsx
+++ b/src/components/Blog/BlogCarousel/BlogCarousel.tsx
@@ -1,43 +1,137 @@
 'use client';
+
 import type { BlogArticleData, StrapiResponseData } from '@/types/strapi';
-import { Carousel } from 'src/components/Carousel/Carousel';
-import { DotsPagination } from 'src/components/Carousel/DotsPagination';
-import { CarouselNavigation } from 'src/components/Carousel/Navigation';
-import { TrackingCategory } from 'src/const/trackingKeys';
-import { BlogArticleCard } from '../BlogArticleCard/BlogArticleCard';
 import { BlogArticleCardSkeleton } from '../BlogArticleCard/BlogArticleCardSkeleton';
-import { BlogCarouselContainer } from './BlogCarousel.style';
-import useMediaQuery from '@mui/material/useMediaQuery';
+import { useState, useEffect, useRef } from 'react';
+import { useMotionValue, animate, useInView } from 'motion/react';
+import { Box, Typography } from '@mui/material';
+import { IconButton } from '@/components/core/buttons/IconButton/IconButton';
+import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded';
+import ArrowForwardRoundedIcon from '@mui/icons-material/ArrowForwardRounded';
+import { BlogCarouselAnimatedCard } from './BlogCarouselAnimatedCard';
+import { BlogCarouselPagination } from './BlogCarouselPagination';
+import { useCarouselDrag, useCarouselMeasure } from './hooks';
+import {
+  BlogCarouselContainer,
+  CarouselViewport,
+  DraggableRow,
+  CARD_GAP,
+  FALLBACK_CARD_WIDTH,
+  SPREAD_SPRING,
+  FALLBACK_CARD_HEIGHT,
+} from './BlogCarousel.style';
 
 interface BlogCarouselProps {
-  showAllButton?: boolean;
   title?: string;
   data: StrapiResponseData<BlogArticleData> | undefined;
 }
 
 export const BlogCarousel = ({ data, title }: BlogCarouselProps) => {
-  const isMobile = useMediaQuery((theme) => theme.breakpoints.down('sm'));
+  const sectionRef = useRef<HTMLDivElement>(null);
+
+  const [isHovered, setIsHovered] = useState(false);
+
+  const motionIndex = useMotionValue(0);
+  const spreadMotion = useMotionValue(0);
+
+  const { firstCardRef, cardSlot, containerHeight } = useCarouselMeasure(data);
+
+  const total = data?.length ?? 0;
+
+  const isInView = useInView(sectionRef, {
+    amount: 'all',
+    margin: `${FALLBACK_CARD_HEIGHT}px 100px 100px 0px`,
+    once: false,
+  });
+
+  const isSpread = isHovered || isInView;
+
+  const {
+    displayIndex,
+    handlePointerCancel,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    handleNext,
+    handlePrev,
+  } = useCarouselDrag(motionIndex, cardSlot, total, isSpread);
+
+  useEffect(() => {
+    animate(spreadMotion, isSpread ? 1 : 0, SPREAD_SPRING);
+  }, [isSpread, spreadMotion]);
+
+  if (!data) {
+    return (
+      <BlogCarouselContainer>
+        <Box sx={{ display: 'flex', gap: `${CARD_GAP}px`, flexWrap: 'wrap' }}>
+          {Array.from({ length: 4 }).map((_, idx) => (
+            <BlogArticleCardSkeleton key={idx} />
+          ))}
+        </Box>
+      </BlogCarouselContainer>
+    );
+  }
+
   return (
-    <BlogCarouselContainer>
-      <Carousel
-        title={title}
-        fixedSlideWidth={true}
-        shouldAutoplay={!isMobile}
-        CarouselNavigation={CarouselNavigation}
-        CarouselPagination={DotsPagination}
-      >
-        {data
-          ? data.map((article, index) => (
-              <BlogArticleCard
+    <BlogCarouselContainer
+      ref={sectionRef}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <Box sx={{ display: 'flex', width: '100%', alignItems: 'center' }}>
+        <Typography variant="bodyXLargeStrong">{title}</Typography>
+
+        <Box sx={{ ml: 'auto', display: isSpread ? 'flex' : 'none', gap: 1 }}>
+          <IconButton onClick={handlePrev}>
+            <ArrowBackRoundedIcon />
+          </IconButton>
+
+          <BlogCarouselPagination total={total} activeIndex={displayIndex} />
+
+          <IconButton onClick={handleNext}>
+            <ArrowForwardRoundedIcon />
+          </IconButton>
+        </Box>
+      </Box>
+
+      <CarouselViewport>
+        <Box
+          sx={{
+            position: 'relative',
+            height: containerHeight ?? FALLBACK_CARD_WIDTH,
+          }}
+        >
+          <DraggableRow
+            onPointerCancel={handlePointerCancel}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+            style={{
+              position: 'absolute',
+              width: '100%',
+              height: '100%',
+              left: 0,
+              top: 0,
+              cursor: isSpread ? 'grab' : 'default',
+              touchAction: isSpread ? 'none' : 'auto',
+            }}
+          >
+            {data.map((article, index) => (
+              <BlogCarouselAnimatedCard
+                key={article.id}
                 article={article}
-                key={`blog-article-card-${article.id}-${index}`}
-                trackingCategory={TrackingCategory.BlogCarousel}
+                index={index}
+                motionIndex={motionIndex}
+                spreadMotion={spreadMotion}
+                cardSlot={cardSlot}
+                total={total}
+                isSpread={isSpread}
+                measureRef={index === 0 ? firstCardRef : undefined}
               />
-            ))
-          : Array.from({ length: 4 }).map((_, idx) => (
-              <BlogArticleCardSkeleton key={'article-card-skeleton-' + idx} />
             ))}
-      </Carousel>
+          </DraggableRow>
+        </Box>
+      </CarouselViewport>
     </BlogCarouselContainer>
   );
 };

--- a/src/components/Blog/BlogCarousel/BlogCarousel.tsx
+++ b/src/components/Blog/BlogCarousel/BlogCarousel.tsx
@@ -82,13 +82,13 @@ export const BlogCarousel = ({ data, title }: BlogCarouselProps) => {
         <Typography variant="bodyXLargeStrong">{title}</Typography>
 
         <Box sx={{ ml: 'auto', display: isSpread ? 'flex' : 'none', gap: 1 }}>
-          <IconButton onClick={handlePrev}>
+          <IconButton onClick={handlePrev} aria-label="Previous slide">
             <ArrowBackRoundedIcon />
           </IconButton>
 
           <BlogCarouselPagination total={total} activeIndex={displayIndex} />
 
-          <IconButton onClick={handleNext}>
+          <IconButton onClick={handleNext} aria-label="Next slide">
             <ArrowForwardRoundedIcon />
           </IconButton>
         </Box>

--- a/src/components/Blog/BlogCarousel/BlogCarousel.tsx
+++ b/src/components/Blog/BlogCarousel/BlogCarousel.tsx
@@ -98,7 +98,7 @@ export const BlogCarousel = ({ data, title }: BlogCarouselProps) => {
         <Box
           sx={{
             position: 'relative',
-            height: containerHeight ?? FALLBACK_CARD_WIDTH,
+            height: containerHeight ?? FALLBACK_CARD_HEIGHT,
           }}
         >
           <DraggableRow

--- a/src/components/Blog/BlogCarousel/BlogCarouselAnimatedCard.tsx
+++ b/src/components/Blog/BlogCarousel/BlogCarouselAnimatedCard.tsx
@@ -4,6 +4,7 @@ import type { BlogArticleData, StrapiResponseData } from '@/types/strapi';
 import { TrackingCategory } from '@/const/trackingKeys';
 import { BlogArticleCard } from '../BlogArticleCard/BlogArticleCard';
 import { useRef } from 'react';
+import { Box } from '@mui/material';
 import {
   motion,
   useMotionValue,
@@ -38,6 +39,8 @@ interface BlogCarouselAnimatedCardProps {
   cardSlot: ReturnType<typeof useMotionValue<number>>;
   total: number;
   isSpread: boolean;
+  isDragging: boolean;
+  carouselSessionActiveRef: React.MutableRefObject<boolean>;
   measureRef?: React.RefObject<HTMLDivElement | null>;
 }
 
@@ -49,6 +52,8 @@ export const BlogCarouselAnimatedCard = ({
   cardSlot,
   total,
   isSpread,
+  isDragging,
+  carouselSessionActiveRef,
   measureRef,
 }: BlogCarouselAnimatedCardProps) => {
   const cardRef = useRef<HTMLDivElement>(null);
@@ -79,7 +84,7 @@ export const BlogCarouselAnimatedCard = ({
   const imgY = useTransform(springY, [-0.5, 0.5], [-8, 8]);
 
   const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (!isSpread) {
+    if (!isSpread || carouselSessionActiveRef.current) {
       return;
     }
     const rect = (
@@ -142,6 +147,12 @@ export const BlogCarouselAnimatedCard = ({
     (mi) => total - Math.round(Math.abs(wrapRelativeIndex(index - mi, total))),
   );
 
+  const handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
+    if (carouselSessionActiveRef.current) {
+      e.preventDefault();
+    }
+  };
+
   return (
     <motion.div
       ref={ref as React.RefObject<HTMLDivElement>}
@@ -159,15 +170,21 @@ export const BlogCarouselAnimatedCard = ({
         left: 0,
         top: 0,
         width: 'max-content',
-        pointerEvents: isSpread ? 'auto' : 'none',
+        pointerEvents: !isSpread || isDragging ? 'none' : 'auto',
       }}
     >
-      <motion.div style={{ x: imgX, y: imgY }}>
-        <BlogArticleCard
-          article={article}
-          trackingCategory={TrackingCategory.BlogCarousel}
-        />
-      </motion.div>
+      <Box
+        component="div"
+        onDragStart={handleDragStart}
+        sx={{ width: 'max-content' }}
+      >
+        <motion.div style={{ x: imgX, y: imgY }}>
+          <BlogArticleCard
+            article={article}
+            trackingCategory={TrackingCategory.BlogCarousel}
+          />
+        </motion.div>
+      </Box>
     </motion.div>
   );
 };

--- a/src/components/Blog/BlogCarousel/BlogCarouselAnimatedCard.tsx
+++ b/src/components/Blog/BlogCarousel/BlogCarouselAnimatedCard.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import type { BlogArticleData, StrapiResponseData } from '@/types/strapi';
+import { TrackingCategory } from '@/const/trackingKeys';
+import { BlogArticleCard } from '../BlogArticleCard/BlogArticleCard';
+import { useRef } from 'react';
+import {
+  motion,
+  useMotionValue,
+  useTransform,
+  useSpring,
+  useMotionValueEvent,
+  animate,
+} from 'motion/react';
+import { STACK_PEEK_PX } from './BlogCarousel.style';
+
+export const wrapRelativeIndex = (raw: number, total: number) => {
+  const half = total / 2;
+  return (((raw % total) + total + half) % total) - half;
+};
+
+export const getConveyorX = (
+  index: number,
+  mi: number,
+  slot: number,
+  total: number,
+) => {
+  const totalWidth = total * slot;
+  const raw = (index - mi) * slot;
+  return ((((raw + slot) % totalWidth) + totalWidth) % totalWidth) - slot;
+};
+
+interface BlogCarouselAnimatedCardProps {
+  article: StrapiResponseData<BlogArticleData>[number];
+  index: number;
+  motionIndex: ReturnType<typeof useMotionValue<number>>;
+  spreadMotion: ReturnType<typeof useMotionValue<number>>;
+  cardSlot: ReturnType<typeof useMotionValue<number>>;
+  total: number;
+  isSpread: boolean;
+  measureRef?: React.RefObject<HTMLDivElement | null>;
+}
+
+export const BlogCarouselAnimatedCard = ({
+  article,
+  index,
+  motionIndex,
+  spreadMotion,
+  cardSlot,
+  total,
+  isSpread,
+  measureRef,
+}: BlogCarouselAnimatedCardProps) => {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const ref = measureRef ?? cardRef;
+
+  const prevConveyorX = useRef(
+    getConveyorX(index, motionIndex.get(), cardSlot.get(), total),
+  );
+  const teleportOpacity = useMotionValue(1);
+
+  useMotionValueEvent(motionIndex, 'change', (latest) => {
+    const slot = cardSlot.get();
+    const newX = getConveyorX(index, latest, slot, total);
+    if (Math.abs(newX - prevConveyorX.current) > total * slot * 0.4) {
+      teleportOpacity.set(0);
+      animate(teleportOpacity, 1, { duration: 0.15, delay: 0.03 });
+    }
+    prevConveyorX.current = newX;
+  });
+
+  const rawX = useMotionValue(0);
+  const rawY = useMotionValue(0);
+  const springX = useSpring(rawX, { stiffness: 120, damping: 20 });
+  const springY = useSpring(rawY, { stiffness: 120, damping: 20 });
+  const tiltX = useTransform(springY, [-0.5, 0.5], [6, -6]);
+  const tiltY = useTransform(springX, [-0.5, 0.5], [-6, 6]);
+  const imgX = useTransform(springX, [-0.5, 0.5], [-8, 8]);
+  const imgY = useTransform(springY, [-0.5, 0.5], [-8, 8]);
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!isSpread) {
+      return;
+    }
+    const rect = (
+      ref as React.RefObject<HTMLDivElement>
+    ).current?.getBoundingClientRect();
+    if (!rect) {
+      return;
+    }
+    rawX.set((e.clientX - rect.left) / rect.width - 0.5);
+    rawY.set((e.clientY - rect.top) / rect.height - 0.5);
+  };
+
+  const handleMouseLeave = () => {
+    rawX.set(0);
+    rawY.set(0);
+  };
+
+  const x = useTransform(
+    [motionIndex, spreadMotion, cardSlot],
+    (inputs: number[]) => {
+      const [mi, sp, slot] = inputs as [number, number, number];
+      return (
+        sp * getConveyorX(index, mi, slot, total) +
+        (1 - sp) * wrapRelativeIndex(index - mi, total) * STACK_PEEK_PX
+      );
+    },
+  );
+
+  const scale = useTransform(
+    [motionIndex, spreadMotion],
+    (inputs: number[]) => {
+      const [mi, sp] = inputs as [number, number];
+      const absRel = Math.abs(wrapRelativeIndex(index - mi, total));
+      return sp + (1 - sp) * (1 - absRel * 0.05);
+    },
+  );
+
+  const baseOpacity = useTransform(
+    [motionIndex, spreadMotion],
+    (inputs: number[]): number => {
+      const [mi, sp] = inputs as [number, number];
+      if (sp > 0.5) {
+        return 1;
+      }
+      const absRel = Math.abs(wrapRelativeIndex(index - mi, total));
+      return absRel < 0.5 ? 1 : 0.55;
+    },
+  );
+
+  const opacity = useTransform(
+    [baseOpacity, teleportOpacity],
+    (inputs: number[]) => {
+      const [base, tp] = inputs as [number, number];
+      return base * tp;
+    },
+  );
+
+  const zIndex = useTransform(
+    motionIndex,
+    (mi) => total - Math.round(Math.abs(wrapRelativeIndex(index - mi, total))),
+  );
+
+  return (
+    <motion.div
+      ref={ref as React.RefObject<HTMLDivElement>}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+      style={{
+        x,
+        scale,
+        opacity,
+        zIndex,
+        rotateX: tiltX,
+        rotateY: tiltY,
+        transformPerspective: 800,
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 'max-content',
+        pointerEvents: isSpread ? 'auto' : 'none',
+      }}
+    >
+      <motion.div style={{ x: imgX, y: imgY }}>
+        <BlogArticleCard
+          article={article}
+          trackingCategory={TrackingCategory.BlogCarousel}
+        />
+      </motion.div>
+    </motion.div>
+  );
+};

--- a/src/components/Blog/BlogCarousel/BlogCarouselPagination.tsx
+++ b/src/components/Blog/BlogCarousel/BlogCarouselPagination.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { motion } from 'motion/react';
+import { styled } from '@mui/material/styles';
+import { Box } from '@mui/material';
+
+const Track = styled(Box)({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '8px',
+});
+
+const Dot = styled(motion.div, {
+  shouldForwardProp: (p) => p !== 'isActive',
+})<{ isActive: boolean }>(({ theme, isActive }) => ({
+  height: '6px',
+  borderRadius: '6px',
+  width: isActive ? '40px' : '6px',
+  position: 'relative',
+  overflow: 'hidden',
+  backgroundColor: `${(theme.vars || theme).palette.alpha300.main}`,
+  transition: 'width 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+}));
+
+const Fill = styled(motion.div)(({ theme }) => ({
+  position: 'absolute',
+  inset: 0,
+  borderRadius: 'inherit',
+  backgroundColor: (theme.vars || theme).palette.accent1.main,
+  transformOrigin: 'left',
+}));
+
+interface BlogCarouselPaginationProps {
+  total: number;
+  activeIndex: number;
+}
+
+export const BlogCarouselPagination = ({
+  total,
+  activeIndex,
+}: BlogCarouselPaginationProps) => {
+  return (
+    <Track>
+      {Array.from({ length: total }).map((_, i) => (
+        <Dot key={i} isActive={i === activeIndex} layout>
+          {i === activeIndex && (
+            <Fill style={{ width: '100%', transformOrigin: 'left' }} />
+          )}
+        </Dot>
+      ))}
+    </Track>
+  );
+};

--- a/src/components/Blog/BlogCarousel/BlogCarouselPagination.tsx
+++ b/src/components/Blog/BlogCarousel/BlogCarouselPagination.tsx
@@ -41,9 +41,16 @@ export const BlogCarouselPagination = ({
   activeIndex,
 }: BlogCarouselPaginationProps) => {
   return (
-    <Track>
+    <Track role="tablist" aria-label="Carousel pagination">
       {Array.from({ length: total }).map((_, i) => (
-        <Dot key={i} isActive={i === activeIndex} layout>
+        <Dot
+          key={i}
+          isActive={i === activeIndex}
+          layout
+          role="tab"
+          aria-selected={i === activeIndex}
+          aria-label={`Slide ${i + 1} of ${total}`}
+        >
           {i === activeIndex && (
             <Fill style={{ width: '100%', transformOrigin: 'left' }} />
           )}

--- a/src/components/Blog/BlogCarousel/hooks.ts
+++ b/src/components/Blog/BlogCarousel/hooks.ts
@@ -1,0 +1,168 @@
+'use client';
+
+import type { BlogArticleData, StrapiResponseData } from '@/types/strapi';
+import type { PointerEvent as ReactPointerEvent } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { animate, useMotionValue } from 'motion/react';
+import { CARD_GAP, FALLBACK_SLOT, NAV_SPRING } from './BlogCarousel.style';
+
+const FLING_VELOCITY_THRESHOLD_PX = 300;
+
+type PointerSession = {
+  active: boolean;
+  lastClientX: number;
+  lastMoveTime: number;
+  lastVelocityX: number;
+};
+
+const getSnapIndexFromFling = (current: number, velocityX: number): number => {
+  if (velocityX > FLING_VELOCITY_THRESHOLD_PX) {
+    return Math.floor(current);
+  }
+  if (velocityX < -FLING_VELOCITY_THRESHOLD_PX) {
+    return Math.ceil(current);
+  }
+  return Math.round(current);
+};
+
+export const useCarouselMeasure = (
+  data: StrapiResponseData<BlogArticleData> | undefined,
+) => {
+  const firstCardRef = useRef<HTMLDivElement>(null);
+  const cardSlot = useMotionValue(FALLBACK_SLOT);
+  const [containerHeight, setContainerHeight] = useState<number | undefined>(
+    undefined,
+  );
+
+  useEffect(() => {
+    const el = firstCardRef.current;
+    if (!el) {
+      return;
+    }
+    const ro = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect;
+      if (width > 0) {
+        cardSlot.set(width + CARD_GAP);
+      }
+      if (height > 0) {
+        setContainerHeight(height);
+      }
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [cardSlot, data]);
+
+  return { firstCardRef, cardSlot, containerHeight };
+};
+
+export const useCarouselDrag = (
+  motionIndex: ReturnType<typeof useMotionValue<number>>,
+  cardSlot: ReturnType<typeof useMotionValue<number>>,
+  total: number,
+  dragEnabled: boolean,
+) => {
+  const isAnimating = useRef(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const pointerSession = useRef<PointerSession>({
+    active: false,
+    lastClientX: 0,
+    lastMoveTime: 0,
+    lastVelocityX: 0,
+  });
+
+  const handlePointerDown = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      if (!dragEnabled) {
+        return;
+      }
+      e.currentTarget.setPointerCapture(e.pointerId);
+      pointerSession.current = {
+        active: true,
+        lastClientX: e.clientX,
+        lastMoveTime: performance.now(),
+        lastVelocityX: 0,
+      };
+    },
+    [dragEnabled],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      if (!pointerSession.current.active) {
+        return;
+      }
+      const now = performance.now();
+      const dx = e.clientX - pointerSession.current.lastClientX;
+      const dt = now - pointerSession.current.lastMoveTime;
+      if (dt > 0) {
+        pointerSession.current.lastVelocityX = (dx / dt) * 1000;
+      }
+      pointerSession.current.lastClientX = e.clientX;
+      pointerSession.current.lastMoveTime = now;
+
+      const next = motionIndex.get() - dx / cardSlot.get();
+      motionIndex.set(next);
+      setActiveIndex(Math.round(next));
+    },
+    [motionIndex, cardSlot],
+  );
+
+  const endPointerDrag = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      if (!pointerSession.current.active) {
+        return;
+      }
+      pointerSession.current.active = false;
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        // already released
+      }
+      const current = motionIndex.get();
+      const vx = pointerSession.current.lastVelocityX;
+      const snapped = getSnapIndexFromFling(current, vx);
+      setActiveIndex(snapped);
+      animate(motionIndex, snapped, NAV_SPRING);
+    },
+    [motionIndex],
+  );
+
+  const scrollToIndex = useCallback(
+    (next: number) => {
+      if (isAnimating.current) {
+        return;
+      }
+      isAnimating.current = true;
+      setActiveIndex(next);
+      animate(motionIndex, next, {
+        ...NAV_SPRING,
+        onComplete: () => {
+          isAnimating.current = false;
+        },
+      });
+    },
+    [motionIndex],
+  );
+
+  const handleNext = useCallback(() => {
+    scrollToIndex(activeIndex + 1);
+  }, [scrollToIndex, activeIndex]);
+
+  const handlePrev = useCallback(() => {
+    scrollToIndex(activeIndex - 1);
+  }, [scrollToIndex, activeIndex]);
+
+  const displayIndex =
+    total === 0 ? 0 : ((activeIndex % total) + total) % total;
+
+  return {
+    displayIndex,
+    handleNext,
+    handlePointerCancel: endPointerDrag,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp: endPointerDrag,
+    handlePrev,
+    scrollToIndex,
+  };
+};

--- a/src/components/Blog/BlogCarousel/hooks.ts
+++ b/src/components/Blog/BlogCarousel/hooks.ts
@@ -7,10 +7,15 @@ import { animate, useMotionValue } from 'motion/react';
 import { CARD_GAP, FALLBACK_SLOT, NAV_SPRING } from './BlogCarousel.style';
 
 const FLING_VELOCITY_THRESHOLD_PX = 300;
+/** Horizontal movement past this (from pointer down) before cards lose pointer events — avoids breaking clicks. */
+const POINTER_DRAG_THRESHOLD_PX = 8;
 
 type PointerSession = {
   active: boolean;
+  pointerId: number;
   lastClientX: number;
+  pointerDownClientX: number;
+  motionIndexAtPointerDown: number;
   lastMoveTime: number;
   lastVelocityX: number;
 };
@@ -63,28 +68,104 @@ export const useCarouselDrag = (
 ) => {
   const isAnimating = useRef(false);
   const [activeIndex, setActiveIndex] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const carouselSessionActiveRef = useRef(false);
+  const dragThresholdMetRef = useRef(false);
+  const pointerCaptureHeldRef = useRef(false);
+  const windowPointerCleanupRef = useRef<(() => void) | null>(null);
   const pointerSession = useRef<PointerSession>({
     active: false,
+    pointerId: -1,
     lastClientX: 0,
+    pointerDownClientX: 0,
+    motionIndexAtPointerDown: 0,
     lastMoveTime: 0,
     lastVelocityX: 0,
   });
+
+  useEffect(() => {
+    return () => {
+      windowPointerCleanupRef.current?.();
+      windowPointerCleanupRef.current = null;
+    };
+  }, []);
+
+  const finalizeDrag = useCallback(
+    (
+      ev: PointerEvent | ReactPointerEvent<HTMLDivElement>,
+      row: HTMLDivElement,
+    ) => {
+      windowPointerCleanupRef.current?.();
+      windowPointerCleanupRef.current = null;
+
+      setIsDragging(false);
+      carouselSessionActiveRef.current = false;
+      dragThresholdMetRef.current = false;
+
+      if (!pointerSession.current.active) {
+        return;
+      }
+      if (ev.pointerId !== pointerSession.current.pointerId) {
+        return;
+      }
+
+      pointerSession.current.active = false;
+
+      if (pointerCaptureHeldRef.current) {
+        try {
+          row.releasePointerCapture(ev.pointerId);
+        } catch {
+          // already released
+        }
+        pointerCaptureHeldRef.current = false;
+      }
+
+      const current = motionIndex.get();
+      const vx = pointerSession.current.lastVelocityX;
+      const snapped = getSnapIndexFromFling(current, vx);
+      setActiveIndex(snapped);
+      animate(motionIndex, snapped, NAV_SPRING);
+    },
+    [motionIndex],
+  );
 
   const handlePointerDown = useCallback(
     (e: ReactPointerEvent<HTMLDivElement>) => {
       if (!dragEnabled) {
         return;
       }
+      dragThresholdMetRef.current = false;
+      pointerCaptureHeldRef.current = false;
       isAnimating.current = false;
-      e.currentTarget.setPointerCapture(e.pointerId);
+      carouselSessionActiveRef.current = true;
+      const row = e.currentTarget;
       pointerSession.current = {
         active: true,
+        pointerId: e.pointerId,
         lastClientX: e.clientX,
+        pointerDownClientX: e.clientX,
+        motionIndexAtPointerDown: motionIndex.get(),
         lastMoveTime: performance.now(),
         lastVelocityX: 0,
       };
+
+      const onWindowPointerEnd = (ev: PointerEvent) => {
+        if (
+          !pointerSession.current.active ||
+          ev.pointerId !== pointerSession.current.pointerId
+        ) {
+          return;
+        }
+        finalizeDrag(ev, row);
+      };
+      window.addEventListener('pointerup', onWindowPointerEnd);
+      window.addEventListener('pointercancel', onWindowPointerEnd);
+      windowPointerCleanupRef.current = () => {
+        window.removeEventListener('pointerup', onWindowPointerEnd);
+        window.removeEventListener('pointercancel', onWindowPointerEnd);
+      };
     },
-    [dragEnabled],
+    [dragEnabled, finalizeDrag, motionIndex],
   );
 
   const handlePointerMove = useCallback(
@@ -92,6 +173,35 @@ export const useCarouselDrag = (
       if (!pointerSession.current.active) {
         return;
       }
+
+      if (!dragThresholdMetRef.current) {
+        const movedFromStart = Math.abs(
+          e.clientX - pointerSession.current.pointerDownClientX,
+        );
+        if (movedFromStart < POINTER_DRAG_THRESHOLD_PX) {
+          return;
+        }
+        dragThresholdMetRef.current = true;
+        setIsDragging(true);
+        try {
+          e.currentTarget.setPointerCapture(e.pointerId);
+          pointerCaptureHeldRef.current = true;
+        } catch {
+          pointerCaptureHeldRef.current = false;
+        }
+        const now = performance.now();
+        const slot = cardSlot.get();
+        const totalDx = e.clientX - pointerSession.current.pointerDownClientX;
+        const mi0 = pointerSession.current.motionIndexAtPointerDown;
+        const next = mi0 - totalDx / slot;
+        pointerSession.current.lastClientX = e.clientX;
+        pointerSession.current.lastMoveTime = now;
+        pointerSession.current.lastVelocityX = 0;
+        motionIndex.set(next);
+        setActiveIndex(Math.round(next));
+        return;
+      }
+
       const now = performance.now();
       const dx = e.clientX - pointerSession.current.lastClientX;
       const dt = now - pointerSession.current.lastMoveTime;
@@ -110,22 +220,9 @@ export const useCarouselDrag = (
 
   const endPointerDrag = useCallback(
     (e: ReactPointerEvent<HTMLDivElement>) => {
-      if (!pointerSession.current.active) {
-        return;
-      }
-      pointerSession.current.active = false;
-      try {
-        e.currentTarget.releasePointerCapture(e.pointerId);
-      } catch {
-        // already released
-      }
-      const current = motionIndex.get();
-      const vx = pointerSession.current.lastVelocityX;
-      const snapped = getSnapIndexFromFling(current, vx);
-      setActiveIndex(snapped);
-      animate(motionIndex, snapped, NAV_SPRING);
+      finalizeDrag(e, e.currentTarget);
     },
-    [motionIndex],
+    [finalizeDrag],
   );
 
   const scrollToIndex = useCallback(
@@ -158,6 +255,8 @@ export const useCarouselDrag = (
 
   return {
     displayIndex,
+    isDragging,
+    carouselSessionActiveRef,
     handleNext,
     handlePointerCancel: endPointerDrag,
     handlePointerDown,

--- a/src/components/Blog/BlogCarousel/hooks.ts
+++ b/src/components/Blog/BlogCarousel/hooks.ts
@@ -75,6 +75,7 @@ export const useCarouselDrag = (
       if (!dragEnabled) {
         return;
       }
+      isAnimating.current = false;
       e.currentTarget.setPointerCapture(e.pointerId);
       pointerSession.current = {
         active: true,


### PR DESCRIPTION
# Which Jira task belongs to this PR?

https://linear.app/lifi-linear/issue/JUM-717/p2-learn-page-animate-blog-carousel-section

## Testing steps
1. Go to `/learn`
2. Check the recent post section - scrolling to it should expand the cards into view
3. Navigate through the articles
4. Open mobile view and check the navigation behaviour
5. Now go to a learn details page 
6. Check the bottom section (Similar posts)
7. Repeat steps 3 and 4

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New drag-and-swipe blog carousel with grab-to-drag interaction, left/right controls, hover-expanded (spread) visuals, per-card motion/tilt effects, and smoother spring animations.
  * Enhanced pagination with a clearer animated active indicator and ARIA semantics.

* **Bug Fixes / UI Changes**
  * Loading/empty state now shows consistent skeleton placeholders.
  * Removed the "view all" button from the similar-posts carousel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->