### PR TITLE
fix: decrease default cropRatio for image colors extraction

### DIFF
--- a/src/components/Cards/ProtocolCard/ProtocolCard.stories.tsx
+++ b/src/components/Cards/ProtocolCard/ProtocolCard.stories.tsx
@@ -64,3 +64,17 @@ export const TitleContrastColor: Story = {
     },
   },
 };
+
+export const TitleContrastColorMidas: Story = {
+  args: {
+    ...commonArgs,
+    fullWidth: false,
+    data: {
+      ...commonArgs.data,
+      protocol: {
+        ...commonArgs.data.protocol,
+        logo: `${JUMPER_STRAPI_URL}/uploads/Midas_Logo_Icon_PRIMARY_c280a8c7c9.png`,
+      },
+    },
+  },
+};

--- a/src/hooks/images/useGetColorsFromImage.ts
+++ b/src/hooks/images/useGetColorsFromImage.ts
@@ -114,7 +114,7 @@ export const useGetColorsFromImage = (
   imageUrl: string,
   useCenterCrop = false,
   useEdgeCrop = false,
-  cropRatio = 0.5,
+  cropRatio = 0.45,
 ) => {
   const [colors, setColors] = useState<Color[]>([]);
 


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-721/protocol-card-contrast-issue-on-earn-detail

## Testing steps
1. You can either open storybook or go to `/earn` and select an opportunity for the Midas protocol
2. Check the Midas text color over the image is showing a high-enough contrast color

# Why did I implement it this way?

The cropped ratio was too large to extract the proper color areas, thus reporting the withish color as being the right contrast color for the background which is not correct. The fix was to decrease this value.

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted image processing parameters to optimize color extraction behavior and enhance visual consistency across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->