### PR TITLE
feat: add trade feature flag for tab and widget title

### DIFF
--- a/src/components/Menus/MainMenu/hooks.tsx
+++ b/src/components/Menus/MainMenu/hooks.tsx
@@ -40,6 +40,9 @@ import { Badge } from '@/components/Badge/Badge';
 import { BadgeVariant } from '@/components/Badge/Badge.styles';
 import * as supportedLanguages from '@/i18n/translations';
 import MuiBadge from '@mui/material/Badge';
+import { useAccount } from '@lifi/wallet-management';
+import { useABTest } from '@/hooks/useABTest';
+import { AB_TEST_NAME } from '@/const/abtests';
 
 interface MenuLink {
   url: string;
@@ -393,6 +396,13 @@ export const useMenuItems = () => {
   const isPortfolioEnabled = isPortfolioFeatureEnabled();
   const { supportModalUnreadCount } = useMenuStore((state) => state);
 
+  const { account } = useAccount();
+
+  const tradeABTest = useABTest({
+    feature: AB_TEST_NAME.A_B_TEST_TRADE_DISPLAY,
+    address: account?.address ?? '',
+  });
+
   const {
     handleLearnClick,
     handleScanClick,
@@ -449,7 +459,10 @@ export const useMenuItems = () => {
 
     if (isTablet) {
       baseItems.push({
-        label: t('navbar.links.exchange'),
+        label:
+          tradeABTest.isEnabled && tradeABTest.value === 'test'
+            ? t('navbar.links.trade')
+            : t('navbar.links.exchange'),
         showMoreIcon: false,
         link: { url: AppPaths.Main },
         onClick: handleExchangeClick,

--- a/src/components/Menus/VerticalMenu/useVerticalTabs.tsx
+++ b/src/components/Menus/VerticalMenu/useVerticalTabs.tsx
@@ -1,9 +1,12 @@
+import { AB_TEST_NAME } from '@/const/abtests';
 import {
   TrackingAction,
   TrackingCategory,
   TrackingEventParameter,
 } from '@/const/trackingKeys';
+import { useABTest } from '@/hooks/useABTest';
 import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
+import { useAccount } from '@lifi/wallet-management';
 import EvStationOutlinedIcon from '@mui/icons-material/EvStationOutlined';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import { useTheme } from '@mui/material';
@@ -15,6 +18,13 @@ export const useVerticalTabs = () => {
   const theme = useTheme();
   const router = useRouter();
   const { t } = useTranslation();
+
+  const { account } = useAccount();
+
+  const tradeABTest = useABTest({
+    feature: AB_TEST_NAME.A_B_TEST_TRADE_DISPLAY,
+    address: account?.address ?? '',
+  });
 
   const handleClickTab = (tab: string) => () => {
     router.push(`/${tab}`);
@@ -32,7 +42,10 @@ export const useVerticalTabs = () => {
     {
       onClick: handleClickTab(''),
       value: 0,
-      tooltip: t('navbar.links.exchange'),
+      tooltip:
+        tradeABTest.isEnabled && tradeABTest.value === 'test'
+          ? t('navbar.links.trade')
+          : t('navbar.links.exchange'),
       icon: (
         <SwapHorizIcon
           sx={(theme) => ({

--- a/src/components/Navbar/hooks.ts
+++ b/src/components/Navbar/hooks.ts
@@ -8,7 +8,7 @@ import { useChains } from '@/hooks/useChains';
 import { useEnsName } from 'wagmi';
 import { mainnet } from 'wagmi/chains';
 import { getAddressLabel } from 'src/utils/getAddressLabel';
-import { getConnectorIcon } from '@lifi/wallet-management';
+import { getConnectorIcon, useAccount } from '@lifi/wallet-management';
 import type { Chain } from '@lifi/sdk';
 import type { Address } from 'viem';
 import { walletDigest } from 'src/utils/walletDigest';
@@ -19,6 +19,8 @@ import {
   isEarnFeatureEnabled,
   isPortfolioFeatureEnabled,
 } from 'src/app/lib/getFeatureFlag';
+import { useABTest } from '@/hooks/useABTest';
+import { AB_TEST_NAME } from '@/const/abtests';
 
 export const useLevelDisplayData = () => {
   const activeAccount = useActiveAccountByChainType();
@@ -83,15 +85,24 @@ interface MainLink {
 export const useMainLinks = () => {
   const { t } = useTranslation();
   const pathname = usePathnameWithoutLocale();
+  const { account } = useAccount();
 
   const isEarnEnabled = isEarnFeatureEnabled();
   const isPortfolioEnabled = isPortfolioFeatureEnabled();
+
+  const tradeABTest = useABTest({
+    feature: AB_TEST_NAME.A_B_TEST_TRADE_DISPLAY,
+    address: account?.address ?? '',
+  });
 
   const links = useMemo(() => {
     const _links: MainLink[] = [
       {
         value: AppPaths.Main,
-        label: t('navbar.links.exchange'),
+        label:
+          tradeABTest.isEnabled && tradeABTest.value === 'test'
+            ? t('navbar.links.trade')
+            : t('navbar.links.exchange'),
         subLinks: [AppPaths.Gas],
         testId: 'navbar-exchange-button',
       },
@@ -123,7 +134,7 @@ export const useMainLinks = () => {
     }
 
     return _links;
-  }, [t, isEarnEnabled, isPortfolioEnabled]);
+  }, [t, isEarnEnabled, isPortfolioEnabled, tradeABTest]);
 
   const activeLink = useMemo(
     () =>

--- a/src/components/Widgets/variants/base/Widget.tsx
+++ b/src/components/Widgets/variants/base/Widget.tsx
@@ -6,7 +6,7 @@ import { useWidgetConfig } from '../widgetConfig/useWidgetConfig';
 import { ClientOnly } from '@/components/ClientOnly';
 
 export const Widget: FC<WidgetProps> = ({ ctx, type, formRef, feeConfig }) => {
-  const widgetConfig = useWidgetConfig(type, ctx);
+  const { config: widgetConfig, isReady } = useWidgetConfig(type, ctx);
 
   const config = useMemo(
     () => (feeConfig ? { ...widgetConfig, feeConfig } : widgetConfig),
@@ -15,11 +15,15 @@ export const Widget: FC<WidgetProps> = ({ ctx, type, formRef, feeConfig }) => {
 
   return (
     <ClientOnly fallback={<LifiWidgetSkeleton config={config} />}>
-      <LiFiWidget
-        config={config}
-        integrator={config.integrator}
-        formRef={formRef}
-      />
+      {isReady ? (
+        <LiFiWidget
+          config={config}
+          integrator={config.integrator}
+          formRef={formRef}
+        />
+      ) : (
+        <LifiWidgetSkeleton config={config} />
+      )}
     </ClientOnly>
   );
 };

--- a/src/components/Widgets/variants/base/ZapWidget/ZapDepositBackendWidget.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapDepositBackendWidget.tsx
@@ -152,9 +152,9 @@ export const ZapDepositBackendWidget: FC<ZapDepositBackendWidgetProps> = ({
     };
   }, [widgetEvents, refetchDepositToken, setSupportModalState]);
 
-  const widgetConfig = useWidgetConfig('zap', enhancedCtx);
+  const { config: widgetConfig, isReady } = useWidgetConfig('zap', enhancedCtx);
 
-  return isZapDataSuccess && toChainId && toTokenAddress ? (
+  return isZapDataSuccess && toChainId && toTokenAddress && isReady ? (
     <LiFiWidget
       formRef={formRef}
       config={widgetConfig}

--- a/src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget.tsx
@@ -116,9 +116,9 @@ export const ZapWithdrawWidget: FC<ZapWithdrawWidgetProps> = ({
     };
   }, [widgetEvents, refetchWithdrawToken, setSupportModalState]);
 
-  const widgetConfig = useWidgetConfig('zap', enhancedCtx);
+  const { config: widgetConfig, isReady } = useWidgetConfig('zap', enhancedCtx);
 
-  return fromChain && fromToken ? (
+  return fromChain && fromToken && isReady ? (
     <LiFiWidget
       formRef={formRef}
       config={widgetConfig}

--- a/src/components/Widgets/variants/widgetConfig/useSharedConfigs.ts
+++ b/src/components/Widgets/variants/widgetConfig/useSharedConfigs.ts
@@ -131,7 +131,10 @@ export function useSharedFormConfig(
  * Shared language configuration
  */
 export function useLanguageConfig(
-  context: WidgetContext & { useMainWidget: boolean; useTradeTitle: boolean },
+  context: WidgetContext & {
+    useMainWidget: boolean;
+    useSwapBridgeTitle: boolean;
+  },
   deps: HookDependencies,
 ): Partial<WidgetConfig> {
   return useMemo(() => {
@@ -146,8 +149,8 @@ export function useLanguageConfig(
       };
 
       languageResourcesEN.header = {
-        exchange: context.useTradeTitle
-          ? deps.translation.t('widget.trade.title')
+        exchange: context.useSwapBridgeTitle
+          ? deps.translation.t('widget.swapBridge.title')
           : deps.translation.t('widget.exchange.title'),
       };
 

--- a/src/components/Widgets/variants/widgetConfig/useSharedConfigs.ts
+++ b/src/components/Widgets/variants/widgetConfig/useSharedConfigs.ts
@@ -131,25 +131,33 @@ export function useSharedFormConfig(
  * Shared language configuration
  */
 export function useLanguageConfig(
-  context: WidgetContext & { useMainWidget: boolean },
+  context: WidgetContext & { useMainWidget: boolean; useTradeTitle: boolean },
   deps: HookDependencies,
 ): Partial<WidgetConfig> {
   return useMemo(() => {
     if (!isMissionContext(context)) {
+      const languageResourcesEN: EnglishLanguageResource = {
+        warning: {
+          message: {
+            lowAddressActivity:
+              "This address has low activity on this blockchain. Please verify above you're sending to the correct ADDRESS and network to prevent potential loss of funds. ABSTRACT WALLET WORKS ONLY ON ABSTRACT CHAIN, DO NOT SEND FUNDS TO ABSTRACT WALLET ON ANOTHER CHAIN.",
+          },
+        },
+      };
+
+      languageResourcesEN.header = {
+        exchange: context.useTradeTitle
+          ? deps.translation.t('widget.trade.title')
+          : deps.translation.t('widget.exchange.title'),
+      };
+
       return {
         languages: {
           default: deps.translation.i18n.language as LanguageKey,
           allow: deps.translation.i18n.languages as LanguageKey[],
         },
         languageResources: {
-          en: {
-            warning: {
-              message: {
-                lowAddressActivity:
-                  "This address has low activity on this blockchain. Please verify above you're sending to the correct ADDRESS and network to prevent potential loss of funds. ABSTRACT WALLET WORKS ONLY ON ABSTRACT CHAIN, DO NOT SEND FUNDS TO ABSTRACT WALLET ON ANOTHER CHAIN.",
-              },
-            },
-          },
+          en: languageResourcesEN,
         },
       };
     }

--- a/src/components/Widgets/variants/widgetConfig/useWidgetConfig.ts
+++ b/src/components/Widgets/variants/widgetConfig/useWidgetConfig.ts
@@ -31,7 +31,7 @@ export function useWidgetConfig<T extends WidgetType>(
     : T extends 'mission'
       ? MissionWidgetContext
       : ZapWidgetContext,
-): WidgetConfig {
+): { config: WidgetConfig; isReady: boolean } {
   const deps = useWidgetDependencies();
   const sharedBase = useSharedBaseConfig(context, deps);
   const sharedRPC = useSharedRPCConfig();
@@ -42,10 +42,16 @@ export function useWidgetConfig<T extends WidgetType>(
     address: account?.address ?? '',
   });
 
+  const tradeABTest = useABTest({
+    feature: AB_TEST_NAME.A_B_TEST_TRADE_DISPLAY,
+    address: account?.address ?? '',
+  });
+
   // Language configuration
   const language = useLanguageConfig(
     {
       useMainWidget: type === 'main',
+      useTradeTitle: tradeABTest.isEnabled && tradeABTest.value === 'test',
       ...context,
     },
     deps,
@@ -77,7 +83,7 @@ export function useWidgetConfig<T extends WidgetType>(
   }, [mainWidgetConfig, missionWidgetConfig, zapWidgetConfig, type]);
 
   // Merge all configurations
-  return useMemo(() => {
+  const config = useMemo(() => {
     const baseConfig = merge(
       {},
       sharedBase,
@@ -128,4 +134,9 @@ export function useWidgetConfig<T extends WidgetType>(
     priceImpactABTest.isEnabled,
     priceImpactABTest.value,
   ]);
+
+  return {
+    config,
+    isReady: !tradeABTest.isLoading && !priceImpactABTest.isLoading,
+  };
 }

--- a/src/components/Widgets/variants/widgetConfig/useWidgetConfig.ts
+++ b/src/components/Widgets/variants/widgetConfig/useWidgetConfig.ts
@@ -51,7 +51,7 @@ export function useWidgetConfig<T extends WidgetType>(
   const language = useLanguageConfig(
     {
       useMainWidget: type === 'main',
-      useTradeTitle: tradeABTest.isEnabled && tradeABTest.value === 'test',
+      useSwapBridgeTitle: tradeABTest.isEnabled && tradeABTest.value === 'test',
       ...context,
     },
     deps,

--- a/src/const/abtests.ts
+++ b/src/const/abtests.ts
@@ -1,6 +1,7 @@
 export enum AB_TEST_NAME {
   TEST_WIDGET_SUBVARIANTS = 'TEST_WIDGET_SUBVARIANTS',
   A_B_TEST_PRICE_IMPACT_DISPLAY = 'a-b-test-price-impact-display',
+  A_B_TEST_TRADE_DISPLAY = 'a-b-test-trade-display',
 }
 
 // Single source of truth for all A/B tests
@@ -11,6 +12,10 @@ export const AbTests = {
   },
   [AB_TEST_NAME.A_B_TEST_PRICE_IMPACT_DISPLAY]: {
     name: 'a-b-test-price-impact-display',
+    enabled: true,
+  },
+  [AB_TEST_NAME.A_B_TEST_TRADE_DISPLAY]: {
+    name: 'a-b-test-trade-display',
     enabled: true,
   },
   // Add more tests here as needed

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -892,8 +892,8 @@ interface Resources {
       exchange: {
         title: 'Exchange';
       };
-      trade: {
-        title: 'Trade';
+      swapBridge: {
+        title: 'Swap & Bridge';
       };
       withdraw: {
         title: 'Withdraw';

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -590,6 +590,7 @@ interface Resources {
         missions: 'Missions';
         portfolio: 'Portfolio';
         refuel: 'Gas';
+        trade: 'Trade';
       };
       navbarMenu: {
         brandAssets: 'Brand Assets';
@@ -887,6 +888,12 @@ interface Resources {
       };
       earn: {
         depositSuccess: 'You will be able to see and manage your position in a few seconds by clicking on <bold>Manage your positions</bold>';
+      };
+      exchange: {
+        title: 'Exchange';
+      };
+      trade: {
+        title: 'Trade';
       };
       withdraw: {
         title: 'Withdraw';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -7,6 +7,7 @@
     },
     "links": {
       "exchange": "Exchange",
+      "trade": "Trade",
       "portfolio": "Portfolio",
       "missions": "Missions",
       "earn": "Earn",
@@ -750,6 +751,12 @@
     },
     "deposit": {
       "title": "Quick deposit"
+    },
+    "exchange": {
+      "title": "Exchange"
+    },
+    "trade": {
+      "title": "Trade"
     }
   },
   "links": {

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -755,8 +755,8 @@
     "exchange": {
       "title": "Exchange"
     },
-    "trade": {
-      "title": "Trade"
+    "swapBridge": {
+      "title": "Swap & Bridge"
     }
   },
   "links": {


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-797/feature-flag-change-tab-and-widget-title

## Testing steps
1. Connect the dev wallet
2. The regular Exchange should show up for both the main nav item and the main widget title
3. Connect another wallet (or ping me for another address) 
4. The nav item should update to `Trade`
5. Main page widget title should be `Swap & Bridge`

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * A/B test introduced to toggle navigation labels between "Trade" and "Exchange" for some users.
  * Widget titles can now switch between "Swap & Bridge" and "Exchange" based on runtime configuration.

* **User Experience**
  * Widgets show loading skeletons until fully initialized, preventing premature rendering.

* **Documentation**
  * i18n updated with "Trade", "Exchange" and "Swap & Bridge" translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->