### PR TITLE
feat: add steps to dust route overview and track actions tx hashes

### DIFF
--- a/src/components/composite/DustFlow/components/RouteOverview.tsx
+++ b/src/components/composite/DustFlow/components/RouteOverview.tsx
@@ -30,7 +30,7 @@ interface RouteOverviewProps {
 }
 
 const COMPOSER_ICON_SRC =
-  'https://cdn.jsdelivr.net/gh/lifinance/types@c55266da1b67513f3aa7ba9c1e066be1fae3a01a/src/assets/icons/protocols/wrapper.svg';
+  'https://github.com/lifinance/types/blob/main/src/assets/icons/protocols/wrapper.svg';
 
 export const RouteOverview: FC<RouteOverviewProps> = ({
   composerQuote,

--- a/src/components/composite/DustFlow/components/RouteOverview.tsx
+++ b/src/components/composite/DustFlow/components/RouteOverview.tsx
@@ -116,7 +116,7 @@ export const RouteOverview: FC<RouteOverviewProps> = ({
           {t('portfolio.dustConversion.routeOverview.composerViaLifi')}
         </Typography>
         <Typography variant="bodyXXSmall" color="textSecondary">
-          {isExecuting && currentActionIndex !== undefined
+          {isExecuting
             ? t('portfolio.dustConversion.routeOverview.executingStep', {
                 current: (currentActionIndex ?? 0) + 1,
                 total: steps.length,

--- a/src/components/composite/DustFlow/components/RouteOverview.tsx
+++ b/src/components/composite/DustFlow/components/RouteOverview.tsx
@@ -4,65 +4,158 @@ import type {
   PortfolioBalance,
   WalletToken,
 } from '@/types/tokens';
-import type { FC } from 'react';
+import { type FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Summary } from '@/components/composite/JumperWidget/components/Summary';
 import type { ComposeResponseData } from '@/app/lib/lifi-composer-client';
 import Box from '@mui/material/Box';
-import { AvatarItem } from '@/components/core/AvatarStack/AvatarItem';
 import Typography from '@mui/material/Typography';
+import { AvatarItem } from '@/components/core/AvatarStack/AvatarItem';
 import { AvatarSize } from '@/components/core/AvatarStack/AvatarStack.types';
-import { ComposerNetworkCost } from '../../JumperWidget/components/NetworkCost/ComposerNetworkCost';
+import { ExpandableSection } from '@/components/core/sections/ExpandableSection/ExpandableSection';
+import { useGetAddressExplorerUrl } from '@/hooks/useBlockchainExplorerURL';
+import type { Hex } from 'viem';
+import type { RouteStepOverviewProps } from './RouteStepOverview';
+import { RouteStepOverview } from './RouteStepOverview';
 
 interface RouteOverviewProps {
   composerQuote?: ComposeResponseData;
   nativeTokenBalance?: Balance<ExtendedToken>;
   /** Tokens the user selected to convert (not merely tokens needing a new approval). */
   selectedInputBalances: PortfolioBalance<WalletToken>[];
+  currentActionIndex?: number;
+  isExecuting?: boolean;
+  actionHashes?: (Hex | undefined)[];
+  chainId?: number;
 }
+
+const COMPOSER_ICON_SRC =
+  'https://cdn.jsdelivr.net/gh/lifinance/types@c55266da1b67513f3aa7ba9c1e066be1fae3a01a/src/assets/icons/protocols/wrapper.svg';
 
 export const RouteOverview: FC<RouteOverviewProps> = ({
   composerQuote,
   nativeTokenBalance,
   selectedInputBalances,
+  currentActionIndex,
+  isExecuting,
+  actionHashes,
+  chainId,
 }) => {
   const { t } = useTranslation();
-  const fromBalances = selectedInputBalances;
+  const [stepsExpanded, setStepsExpanded] = useState(false);
+  const getExplorerUrl = useGetAddressExplorerUrl('tx');
 
-  if (!composerQuote || fromBalances.length === 0 || !nativeTokenBalance) {
+  useEffect(() => {
+    if (isExecuting) {
+      setStepsExpanded(true);
+    }
+  }, [isExecuting]);
+
+  const steps = useMemo(() => {
+    if (!composerQuote || !nativeTokenBalance) {
+      return [];
+    }
+
+    const approvalLabels =
+      composerQuote.approvals?.map((approval) => {
+        const match = selectedInputBalances.find(
+          (b) => b.token.address.toLowerCase() === approval.token.toLowerCase(),
+        );
+        const symbol = match?.token.symbol ?? approval.token.slice(0, 6);
+        return t('portfolio.dustConversion.routeOverview.approveToken', {
+          symbol,
+        });
+      }) ?? [];
+
+    const labels = [
+      ...approvalLabels,
+      t('portfolio.dustConversion.routeOverview.swapTo', {
+        symbol: nativeTokenBalance.token.symbol,
+      }),
+    ];
+
+    return labels.map((label, index) => {
+      const status =
+        currentActionIndex !== undefined && index < currentActionIndex
+          ? 'completed'
+          : isExecuting && index === currentActionIndex
+            ? 'executing'
+            : 'pending';
+
+      const txHash = actionHashes?.[index];
+      const explorerUrl =
+        txHash && chainId ? getExplorerUrl(chainId, txHash) : undefined;
+
+      return { label, status, explorerUrl };
+    });
+  }, [
+    composerQuote,
+    nativeTokenBalance,
+    selectedInputBalances,
+    currentActionIndex,
+    isExecuting,
+    actionHashes,
+    chainId,
+    getExplorerUrl,
+    t,
+  ]);
+
+  if (
+    !composerQuote ||
+    selectedInputBalances.length === 0 ||
+    !nativeTokenBalance
+  ) {
     return null;
   }
 
+  const header = (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+      <AvatarItem
+        avatar={{
+          src: COMPOSER_ICON_SRC,
+          alt: t('portfolio.dustConversion.routeOverview.composerAlt'),
+          id: 'step',
+        }}
+        size={AvatarSize.XL}
+      />
+      <Box>
+        <Typography variant="bodySmallStrong">
+          {t('portfolio.dustConversion.routeOverview.composerViaLifi')}
+        </Typography>
+        <Typography variant="bodyXXSmall" color="textSecondary">
+          {t('portfolio.dustConversion.routeOverview.stepsCount', {
+            count: steps.length,
+          })}
+        </Typography>
+      </Box>
+    </Box>
+  );
+
   return (
-    <>
-      <Summary
-        label={t('form.labels.convert')}
-        from={fromBalances}
-        amountUSD={composerQuote.priceImpact.inputValueUsd}
-        to={nativeTokenBalance}
-        fieldSx={{ background: 'transparent', boxShadow: 'none', padding: 0 }}
-      >
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'row',
-            alignItems: 'center',
-            gap: 2,
-          }}
-        >
-          <AvatarItem
-            avatar={{
-              src: 'https://cdn.jsdelivr.net/gh/lifinance/types@c55266da1b67513f3aa7ba9c1e066be1fae3a01a/src/assets/icons/protocols/wrapper.svg',
-              alt: t('portfolio.dustConversion.routeOverview.composerAlt'),
-              id: 'step',
-            }}
-            size={AvatarSize.XL}
-          />
-          <Typography variant="bodySmallStrong">
-            {t('portfolio.dustConversion.routeOverview.composerViaLifi')}
-          </Typography>
-        </Box>
-      </Summary>
-    </>
+    <Summary
+      label={t('form.labels.convert')}
+      from={selectedInputBalances}
+      amountUSD={composerQuote.priceImpact.inputValueUsd}
+      to={nativeTokenBalance}
+      fieldSx={{ background: 'transparent', boxShadow: 'none', padding: 0 }}
+    >
+      <ExpandableSection
+        header={header}
+        items={steps}
+        isExpanded={stepsExpanded}
+        isDetailsItemClickable={false}
+        detailsItemSx={{
+          padding: 0,
+          '&.MuiStack-root:hover': { background: 'transparent' },
+        }}
+        sx={{
+          '& .MuiAccordion-heading > .MuiButtonBase-root': { padding: 0 },
+          '& .MuiCollapse-root': { paddingTop: 1 },
+        }}
+        renderItem={(step) => (
+          <RouteStepOverview {...(step as RouteStepOverviewProps)} />
+        )}
+      />
+    </Summary>
   );
 };

--- a/src/components/composite/DustFlow/components/RouteOverview.tsx
+++ b/src/components/composite/DustFlow/components/RouteOverview.tsx
@@ -68,12 +68,14 @@ export const RouteOverview: FC<RouteOverviewProps> = ({
     ];
 
     return labels.map((label, index) => {
-      const status =
-        currentActionIndex !== undefined && index < currentActionIndex
-          ? 'completed'
-          : isExecuting && index === currentActionIndex
-            ? 'executing'
-            : 'pending';
+      const isCompleted =
+        Boolean(actionHashes?.[index]) ||
+        (currentActionIndex !== undefined && index < currentActionIndex);
+      const status = isCompleted
+        ? 'completed'
+        : isExecuting && index === currentActionIndex
+          ? 'executing'
+          : 'pending';
 
       const txHash = actionHashes?.[index];
       const explorerUrl =

--- a/src/components/composite/DustFlow/components/RouteOverview.tsx
+++ b/src/components/composite/DustFlow/components/RouteOverview.tsx
@@ -42,14 +42,7 @@ export const RouteOverview: FC<RouteOverviewProps> = ({
   chainId,
 }) => {
   const { t } = useTranslation();
-  const [stepsExpanded, setStepsExpanded] = useState(false);
   const getExplorerUrl = useGetAddressExplorerUrl('tx');
-
-  useEffect(() => {
-    if (isExecuting) {
-      setStepsExpanded(true);
-    }
-  }, [isExecuting]);
 
   const steps = useMemo(() => {
     if (!composerQuote || !nativeTokenBalance) {
@@ -123,9 +116,14 @@ export const RouteOverview: FC<RouteOverviewProps> = ({
           {t('portfolio.dustConversion.routeOverview.composerViaLifi')}
         </Typography>
         <Typography variant="bodyXXSmall" color="textSecondary">
-          {t('portfolio.dustConversion.routeOverview.stepsCount', {
-            count: steps.length,
-          })}
+          {isExecuting && currentActionIndex !== undefined
+            ? t('portfolio.dustConversion.routeOverview.executingStep', {
+                current: (currentActionIndex ?? 0) + 1,
+                total: steps.length,
+              })
+            : t('portfolio.dustConversion.routeOverview.stepsCount', {
+                count: steps.length,
+              })}
         </Typography>
       </Box>
     </Box>
@@ -142,7 +140,6 @@ export const RouteOverview: FC<RouteOverviewProps> = ({
       <ExpandableSection
         header={header}
         items={steps}
-        isExpanded={stepsExpanded}
         isDetailsItemClickable={false}
         detailsItemSx={{
           padding: 0,

--- a/src/components/composite/DustFlow/components/RouteStepOverview.tsx
+++ b/src/components/composite/DustFlow/components/RouteStepOverview.tsx
@@ -1,0 +1,71 @@
+import { Badge } from '@/components/Badge/Badge';
+import { BadgeSize, BadgeVariant } from '@/components/Badge/Badge.styles';
+import { ExternalLink } from '@/components/Link/ExternalLink';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import Typography from '@mui/material/Typography';
+import CheckIcon from '@mui/icons-material/Check';
+import type { FC } from 'react';
+
+type StepStatus = 'completed' | 'executing' | 'pending';
+
+export interface RouteStepOverviewProps {
+  label: string;
+  status: StepStatus;
+  explorerUrl?: string;
+}
+
+export const RouteStepOverview: FC<RouteStepOverviewProps> = ({
+  label,
+  status,
+  explorerUrl,
+}) => {
+  return (
+    <Badge
+      variant={BadgeVariant.Alpha}
+      size={BadgeSize.MD}
+      sx={{ width: '100%', justifyContent: 'flex-start', gap: 1 }}
+      startIcon={
+        status === 'completed' ? (
+          <Box
+            sx={{
+              width: 16,
+              height: 16,
+              borderRadius: (theme) => theme.shape.radiusRoundedFull,
+              backgroundColor: (theme) =>
+                (theme.vars || theme).palette.statusSuccessBg,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+              '& svg': {
+                height: 12,
+                width: 12,
+                color: (theme) => (theme.vars || theme).palette.statusSuccessFg,
+              },
+            }}
+          >
+            <CheckIcon />
+          </Box>
+        ) : (
+          <CircularProgress
+            size={16}
+            color="inherit"
+            enableTrackSlot
+            variant={status === 'executing' ? 'indeterminate' : 'determinate'}
+            sx={{ flexShrink: 0 }}
+          />
+        )
+      }
+      label={<Typography variant="bodyXXSmallStrong">{label}</Typography>}
+      endIcon={
+        explorerUrl ? (
+          <ExternalLink
+            href={explorerUrl}
+            sx={{ marginLeft: 'auto', '& svg': { height: 12, width: 12 } }}
+          />
+        ) : undefined
+      }
+    />
+  );
+};

--- a/src/components/composite/DustFlow/hooks/useDustModalFlow.tsx
+++ b/src/components/composite/DustFlow/hooks/useDustModalFlow.tsx
@@ -309,6 +309,13 @@ export const useDustModalFlow = ({
             composerQuote={composerQuote ?? undefined}
             nativeTokenBalance={nativeTokenBalance}
             selectedInputBalances={dustSummary?.selectedBalances ?? []}
+            currentActionIndex={transactionForm.currentActionIndex}
+            isExecuting={
+              transactionForm.currentStep === 'approving' ||
+              transactionForm.currentStep === 'requesting'
+            }
+            actionHashes={transactionForm.actionHashes}
+            chainId={nativeTokenChainId}
           />
         ),
         onSubmit: async () => {
@@ -328,6 +335,7 @@ export const useDustModalFlow = ({
       formFields,
       transactionForm,
       widgetNav,
+      nativeTokenChainId,
       t,
     ],
   );

--- a/src/components/core/sections/ExpandableSection/ExpandableSection.tsx
+++ b/src/components/core/sections/ExpandableSection/ExpandableSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   StyledAccordion,
   StyledAccordionDetails,
@@ -43,6 +43,12 @@ export const ExpandableSection = <T,>({
   dataTestId,
 }: ExpandableSectionProps<T>) => {
   const [isExpanded, setIsExpanded] = useState<boolean>(initialIsExpanded);
+
+  useEffect(() => {
+    if (initialIsExpanded) {
+      setIsExpanded(true);
+    }
+  }, [initialIsExpanded]);
 
   const handleHeaderClick = () => {
     if (!shouldExpand) {

--- a/src/components/core/sections/ExpandableSection/ExpandableSection.tsx
+++ b/src/components/core/sections/ExpandableSection/ExpandableSection.tsx
@@ -45,9 +45,7 @@ export const ExpandableSection = <T,>({
   const [isExpanded, setIsExpanded] = useState<boolean>(initialIsExpanded);
 
   useEffect(() => {
-    if (initialIsExpanded) {
-      setIsExpanded(true);
-    }
+    setIsExpanded(initialIsExpanded);
   }, [initialIsExpanded]);
 
   const handleHeaderClick = () => {

--- a/src/hooks/transactions/useTransactionFlow.ts
+++ b/src/hooks/transactions/useTransactionFlow.ts
@@ -95,6 +95,9 @@ export const useTransactionFlow = (options: UseTransactionFlowOptions = {}) => {
       executeAction(callData.actions[nextIndex]);
     } else {
       setCompletedActionHashes((prev) => {
+        if (executorType === 'batch') {
+          return Array(callData.actions.length).fill(executor.txHash);
+        }
         const next = [...prev];
         next[currentActionIndex] = executor.txHash;
         return next;

--- a/src/hooks/transactions/useTransactionFlow.ts
+++ b/src/hooks/transactions/useTransactionFlow.ts
@@ -32,6 +32,9 @@ export const useTransactionFlow = (options: UseTransactionFlowOptions = {}) => {
   >('idle');
   const [error, setError] = useState<Error | null>(null);
   const [txHash, setTxHash] = useState<Hex | undefined>(undefined);
+  const [completedActionHashes, setCompletedActionHashes] = useState<
+    (Hex | undefined)[]
+  >([]);
   const flowLockedRef = useRef(false);
 
   const executeAction = useCallback(
@@ -82,10 +85,20 @@ export const useTransactionFlow = (options: UseTransactionFlowOptions = {}) => {
     const nextIndex = currentActionIndex + 1;
 
     if (executorType !== 'batch' && nextIndex < callData.actions.length) {
+      setCompletedActionHashes((prev) => {
+        const next = [...prev];
+        next[currentActionIndex] = executor.txHash;
+        return next;
+      });
       setCurrentActionIndex(nextIndex);
       executor.reset();
       executeAction(callData.actions[nextIndex]);
     } else {
+      setCompletedActionHashes((prev) => {
+        const next = [...prev];
+        next[currentActionIndex] = executor.txHash;
+        return next;
+      });
       flowLockedRef.current = false;
       setIsExecuting(false);
       setCurrentActionIndex(0);
@@ -152,6 +165,7 @@ export const useTransactionFlow = (options: UseTransactionFlowOptions = {}) => {
     setCurrentStep('idle');
     setError(null);
     setTxHash(undefined);
+    setCompletedActionHashes([]);
     executor.reset();
   }, [executor]);
 
@@ -163,6 +177,7 @@ export const useTransactionFlow = (options: UseTransactionFlowOptions = {}) => {
     isConfirming: executor.isConfirming,
     error: error ?? executor.error,
     txHash: currentStep === 'success' ? txHash : executor.txHash,
+    completedActionHashes,
     executeFlow,
     retryCurrentAction,
     resetFlow,

--- a/src/hooks/transactions/useTransactionForm.ts
+++ b/src/hooks/transactions/useTransactionForm.ts
@@ -254,6 +254,7 @@ export const useTransactionForm = ({
     showSuccessSheet: state.showSuccessSheet,
     showErrorBottomSheet: state.showErrorBottomSheet,
     currentActionIndex: transactionFlow.currentActionIndex,
+    actionHashes: transactionFlow.completedActionHashes,
 
     handleSubmit,
     handleConfirm,

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -830,6 +830,7 @@ interface Resources {
           approveToken: 'Approve {{symbol}}';
           composerAlt: 'Composer';
           composerViaLifi: 'Composer via LI.FI';
+          executingStep: 'Executing step {{current, number}} out of {{total, number}}...';
           stepsCount_one: '{{count, number}} step';
           stepsCount_other: '{{count, number}} steps';
           swapTo: 'Swap to {{symbol}}';

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -779,10 +779,6 @@ interface Resources {
       };
       dustConversion: {
         banner: 'You have <strong>{{value}}</strong> worth of Dust tokens that can be converted!';
-        routeOverview: {
-          composerAlt: 'Composer';
-          composerViaLifi: 'Composer via Li.Fi';
-        };
         error: {
           chainSwitchFailed: {
             close: 'Close';
@@ -829,6 +825,14 @@ interface Resources {
             description: 'Your connected wallet does not support batch transactions (EIP-5792). Please connect a different wallet.';
             title: 'Wallet does not support batch transactions';
           };
+        };
+        routeOverview: {
+          approveToken: 'Approve {{symbol}}';
+          composerAlt: 'Composer';
+          composerViaLifi: 'Composer via LI.FI';
+          stepsCount_one: '{{count, number}} step';
+          stepsCount_other: '{{count, number}} steps';
+          swapTo: 'Swap to {{symbol}}';
         };
         success: {
           done: 'Done';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -709,7 +709,11 @@
       "title": "Convert dust",
       "routeOverview": {
         "composerAlt": "Composer",
-        "composerViaLifi": "Composer via Li.Fi"
+        "composerViaLifi": "Composer via LI.FI",
+        "approveToken": "Approve {{symbol}}",
+        "swapTo": "Swap to {{symbol}}",
+        "stepsCount_one": "{{count, number}} step",
+        "stepsCount_other": "{{count, number}} steps"
       },
       "error": {
         "transactionRejected": {

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -713,7 +713,8 @@
         "approveToken": "Approve {{symbol}}",
         "swapTo": "Swap to {{symbol}}",
         "stepsCount_one": "{{count, number}} step",
-        "stepsCount_other": "{{count, number}} steps"
+        "stepsCount_other": "{{count, number}} steps",
+        "executingStep": "Executing step {{current, number}} out of {{total, number}}..."
       },
       "error": {
         "transactionRejected": {


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-912/dust-show-approval-step-count-in-execution-flow-progress-eg-15-25-55

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Step-by-step dust-conversion overview with per-step badges, progress indicators, explorer links, and a composer avatar header showing total or active step.

* **Bug Fixes**
  * Summary view and expandable section now stay synchronized with execution state and chain changes; completed/executing steps reflect real-time progress.

* **Documentation**
  * Improved, pluralized, token-aware translations and corrected composer branding text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->