### PR TITLE
fix: reduce cold-load latency for Portfolio, Earn, and Mission detail routes

### DIFF
--- a/src/app/[lng]/missions/[slug]/loading.tsx
+++ b/src/app/[lng]/missions/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { MissionPageSkeleton } from 'src/app/ui/mission/MissionPageSkeleton';
+
+export default function Loading() {
+  return <MissionPageSkeleton />;
+}

--- a/src/app/[lng]/missions/[slug]/page.tsx
+++ b/src/app/[lng]/missions/[slug]/page.tsx
@@ -23,15 +23,35 @@ const getPageTitle = (title: string) => {
 const formatSlugToTitle = (slug: string) => slug.replaceAll('-', ' ');
 
 export async function generateStaticParams() {
-  const { data: missionsResponse } = await getQuestsWithNoCampaignAttached(
-    {
-      page: 1,
-      pageSize: 12,
-    },
+  const pageSize = 25;
+
+  const { data: firstPage } = await getQuestsWithNoCampaignAttached(
+    { page: 1, pageSize, withCount: true },
     UPCOMING_DAYS_AHEAD,
   );
 
-  return missionsResponse.data.map((mission) => ({ slug: mission.Slug || '' }));
+  const { pageCount } = firstPage.meta.pagination;
+
+  const remainingPages =
+    pageCount > 1
+      ? await Promise.all(
+          Array.from({ length: pageCount - 1 }, (_, i) =>
+            getQuestsWithNoCampaignAttached(
+              { page: i + 2, pageSize },
+              UPCOMING_DAYS_AHEAD,
+            ),
+          ),
+        )
+      : [];
+
+  const allMissions = [
+    ...firstPage.data,
+    ...remainingPages.flatMap(({ data }) => data.data),
+  ];
+
+  return allMissions
+    .filter((mission) => mission.Slug)
+    .map((mission) => ({ slug: mission.Slug! }));
 }
 
 export async function generateMetadata({

--- a/src/app/[lng]/portfolio/loading.tsx
+++ b/src/app/[lng]/portfolio/loading.tsx
@@ -1,0 +1,5 @@
+import { PortfolioPageSkeleton } from '@/app/ui/portfolio/PortfolioPageSkeleton';
+
+export default function Loading() {
+  return <PortfolioPageSkeleton />;
+}

--- a/src/components/Widgets/Widget.tsx
+++ b/src/components/Widgets/Widget.tsx
@@ -63,9 +63,14 @@ export function Widget({
   );
 
   useEffect(() => {
-    const routes = [AppPaths.Main, AppPaths.Gas, AppPaths.Private].filter(
-      (route) => route !== pathname,
-    );
+    const routes = [
+      AppPaths.Main,
+      AppPaths.Gas,
+      AppPaths.Private,
+      AppPaths.Portfolio,
+      AppPaths.Earn,
+      AppPaths.Missions,
+    ].filter((route) => route !== pathname);
 
     const runPrefetch = () => {
       routes.forEach((route) =>


### PR DESCRIPTION
# Which Jira task belongs to this PR?
https://linear.app/lifi-linear/issue/JUM-891/performance-reduce-cold-load-latency-for-portfolio-earn-and-mission

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading UI skeletons for mission details and portfolio pages to enhance user experience during content loading.

* **Performance Improvements**
  * Optimized mission data pagination to fetch and process multiple pages in parallel for comprehensive results.
  * Expanded route prefetching to include additional app sections for faster navigation across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->