### PR TITLE
feat: query positions by same chain type wallets

### DIFF
--- a/src/app/lib/getPositionsForAddress.ts
+++ b/src/app/lib/getPositionsForAddress.ts
@@ -3,6 +3,7 @@ import type {
   JumperBackend,
   WalletPositions,
 } from '@/types/jumper-backend';
+import { ChainType } from '@lifi/sdk';
 import { makeClient } from './client';
 
 export type GetPositionsForAddressResult = HttpResponse<
@@ -14,7 +15,27 @@ export type PortfolioPositionsQuery = Parameters<
   JumperBackend<unknown>['v1']['portfolioControllerGetPositionsForAddressV1']
 >[0];
 
-export async function getPositionsForAddress(
+export type AddressQueryParams = Pick<
+  NonNullable<PortfolioPositionsQuery>,
+  'evm' | 'svm' | 'mvm' | 'utxo' | 'tvm'
+>;
+
+export type PositionsFilter = Omit<
+  NonNullable<PortfolioPositionsQuery>,
+  keyof AddressQueryParams
+>;
+
+export const CHAIN_TYPE_TO_QUERY_PARAM: Partial<
+  Record<ChainType, keyof AddressQueryParams>
+> = {
+  [ChainType.EVM]: 'evm',
+  [ChainType.SVM]: 'svm',
+  [ChainType.MVM]: 'mvm',
+  [ChainType.UTXO]: 'utxo',
+  [ChainType.TVM]: 'tvm',
+};
+
+export async function getPositionsForAddresses(
   query: PortfolioPositionsQuery,
 ): Promise<GetPositionsForAddressResult> {
   const client = makeClient();

--- a/src/hooks/accounts/useAccountGroupsByChainType.ts
+++ b/src/hooks/accounts/useAccountGroupsByChainType.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+import groupBy from 'lodash/groupBy';
+import type { Account } from '@lifi/wallet-management';
+import type { AddressQueryParams } from '@/app/lib/getPositionsForAddress';
+import { CHAIN_TYPE_TO_QUERY_PARAM } from '@/app/lib/getPositionsForAddress';
+
+export const useAccountGroupsByChainType = (accounts: Account[]) =>
+  useMemo(() => {
+    const connected = accounts.filter(
+      (acc) =>
+        acc.isConnected &&
+        acc.address &&
+        CHAIN_TYPE_TO_QUERY_PARAM[acc.chainType],
+    );
+
+    const grouped = groupBy(
+      connected,
+      (acc) => CHAIN_TYPE_TO_QUERY_PARAM[acc.chainType],
+    );
+
+    return Object.entries(grouped).map(([addressParam, accs]) => ({
+      addressParam: addressParam as keyof AddressQueryParams,
+      addresses: [...new Set(accs.map((acc) => acc.address!))].sort(),
+    }));
+  }, [accounts]);

--- a/src/hooks/portfolio/usePortfolioDeFiPositions.ts
+++ b/src/hooks/portfolio/usePortfolioDeFiPositions.ts
@@ -2,20 +2,23 @@ import { useQueries } from '@tanstack/react-query';
 import { min } from 'date-fns';
 import { useCallback, useMemo } from 'react';
 import { ONE_HOUR_MS } from 'src/const/time';
-import type { Address, Hex } from 'viem';
-import type { PortfolioPositionsQuery } from '@/app/lib/getPositionsForAddress';
-import { getPositionsForAddress } from '@/app/lib/getPositionsForAddress';
+import type { Address } from 'viem';
+import type {
+  AddressQueryParams,
+  PortfolioPositionsQuery,
+} from '@/app/lib/getPositionsForAddress';
+import { getPositionsForAddresses } from '@/app/lib/getPositionsForAddress';
 import type { WalletPositions } from '@/types/jumper-backend';
 import type { DefiPosition } from '@/utils/positions/type-guards';
 import type { GetTokenUSDPrice } from '@/utils/positions/update-price';
 import { updateWalletPositionsPrice } from '@/utils/positions/update-price';
 import { useTokens } from '../useTokens';
 import type { Account } from '@lifi/wallet-management';
-import { ChainType } from '@lifi/sdk';
+import { useAccountGroupsByChainType } from '../accounts/useAccountGroupsByChainType';
 
 export interface Props {
   accounts: Account[];
-  filter?: Omit<PortfolioPositionsQuery, 'evm'>;
+  filter?: Omit<PortfolioPositionsQuery, keyof AddressQueryParams>;
 }
 
 export interface Result {
@@ -26,31 +29,29 @@ export interface Result {
   refetch: () => void;
 }
 
+// @Note: wrap earn pages with portfolio provider and remove this hook
 export const usePortfolioDeFiPositions = ({
   accounts,
   filter,
 }: Props): Result => {
   const { getToken, isLoading: isLoadingTokens, updatedAt } = useTokens();
+  const accountGroups = useAccountGroupsByChainType(accounts);
 
   const getTokenUSDPrice: GetTokenUSDPrice = useCallback(
     (token: { chainId: number; address: string }) => {
       try {
         const tokenFound = getToken(token.chainId, token.address as Address);
-
         if (!tokenFound) {
           throw new Error(
             `Token not found for address ${token.address} on chain ${token.chainId}`,
           );
         }
-
         const priceUSD = parseFloat(tokenFound.priceUSD);
-
         if (isNaN(priceUSD)) {
           throw new Error(
             `Price USD is NaN for token ${token.address} on chain ${token.chainId}`,
           );
         }
-
         return priceUSD;
       } catch (error) {
         console.warn('Could not get token USD price', token, error);
@@ -61,74 +62,56 @@ export const usePortfolioDeFiPositions = ({
   );
 
   const queries = useQueries({
-    queries: accounts.map((account) => ({
+    queries: accountGroups.map(({ addressParam, addresses }) => ({
       queryKey: [
         'portfolio-defi-positions',
-        account.address,
+        addressParam,
+        addresses,
         filter,
         updatedAt,
       ],
       queryFn: async () => {
-        // @TODO JUM-624 handle svm address as query param
-        if (account.chainType !== ChainType.EVM) {
-          return;
-        }
-
-        const result = await getPositionsForAddress({
-          evm: account.address as Hex,
+        const result = await getPositionsForAddresses({
           ...filter,
+          [addressParam]: addresses,
         });
-        const positions = result.data;
-        return updateWalletPositionsPrice(positions, getTokenUSDPrice);
+        return updateWalletPositionsPrice(result.data, getTokenUSDPrice);
       },
-      enabled: !!account.address && account.isConnected && !isLoadingTokens,
+      enabled: !isLoadingTokens && addresses.length > 0,
       refetchInterval: ONE_HOUR_MS,
     })),
   });
 
-  const isLoading = isLoadingTokens || queries.some((query) => query.isLoading);
-  const isSuccess = queries.every((query) => query.isSuccess);
-  const error = queries.find((query) => query.error)?.error ?? null;
+  const isLoading = isLoadingTokens || queries.some((q) => q.isLoading);
+  const isSuccess = queries.every((q) => q.isSuccess);
+  const error = queries.find((q) => q.error)?.error ?? null;
 
   const data = useMemo((): WalletPositions | undefined => {
     if (!isSuccess || queries.length === 0) {
       return undefined;
     }
 
-    const successfulQueries = queries.filter(
-      (query) => query.isSuccess && query.data,
-    );
-
+    const successfulQueries = queries.filter((q) => q.isSuccess && q.data);
     const allPositions: DefiPosition[] = successfulQueries.flatMap(
-      (query) => query.data?.data ?? [],
+      (q) => q.data?.data ?? [],
     );
 
-    // Extract dates from all queries (meta.updatedAt is ISO string, dataUpdatedAt is timestamp)
-    const dates = successfulQueries.map((query) => {
-      const metaUpdatedAt = query.data?.meta?.updatedAt;
+    const dates = successfulQueries.map((q) => {
+      const metaUpdatedAt = q.data?.meta?.updatedAt;
       return metaUpdatedAt
         ? new Date(metaUpdatedAt)
-        : new Date(query.dataUpdatedAt);
+        : new Date(q.dataUpdatedAt);
     });
 
-    const oldestUpdatedAtOrFallback =
+    const oldestUpdatedAt =
       dates.length > 0 ? min(dates).toISOString() : new Date().toISOString();
 
-    return {
-      data: allPositions,
-      meta: { updatedAt: oldestUpdatedAtOrFallback },
-    };
+    return { data: allPositions, meta: { updatedAt: oldestUpdatedAt } };
   }, [queries, isSuccess]);
 
   const refetch = () => {
-    queries.forEach((query) => query.refetch());
+    queries.forEach((q) => q.refetch());
   };
 
-  return {
-    data,
-    isLoading,
-    isSuccess,
-    error,
-    refetch,
-  };
+  return { data, isLoading, isSuccess, error, refetch };
 };

--- a/src/providers/PortfolioProvider/hooks/usePositionsData.ts
+++ b/src/providers/PortfolioProvider/hooks/usePositionsData.ts
@@ -1,25 +1,35 @@
 import { useQueries } from '@tanstack/react-query';
 import { min } from 'date-fns';
+import groupBy from 'lodash/groupBy';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ONE_HOUR_MS } from 'src/const/time';
 import type { Hex } from 'viem';
-import type { PortfolioPositionsQuery } from '@/app/lib/getPositionsForAddress';
-import { getPositionsForAddress } from '@/app/lib/getPositionsForAddress';
+import type {
+  AddressQueryParams,
+  PortfolioPositionsQuery,
+} from '@/app/lib/getPositionsForAddress';
+import { getPositionsForAddresses } from '@/app/lib/getPositionsForAddress';
 import type { DefiPosition } from '@/utils/positions/type-guards';
-import type { EVMAccount } from '@lifi/wallet-management';
+import type { Account } from '@lifi/wallet-management';
 import { useAccount } from '@lifi/wallet-management';
 import { usePortfolioCacheStore } from '@/stores/portfolio/PortfolioCacheStore';
 import { usePathnameWithoutLocale } from '@/hooks/routing/usePathnameWithoutLocale';
 import { isCurrentPageUsingPositionData } from '../utils';
+import { useAccountGroupsByChainType } from '@/hooks/accounts/useAccountGroupsByChainType';
+
+type PositionsFilter = Omit<
+  NonNullable<PortfolioPositionsQuery>,
+  keyof AddressQueryParams
+>;
 
 export interface UsePositionsDataProps {
-  filter?: Omit<PortfolioPositionsQuery, 'evm'>;
+  filter?: PositionsFilter;
 }
 
 export interface UsePositionsDataResult {
   positions: DefiPosition[];
   positionsByAddress: Record<string, DefiPosition[]>;
-  accounts: EVMAccount[];
+  accounts: Account[];
   isLoading: boolean;
   isFetching: boolean;
   isPlaceholderData: boolean;
@@ -29,15 +39,11 @@ export interface UsePositionsDataResult {
   refetch: () => void;
 }
 
-type PositionsFilter = Omit<PortfolioPositionsQuery, 'evm'>;
-
 const hasFilteringKeys = (filter?: PositionsFilter): boolean => {
   if (!filter) {
     return false;
   }
-
   const nonFilteringKeys: Array<keyof PositionsFilter> = ['sortBy', 'order'];
-
   return Object.keys(filter).some(
     (key) => !nonFilteringKeys.includes(key as keyof PositionsFilter),
   );
@@ -46,7 +52,8 @@ const hasFilteringKeys = (filter?: PositionsFilter): boolean => {
 interface QueryData {
   data: DefiPosition[];
   meta: { updatedAt: string };
-  address: Hex;
+  addresses: string[];
+  addressParam: keyof AddressQueryParams;
 }
 
 export const usePositionsData = ({
@@ -55,11 +62,9 @@ export const usePositionsData = ({
   const pathname = usePathnameWithoutLocale();
   const isEnabled = isCurrentPageUsingPositionData(pathname);
   const { accounts } = useAccount();
+
   const connectedAccounts = useMemo(
-    () =>
-      accounts.filter(
-        (acc) => acc.isConnected && acc.chainType === 'EVM' && acc.address,
-      ) as EVMAccount[],
+    () => accounts.filter((acc) => acc.isConnected && acc.address) as Account[],
     [accounts],
   );
 
@@ -67,6 +72,8 @@ export const usePositionsData = ({
     () => connectedAccounts.map((acc) => acc.address as Hex),
     [connectedAccounts],
   );
+
+  const accountGroups = useAccountGroupsByChainType(connectedAccounts);
 
   const getPositions = usePortfolioCacheStore((s) => s.getPositions);
   const setPositionsCache = usePortfolioCacheStore((s) => s.setPositions);
@@ -82,30 +89,30 @@ export const usePositionsData = ({
   const shouldUseCache = !hasFilteringKeys(filter);
 
   const queries = useQueries({
-    queries: addresses.map((address) => ({
-      queryKey: ['portfolio-positions', address, filter],
+    queries: accountGroups.map(({ addressParam, addresses: batch }) => ({
+      queryKey: ['portfolio-positions', addressParam, batch, filter],
       queryFn: async (): Promise<QueryData> => {
         shouldSetCacheRef.current = shouldUseCache;
-
-        const result = await getPositionsForAddress({
-          evm: address,
+        const result = await getPositionsForAddresses({
           ...filter,
+          [addressParam]: batch,
         });
-        return { ...result.data, address };
+        return { ...result.data, addresses: batch, addressParam };
       },
-      enabled: !!address && isEnabled,
+      enabled: isEnabled && batch.length > 0,
       refetchInterval: ONE_HOUR_MS,
       placeholderData: shouldUseCache
         ? (): QueryData | undefined => {
-            const cached = getPositions(address);
-            if (cached.length > 0) {
-              return {
-                data: cached,
-                meta: { updatedAt: '' },
-                address,
-              };
+            const cachedChunks = batch.map((addr) => getPositions(addr));
+            if (!cachedChunks.some((c) => c.length > 0)) {
+              return undefined;
             }
-            return undefined;
+            return {
+              data: batch.flatMap((addr) => getPositions(addr)),
+              meta: { updatedAt: '' },
+              addresses: batch,
+              addressParam,
+            };
           }
         : undefined,
     })),
@@ -115,15 +122,18 @@ export const usePositionsData = ({
     if (!shouldUseCache || !shouldSetCacheRef.current) {
       return;
     }
-
     shouldSetCacheRef.current = false;
 
-    queries.forEach((query) => {
-      if (query.isSuccess && query.data && !query.isPlaceholderData) {
-        const { address, data: positions } = query.data;
-        setPositionsCache(address, positions);
+    for (const query of queries) {
+      if (!query.isSuccess || !query.data || query.isPlaceholderData) {
+        continue;
       }
-    });
+      const { addresses: batch, data: positions } = query.data;
+      const byAddress = groupBy(positions, (p) => p.address.toLowerCase());
+      for (const addr of batch) {
+        setPositionsCache(addr, byAddress[addr.toLowerCase()] ?? []);
+      }
+    }
   }, [queries, setPositionsCache, shouldUseCache]);
 
   useEffect(() => {
@@ -132,22 +142,22 @@ export const usePositionsData = ({
     }
   }, [positionPatchVersion, wasCachePatched]);
 
-  const isLoading = queries.some((query) => query.isLoading);
-  const isFetching = queries.some((query) => query.isFetching);
-  const isPlaceholderData = queries.some((query) => query.isPlaceholderData);
-  const isSuccess = queries.every((query) => query.isSuccess);
-  const error = (queries.find((query) => query.error)?.error as Error) ?? null;
+  const isLoading = queries.some((q) => q.isLoading);
+  const isFetching = queries.some((q) => q.isFetching);
+  const isPlaceholderData = queries.some((q) => q.isPlaceholderData);
+  const isSuccess = queries.every((q) => q.isSuccess);
+  const error = (queries.find((q) => q.error)?.error as Error) ?? null;
 
   const successfulQueries = useMemo(
-    () => queries.filter((query) => query.isSuccess && query.data),
+    () => queries.filter((q) => q.isSuccess && q.data),
     [queries],
   );
 
   const positions = useMemo((): DefiPosition[] => {
     if (wasCachePatched && shouldUseCache) {
-      return addresses.flatMap((address) => getPositions(address));
+      return addresses.flatMap((addr) => getPositions(addr));
     }
-    return successfulQueries.flatMap((query) => query.data?.data ?? []);
+    return successfulQueries.flatMap((q) => q.data?.data ?? []);
   }, [
     successfulQueries,
     wasCachePatched,
@@ -158,24 +168,16 @@ export const usePositionsData = ({
 
   const positionsByAddress = useMemo((): Record<string, DefiPosition[]> => {
     if (wasCachePatched && shouldUseCache) {
-      return addresses.reduce(
-        (acc, address) => {
-          acc[address] = getPositions(address);
-          return acc;
-        },
-        {} as Record<string, DefiPosition[]>,
+      return Object.fromEntries(
+        addresses.map((addr) => [addr, getPositions(addr)]),
       );
     }
 
-    return addresses.reduce(
-      (acc, address) => {
-        const query = successfulQueries.find(
-          (q) => q.data?.address === address,
-        );
-        acc[address] = query?.data?.data ?? [];
-        return acc;
-      },
-      {} as Record<string, DefiPosition[]>,
+    const allPositions = successfulQueries.flatMap((q) => q.data?.data ?? []);
+    const byAddress = groupBy(allPositions, (p) => p.address.toLowerCase());
+
+    return Object.fromEntries(
+      addresses.map((addr) => [addr, byAddress[addr.toLowerCase()] ?? []]),
     );
   }, [
     addresses,
@@ -189,19 +191,17 @@ export const usePositionsData = ({
     if (successfulQueries.length === 0) {
       return null;
     }
-
-    const dates = successfulQueries.map((query) => {
-      const metaUpdatedAt = query.data?.meta?.updatedAt;
+    const dates = successfulQueries.map((q) => {
+      const metaUpdatedAt = q.data?.meta?.updatedAt;
       return metaUpdatedAt
         ? new Date(metaUpdatedAt)
-        : new Date(query.dataUpdatedAt);
+        : new Date(q.dataUpdatedAt);
     });
-
-    return dates.length > 0 ? min(dates).getTime() : null;
+    return min(dates).getTime();
   }, [successfulQueries]);
 
   const refetch = useCallback(() => {
-    queries.forEach((query) => query.refetch());
+    queries.forEach((q) => q.refetch());
   }, [queries]);
 
   return {

--- a/src/providers/PortfolioProvider/lib/fetchPositionsForAddresses.ts
+++ b/src/providers/PortfolioProvider/lib/fetchPositionsForAddresses.ts
@@ -1,4 +1,4 @@
-import { getPositionsForAddress } from '@/app/lib/getPositionsForAddress';
+import { getPositionsForAddresses } from '@/app/lib/getPositionsForAddress';
 import type {
   HttpResponse,
   JumperBackend,
@@ -11,17 +11,9 @@ export type FetchPositionsParams = Parameters<
 
 export type FetchPositionsResult = HttpResponse<WalletPositions, unknown>;
 
-/** Fetch positions for a single wallet address */
-export const fetchPositionsForAddress = async (
+export const fetchPositionsForAddresses = async (
   params: FetchPositionsParams,
 ): Promise<FetchPositionsResult> => {
-  const result = await getPositionsForAddress(params);
+  const result = await getPositionsForAddresses(params);
   return result;
-};
-
-/** Fetch positions for multiple addresses */
-export const fetchPositionsForAddresses = async (
-  params: FetchPositionsParams[],
-): Promise<FetchPositionsResult[]> => {
-  return Promise.all(params.map(fetchPositionsForAddress));
 };

--- a/src/types/jumper-backend.ts
+++ b/src/types/jumper-backend.ts
@@ -13,6 +13,37 @@ import type { Hex } from 'viem';
  * ---------------------------------------------------------------
  */
 
+export interface WalletEVM {
+  address: string;
+  message: string;
+  signature: string;
+}
+
+export interface SolanaSignature {
+  type: string;
+  data: number[];
+}
+
+export interface WalletSolana {
+  message: string;
+  signature: SolanaSignature;
+  publicKey: string;
+}
+
+export interface VerifyWalletDto {
+  /** EVM wallet */
+  evm?: WalletEVM;
+  /** Solana wallet */
+  solana?: WalletSolana;
+}
+
+export interface WalletVerificationDto {
+  /** Origin wallet data */
+  origin_wallet: WalletEVM;
+  /** Destination wallet data */
+  destination_wallet: WalletEVM;
+}
+
 export interface CreateUserTrackingDto {
   /**
    * The category of the tracking event
@@ -500,37 +531,6 @@ export interface PosthogFeatureFlag {
   data: string | boolean;
 }
 
-export interface WalletEVM {
-  address: string;
-  message: string;
-  signature: string;
-}
-
-export interface SolanaSignature {
-  type: string;
-  data: number[];
-}
-
-export interface WalletSolana {
-  message: string;
-  signature: SolanaSignature;
-  publicKey: string;
-}
-
-export interface VerifyWalletDto {
-  /** EVM wallet */
-  evm?: WalletEVM;
-  /** Solana wallet */
-  solana?: WalletSolana;
-}
-
-export interface WalletVerificationDto {
-  /** Origin wallet data */
-  origin_wallet: WalletEVM;
-  /** Destination wallet data */
-  destination_wallet: WalletEVM;
-}
-
 export interface CreateWalletTransactionDto {
   sessionId: string;
   /**
@@ -668,9 +668,9 @@ export interface EarnOpportunityHistoryItem {
 
 export interface EarnOpportunityWithLatestAnalytics {
   name: string;
-  isRedeemable: boolean;
   asset: Token;
   protocol: Protocol;
+  isRedeemable: boolean;
   url?: string;
   description: string;
   tags: string[];
@@ -930,9 +930,9 @@ export interface GeneratePayloadDto {
 
 export interface EarnOpportunityWithScore {
   name: string;
-  isRedeemable: boolean;
   asset: Token;
   protocol: Protocol;
+  isRedeemable: boolean;
   url?: string;
   description: string;
   tags: string[];
@@ -1638,14 +1638,16 @@ export class JumperBackend<
      */
     portfolioControllerGetTokensForAddressV1: (
       query?: {
-        /** The EVM address to get tokens for */
-        evm?: string;
-        /** The Solana address to get tokens for */
-        solana?: string;
-        /** The SUI address to get tokens for */
-        sui?: string;
-        /** The UTXO address to get tokens for */
-        bitcoin?: string;
+        /** EVM addresses to get tokens for */
+        evm?: string[];
+        /** Solana Virtual Machine (SVM) addresses to get tokens for */
+        svm?: string[];
+        /** Move Virtual Machine (MVM) addresses to get tokens for, e.g. Sui */
+        mvm?: string[];
+        /** Unspent transaction output (UTXO) addresses to get tokens for, e.g. Bitcoin */
+        utxo?: string[];
+        /** Tron Virtual Machine (TVM) addresses to get tokens for */
+        tvm?: string[];
         /**
          * The chain ids to filter for
          * @example [1,10,137]
@@ -1686,9 +1688,17 @@ export class JumperBackend<
      * @request GET:/v1/portfolio/positions
      */
     portfolioControllerGetPositionsForAddressV1: (
-      query: {
-        /** The EVM address to get positions for */
-        evm: string;
+      query?: {
+        /** EVM addresses to get positions for */
+        evm?: string[];
+        /** Solana Virtual Machine (SVM) addresses (reserved for future use) */
+        svm?: string[];
+        /** Move Virtual Machine (MVM) addresses (reserved for future use), e.g. Sui */
+        mvm?: string[];
+        /** Unspent transaction output (UTXO) addresses (reserved for future use), e.g. Bitcoin */
+        utxo?: string[];
+        /** Tron Virtual Machine (TVM) addresses (reserved for future use) */
+        tvm?: string[];
         /**
          * Sort by field.
          * @example "value"


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-730/query-all-wallets-and-chain-type-on-position-from-the-frontend
Needs https://github.com/jumperexchange/jumper-backend/pull/797 to be merged before testing

## Testing steps
1. Once BE PR is merged (or if you run it locally)
2. Connect the dev wallet on Solana `XmLV4Fk3FYvZx83fmx3e1UWwzCkcwuP9SHzvoxRJ7ZG`
3. Go to `/portfolio`
4. Remove the value filter for the defi positions
5. Check the Solana positions show up in the list (fixing the bg image for the Carrot position is in a subsequent PR)

<img width="1234" height="441" alt="Screenshot 2026-03-27 at 13 20 25" src="https://github.com/user-attachments/assets/7dd7bd9b-0748-4562-a670-6954785387c6" />


# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended portfolio support to multiple blockchain networks including Solana, Sui, and Bitcoin, moving beyond EVM-only capabilities.
  * Implemented batch address querying for improved efficiency across supported chains.

* **Updates**
  * Refined portfolio API endpoints to accept multi-chain address parameters with standardized query structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->