### PR TITLE
fix: table rendering

### DIFF
--- a/src/components/RichBlocks/blocks/ParagraphBlock.tsx
+++ b/src/components/RichBlocks/blocks/ParagraphBlock.tsx
@@ -1,9 +1,17 @@
-import type { FC, PropsWithChildren } from 'react';
+import type { FC, PropsWithChildren, ReactNode } from 'react';
 import { ParagraphBlockContainer } from '../RichBlocks.style';
 import type { CommonBlockProps, ParagraphProps, TrackingKeys } from '../types';
 import { RichBlocksVariant } from '../types';
 import dynamic from 'next/dynamic';
-import { parseMarkdownTable } from '../utils/parseMarkdownTable';
+import { renderTableCellFromSegments } from '../renderers/renderTableCellFromSegments';
+import {
+  parseMarkdownTable,
+  parseMarkdownTableWithRanges,
+} from '../utils/parseMarkdownTable';
+import {
+  buildPositionedInlineParts,
+  serializeParagraphInlinesFromReact,
+} from '../utils/serializeParagraphInlinesFromReact';
 
 const ParagraphRenderer = dynamic(() =>
   import('../renderers/ParagraphRenderer').then((mod) => mod.ParagraphRenderer),
@@ -46,35 +54,53 @@ export const ParagraphBlock: FC<ParagraphBlockProps> = ({
   }
 
   const paragraphChildren = children as Array<{ props: ParagraphProps }>;
+  const firstText = String(paragraphChildren[0]?.props?.text ?? '');
 
   if (
-    paragraphChildren[0].props.text.includes('<JUMPER_CTA') &&
+    firstText.includes('<JUMPER_CTA') &&
     variant === RichBlocksVariant.BlogArticle
   ) {
-    return (
-      <CTARenderer
-        text={paragraphChildren[0].props.text}
-        trackingKeys={trackingKeys?.cta}
-      />
-    );
+    return <CTARenderer text={firstText} trackingKeys={trackingKeys?.cta} />;
   }
 
   if (
-    paragraphChildren[0].props.text.includes('<WIDGET') &&
+    firstText.includes('<WIDGET') &&
     variant === RichBlocksVariant.BlogArticle
   ) {
-    return <WidgetRenderer text={paragraphChildren[0].props.text} />;
+    return <WidgetRenderer text={firstText} />;
   }
 
   if (
-    paragraphChildren[0].props.text.includes('<INSTRUCTIONS') &&
+    firstText.includes('<INSTRUCTIONS') &&
     variant === RichBlocksVariant.BlogArticle
   ) {
-    return <InstructionsRenderer text={paragraphChildren[0].props.text} />;
+    return <InstructionsRenderer text={firstText} />;
   }
 
-  const tableData = parseMarkdownTable(paragraphChildren[0].props.text);
+  const inlineNodes = children as ReactNode[];
+  const tablePlain = serializeParagraphInlinesFromReact(inlineNodes);
+  const tableData = parseMarkdownTable(tablePlain);
   if (tableData) {
+    const { plain, positioned } = buildPositionedInlineParts(inlineNodes);
+    const work = plain.trim();
+    const lead = plain.length - plain.trimStart().length;
+    const withRanges = parseMarkdownTableWithRanges(work);
+
+    if (withRanges && positioned.length > 0) {
+      const mapCell = (r: { start: number; end: number }) =>
+        renderTableCellFromSegments(
+          plain,
+          positioned,
+          lead + r.start,
+          lead + r.end,
+        );
+      return (
+        <TableRenderer
+          headers={withRanges.headerCellRanges.map(mapCell)}
+          rows={withRanges.dataRowCellRanges.map((row) => row.map(mapCell))}
+        />
+      );
+    }
     return <TableRenderer headers={tableData.headers} rows={tableData.rows} />;
   }
 

--- a/src/components/RichBlocks/renderers/TableRenderer.tsx
+++ b/src/components/RichBlocks/renderers/TableRenderer.tsx
@@ -18,7 +18,7 @@ export interface TableRendererProps {
 }
 
 export const TableRenderer: FC<TableRendererProps> = ({ headers, rows }) => (
-  <StyledTableContainer>
+  <StyledTableContainer sx={{ '& a': { marginLeft: 0 } }}>
     <Table size="small">
       <TableHead>
         <TableRow>

--- a/src/components/RichBlocks/renderers/TableRenderer.tsx
+++ b/src/components/RichBlocks/renderers/TableRenderer.tsx
@@ -1,16 +1,21 @@
-import type { FC } from 'react';
+import type { FC, ReactNode } from 'react';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import type { ParsedTable } from '../utils/parseMarkdownTable';
 import {
   StyledTableContainer,
   StyledHeaderCell,
   StyledBodyCell,
 } from '../RichBlocks.style';
 
-interface TableRendererProps extends ParsedTable {}
+/**
+ * `ParsedTable` uses `string` cells; rich tables pass `ReactNode` from segment rendering.
+ */
+export interface TableRendererProps {
+  headers: Array<string | ReactNode>;
+  rows: Array<Array<string | ReactNode>>;
+}
 
 export const TableRenderer: FC<TableRendererProps> = ({ headers, rows }) => (
   <StyledTableContainer>

--- a/src/components/RichBlocks/renderers/renderTableCellFromSegments.tsx
+++ b/src/components/RichBlocks/renderers/renderTableCellFromSegments.tsx
@@ -1,0 +1,62 @@
+import { compact, filter, map } from 'lodash';
+import type { ReactNode } from 'react';
+import { Fragment } from 'react';
+import { LinkRenderer } from './LinkRenderer';
+import { renderTextWithOptionalBoldMarkdown } from './textWithOptionalBoldMarkdown';
+import type { PositionedPart } from '../utils/inlinePartTypes';
+import generateKey from 'src/app/lib/generateKey';
+
+/**
+ * Renders a slice [a, b) of the paragraph plain string using positioned inline parts.
+ * `a` / `b` are indices into `plain` (untrimmed); caller maps work-space ranges with `lead` offset.
+ */
+export function renderTableCellFromSegments(
+  plain: string,
+  positioned: PositionedPart[],
+  a: number,
+  b: number,
+): ReactNode {
+  if (a >= b) {
+    return null;
+  }
+  const overlapping = filter(
+    positioned,
+    ({ start, end }) => end > a && start < b,
+  );
+  const out = compact(
+    map(overlapping, ({ start, end, part }) => {
+      const lo = Math.max(a, start);
+      const hi = Math.min(b, end);
+      if (lo >= hi) {
+        return null;
+      }
+      if (part.kind === 'text') {
+        return (
+          <Fragment key={generateKey(`c-${lo}-${hi}`)}>
+            {renderTextWithOptionalBoldMarkdown(
+              plain.slice(lo, hi),
+              part.textProps,
+            )}
+          </Fragment>
+        );
+      }
+      const labelSlice = plain.slice(lo, hi);
+      return (
+        <LinkRenderer
+          key={generateKey(`l-${lo}`)}
+          content={{
+            url: part.url,
+            children: [{ text: labelSlice }],
+          }}
+        />
+      );
+    }),
+  );
+  if (out.length === 0) {
+    return plain.slice(a, b) || null;
+  }
+  if (out.length === 1) {
+    return out[0]!;
+  }
+  return <Fragment>{out}</Fragment>;
+}

--- a/src/components/RichBlocks/renderers/textWithOptionalBoldMarkdown.tsx
+++ b/src/components/RichBlocks/renderers/textWithOptionalBoldMarkdown.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from 'react';
+import { Fragment } from 'react';
+import { TextRenderer } from './TextRenderer';
+import { HtmlRenderer } from './HtmlRenderer';
+import type { InlineTextProps } from '../utils/inlinePartTypes';
+import generateKey from 'src/app/lib/generateKey';
+
+const BOLD_MD = /\*\*([^*]+)\*\*/g;
+
+/**
+ * Renders a text slice with `**...**` split into bold runs (pasted markdown in a cell).
+ * Strapi `bold: true` is applied via `textProps` on the outer TextRenderer when no `**` is used.
+ */
+export function renderTextWithOptionalBoldMarkdown(
+  text: string,
+  textProps: InlineTextProps = {},
+): ReactNode {
+  if (!text) {
+    return null;
+  }
+  if (text.includes('<') && text.includes('>')) {
+    return (
+      <HtmlRenderer
+        text={text}
+        bold={textProps.bold}
+        italic={textProps.italic}
+        underline={textProps.underline}
+        strikethrough={textProps.strikethrough}
+      />
+    );
+  }
+  if (!text.includes('**')) {
+    return <TextRenderer {...textProps} text={text} />;
+  }
+  const parts: ReactNode[] = [];
+  let last = 0;
+  BOLD_MD.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  let k = 0;
+
+  while ((m = BOLD_MD.exec(text)) !== null) {
+    if (m.index > last) {
+      parts.push(
+        <TextRenderer
+          key={generateKey(`b-${k++}`)}
+          {...textProps}
+          text={text.slice(last, m.index)}
+        />,
+      );
+    }
+    parts.push(
+      <TextRenderer
+        key={generateKey(`B-${k++}`)}
+        {...textProps}
+        text={m[1] ?? ''}
+        bold
+      />,
+    );
+    last = m.index + m[0]!.length;
+  }
+  if (last < text.length) {
+    parts.push(
+      <TextRenderer
+        key={generateKey(`b-${k++}`)}
+        {...textProps}
+        text={text.slice(last)}
+      />,
+    );
+  }
+  if (parts.length === 0) {
+    return <TextRenderer {...textProps} text={text} />;
+  }
+  return <Fragment>{parts}</Fragment>;
+}

--- a/src/components/RichBlocks/utils/inlineNodeWalker.ts
+++ b/src/components/RichBlocks/utils/inlineNodeWalker.ts
@@ -1,0 +1,120 @@
+import {
+  Children,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import { flatMap } from 'lodash';
+import type { InlinePart, InlineTextProps } from './inlinePartTypes';
+
+type Recurse = (n: ReactNode) => InlinePart[];
+
+/**
+ * Public for tests; re-exported from serialize module.
+ */
+export function inlinePartsToPlainString(parts: InlinePart[]): string {
+  return parts.map((x) => (x.kind === 'text' ? x.value : x.label)).join('');
+}
+
+function readTextStyleProps(p: Record<string, unknown>): InlineTextProps {
+  return {
+    bold: p.bold as boolean | undefined,
+    italic: p.italic as boolean | undefined,
+    underline: p.underline as boolean | undefined,
+    strikethrough: p.strikethrough as boolean | undefined,
+  };
+}
+
+const strapiTextHandler = {
+  predicate: (el: ReactElement<Record<string, unknown>>) =>
+    typeof el.props.text === 'string',
+  toParts: (el: ReactElement<Record<string, unknown>>, _walk: Recurse) => {
+    const p = el.props;
+    return [
+      {
+        kind: 'text' as const,
+        value: p.text as string,
+        textProps: readTextStyleProps(p as Record<string, unknown>),
+      },
+    ];
+  },
+};
+
+const strapiContentLinkHandler = {
+  predicate: (el: ReactElement<Record<string, unknown>>) => {
+    const c = el.props.content;
+    return (
+      c != null &&
+      typeof c === 'object' &&
+      (c as { type?: string }).type === 'link' &&
+      typeof (c as { url?: string }).url === 'string'
+    );
+  },
+  toParts: (el: ReactElement<Record<string, unknown>>, _walk: Recurse) => {
+    const c = el.props.content as {
+      url: string;
+      children: Array<{ text?: string }>;
+    };
+    const { url, children: linkChildren = [] } = c;
+    const label = linkChildren.map((x) => x.text ?? '').join('');
+    return [{ kind: 'link' as const, url, label }];
+  },
+};
+
+const hrefLinkHandler = {
+  predicate: (el: ReactElement<Record<string, unknown>>) =>
+    typeof el.props.href === 'string',
+  toParts: (el: ReactElement<Record<string, unknown>>, walk: Recurse) => {
+    const ch = el.props.children;
+    const inner = flatMap(Children.toArray(ch as ReactNode), (n) => walk(n));
+    return [
+      {
+        kind: 'link' as const,
+        url: el.props.href as string,
+        label: inlinePartsToPlainString(inner),
+      },
+    ];
+  },
+};
+
+const childrenRecursionHandler = {
+  predicate: (el: ReactElement<Record<string, unknown>>) =>
+    el.props.children != null,
+  toParts: (el: ReactElement<Record<string, unknown>>, walk: Recurse) =>
+    flatMap(Children.toArray(el.props.children as ReactNode), (n) => walk(n)),
+};
+
+/**
+ * OCP: add new entry here for new Strapi inline node shapes; do not change core walk.
+ */
+const INLINE_NODE_HANDLERS: ReadonlyArray<{
+  predicate: (el: ReactElement<Record<string, unknown>>) => boolean;
+  toParts: (
+    el: ReactElement<Record<string, unknown>>,
+    walk: Recurse,
+  ) => InlinePart[];
+}> = [
+  strapiTextHandler,
+  strapiContentLinkHandler,
+  hrefLinkHandler,
+  childrenRecursionHandler,
+];
+
+export function walkInlines(node: ReactNode): InlinePart[] {
+  if (node == null || node === false) {
+    return [];
+  }
+  if (typeof node === 'string' || typeof node === 'number') {
+    return [{ kind: 'text', value: String(node), textProps: {} }];
+  }
+  if (!isValidElement(node)) {
+    return [];
+  }
+  const el = node as ReactElement<Record<string, unknown>>;
+  for (const h of INLINE_NODE_HANDLERS) {
+    if (h.predicate(el)) {
+      return h.toParts(el, walkInlines);
+    }
+  }
+  return [];
+}

--- a/src/components/RichBlocks/utils/inlinePartTypes.ts
+++ b/src/components/RichBlocks/utils/inlinePartTypes.ts
@@ -1,0 +1,20 @@
+import type { ParagraphProps } from '../types';
+
+export type InlineTextProps = Pick<
+  ParagraphProps,
+  'bold' | 'italic' | 'underline' | 'strikethrough'
+>;
+
+/**
+ * A single run of plain text with Strapi-like modifiers, or a link.
+ * @see serializeParagraphInlinesFromReact
+ */
+export type InlinePart =
+  | { kind: 'text'; value: string; textProps: InlineTextProps }
+  | { kind: 'link'; url: string; label: string };
+
+export type PositionedPart = {
+  start: number;
+  end: number;
+  part: InlinePart;
+};

--- a/src/components/RichBlocks/utils/parseMarkdownTable.ts
+++ b/src/components/RichBlocks/utils/parseMarkdownTable.ts
@@ -3,43 +3,41 @@
  * Strapi Blocks store this as plain text in a paragraph, not as structured table nodes.
  */
 
+import { compact, times } from 'lodash';
+import {
+  forEachLine,
+  getCellCharRangesInLine,
+  isDelimiterRow,
+  splitRow,
+  type CellCharRange,
+} from './tableRowUtils';
+
+export type { CellCharRange } from './tableRowUtils';
+export { splitRow };
+
 export interface ParsedTable {
   headers: string[];
   rows: string[][];
 }
 
-const splitRow = (line: string): string[] => {
-  const trimmed = line.trim();
-  if (!trimmed.includes('|')) {
-    return [];
-  }
-
-  return trimmed
-    .replace(/^\||\|$/g, '')
-    .split('|')
-    .map((cell) => cell.trim());
-};
-
-const isDelimiterRow = (cells: string[]): boolean =>
-  cells.length > 0 && cells.every((cell) => /^:?-+:?$/.test(cell));
-
 export const parseMarkdownTable = (text: string): ParsedTable | null => {
-  const lines = text
-    .trim()
-    .split(/\r?\n/)
-    .map((l) => l.trim())
-    .filter(Boolean);
+  const lines = compact(
+    text
+      .trim()
+      .split(/\r?\n/)
+      .map((l) => l.trim()),
+  );
 
   if (lines.length < 2) {
     return null;
   }
 
-  const headers = splitRow(lines[0]);
+  const headers = splitRow(lines[0]!);
   if (headers.length === 0) {
     return null;
   }
 
-  const delimiterCells = splitRow(lines[1]);
+  const delimiterCells = splitRow(lines[1]!);
   if (
     !isDelimiterRow(delimiterCells) ||
     delimiterCells.length !== headers.length
@@ -53,12 +51,79 @@ export const parseMarkdownTable = (text: string): ParsedTable | null => {
       return acc;
     }
 
-    const padded = Array.from(
-      { length: headers.length },
-      (_, i) => cells[i] ?? '',
-    );
+    const padded = times(headers.length, (i) => cells[i] ?? '');
     return [...acc, padded];
   }, []);
 
   return { headers, rows };
+};
+
+export interface ParsedTableWithRanges extends ParsedTable {
+  /** Indices into the trimmed `text` passed in. */
+  headerCellRanges: CellCharRange[];
+  dataRowCellRanges: CellCharRange[][];
+}
+
+/**
+ * As parseMarkdownTable, plus [start, end) per cell in the same trimmed `text` space.
+ */
+export const parseMarkdownTableWithRanges = (
+  text: string,
+): ParsedTableWithRanges | null => {
+  const work = text.trim();
+  const lineEntries: { t: string; start: number }[] = [];
+  forEachLine(work, (lineTrim, lineStart) => {
+    lineEntries.push({ t: lineTrim, start: lineStart });
+  });
+
+  if (lineEntries.length < 2) {
+    return null;
+  }
+  const [first, second, ...dataLines] = lineEntries;
+  if (!first || !second) {
+    return null;
+  }
+  const headers = splitRow(first.t);
+  if (headers.length === 0) {
+    return null;
+  }
+  const delimiterCells = splitRow(second.t);
+  if (
+    !isDelimiterRow(delimiterCells) ||
+    delimiterCells.length !== headers.length
+  ) {
+    return null;
+  }
+
+  const headerCellRanges = getCellCharRangesInLine(first.t, first.start);
+  if (headerCellRanges.length < headers.length) {
+    for (let i = headerCellRanges.length; i < headers.length; i++) {
+      headerCellRanges.push({
+        start: first.start + first.t.length,
+        end: first.start + first.t.length,
+      });
+    }
+  }
+
+  const rows: string[][] = [];
+  const dataRowCellRanges: CellCharRange[][] = [];
+  for (const { t: line, start: lineStart } of dataLines) {
+    const cells = splitRow(line);
+    if (cells.length === 0) {
+      continue;
+    }
+    const padded = times(headers.length, (j) => cells[j] ?? '');
+    const ranges = getCellCharRangesInLine(line, lineStart);
+    const paddedRanges: CellCharRange[] = times(headers.length, (j) => {
+      if (j < ranges.length) {
+        return ranges[j]!;
+      }
+      const last = lineStart + line.length;
+      return { start: last, end: last };
+    });
+    rows.push(padded);
+    dataRowCellRanges.push(paddedRanges);
+  }
+
+  return { headers, rows, headerCellRanges, dataRowCellRanges };
 };

--- a/src/components/RichBlocks/utils/serializeParagraphInlinesFromReact.spec.ts
+++ b/src/components/RichBlocks/utils/serializeParagraphInlinesFromReact.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { createElement, Fragment, type FC } from 'react';
+import {
+  buildPositionedInlineParts,
+  serializeParagraphInlinesFromReact,
+} from './serializeParagraphInlinesFromReact';
+import {
+  parseMarkdownTable,
+  parseMarkdownTableWithRanges,
+} from './parseMarkdownTable';
+
+/** @strapi/blocks-react-renderer `Text` passes `{ text, bold?, ... }` on `props`. */
+const StrapiText: FC<{
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+}> = () => null;
+
+describe('serializeParagraphInlinesFromReact', () => {
+  it('joins only props.text (Strapi text node)', () => {
+    const el = createElement(StrapiText, { text: '|x|' });
+    expect(serializeParagraphInlinesFromReact([el])).toBe('|x|');
+  });
+
+  it('includes link label from default <a> shape', () => {
+    const link = createElement(
+      'a',
+      { href: 'https://li.fi' },
+      createElement(StrapiText, { text: 'Li' }),
+    );
+    const after = createElement(StrapiText, { text: ' | rest' });
+    expect(serializeParagraphInlinesFromReact([link, after])).toBe('Li | rest');
+  });
+});
+
+describe('table detection with mixed inlines + parseMarkdownTable', () => {
+  it('parses a GFM table from serialized Strapi-like children', () => {
+    const header = createElement(
+      Fragment,
+      null,
+      createElement(StrapiText, { text: '| A | B |\n' }),
+      createElement(StrapiText, { text: '| --- | --- |\n' }),
+    );
+    const row = createElement(StrapiText, { text: '| 1 | 2 |' });
+    const plain = serializeParagraphInlinesFromReact([header, row]);
+    const parsed = parseMarkdownTable(plain);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.headers).toEqual(['A', 'B']);
+    expect(parsed!.rows).toEqual([['1', '2']]);
+  });
+});
+
+describe('buildPositionedInlineParts + parseMarkdownTableWithRanges', () => {
+  it('aligns positions with plain string', () => {
+    const { plain, positioned } = buildPositionedInlineParts([
+      createElement(StrapiText, { text: 'ab' }),
+      createElement(
+        'a',
+        { href: 'https://x' },
+        createElement(StrapiText, { text: 'cd' }),
+      ),
+    ]);
+    expect(plain).toBe('abcd');
+    expect(positioned).toHaveLength(2);
+    expect(positioned[0]!.start).toBe(0);
+    expect(positioned[0]!.end).toBe(2);
+    expect(positioned[1]!.start).toBe(2);
+    expect(positioned[1]!.end).toBe(4);
+  });
+
+  it('cell ranges in trimmed work string slice the same substrings as splitRow', () => {
+    const work = '| A | B |\n| --- | --- |\n| 1 | 2 |';
+    const p = parseMarkdownTableWithRanges(work);
+    expect(p).not.toBeNull();
+    expect(
+      work.slice(p!.headerCellRanges[0]!.start, p!.headerCellRanges[0]!.end),
+    ).toBe('A');
+  });
+});

--- a/src/components/RichBlocks/utils/serializeParagraphInlinesFromReact.ts
+++ b/src/components/RichBlocks/utils/serializeParagraphInlinesFromReact.ts
@@ -1,0 +1,41 @@
+import { flatMap } from 'lodash';
+import type { ReactNode } from 'react';
+import { inlinePartsToPlainString, walkInlines } from './inlineNodeWalker';
+import type { InlinePart, PositionedPart } from './inlinePartTypes';
+
+export type {
+  InlineTextProps,
+  InlinePart,
+  PositionedPart,
+} from './inlinePartTypes';
+export { inlinePartsToPlainString } from './inlineNodeWalker';
+
+/**
+ * One concatenated string matching visual order, including link labels (not URLs if label empty).
+ */
+export function serializeParagraphInlinesFromReact(
+  children: Array<ReactNode> | ReadonlyArray<ReactNode>,
+): string {
+  const list = Array.isArray(children) ? children : [children];
+  const parts: InlinePart[] = flatMap(list, (c) => walkInlines(c));
+  return inlinePartsToPlainString(parts);
+}
+
+/**
+ * Same plain string as `serialize` plus `[start, end)` ranges in that string for each part.
+ */
+export function buildPositionedInlineParts(
+  children: Array<ReactNode> | ReadonlyArray<ReactNode>,
+): { plain: string; positioned: PositionedPart[] } {
+  const list = Array.isArray(children) ? children : [children];
+  const parts: InlinePart[] = flatMap(list, (c) => walkInlines(c));
+  const positioned: PositionedPart[] = [];
+  let o = 0;
+  for (const part of parts) {
+    const s = o;
+    const len = part.kind === 'text' ? part.value.length : part.label.length;
+    o += len;
+    positioned.push({ start: s, end: o, part });
+  }
+  return { plain: inlinePartsToPlainString(parts), positioned };
+}

--- a/src/components/RichBlocks/utils/tableRowUtils.ts
+++ b/src/components/RichBlocks/utils/tableRowUtils.ts
@@ -1,0 +1,112 @@
+import { take } from 'lodash';
+
+export const splitRow = (line: string): string[] => {
+  const trimmed = line.trim();
+  if (!trimmed.includes('|')) {
+    return [];
+  }
+
+  return trimmed
+    .replace(/^\||\|$/g, '')
+    .split('|')
+    .map((cell) => cell.trim());
+};
+
+export const isDelimiterRow = (cells: string[]): boolean =>
+  cells.length > 0 && cells.every((cell) => /^:?-+:?$/.test(cell));
+
+export type CellCharRange = {
+  start: number;
+  end: number;
+};
+
+/**
+ * Ranges in the trimmed work string.
+ */
+export const getCellCharRangesInLine = (
+  t: string,
+  lineStartInWork: number,
+): CellCharRange[] => {
+  const cells = splitRow(t);
+  if (cells.length === 0) {
+    return [];
+  }
+  const u = t;
+  if (!u.includes('|')) {
+    return [];
+  }
+  const hasLead = u[0] === '|';
+  const hasTrail = u[u.length - 1] === '|';
+  const i0 = hasLead ? 1 : 0;
+  const innerT = u.slice(i0, u.length - (hasTrail ? 1 : 0));
+  const parts = innerT.split('|');
+  if (parts.length < cells.length) {
+    return cells.map(() => ({ start: lineStartInWork, end: lineStartInWork }));
+  }
+  const out: CellCharRange[] = [];
+  let cpos = i0;
+  for (let k = 0; k < parts.length; k++) {
+    if (k > 0) {
+      cpos += 1;
+    }
+    const part = parts[k]!;
+    if (k >= cells.length) {
+      cpos += part.length;
+      continue;
+    }
+    const firstNonWs = part.search(/\S/);
+    const lead = firstNonWs < 0 ? 0 : firstNonWs;
+    let lastNonWs = -1;
+    for (let i = part.length - 1; i >= 0; i--) {
+      if (part[i] !== ' ' && part[i] !== '\t') {
+        lastNonWs = i;
+        break;
+      }
+    }
+    if (lastNonWs < 0) {
+      out.push({ start: lineStartInWork, end: lineStartInWork });
+    } else {
+      out.push({
+        start: lineStartInWork + cpos + lead,
+        end: lineStartInWork + cpos + lastNonWs + 1,
+      });
+    }
+    cpos += part.length;
+  }
+  if (out.length < cells.length) {
+    for (let i = out.length; i < cells.length; i++) {
+      out.push({
+        start: lineStartInWork + u.length,
+        end: lineStartInWork + u.length,
+      });
+    }
+  }
+  return take(out, cells.length);
+};
+
+export function forEachLine(
+  work: string,
+  onLine: (lineTrimmed: string, lineStartInWork: number) => void,
+) {
+  let i = 0;
+  while (i < work.length) {
+    let end = i;
+    while (end < work.length && work[end] !== '\n' && work[end] !== '\r') {
+      end += 1;
+    }
+    const rawLine = work.slice(i, end);
+    const lineTrim = rawLine.trim();
+    if (lineTrim) {
+      const lineStart = i + (rawLine.length - rawLine.trimStart().length);
+      onLine(lineTrim, lineStart);
+    }
+    i = end;
+    if (i < work.length) {
+      if (work[i] === '\r' && work[i + 1] === '\n') {
+        i += 2;
+      } else {
+        i += 1;
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Which Jira task belongs to this PR?

## Testing steps

> [!NOTE]
> Might need to run locally having STRAPI env vars pointed to prod environment

1. Check the table rendered for `/learn/dex-aggregator-best-swap-rates` on production compared to this branch

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tables support rich inline content (formatted text and links) with precise cell-range-aware rendering.
  * Paragraph handling improved to detect CTAs/widgets and serialize inline content into plain text with positions.

* **Bug Fixes**
  * Safer paragraph text extraction and more reliable table parsing with fallback for unsupported cases.

* **Tests**
  * Added tests covering inline serialization, positioned ranges, and markdown table parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->