### PR TITLE
fix: disable notifications UI in production (for now)

### DIFF
--- a/src/components/Navbar/layout/DesktopLayout.tsx
+++ b/src/components/Navbar/layout/DesktopLayout.tsx
@@ -32,7 +32,7 @@ export const DesktopLayout: FC<LayoutVariantProps> = ({ secondaryButtons }) => {
 
       <SecondaryLinksContainer>
         {secondaryButtons}
-        {isProduction && <NotificationBell />}
+        {!isProduction && <NotificationBell />}
         <MainMenuToggle />
       </SecondaryLinksContainer>
     </>

--- a/src/components/Navbar/layout/DesktopLayout.tsx
+++ b/src/components/Navbar/layout/DesktopLayout.tsx
@@ -7,6 +7,7 @@ import { LabelButton } from '../components/Buttons/LabelButton';
 import { MainMenuToggle } from '../components/Buttons/MainMenuToggle';
 import type { LayoutVariantProps } from './Layout.types';
 import { NotificationBell } from '@/components/Notifications/NotificationBell';
+import { isProduction } from '@/utils/isProduction';
 
 export const DesktopLayout: FC<LayoutVariantProps> = ({ secondaryButtons }) => {
   const { links, activeLink } = useMainLinks();
@@ -31,7 +32,7 @@ export const DesktopLayout: FC<LayoutVariantProps> = ({ secondaryButtons }) => {
 
       <SecondaryLinksContainer>
         {secondaryButtons}
-        <NotificationBell />
+        {isProduction && <NotificationBell />}
         <MainMenuToggle />
       </SecondaryLinksContainer>
     </>

--- a/src/components/Navbar/layout/MobileLayout.tsx
+++ b/src/components/Navbar/layout/MobileLayout.tsx
@@ -3,6 +3,7 @@
 import type { FC } from 'react';
 
 import { NotificationBell } from '@/components/Notifications/NotificationBell';
+import { isProduction } from '@/utils/isProduction';
 import { SecondaryLinksContainer } from './Layout.styles';
 import { MainMenuToggle } from '../components/Buttons/MainMenuToggle';
 import type { LayoutVariantProps } from './Layout.types';
@@ -11,7 +12,7 @@ export const MobileLayout: FC<LayoutVariantProps> = ({ secondaryButtons }) => {
   return (
     <SecondaryLinksContainer>
       {secondaryButtons}
-      <NotificationBell />
+      {isProduction && <NotificationBell />}
       <MainMenuToggle />
     </SecondaryLinksContainer>
   );

--- a/src/components/Navbar/layout/MobileLayout.tsx
+++ b/src/components/Navbar/layout/MobileLayout.tsx
@@ -12,7 +12,7 @@ export const MobileLayout: FC<LayoutVariantProps> = ({ secondaryButtons }) => {
   return (
     <SecondaryLinksContainer>
       {secondaryButtons}
-      {isProduction && <NotificationBell />}
+      {!isProduction && <NotificationBell />}
       <MainMenuToggle />
     </SecondaryLinksContainer>
   );


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/JUM-825/disable-notification-ui-in-production-for-now

# Why did I implement it this way?

`isProduction` is the canonical way of detecting the jumper production environment.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notification bell is now hidden in production and remains visible in non-production (applies to both desktop and mobile navigation), reducing production noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->