### PR TITLE
feat: put notification bell behind a WAC flag

### DIFF
--- a/src/app/api/profile/[walletAddress]/flags/route.tsx
+++ b/src/app/api/profile/[walletAddress]/flags/route.tsx
@@ -20,12 +20,12 @@ export async function GET(
     const data = await getWalletAccessControl(walletAddress);
 
     if (!data.data || data.data.length === 0) {
-      return NextResponse.json({ hasEarn: false });
+      return NextResponse.json({ hasEarn: false, hasNotifications: false });
     }
 
     const flags = data.data[0];
 
-    return NextResponse.json(pick(flags, ['hasEarn']));
+    return NextResponse.json(pick(flags, ['hasEarn', 'hasNotifications']));
   } catch (error) {
     console.error('Error fetching wallet access control:', error);
     return NextResponse.json(

--- a/src/components/Navbar/layout/DesktopLayout.tsx
+++ b/src/components/Navbar/layout/DesktopLayout.tsx
@@ -7,10 +7,15 @@ import { LabelButton } from '../components/Buttons/LabelButton';
 import { MainMenuToggle } from '../components/Buttons/MainMenuToggle';
 import type { LayoutVariantProps } from './Layout.types';
 import { NotificationBell } from '@/components/Notifications/NotificationBell';
-import { isBeta } from '@/utils/isBeta';
+import {
+  GatekeeperStatus,
+  useGatekeeperStatus,
+} from '@/app/ui/gatekeeper/useGatekeeperStatus';
 
 export const DesktopLayout: FC<LayoutVariantProps> = ({ secondaryButtons }) => {
   const { links, activeLink } = useMainLinks();
+
+  const { status } = useGatekeeperStatus('hasNotifications');
 
   return (
     <>
@@ -32,7 +37,7 @@ export const DesktopLayout: FC<LayoutVariantProps> = ({ secondaryButtons }) => {
 
       <SecondaryLinksContainer>
         {secondaryButtons}
-        {isBeta() && <NotificationBell />}
+        {status === GatekeeperStatus.SUCCESS && <NotificationBell />}
         <MainMenuToggle />
       </SecondaryLinksContainer>
     </>

--- a/src/components/Navbar/layout/MobileLayout.tsx
+++ b/src/components/Navbar/layout/MobileLayout.tsx
@@ -3,16 +3,21 @@
 import type { FC } from 'react';
 
 import { NotificationBell } from '@/components/Notifications/NotificationBell';
-import { isBeta } from '@/utils/isBeta';
+import {
+  GatekeeperStatus,
+  useGatekeeperStatus,
+} from '@/app/ui/gatekeeper/useGatekeeperStatus';
 import { SecondaryLinksContainer } from './Layout.styles';
 import { MainMenuToggle } from '../components/Buttons/MainMenuToggle';
 import type { LayoutVariantProps } from './Layout.types';
 
 export const MobileLayout: FC<LayoutVariantProps> = ({ secondaryButtons }) => {
+  const { status } = useGatekeeperStatus('hasNotifications');
+
   return (
     <SecondaryLinksContainer>
       {secondaryButtons}
-      {isBeta() && <NotificationBell />}
+      {status === GatekeeperStatus.SUCCESS && <NotificationBell />}
       <MainMenuToggle />
     </SecondaryLinksContainer>
   );


### PR DESCRIPTION
**NOTE** this is in draft as it's based on https://github.com/jumperexchange/strapi-cms/pull/107

# Which Jira task belongs to this PR?
https://linear.app/lifi-linear/issue/JUM-722/strapi-based-feature-flag-to-activate-notifications-for-a-subset-of

# Why did I implement it this way?
The gatekeeper was already used for Earn so I could just re-use the existing logic.

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backend now returns two feature flags (earn and notifications), enabling explicit notification gating.
  * Notification bell visibility is now driven by the new notifications flag.

* **Chores**
  * Migrated notification visibility from the beta check to flag-based access control across desktop and mobile navigation layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->