### PR TITLE
fix: blog article card width on mobile

### DIFF
--- a/src/components/Blog/BlogArticleCard/BlogArticleCard.style.ts
+++ b/src/components/Blog/BlogArticleCard/BlogArticleCard.style.ts
@@ -15,7 +15,8 @@ export const BlogArticleCardContainer = styled(Card)(({ theme }) => ({
   flexShrink: 0,
   display: 'flex',
   flexDirection: 'column',
-  width: 'auto',
+  width: 'min(416px, calc(100vw - 64px))',
+  minWidth: 0,
   maxWidth: 416,
   border: getSurfaceBorder(theme, 'surface1'),
   padding: theme.spacing(2),
@@ -39,6 +40,7 @@ export const BlogArticleCardContainer = styled(Card)(({ theme }) => ({
 export const BlogArticleCardDetails = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column-reverse',
+  minWidth: 0,
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   width: '100%',
@@ -49,7 +51,9 @@ export const BlogArticleCardDetails = styled(Box)(({ theme }) => ({
 }));
 
 export const BlogArticleCardImage = styled(Image)(({ theme }) => ({
+  display: 'block',
   width: '100%',
+  maxWidth: '100%',
   height: 'auto',
   borderRadius: theme.shape.cardBorderRadiusMedium,
   objectFit: 'cover',
@@ -68,12 +72,15 @@ export const BlogArticleCardImageSkeleton = styled(BaseSurfaceSkeleton)(
 );
 
 export const BlogArticleCardContent = styled(CardContent)(({ theme }) => ({
+  minWidth: 0,
   margin: 0,
   padding: theme.spacing(2),
   '&:last-child': { paddingBottom: theme.spacing(1) },
 }));
 
 export const BlogArticleCardTitle = styled(Typography)(({ theme }) => ({
+  width: '100%',
+  minWidth: 0,
   color: 'inherit',
   fontWeight: 700, //todo: use typography
   fontSize: '24px',

--- a/src/components/Blog/BlogArticleCard/BlogArticleCard.tsx
+++ b/src/components/Blog/BlogArticleCard/BlogArticleCard.tsx
@@ -48,7 +48,7 @@ export const BlogArticleCard = ({
   return (
     <Link
       href={article?.RedirectURL ?? `${JUMPER_LEARN_PATH}/${article?.Slug}`}
-      style={{ textDecoration: 'none', width: '100%' }}
+      style={{ textDecoration: 'none', display: 'block' }}
     >
       <BlogArticleCardContainer
         variant="outlined"


### PR DESCRIPTION
# Which Jira task belongs to this PR?
Closes https://linear.app/lifi-linear/issue/JUM-747/carousel-card-overflow-at-375px-mobile-text-and-image-clipped

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed blog article card layout to prevent content overflow on all screen sizes.
* Enhanced responsive constraints with improved handling of card dimensions and element sizing.
* Resolved text and image containment to ensure consistent visual presentation.
* Improved text truncation behavior for properly constrained card content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->