### PR TITLE
feat: pass abTestVariants for wallet tx tracking

### DIFF
--- a/src/components/Widgets/Widgets.tsx
+++ b/src/components/Widgets/Widgets.tsx
@@ -14,7 +14,6 @@ import {
 import { WidgetTrackingProvider } from 'src/providers/WidgetTrackingProvider';
 import { AB_TEST_NAME, AbTests } from '@/const/abtests';
 import { useABTest } from '@/hooks/useABTest';
-import { account } from 'node_modules/@base-org/account/dist/store/store';
 import { useAccount } from '@lifi/wallet-management';
 
 interface WidgetsProps {

--- a/src/components/Widgets/Widgets.tsx
+++ b/src/components/Widgets/Widgets.tsx
@@ -12,6 +12,10 @@ import {
   TrackingEventDataAction,
 } from 'src/const/trackingKeys';
 import { WidgetTrackingProvider } from 'src/providers/WidgetTrackingProvider';
+import { AB_TEST_NAME, AbTests } from '@/const/abtests';
+import { useABTest } from '@/hooks/useABTest';
+import { account } from 'node_modules/@base-org/account/dist/store/store';
+import { useAccount } from '@lifi/wallet-management';
 
 interface WidgetsProps {
   widgetVariant: StarterVariantType;
@@ -20,6 +24,12 @@ interface WidgetsProps {
 export function Widgets({ widgetVariant }: WidgetsProps) {
   const { activeTab, setActiveTab } = useActiveTabStore();
   const [starterVariantUsed, setStarterVariantUsed] = useState(false);
+
+  const { account } = useAccount();
+  const tradeABTest = useABTest({
+    feature: AB_TEST_NAME.A_B_TEST_TRADE_DISPLAY,
+    address: account?.address ?? '',
+  });
 
   const starterVariant: StarterVariantType = useMemo(() => {
     if (widgetVariant) {
@@ -93,6 +103,20 @@ export function Widgets({ widgetVariant }: WidgetsProps) {
           routeExecutionUpdated: TrackingEventDataAction.ExecutionUpdated,
           routeExecutionCompleted: TrackingEventDataAction.ExecutionCompleted,
           routeExecutionFailed: TrackingEventDataAction.ExecutionFailed,
+        }}
+        trackingDataProperties={{
+          routeExecutionCompleted: {
+            abTestVariants: {
+              [AbTests[AB_TEST_NAME.A_B_TEST_TRADE_DISPLAY].name]:
+                tradeABTest.value,
+            },
+          },
+          routeExecutionStarted: {
+            abTestVariants: {
+              [AbTests[AB_TEST_NAME.A_B_TEST_TRADE_DISPLAY].name]:
+                tradeABTest.value,
+            },
+          },
         }}
       >
         <WidgetEvents />

--- a/src/const/abtests.ts
+++ b/src/const/abtests.ts
@@ -30,6 +30,11 @@ export const AbTests = {
 export const isAbTestingEnabled = true;
 
 export type AbTestName = keyof typeof AbTests;
+export type AbTestFeatureKey =
+  `$feature/${(typeof AbTests)[keyof typeof AbTests]['name']}`;
+export type AbTestVariants = Partial<
+  Record<(typeof AbTests)[keyof typeof AbTests]['name'], string | boolean>
+>;
 
 // For backward compatibility with AbTestConfig usage
 export const AbTestConfig = {

--- a/src/hooks/useJumperTracking.ts
+++ b/src/hooks/useJumperTracking.ts
@@ -6,11 +6,19 @@ import {
   JUMPER_ANALYTICS_EVENT,
   JUMPER_ANALYTICS_TRANSACTION,
 } from 'src/const/abi/jumperApiUrls';
+import type { AbTestVariants } from 'src/const/abtests';
 import type { TransformedRoute } from 'src/types/internal';
 import config from '@/config/env-config';
 
 export type JumperEventData = {
-  [key: string]: string | number | boolean | Record<number, TransformedRoute>;
+  [key: string]:
+    | string
+    | number
+    | boolean
+    | Record<number, TransformedRoute>
+    | AbTestVariants;
+} & {
+  abTestVariants?: AbTestVariants;
 };
 
 interface JumperDataTrackEventProps {
@@ -56,7 +64,7 @@ const track = async (data: object, path: string) => {
   }
 };
 
-export interface JumperDataTrackTransactionProps {
+export type JumperDataTrackTransactionProps = {
   abtests?: { [key: string]: boolean };
   action: string;
   browserFingerprint: string;
@@ -107,7 +115,8 @@ export interface JumperDataTrackTransactionProps {
   toAmountFormatted?: string;
   transactionId?: string;
   transactionLink?: string;
-}
+  abTestVariants?: AbTestVariants;
+};
 
 export const useJumperTracking = () => {
   const trackEvent = async (data: JumperDataTrackEventProps) => {
@@ -188,6 +197,7 @@ export const useJumperTracking = () => {
       }),
       ...(data.transactionId && { transactionId: data.transactionId }),
       ...(data.transactionLink && { transactionLink: data.transactionLink }),
+      ...(data.abTestVariants && { abTestVariants: data.abTestVariants }),
     };
     await track(transactionData, JUMPER_ANALYTICS_TRANSACTION);
   };

--- a/src/hooks/userTracking/useUserTracking.ts
+++ b/src/hooks/userTracking/useUserTracking.ts
@@ -210,6 +210,7 @@ export function useUserTracking(): UserTracking {
           transactionLink: data[TrackingEventParameter.TransactionLink],
           transactionStatus: data[TrackingEventParameter.TransactionStatus],
           type: data[TrackingEventParameter.Type],
+          abTestVariants: data.abTestVariants,
         };
         await jumperTrackTransaction(transactionData);
       }

--- a/src/providers/WidgetTrackingProvider.tsx
+++ b/src/providers/WidgetTrackingProvider.tsx
@@ -1,3 +1,4 @@
+import type { JumperEventData } from '@/hooks/useJumperTracking';
 import type {
   ChainTokenSelected,
   FormFieldChanged,
@@ -81,6 +82,10 @@ interface WidgetTrackingProviderProps extends PropsWithChildren {
     routeExecutionFailed: TrackingEventDataAction;
     routeExecutionUpdated?: TrackingEventDataAction;
   };
+  trackingDataProperties?: {
+    routeExecutionCompleted?: JumperEventData;
+    routeExecutionStarted?: JumperEventData;
+  };
 }
 
 export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
@@ -105,6 +110,7 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
     routeExecutionFailed: TrackingEventDataAction.ExecutionFailedZap,
     routeExecutionUpdated: '',
   },
+  trackingDataProperties,
 }) => {
   const { trackTransaction, trackEvent } = useUserTracking();
   const sourceChainToken = useRef<ChainTokenSelected | null>(null);
@@ -226,6 +232,7 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
           [TrackingEventParameter.Action]:
             trackingDataActionKeys.routeExecutionStarted,
           [TrackingEventParameter.TransactionStatus]: 'STARTED',
+          ...(trackingDataProperties?.routeExecutionStarted || {}),
         });
 
         trackedRoutesData.current[route.id] = routeData;
@@ -243,6 +250,7 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
       trackTransaction,
       trackingActionKeys.routeExecutionStarted,
       trackingDataActionKeys.routeExecutionStarted,
+      trackingDataProperties?.routeExecutionStarted,
     ],
   );
 
@@ -304,6 +312,7 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
           [TrackingEventParameter.Action]:
             trackingDataActionKeys.routeExecutionCompleted,
           [TrackingEventParameter.TransactionStatus]: 'COMPLETED',
+          ...(trackingDataProperties?.routeExecutionCompleted || {}),
         }),
         enableAddressable: true,
         isConversion: true,
@@ -313,6 +322,7 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
       trackTransaction,
       trackingActionKeys.routeExecutionCompleted,
       trackingDataActionKeys.routeExecutionCompleted,
+      trackingDataProperties?.routeExecutionCompleted,
     ],
   );
 

--- a/src/types/userTracking.ts
+++ b/src/types/userTracking.ts
@@ -1,4 +1,5 @@
 import type { Route, TokenAmount } from '@lifi/sdk';
+import type { AbTestVariants } from 'src/const/abtests';
 import type { TrackingEventParameter } from 'src/const/trackingKeys';
 import type { JumperEventData } from 'src/hooks/useJumperTracking';
 
@@ -65,6 +66,7 @@ export interface TrackTransactionDataProps {
   [TrackingEventParameter.Tags]?: string;
   [TrackingEventParameter.TransactionHash]?: string;
   [TrackingEventParameter.TransactionLink]?: string;
+  abTestVariants?: AbTestVariants;
 }
 
 export interface TrackTransactionProps {


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-814/ab-testing-flag-available-on-execution-completed-event

Sister PR https://github.com/jumperexchange/jumper-backend/pull/835

## Testing steps
1. Go to `/`
2. Open the network tab and filter for `wallets/transactions`
3. Trigger a route execution
4. Check in the network tab an event with action "execution_start" has been sent
<img width="720" height="365" alt="Screenshot 2026-04-15 at 12 15 50" src="https://github.com/user-attachments/assets/e63b5d93-81f1-476e-845b-cd0b45f8b655" />

5. It should include the `abTestVariants` with `a-b-test-trade-display` set to either control or test
6. If you go to Posthog, the same event should have the feature flag `a-b-test-trade-display` set to the same value
<img width="1225" height="213" alt="Screenshot 2026-04-15 at 11 54 18" src="https://github.com/user-attachments/assets/a8481e3e-9e53-4912-ae43-ffe4a2b7023a" />

7. Now perform the same check after finalising a swap/bridge
8. In the network tab there is an event with action "execution_completed"
9. Perform steps 5-6
10. Check for earn/mission widgets these events are not sent with `abTestVariants` property set

> [!NOTE]
> Might include the `abTestVariants` property to more events for the main widget after getting the confirmation


# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Widgets now participate in an A/B test that can alter trade display behavior.

* **Chores**
  * Enhanced tracking to include A/B test variant data in transaction and route execution analytics.
  * Tracking provider accepts optional extra tracking properties to surface A/B variant info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->