### PR TITLE
fix: add fee contribution feature flag

### DIFF
--- a/src/components/Widgets/FeeContribution/constants.ts
+++ b/src/components/Widgets/FeeContribution/constants.ts
@@ -1,5 +1,5 @@
 import { ChainId } from '@lifi/sdk';
-import { Hex } from 'viem';
+import type { Hex } from 'viem';
 
 // Constants for contribution amounts based on transaction volume
 export const CONTRIBUTION_AMOUNTS = {
@@ -17,9 +17,6 @@ export const VOLUME_THRESHOLDS = {
 
 // Minimum USD amount required to show contribution
 export const MIN_CONTRIBUTION_USD = 10;
-
-// Percentage of users that should see the contribution (AB test)
-export const CONTRIBUTION_AB_TEST_PERCENTAGE = 0.1;
 
 export const USD_CURRENCY_SYMBOL = '$';
 

--- a/src/components/Widgets/FeeContribution/hooks.ts
+++ b/src/components/Widgets/FeeContribution/hooks.ts
@@ -21,10 +21,7 @@ import {
   useWaitForTransactionReceipt,
   useWriteContract,
 } from 'wagmi';
-import {
-  CONTRIBUTION_AB_TEST_PERCENTAGE,
-  CONTRIBUTION_AMOUNTS,
-} from './constants';
+import { CONTRIBUTION_AMOUNTS } from './constants';
 import {
   getContributionAmounts,
   getContributionFeeAddress,
@@ -38,12 +35,6 @@ export const useContributionData = () => {
   const [contributionOptions, setContributionOptions] = useState<number[]>(
     CONTRIBUTION_AMOUNTS.DEFAULT,
   );
-
-  // AB test flag - show contribution for ~10% of users
-  // @TODO: use feature flag from PostHog
-  const isContributionAbEnabled = useMemo(() => {
-    return Math.random() < CONTRIBUTION_AB_TEST_PERCENTAGE;
-  }, []);
 
   const { setContributionDisplayed } = useContributionStore((state) => state);
   const { completedRoute } = useRouteStore((state) => state);
@@ -68,16 +59,12 @@ export const useContributionData = () => {
 
   // Check if contribution should be shown based on:
   // - Transaction history
-  // - AB test
   // - Transaction amount >= $10
   // - Chain type is EVM
   // - Same wallet tx with fromAddress === toAddress
   // - Valid contribution fee address exists for the chain
   useEffect(() => {
-    if (
-      !isContributionAbEnabled ||
-      !isEligibleForContribution(txHistoryData, completedRoute, account)
-    ) {
+    if (!isEligibleForContribution(txHistoryData, completedRoute, account)) {
       setContributionDisplayed(false);
       return;
     }
@@ -90,7 +77,6 @@ export const useContributionData = () => {
     txHistoryData?.transfers,
     completedRoute?.toAmountUSD,
     account?.chainType,
-    isContributionAbEnabled,
     completedRoute?.toChainId,
   ]);
 

--- a/src/components/Widgets/Widget.tsx
+++ b/src/components/Widgets/Widget.tsx
@@ -7,7 +7,6 @@ import type { FormState } from '@lifi/widget';
 import { PrefetchKind } from 'next/dist/client/components/router-reducer/router-reducer-types';
 import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useWelcomeScreen } from 'src/hooks/useWelcomeScreen';
 import { useBridgeConditions } from 'src/hooks/useBridgeConditions';
 import { useActiveTabStore } from 'src/stores/activeTab';
@@ -18,7 +17,6 @@ import type { MainWidgetContext } from './variants/widgetConfig/types';
 import { useFormParameters } from './hooks';
 import { AppPaths } from '@/const/urls';
 import { Widget as BaseWidget } from './variants/base/Widget';
-import FeeContribution from './FeeContribution/FeeContribution';
 import dynamic from 'next/dynamic';
 
 const PrivateSwapModal = dynamic(() =>
@@ -55,7 +53,6 @@ export function Widget({
 
   const router = useRouter();
   const pathname = usePathname();
-  const { t } = useTranslation();
   const { account } = useAccount();
   const isConnectedAGW = account?.connector?.name === 'Abstract';
 
@@ -154,14 +151,7 @@ export function Widget({
       autoHeight={autoHeight}
       contributionDisplayed={contributionDisplayed}
     >
-      <BaseWidget
-        type="main"
-        ctx={context}
-        formRef={formRef}
-        feeConfig={{
-          _vcComponent: () => <FeeContribution translationFn={t} />,
-        }}
-      />
+      <BaseWidget type="main" ctx={context} formRef={formRef} />
       {isPrivateSwapModalOpen && (
         <PrivateSwapModal
           open={isPrivateSwapModalOpen}

--- a/src/components/Widgets/variants/base/Widget.tsx
+++ b/src/components/Widgets/variants/base/Widget.tsx
@@ -1,17 +1,11 @@
 import type { FC } from 'react';
-import { useMemo } from 'react';
 import { LiFiWidget, WidgetSkeleton as LifiWidgetSkeleton } from '@lifi/widget';
 import type { WidgetProps } from './Widget.types';
 import { useWidgetConfig } from '../widgetConfig/useWidgetConfig';
 import { ClientOnly } from '@/components/ClientOnly';
 
-export const Widget: FC<WidgetProps> = ({ ctx, type, formRef, feeConfig }) => {
-  const { config: widgetConfig, isReady } = useWidgetConfig(type, ctx);
-
-  const config = useMemo(
-    () => (feeConfig ? { ...widgetConfig, feeConfig } : widgetConfig),
-    [widgetConfig, feeConfig],
-  );
+export const Widget: FC<WidgetProps> = ({ ctx, type, formRef }) => {
+  const { config, isReady } = useWidgetConfig(type, ctx);
 
   return (
     <ClientOnly fallback={<LifiWidgetSkeleton config={config} />}>

--- a/src/components/Widgets/variants/base/Widget.types.ts
+++ b/src/components/Widgets/variants/base/Widget.types.ts
@@ -1,6 +1,7 @@
-import { CustomInformation } from 'src/types/loyaltyPass';
-import { WidgetContext, WidgetType } from '../widgetConfig/types';
-import { FormRef, WidgetFeeConfig } from '@lifi/widget';
+import type { CustomInformation } from 'src/types/loyaltyPass';
+import type { WidgetContext, WidgetType } from '../widgetConfig/types';
+import type { FormRef } from '@lifi/widget';
+import { WidgetFeeConfig } from '@lifi/widget';
 
 export interface EntityWidgetProps {
   customInformation?: Partial<CustomInformation>;
@@ -10,5 +11,4 @@ export interface WidgetProps extends EntityWidgetProps {
   ctx: WidgetContext;
   type: WidgetType;
   formRef?: FormRef;
-  feeConfig?: WidgetFeeConfig;
 }

--- a/src/components/Widgets/variants/widgetConfig/useWidgetConfig.tsx
+++ b/src/components/Widgets/variants/widgetConfig/useWidgetConfig.tsx
@@ -50,7 +50,7 @@ export function useWidgetConfig<T extends WidgetType>(
 
   const feeContributionABTest = useABTest({
     feature: AB_TEST_NAME.A_B_TEST_FEE_CONTRIBUTION_DISPLAY,
-    address: account.address ?? '',
+    address: account?.address ?? '',
   });
 
   // Language configuration

--- a/src/components/Widgets/variants/widgetConfig/useWidgetConfig.tsx
+++ b/src/components/Widgets/variants/widgetConfig/useWidgetConfig.tsx
@@ -20,6 +20,7 @@ import {
 } from './useSharedConfigs';
 import { useWidgetDependencies } from './useWidgetDependencies';
 import { useZapWidgetConfig } from './useZapWidgetConfig';
+import FeeContribution from '../../FeeContribution/FeeContribution';
 
 /**
  * Main widget configuration hook that orchestrates all configuration logic
@@ -45,6 +46,11 @@ export function useWidgetConfig<T extends WidgetType>(
   const tradeABTest = useABTest({
     feature: AB_TEST_NAME.A_B_TEST_TRADE_DISPLAY,
     address: account?.address ?? '',
+  });
+
+  const feeContributionABTest = useABTest({
+    feature: AB_TEST_NAME.A_B_TEST_FEE_CONTRIBUTION_DISPLAY,
+    address: account.address ?? '',
   });
 
   // Language configuration
@@ -121,6 +127,18 @@ export function useWidgetConfig<T extends WidgetType>(
       ];
     }
 
+    if (
+      type === 'main' &&
+      feeContributionABTest.isEnabled &&
+      feeContributionABTest.value
+    ) {
+      baseConfig.feeConfig = {
+        _vcComponent: () => (
+          <FeeContribution translationFn={deps.translation.t} />
+        ),
+      };
+    }
+
     return baseConfig;
   }, [
     sharedBase,
@@ -131,12 +149,19 @@ export function useWidgetConfig<T extends WidgetType>(
     context.theme,
     context.disabledUI,
     context.hiddenUI,
+    deps.translation.t,
     priceImpactABTest.isEnabled,
     priceImpactABTest.value,
+    type,
+    feeContributionABTest.isEnabled,
+    feeContributionABTest.value,
   ]);
 
   return {
     config,
-    isReady: !tradeABTest.isLoading && !priceImpactABTest.isLoading,
+    isReady:
+      !tradeABTest.isLoading &&
+      !priceImpactABTest.isLoading &&
+      !feeContributionABTest.isLoading,
   };
 }

--- a/src/const/abtests.ts
+++ b/src/const/abtests.ts
@@ -2,6 +2,7 @@ export enum AB_TEST_NAME {
   TEST_WIDGET_SUBVARIANTS = 'TEST_WIDGET_SUBVARIANTS',
   A_B_TEST_PRICE_IMPACT_DISPLAY = 'a-b-test-price-impact-display',
   A_B_TEST_TRADE_DISPLAY = 'a-b-test-trade-display',
+  A_B_TEST_FEE_CONTRIBUTION_DISPLAY = 'a-b-test-fee-contribution-display',
 }
 
 // Single source of truth for all A/B tests
@@ -16,6 +17,10 @@ export const AbTests = {
   },
   [AB_TEST_NAME.A_B_TEST_TRADE_DISPLAY]: {
     name: 'a-b-test-trade-display',
+    enabled: true,
+  },
+  [AB_TEST_NAME.A_B_TEST_FEE_CONTRIBUTION_DISPLAY]: {
+    name: 'a-b-test-fee-contribution-display',
     enabled: true,
   },
   // Add more tests here as needed


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-798/remove-voluntary-tip-from-jumper-ui

## Testing steps
1. Go to `/`
2. Open the network tab
3. Filter requests for `/feature-flag?key=a-b-test-fee-contribution-display`
<img width="622" height="394" alt="Screenshot 2026-04-13 at 09 48 44" src="https://github.com/user-attachments/assets/37818194-34cd-4bd2-aaf3-82c553f8826a" />

4. Refresh page and connect a wallet
5. Check the response has data set to `false`
<img width="621" height="282" alt="Screenshot 2026-04-13 at 09 48 52" src="https://github.com/user-attachments/assets/f021b935-f12d-4a74-a55a-9d699c26f8dd" />

6. Go to Posthog
7. Check feature flag `a-b-test-fee-contribution-display` is set to rollout to `0%` of users on both development and production


# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a centralized A/B test to control the Fee Contribution widget display.

* **Refactor**
  * Fee contribution visibility and rollout were moved from a local percentage-based mechanism to the centralized A/B test framework, simplifying widget configuration and feature gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->