### PR TITLE
chore: update newsletter page title

### DIFF
--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -664,7 +664,7 @@ interface Resources {
         subscribe: 'Subscribe';
         subtitle: 'Get the latest news and updates directly from <strong>Jumper.</strong>';
         success: 'Newsletter subscription successful!';
-        title: 'Make. The. Jump.';
+        title: 'Subscribe to the Jumper Newsletter';
       };
     };
     portfolio: {

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -695,7 +695,7 @@
   },
   "newsletter": {
     "welcome": {
-      "title": "Make. The. Jump.",
+      "title": "Subscribe to the Jumper Newsletter",
       "subtitle": "Get the latest news and updates directly from <strong>Jumper.</strong>",
       "hint": "By signing up to our newsletter you are implicitly agreeing to Jumper's <0>terms of service</0> and <1>privacy policy</1>. You can unsubscribe at any time from the link in the email footer.",
       "subscribe": "Subscribe",


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-764/update-newsletter-page-title

## Testing steps
1. Head to `/newsletter` page
2. Check the title has been updated

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the newsletter success-screen title text from "Make. The. Jump." to "Subscribe to the Jumper Newsletter".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->