### PR TITLE
fix: remove min max normalisation for same value charts

### DIFF
--- a/src/components/core/charts/LineChart/LineChart.stories.tsx
+++ b/src/components/core/charts/LineChart/LineChart.stories.tsx
@@ -123,6 +123,26 @@ export const MonthlyTVL: Story = {
   },
 };
 
+export const ApySameWithNulls: Story = {
+  render: DefaultRenderer,
+  args: {
+    ...commonArgs,
+    dateFormat: 'dd MMM HH:mm',
+    data: [
+      { date: '2026-03-20T08:00:00.000Z', value: 0.0375 },
+      { date: '2026-03-20T09:00:00.000Z', value: 0.0375 },
+      { date: '2026-03-20T10:00:00.000Z', value: 0.0375 },
+      { date: '2026-03-20T11:00:00.000Z', value: 0.0375 },
+      { date: '2026-03-20T12:00:00.000Z', value: 0.0375 },
+      { date: '2026-03-20T13:00:00.000Z', value: null },
+      { date: '2026-03-20T14:00:00.000Z', value: null },
+      { date: '2026-03-20T15:00:00.000Z', value: null },
+      { date: '2026-03-20T16:00:00.000Z', value: 0.0375 },
+      { date: '2026-03-20T17:00:00.000Z', value: 0.0375 },
+    ] as unknown as LineChartProps<number>['data'],
+  },
+};
+
 export const OnlyWithBaseLayers: Story = {
   render: DefaultRenderer,
   args: {

--- a/src/components/core/charts/LineChart/__snapshots__/LineChart.snapshot.spec.tsx.snap
+++ b/src/components/core/charts/LineChart/__snapshots__/LineChart.snapshot.spec.tsx.snap
@@ -5561,20 +5561,38 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                 <rect
                   class="recharts-cartesian-grid-bg"
                   fill="transparent"
-                  height="35"
+                  height="15"
                   stroke="none"
                   width="30"
                   x="65"
-                  y="0"
+                  y="5"
                 />
                 <rect
                   class="recharts-cartesian-grid-bg"
                   fill="transparent"
-                  height="30"
+                  height="15"
+                  stroke="none"
+                  width="30"
+                  x="65"
+                  y="20"
+                />
+                <rect
+                  class="recharts-cartesian-grid-bg"
+                  fill="transparent"
+                  height="15"
                   stroke="none"
                   width="30"
                   x="65"
                   y="35"
+                />
+                <rect
+                  class="recharts-cartesian-grid-bg"
+                  fill="transparent"
+                  height="15"
+                  stroke="none"
+                  width="30"
+                  x="65"
+                  y="50"
                 />
               </g>
               <g
@@ -5590,8 +5608,21 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                   x1="65"
                   x2="95"
                   y="5"
-                  y1="35"
-                  y2="35"
+                  y1="65"
+                  y2="65"
+                />
+                <line
+                  fill="none"
+                  height="60"
+                  stroke="color-mix(in srgb, var(--jumper-palette-alpha900-main) 10%, transparent)"
+                  stroke-dasharray="0"
+                  width="30"
+                  x="65"
+                  x1="65"
+                  x2="95"
+                  y="5"
+                  y1="50"
+                  y2="50"
                 />
                 <line
                   fill="none"
@@ -5616,8 +5647,8 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                   x1="65"
                   x2="95"
                   y="5"
-                  y1="35"
-                  y2="35"
+                  y1="20"
+                  y2="20"
                 />
                 <line
                   fill="none"
@@ -5629,21 +5660,8 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                   x1="65"
                   x2="95"
                   y="5"
-                  y1="35"
-                  y2="35"
-                />
-                <line
-                  fill="none"
-                  height="60"
-                  stroke="color-mix(in srgb, var(--jumper-palette-alpha900-main) 10%, transparent)"
-                  stroke-dasharray="0"
-                  width="30"
-                  x="65"
-                  x1="65"
-                  x2="95"
-                  y="5"
-                  y1="35"
-                  y2="35"
+                  y1="5"
+                  y2="5"
                 />
               </g>
             </g>
@@ -5697,7 +5715,7 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                     id="animationClipPath-recharts-area-_r_t_"
                   >
                     <rect
-                      height="36"
+                      height="66"
                       width="0"
                       x="65"
                       y="0"
@@ -5713,7 +5731,7 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                   >
                     <path
                       class="recharts-curve recharts-area-area"
-                      d="M65,35C67.5,35,70,35,72.5,35C75,35,77.5,35,80,35C82.5,35,85,35,87.5,35C90,35,92.5,35,95,35L95,35C92.5,35,90,35,87.5,35C85,35,82.5,35,80,35C77.5,35,75,35,72.5,35C70,35,67.5,35,65,35Z"
+                      d="M65,65C67.5,65,70,65,72.5,65C75,65,77.5,65,80,65C82.5,65,85,65,87.5,65C90,65,92.5,65,95,65L95,65C92.5,65,90,65,87.5,65C85,65,82.5,65,80,65C77.5,65,75,65,72.5,65C70,65,67.5,65,65,65Z"
                       fill="url(#_r_s_)"
                       fill-opacity="1"
                       height="60"
@@ -5725,7 +5743,7 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                     />
                     <path
                       class="recharts-curve recharts-area-curve"
-                      d="M65,35C67.5,35,70,35,72.5,35C75,35,77.5,35,80,35C82.5,35,85,35,87.5,35C90,35,92.5,35,95,35"
+                      d="M65,65C67.5,65,70,65,72.5,65C75,65,77.5,65,80,65C82.5,65,85,65,87.5,65C90,65,92.5,65,95,65"
                       fill="none"
                       fill-opacity="1"
                       height="60"
@@ -5962,7 +5980,7 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                   text-anchor="end"
                   width="60"
                   x="51"
-                  y="35"
+                  y="65"
                 >
                   <tspan
                     dy="0.355em"
@@ -5986,13 +6004,13 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                   text-anchor="end"
                   width="60"
                   x="51"
-                  y="35"
+                  y="50"
                 >
                   <tspan
                     dy="0.355em"
                     x="51"
                   >
-                    0
+                    0.25
                   </tspan>
                 </text>
               </g>
@@ -6016,7 +6034,7 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                     dy="0.355em"
                     x="51"
                   >
-                    0
+                    0.5
                   </tspan>
                 </text>
               </g>
@@ -6034,13 +6052,13 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                   text-anchor="end"
                   width="60"
                   x="51"
-                  y="35"
+                  y="20"
                 >
                   <tspan
                     dy="0.355em"
                     x="51"
                   >
-                    0
+                    0.75
                   </tspan>
                 </text>
               </g>
@@ -6058,13 +6076,13 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                   text-anchor="end"
                   width="60"
                   x="51"
-                  y="35"
+                  y="5"
                 >
                   <tspan
                     dy="0.355em"
                     x="51"
                   >
-                    0
+                    1
                   </tspan>
                 </text>
               </g>

--- a/src/components/core/charts/LineChart/__snapshots__/LineChart.snapshot.spec.tsx.snap
+++ b/src/components/core/charts/LineChart/__snapshots__/LineChart.snapshot.spec.tsx.snap
@@ -2133,7 +2133,7 @@ exports[`LineChart snapshot > negative values same small matches snapshot 1`] = 
                     id="animationClipPath-recharts-area-_r_e_"
                   >
                     <rect
-                      height="36"
+                      height="66"
                       width="0"
                       x="65"
                       y="0"
@@ -2149,7 +2149,7 @@ exports[`LineChart snapshot > negative values same small matches snapshot 1`] = 
                   >
                     <path
                       class="recharts-curve recharts-area-area"
-                      d="M65,35C67.5,35,70,35,72.5,35C75,35,77.5,35,80,35C82.5,35,85,35,87.5,35C90,35,92.5,35,95,35L95,5C92.5,5,90,5,87.5,5C85,5,82.5,5,80,5C77.5,5,75,5,72.5,5C70,5,67.5,5,65,5Z"
+                      d="M65,65C67.5,65,70,65,72.5,65C75,65,77.5,65,80,65C82.5,65,85,65,87.5,65C90,65,92.5,65,95,65L95,5C92.5,5,90,5,87.5,5C85,5,82.5,5,80,5C77.5,5,75,5,72.5,5C70,5,67.5,5,65,5Z"
                       fill="url(#_r_d_)"
                       fill-opacity="1"
                       height="60"
@@ -2161,7 +2161,7 @@ exports[`LineChart snapshot > negative values same small matches snapshot 1`] = 
                     />
                     <path
                       class="recharts-curve recharts-area-curve"
-                      d="M65,35C67.5,35,70,35,72.5,35C75,35,77.5,35,80,35C82.5,35,85,35,87.5,35C90,35,92.5,35,95,35"
+                      d="M65,65C67.5,65,70,65,72.5,65C75,65,77.5,65,80,65C82.5,65,85,65,87.5,65C90,65,92.5,65,95,65"
                       fill="none"
                       fill-opacity="1"
                       height="60"
@@ -2404,7 +2404,7 @@ exports[`LineChart snapshot > negative values same small matches snapshot 1`] = 
                     dy="0.355em"
                     x="51"
                   >
-                    -1
+                    -0.5
                   </tspan>
                 </text>
               </g>
@@ -2428,7 +2428,7 @@ exports[`LineChart snapshot > negative values same small matches snapshot 1`] = 
                     dy="0.355em"
                     x="51"
                   >
-                    -0.75
+                    -0.375
                   </tspan>
                 </text>
               </g>
@@ -2452,7 +2452,7 @@ exports[`LineChart snapshot > negative values same small matches snapshot 1`] = 
                     dy="0.355em"
                     x="51"
                   >
-                    -0.5
+                    -0.25
                   </tspan>
                 </text>
               </g>
@@ -2476,7 +2476,7 @@ exports[`LineChart snapshot > negative values same small matches snapshot 1`] = 
                     dy="0.355em"
                     x="51"
                   >
-                    -0.25
+                    -0.125
                   </tspan>
                 </text>
               </g>
@@ -3886,7 +3886,7 @@ exports[`LineChart snapshot > positive values same small matches snapshot 1`] = 
                   >
                     <path
                       class="recharts-curve recharts-area-area"
-                      d="M65,35C67.5,35,70,35,72.5,35C75,35,77.5,35,80,35C82.5,35,85,35,87.5,35C90,35,92.5,35,95,35L95,65C92.5,65,90,65,87.5,65C85,65,82.5,65,80,65C77.5,65,75,65,72.5,65C70,65,67.5,65,65,65Z"
+                      d="M65,14.999999999999996C67.5,14.999999999999996,70,14.999999999999996,72.5,14.999999999999996C75,14.999999999999996,77.5,14.999999999999996,80,14.999999999999996C82.5,14.999999999999996,85,14.999999999999996,87.5,14.999999999999996C90,14.999999999999996,92.5,14.999999999999996,95,14.999999999999996L95,65C92.5,65,90,65,87.5,65C85,65,82.5,65,80,65C77.5,65,75,65,72.5,65C70,65,67.5,65,65,65Z"
                       fill="url(#_r_m_)"
                       fill-opacity="1"
                       height="60"
@@ -3898,7 +3898,7 @@ exports[`LineChart snapshot > positive values same small matches snapshot 1`] = 
                     />
                     <path
                       class="recharts-curve recharts-area-curve"
-                      d="M65,35C67.5,35,70,35,72.5,35C75,35,77.5,35,80,35C82.5,35,85,35,87.5,35C90,35,92.5,35,95,35"
+                      d="M65,14.999999999999996C67.5,14.999999999999996,70,14.999999999999996,72.5,14.999999999999996C75,14.999999999999996,77.5,14.999999999999996,80,14.999999999999996C82.5,14.999999999999996,85,14.999999999999996,87.5,14.999999999999996C90,14.999999999999996,92.5,14.999999999999996,95,14.999999999999996"
                       fill="none"
                       fill-opacity="1"
                       height="60"
@@ -4165,7 +4165,7 @@ exports[`LineChart snapshot > positive values same small matches snapshot 1`] = 
                     dy="0.355em"
                     x="51"
                   >
-                    0.25
+                    0.15
                   </tspan>
                 </text>
               </g>
@@ -4189,7 +4189,7 @@ exports[`LineChart snapshot > positive values same small matches snapshot 1`] = 
                     dy="0.355em"
                     x="51"
                   >
-                    0.5
+                    0.3
                   </tspan>
                 </text>
               </g>
@@ -4213,7 +4213,7 @@ exports[`LineChart snapshot > positive values same small matches snapshot 1`] = 
                     dy="0.355em"
                     x="51"
                   >
-                    0.75
+                    0.44999999999999996
                   </tspan>
                 </text>
               </g>
@@ -4237,7 +4237,7 @@ exports[`LineChart snapshot > positive values same small matches snapshot 1`] = 
                     dy="0.355em"
                     x="51"
                   >
-                    1
+                    0.6
                   </tspan>
                 </text>
               </g>
@@ -5561,38 +5561,20 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                 <rect
                   class="recharts-cartesian-grid-bg"
                   fill="transparent"
-                  height="15"
+                  height="35"
                   stroke="none"
                   width="30"
                   x="65"
-                  y="5"
+                  y="0"
                 />
                 <rect
                   class="recharts-cartesian-grid-bg"
                   fill="transparent"
-                  height="15"
-                  stroke="none"
-                  width="30"
-                  x="65"
-                  y="20"
-                />
-                <rect
-                  class="recharts-cartesian-grid-bg"
-                  fill="transparent"
-                  height="15"
+                  height="30"
                   stroke="none"
                   width="30"
                   x="65"
                   y="35"
-                />
-                <rect
-                  class="recharts-cartesian-grid-bg"
-                  fill="transparent"
-                  height="15"
-                  stroke="none"
-                  width="30"
-                  x="65"
-                  y="50"
                 />
               </g>
               <g
@@ -5608,21 +5590,8 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                   x1="65"
                   x2="95"
                   y="5"
-                  y1="65"
-                  y2="65"
-                />
-                <line
-                  fill="none"
-                  height="60"
-                  stroke="color-mix(in srgb, var(--jumper-palette-alpha900-main) 10%, transparent)"
-                  stroke-dasharray="0"
-                  width="30"
-                  x="65"
-                  x1="65"
-                  x2="95"
-                  y="5"
-                  y1="50"
-                  y2="50"
+                  y1="35"
+                  y2="35"
                 />
                 <line
                   fill="none"
@@ -5647,8 +5616,8 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                   x1="65"
                   x2="95"
                   y="5"
-                  y1="20"
-                  y2="20"
+                  y1="35"
+                  y2="35"
                 />
                 <line
                   fill="none"
@@ -5660,8 +5629,21 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                   x1="65"
                   x2="95"
                   y="5"
-                  y1="5"
-                  y2="5"
+                  y1="35"
+                  y2="35"
+                />
+                <line
+                  fill="none"
+                  height="60"
+                  stroke="color-mix(in srgb, var(--jumper-palette-alpha900-main) 10%, transparent)"
+                  stroke-dasharray="0"
+                  width="30"
+                  x="65"
+                  x1="65"
+                  x2="95"
+                  y="5"
+                  y1="35"
+                  y2="35"
                 />
               </g>
             </g>
@@ -5715,7 +5697,7 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                     id="animationClipPath-recharts-area-_r_t_"
                   >
                     <rect
-                      height="66"
+                      height="36"
                       width="0"
                       x="65"
                       y="0"
@@ -5731,7 +5713,7 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                   >
                     <path
                       class="recharts-curve recharts-area-area"
-                      d="M65,65C67.5,65,70,65,72.5,65C75,65,77.5,65,80,65C82.5,65,85,65,87.5,65C90,65,92.5,65,95,65L95,65C92.5,65,90,65,87.5,65C85,65,82.5,65,80,65C77.5,65,75,65,72.5,65C70,65,67.5,65,65,65Z"
+                      d="M65,35C67.5,35,70,35,72.5,35C75,35,77.5,35,80,35C82.5,35,85,35,87.5,35C90,35,92.5,35,95,35L95,35C92.5,35,90,35,87.5,35C85,35,82.5,35,80,35C77.5,35,75,35,72.5,35C70,35,67.5,35,65,35Z"
                       fill="url(#_r_s_)"
                       fill-opacity="1"
                       height="60"
@@ -5743,7 +5725,7 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                     />
                     <path
                       class="recharts-curve recharts-area-curve"
-                      d="M65,65C67.5,65,70,65,72.5,65C75,65,77.5,65,80,65C82.5,65,85,65,87.5,65C90,65,92.5,65,95,65"
+                      d="M65,35C67.5,35,70,35,72.5,35C75,35,77.5,35,80,35C82.5,35,85,35,87.5,35C90,35,92.5,35,95,35"
                       fill="none"
                       fill-opacity="1"
                       height="60"
@@ -5980,7 +5962,7 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                   text-anchor="end"
                   width="60"
                   x="51"
-                  y="65"
+                  y="35"
                 >
                   <tspan
                     dy="0.355em"
@@ -6004,13 +5986,13 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                   text-anchor="end"
                   width="60"
                   x="51"
-                  y="50"
+                  y="35"
                 >
                   <tspan
                     dy="0.355em"
                     x="51"
                   >
-                    0.25
+                    0
                   </tspan>
                 </text>
               </g>
@@ -6034,7 +6016,7 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                     dy="0.355em"
                     x="51"
                   >
-                    0.5
+                    0
                   </tspan>
                 </text>
               </g>
@@ -6052,13 +6034,13 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                   text-anchor="end"
                   width="60"
                   x="51"
-                  y="20"
+                  y="35"
                 >
                   <tspan
                     dy="0.355em"
                     x="51"
                   >
-                    0.75
+                    0
                   </tspan>
                 </text>
               </g>
@@ -6076,13 +6058,13 @@ exports[`LineChart snapshot > zero values matches snapshot 1`] = `
                   text-anchor="end"
                   width="60"
                   x="51"
-                  y="5"
+                  y="35"
                 >
                   <tspan
                     dy="0.355em"
                     x="51"
                   >
-                    1
+                    0
                   </tspan>
                 </text>
               </g>

--- a/src/components/core/charts/LineChart/utils.spec.ts
+++ b/src/components/core/charts/LineChart/utils.spec.ts
@@ -20,18 +20,18 @@ describe('calculateVisibleYRange', () => {
     });
   });
 
-  it('extends maxValue to 1 for single small positive value', () => {
+  it('applies 20% headroom for small positive value', () => {
     const result = calculateVisibleYRange(createDataPoints([0.5]));
 
     expect(result.minValue).toBe(0);
-    expect(result.maxValue).toBe(1);
+    expect(result.maxValue).toBe(0.6);
     expect(result.isNegative).toBe(false);
   });
 
-  it('extends minValue to -1 for single small negative value', () => {
+  it('keeps min to same value for single small negative value', () => {
     const result = calculateVisibleYRange(createDataPoints([-0.5]));
 
-    expect(result.minValue).toBe(-1);
+    expect(result.minValue).toBe(-0.5);
     expect(result.maxValue).toBe(0);
     expect(result.isNegative).toBe(true);
   });
@@ -60,7 +60,7 @@ describe('calculateVisibleYRange', () => {
     expect(result.isNegative).toBe(false);
   });
 
-  it('spans min to 0 for multiple negative values', () => {
+  it('spans max to 0 for multiple negative values', () => {
     const result = calculateVisibleYRange(createDataPoints([-10, -5]));
 
     expect(result.minValue).toBe(-10);

--- a/src/components/core/charts/LineChart/utils.ts
+++ b/src/components/core/charts/LineChart/utils.ts
@@ -121,9 +121,19 @@ export const calculateVisibleYRange = <
   const dataMaxValue = Math.max(...values);
 
   const isNegative = dataMinValue < 0;
+  const isSame = Math.abs(dataMinValue - dataMaxValue) < Number.EPSILON;
+  const isZero = Math.abs(dataMinValue) < Number.EPSILON;
 
-  const minValue = Math.min(0, dataMinValue);
-  const maxValue = dataMaxValue > 0 ? dataMaxValue * 1.2 : 0;
+  let minValue = Math.min(0, dataMinValue);
+  let maxValue = dataMaxValue > 0 ? dataMaxValue * 1.2 : 0;
+
+  if (isSame && isZero) {
+    if (isNegative) {
+      minValue = -1;
+    } else {
+      maxValue = 1;
+    }
+  }
 
   return {
     minValue,

--- a/src/components/core/charts/LineChart/utils.ts
+++ b/src/components/core/charts/LineChart/utils.ts
@@ -121,18 +121,9 @@ export const calculateVisibleYRange = <
   const dataMaxValue = Math.max(...values);
 
   const isNegative = dataMinValue < 0;
-  const isSame = Math.abs(dataMinValue - dataMaxValue) < Number.EPSILON;
 
-  let minValue = Math.min(0, dataMinValue);
-  let maxValue = dataMaxValue > 0 ? dataMaxValue * 1.2 : 0;
-
-  if (isSame && Math.abs(dataMinValue) < 1) {
-    if (isNegative) {
-      minValue = -1;
-    } else {
-      maxValue = 1;
-    }
-  }
+  const minValue = Math.min(0, dataMinValue);
+  const maxValue = dataMaxValue > 0 ? dataMaxValue * 1.2 : 0;
 
   return {
     minValue,


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-733/earn-y-axtis-misconfigured-on-the-apy-and-instant-apy-weekly-chart

## Testings steps
> [!IMPORTANT]
> The fix will need to be checked in prod for vault `/earn/usdc-savings-vault-on-base`

1. Build storybook `pnpm build-storybook`
2. Run storybook `pnpm storybook`
3. Filter for `ApySameWithNulls` - should be a variant of the LineChart stories
4. The chart should be scaled to the given value of 3,75% and now show the range from 0-100% on the y axis

<img width="1532" height="598" alt="Screenshot 2026-03-27 at 11 41 58" src="https://github.com/user-attachments/assets/0de70454-3924-47eb-b03e-0bdf7c11c91d" />


# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Storybook story demonstrating line charts with repeated values and intervening nulls.

* **Improvements**
  * Tightened Y-axis range logic to handle near-zero and identical-value series more consistently.

* **Tests**
  * Updated unit tests to reflect the refined Y-range behavior for small positive, small negative, and multi-negative data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->