### PR TITLE
fix: resolve MUI v9 migration regressions for gap and alignItems

### DIFF
--- a/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
+++ b/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
@@ -97,7 +97,7 @@ exports[`EarnCard snapshot > compact card matches snapshot 1`] = `
         class="MuiStack-root css-4e6rn7-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"
@@ -419,7 +419,7 @@ exports[`EarnCard snapshot > compact card with cap in dollar matches snapshot 1`
         class="MuiStack-root css-4e6rn7-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"
@@ -745,7 +745,7 @@ exports[`EarnCard snapshot > compact card with href matches snapshot 1`] = `
           class="MuiStack-root css-4e6rn7-MuiStack-root"
         >
           <div
-            class="MuiBox-root css-1lz6fjj"
+            class="MuiBox-root css-1hq6w3b"
           >
             <div
               class="MuiBox-root css-wioyy2"
@@ -1026,7 +1026,7 @@ exports[`EarnCard snapshot > compact card with loading matches snapshot 1`] = `
         class="MuiStack-root css-4e6rn7-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lr3mj0"
+          class="MuiBox-root css-bcpzx5"
         >
           <span
             class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-ylkla6-MuiSkeleton-root"
@@ -1125,7 +1125,7 @@ exports[`EarnCard snapshot > compact card with lockup months and cap in dollar m
         class="MuiStack-root css-4e6rn7-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"
@@ -1447,7 +1447,7 @@ exports[`EarnCard snapshot > compact card with lockup months matches snapshot 1`
         class="MuiStack-root css-4e6rn7-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"
@@ -1764,7 +1764,7 @@ exports[`EarnCard snapshot > compact card with no recommendation matches snapsho
         class="MuiStack-root css-4e6rn7-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"
@@ -2112,7 +2112,7 @@ exports[`EarnCard snapshot > compact card with single asset matches snapshot 1`]
         class="MuiStack-root css-4e6rn7-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"
@@ -2460,7 +2460,7 @@ exports[`EarnCard snapshot > compact card with two items matches snapshot 1`] = 
         class="MuiStack-root css-4e6rn7-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"
@@ -2651,7 +2651,7 @@ exports[`EarnCard snapshot > list item card matches snapshot 1`] = `
         class="MuiStack-root css-ksl325-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"
@@ -2885,7 +2885,7 @@ exports[`EarnCard snapshot > list item card with cap in dollar matches snapshot 
         class="MuiStack-root css-ksl325-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"
@@ -3097,7 +3097,7 @@ exports[`EarnCard snapshot > list item card with href matches snapshot 1`] = `
           class="MuiStack-root css-ksl325-MuiStack-root"
         >
           <div
-            class="MuiBox-root css-1lz6fjj"
+            class="MuiBox-root css-1hq6w3b"
           >
             <div
               class="MuiBox-root css-wioyy2"
@@ -3306,7 +3306,7 @@ exports[`EarnCard snapshot > list item card with loading matches snapshot 1`] = 
         class="MuiStack-root css-ksl325-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lr3mj0"
+          class="MuiBox-root css-bcpzx5"
         >
           <span
             class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-kqkmxp-MuiSkeleton-root"
@@ -3368,7 +3368,7 @@ exports[`EarnCard snapshot > list item card with lockup months and cap in dollar
         class="MuiStack-root css-ksl325-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"
@@ -3576,7 +3576,7 @@ exports[`EarnCard snapshot > list item card with lockup months matches snapshot 
         class="MuiStack-root css-ksl325-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"
@@ -3784,7 +3784,7 @@ exports[`EarnCard snapshot > list item card with no recommendation matches snaps
         class="MuiStack-root css-ksl325-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"
@@ -3987,7 +3987,7 @@ exports[`EarnCard snapshot > list item card with single asset matches snapshot 1
         class="MuiStack-root css-ksl325-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"
@@ -4348,7 +4348,7 @@ exports[`EarnCard snapshot > overview card matches snapshot 1`] = `
               class="MuiBox-root css-1xdhyk6"
             >
               <div
-                class="MuiBox-root css-ex4fx8"
+                class="MuiBox-root css-1i97kwt"
               >
                 <div
                   class="MuiBox-root css-wioyy2"
@@ -4500,7 +4500,7 @@ exports[`EarnCard snapshot > overview card matches snapshot 1`] = `
               class="MuiBox-root css-1xdhyk6"
             >
               <div
-                class="MuiBox-root css-ex4fx8"
+                class="MuiBox-root css-1i97kwt"
               >
                 <div
                   class="MuiBox-root css-wioyy2"
@@ -4732,7 +4732,7 @@ exports[`EarnCard snapshot > overview card with badge matches snapshot 1`] = `
               class="MuiBox-root css-1xdhyk6"
             >
               <div
-                class="MuiBox-root css-ex4fx8"
+                class="MuiBox-root css-1i97kwt"
               >
                 <div
                   class="MuiBox-root css-wioyy2"
@@ -4884,7 +4884,7 @@ exports[`EarnCard snapshot > overview card with badge matches snapshot 1`] = `
               class="MuiBox-root css-1xdhyk6"
             >
               <div
-                class="MuiBox-root css-ex4fx8"
+                class="MuiBox-root css-1i97kwt"
               >
                 <div
                   class="MuiBox-root css-wioyy2"
@@ -5113,7 +5113,7 @@ exports[`EarnCard snapshot > overview card with cap in dollar matches snapshot 1
               class="MuiBox-root css-1xdhyk6"
             >
               <div
-                class="MuiBox-root css-ex4fx8"
+                class="MuiBox-root css-1i97kwt"
               >
                 <div
                   class="MuiBox-root css-wioyy2"
@@ -5265,7 +5265,7 @@ exports[`EarnCard snapshot > overview card with cap in dollar matches snapshot 1
               class="MuiBox-root css-1xdhyk6"
             >
               <div
-                class="MuiBox-root css-ex4fx8"
+                class="MuiBox-root css-1i97kwt"
               >
                 <div
                   class="MuiBox-root css-wioyy2"
@@ -5528,7 +5528,7 @@ exports[`EarnCard snapshot > overview card with lockup months and cap in dollar 
               class="MuiBox-root css-1xdhyk6"
             >
               <div
-                class="MuiBox-root css-ex4fx8"
+                class="MuiBox-root css-1i97kwt"
               >
                 <div
                   class="MuiBox-root css-wioyy2"
@@ -5680,7 +5680,7 @@ exports[`EarnCard snapshot > overview card with lockup months and cap in dollar 
               class="MuiBox-root css-1xdhyk6"
             >
               <div
-                class="MuiBox-root css-ex4fx8"
+                class="MuiBox-root css-1i97kwt"
               >
                 <div
                   class="MuiBox-root css-wioyy2"
@@ -5909,7 +5909,7 @@ exports[`EarnCard snapshot > overview card with lockup months matches snapshot 1
               class="MuiBox-root css-1xdhyk6"
             >
               <div
-                class="MuiBox-root css-ex4fx8"
+                class="MuiBox-root css-1i97kwt"
               >
                 <div
                   class="MuiBox-root css-wioyy2"
@@ -6061,7 +6061,7 @@ exports[`EarnCard snapshot > overview card with lockup months matches snapshot 1
               class="MuiBox-root css-1xdhyk6"
             >
               <div
-                class="MuiBox-root css-ex4fx8"
+                class="MuiBox-root css-1i97kwt"
               >
                 <div
                   class="MuiBox-root css-wioyy2"

--- a/src/components/Cards/HeroEarnCard/__snapshots__/HeroEarnCard.snapshot.spec.tsx.snap
+++ b/src/components/Cards/HeroEarnCard/__snapshots__/HeroEarnCard.snapshot.spec.tsx.snap
@@ -70,7 +70,7 @@ exports[`HeroEarnCard snapshot > hero card matches snapshot 1`] = `
         class="MuiStack-root css-4n2h5n-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"
@@ -217,7 +217,7 @@ exports[`HeroEarnCard snapshot > hero card with EARN_UP_TO copy matches snapshot
         class="MuiStack-root css-4n2h5n-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"
@@ -364,7 +364,7 @@ exports[`HeroEarnCard snapshot > hero card with MAKE_THE_JUMP copy matches snaps
         class="MuiStack-root css-4n2h5n-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"
@@ -511,7 +511,7 @@ exports[`HeroEarnCard snapshot > hero card with MAXIMIZE_YOUR_REVENUE copy match
         class="MuiStack-root css-4n2h5n-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"
@@ -662,7 +662,7 @@ exports[`HeroEarnCard snapshot > hero card with link matches snapshot 1`] = `
           class="MuiStack-root css-4n2h5n-MuiStack-root"
         >
           <div
-            class="MuiBox-root css-1lz6fjj"
+            class="MuiBox-root css-1hq6w3b"
           >
             <div
               class="MuiBox-root css-wioyy2"
@@ -768,7 +768,7 @@ exports[`HeroEarnCard snapshot > hero card with loading matches snapshot 1`] = `
         class="MuiStack-root css-4n2h5n-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lr3mj0"
+          class="MuiBox-root css-bcpzx5"
         >
           <span
             class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-kqkmxp-MuiSkeleton-root"
@@ -853,7 +853,7 @@ exports[`HeroEarnCard snapshot > hero card with single asset matches snapshot 1`
         class="MuiStack-root css-4n2h5n-MuiStack-root"
       >
         <div
-          class="MuiBox-root css-1lz6fjj"
+          class="MuiBox-root css-1hq6w3b"
         >
           <div
             class="MuiBox-root css-wioyy2"

--- a/src/components/composite/EntityChainStack/EntityChainStack.styles.ts
+++ b/src/components/composite/EntityChainStack/EntityChainStack.styles.ts
@@ -11,7 +11,7 @@ export const EntityChainContainer = styled(Box, {
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: 16,
+  gap: theme.spacing(2),
   ...(isContentVisible && {
     minWidth: 0,
     overflow: 'hidden',

--- a/src/components/composite/EntityChainStack/variants/BaseChainStack.tsx
+++ b/src/components/composite/EntityChainStack/variants/BaseChainStack.tsx
@@ -52,7 +52,7 @@ export const BaseChainStack: FC<BaseChainStackProps> = ({
   const spacing = {
     main: -1.5,
     chains: -1,
-    containerGap: 16,
+    containerGap: 2,
     infoContainerGap: 2,
     ...spacingProp,
   };

--- a/src/components/composite/EntityStackWithBadge/EntityStackWithBadge.styles.ts
+++ b/src/components/composite/EntityStackWithBadge/EntityStackWithBadge.styles.ts
@@ -12,11 +12,11 @@ interface EntityStackContainerProps {
  */
 export const EntityStackContainer = styled(Box, {
   shouldForwardProp: (prop) => prop !== 'isContentVisible',
-})<EntityStackContainerProps>(({ isContentVisible }) => ({
+})<EntityStackContainerProps>(({ theme, isContentVisible }) => ({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: 16,
+  gap: theme.spacing(2),
   ...(isContentVisible && {
     minWidth: 0,
   }),

--- a/src/components/composite/EntityStackWithBadge/EntityStackWithBadge.tsx
+++ b/src/components/composite/EntityStackWithBadge/EntityStackWithBadge.tsx
@@ -53,7 +53,7 @@ export const EntityStackWithBadge: FC<EntityStackWithBadgeProps> = ({
     () => ({
       main: -1.5,
       badge: -1,
-      containerGap: 16,
+      containerGap: 2,
       infoContainerGap: 2,
       ...spacingProp,
     }),

--- a/src/components/composite/WalletBalanceCard/__snapshots__/WalletBalanceCard.snapshot.spec.tsx.snap
+++ b/src/components/composite/WalletBalanceCard/__snapshots__/WalletBalanceCard.snapshot.spec.tsx.snap
@@ -128,12 +128,10 @@ exports[`WalletBalanceCard snapshot > with error renders alert 1`] = `
                     navbar.walletMenu.walletBalance
                   </p>
                   <div
-                    alignitems="center"
-                    class="MuiStack-root css-14dudhf-MuiStack-root"
+                    class="MuiStack-root css-1iw8hzp-MuiStack-root"
                   >
                     <div
-                      alignitems="center"
-                      class="MuiStack-root css-1nvw2kh-MuiStack-root"
+                      class="MuiStack-root css-6y1ufm-MuiStack-root"
                     >
                       <div
                         class="css-1l8j7hy"
@@ -363,12 +361,10 @@ exports[`WalletBalanceCard snapshot > without error renders normally 1`] = `
                     navbar.walletMenu.walletBalance
                   </p>
                   <div
-                    alignitems="center"
-                    class="MuiStack-root css-14dudhf-MuiStack-root"
+                    class="MuiStack-root css-1iw8hzp-MuiStack-root"
                   >
                     <div
-                      alignitems="center"
-                      class="MuiStack-root css-1nvw2kh-MuiStack-root"
+                      class="MuiStack-root css-6y1ufm-MuiStack-root"
                     >
                       <div
                         class="css-1l8j7hy"
@@ -454,7 +450,7 @@ exports[`WalletBalanceCard snapshot > without error renders normally 1`] = `
                               class="MuiStack-root css-1whz3z4-MuiStack-root"
                             >
                               <div
-                                class="MuiBox-root css-1lz6fjj"
+                                class="MuiBox-root css-1hq6w3b"
                               >
                                 <div
                                   class="MuiBox-root css-wioyy2"
@@ -564,7 +560,7 @@ exports[`WalletBalanceCard snapshot > without error renders normally 1`] = `
                                     class="MuiStack-root css-2mffmj-MuiStack-root"
                                   >
                                     <div
-                                      class="MuiBox-root css-1lz6fjj"
+                                      class="MuiBox-root css-1hq6w3b"
                                     >
                                       <div
                                         class="MuiBox-root css-wioyy2"
@@ -654,7 +650,7 @@ exports[`WalletBalanceCard snapshot > without error renders normally 1`] = `
                                     class="MuiStack-root css-2mffmj-MuiStack-root"
                                   >
                                     <div
-                                      class="MuiBox-root css-1lz6fjj"
+                                      class="MuiBox-root css-1hq6w3b"
                                     >
                                       <div
                                         class="MuiBox-root css-wioyy2"

--- a/src/components/composite/WalletBalanceCard/components/WalletTotalBalance.tsx
+++ b/src/components/composite/WalletBalanceCard/components/WalletTotalBalance.tsx
@@ -17,7 +17,6 @@ import { usePortfolioFormatters } from '@/hooks/tokens/usePortfolioFormatters';
 
 const sharedStackProps = {
   direction: 'row',
-  alignItems: 'center',
   useFlexGap: true,
 } as const;
 
@@ -58,9 +57,9 @@ export const WalletTotalBalance: FC<WalletTotalBalanceProps> = ({
         </Typography>
         <Stack
           {...sharedStackProps}
-          sx={{ gap: 2, justifyContent: 'space-between' }}
+          sx={{ gap: 2, justifyContent: 'space-between', alignItems: 'center' }}
         >
-          <Stack {...sharedStackProps} sx={{ gap: 1 }}>
+          <Stack {...sharedStackProps} sx={{ gap: 1, alignItems: 'center' }}>
             <WalletTotalBalanceValue as="div">
               <>
                 {prefix}

--- a/src/components/composite/cards/ProcessingTransactionCard/__snapshots__/ProcessingTransactionCard.snapshot.spec.tsx.snap
+++ b/src/components/composite/cards/ProcessingTransactionCard/__snapshots__/ProcessingTransactionCard.snapshot.spec.tsx.snap
@@ -39,7 +39,7 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot 1`] = `
           class="MuiBox-root css-ep7xq6"
         >
           <div
-            class="MuiBox-root css-ex4fx8"
+            class="MuiBox-root css-1i97kwt"
             data-testid="tokens-ETH"
           >
             <div
@@ -91,7 +91,7 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot 1`] = `
           class="MuiBox-root css-exjb9r"
         >
           <div
-            class="MuiBox-root css-ex4fx8"
+            class="MuiBox-root css-1i97kwt"
             data-testid="tokens-USDC"
           >
             <div
@@ -218,7 +218,7 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot with status faile
           class="MuiBox-root css-ep7xq6"
         >
           <div
-            class="MuiBox-root css-ex4fx8"
+            class="MuiBox-root css-1i97kwt"
             data-testid="tokens-ETH"
           >
             <div
@@ -270,7 +270,7 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot with status faile
           class="MuiBox-root css-exjb9r"
         >
           <div
-            class="MuiBox-root css-ex4fx8"
+            class="MuiBox-root css-1i97kwt"
             data-testid="tokens-USDC"
           >
             <div
@@ -397,7 +397,7 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot with status succe
           class="MuiBox-root css-ep7xq6"
         >
           <div
-            class="MuiBox-root css-ex4fx8"
+            class="MuiBox-root css-1i97kwt"
             data-testid="tokens-ETH"
           >
             <div
@@ -449,7 +449,7 @@ exports[`ProcessingTransactionCard snapshot > matches snapshot with status succe
           class="MuiBox-root css-exjb9r"
         >
           <div
-            class="MuiBox-root css-ex4fx8"
+            class="MuiBox-root css-1i97kwt"
             data-testid="tokens-USDC"
           >
             <div


### PR DESCRIPTION
## Summary
- Fix `containerGap: 16` default in `EntityStackWithBadge` and `BaseChainStack` — the MUI v9 migration moved `gap` from a direct Box prop (raw CSS `16px`) to `sx` prop (processed through spacing system: `spacing(16) = 128px`). Changed to `2` so `spacing(2) = 16px`
- Fix `gap: 16` in styled components `EntityStackContainer` and `EntityChainContainer` to use `theme.spacing(2)` for consistency
- Move `alignItems: 'center'` from direct Stack prop to `sx` in `WalletTotalBalance` — MUI v9 no longer processes direct system props on Stack, causing default `stretch` (oval buttons)

Closes https://linear.app/lifi-linear/issue/JUM-823/release-blocker-row-layout-broken-across-lists-symbolchain-floating

### Affected surfaces
- Wallet drawer — token list
- Portfolio page → Tokens tab
- Portfolio page → DeFi Protocols tab
- Earn page → vault cards
- Wallet balance refresh button (oval → circular)

## Test plan
- [ ] Verify wallet drawer token list has correct icon-to-text spacing
- [ ] Verify portfolio tokens tab layout is correct
- [ ] Verify portfolio DeFi protocols tab layout is correct
- [ ] Verify Earn page vault cards have correct icon-to-text spacing
- [ ] Verify refresh button in wallet balance is circular, not oval
- [ ] Verify vitest snapshots pass (`pnpm run test:snapshots`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated component spacing to use theme-based values for consistency across entity chain stack, entity stack with badge, and wallet balance components.

* **Refactor**
  * Adjusted layout alignment properties in wallet balance component for improved styling structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->