### PR TITLE
feat: use url params as fallback for available_routes tracking event

### DIFF
--- a/src/providers/WidgetTrackingProvider.tsx
+++ b/src/providers/WidgetTrackingProvider.tsx
@@ -1,3 +1,4 @@
+import { useUrlParams } from '@/hooks/useUrlParams';
 import type { JumperEventData } from '@/utils/tracking/jumperTracking';
 import type {
   ChainTokenSelected,
@@ -7,7 +8,8 @@ import type {
   RouteHighValueLossUpdate,
   SettingUpdated,
 } from '@lifi/widget';
-import { useWidgetEvents } from '@lifi/widget';
+import { formatTokenPrice, useWidgetEvents } from '@lifi/widget';
+import { useToken } from 'src/hooks/useToken';
 import { isEqual, omit } from 'lodash';
 import type { FC, PropsWithChildren } from 'react';
 import {
@@ -38,6 +40,7 @@ import {
   parseFormFieldChangedToTrackingData,
   parseWidgetSettingsToTrackingData,
 } from 'src/utils/tracking/widget';
+import type { Hex } from 'viem';
 
 interface WidgetTrackingState {
   setDestinationChainTokenForTracking: (
@@ -122,6 +125,26 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
   const trackedRoutesData = useRef<Record<string, TrackTransactionDataProps>>(
     {},
   );
+  const urlParams = useUrlParams();
+  const urlParamsRef = useRef(urlParams);
+  urlParamsRef.current = urlParams;
+
+  const { token: sourceTokenData } = useToken(
+    sourceChainToken.current?.chainId ??
+      urlParams.sourceChainToken.chainId ??
+      0,
+    (sourceChainToken.current?.tokenAddress ??
+      urlParams.sourceChainToken.token ??
+      '0x') as Hex,
+    { extended: true },
+  );
+
+  const fromAmountUSDFallback = useRef<number>(0);
+  fromAmountUSDFallback.current =
+    sourceTokenData?.priceUSD && urlParams.fromAmount
+      ? Number(formatTokenPrice(urlParams.fromAmount, sourceTokenData.priceUSD))
+      : 0;
+
   const posthogTracker = useMemo(() => {
     return makePosthogTracker({ trackTransaction, trackEvent });
   }, [trackTransaction, trackEvent]);
@@ -155,8 +178,14 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
 
   const availableRoutes = useCallback(
     (availableRoutes: Route[]) => {
-      if (currentFromAmount.current !== availableRoutes[0]?.fromAmount) {
-        currentFromAmount.current = availableRoutes[0]?.fromAmount;
+      const fromAmount =
+        availableRoutes[0]?.fromAmount ?? urlParamsRef.current.fromAmount;
+      const fromAmountUSD = availableRoutes[0]
+        ? Number(availableRoutes[0].fromAmountUSD)
+        : fromAmountUSDFallback.current;
+
+      if (currentFromAmount.current !== fromAmount) {
+        currentFromAmount.current = fromAmount;
         isRoutesForCurrentFromAmountTracked.current = false;
       }
 
@@ -202,17 +231,23 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
         enableAddressable: true,
         data: {
           [TrackingEventParameter.FromToken]:
-            sourceChainToken.current?.tokenAddress || '',
+            sourceChainToken.current?.tokenAddress ||
+            urlParamsRef.current.sourceChainToken.token ||
+            '',
           [TrackingEventParameter.FromChainId]:
-            sourceChainToken.current?.chainId || '',
+            sourceChainToken.current?.chainId ||
+            urlParamsRef.current.sourceChainToken.chainId ||
+            '',
           [TrackingEventParameter.ToToken]:
-            destinationChainToken.current?.tokenAddress || '',
+            destinationChainToken.current?.tokenAddress ||
+            urlParamsRef.current.destinationChainToken.token ||
+            '',
           [TrackingEventParameter.ToChainId]:
-            destinationChainToken.current?.chainId || '',
-          [TrackingEventParameter.FromAmountUSD]: Number(
-            availableRoutes?.[0]?.fromAmountUSD,
-          ),
-          [TrackingEventParameter.FromAmount]: availableRoutes?.[0]?.fromAmount,
+            destinationChainToken.current?.chainId ||
+            urlParamsRef.current.destinationChainToken.chainId ||
+            '',
+          [TrackingEventParameter.FromAmountUSD]: fromAmountUSD,
+          [TrackingEventParameter.FromAmount]: fromAmount || '',
           [TrackingEventParameter.NbOfSteps]: availableRoutes.length,
           [TrackingEventParameter.Routes]: transformedRoutes,
         },

--- a/src/providers/WidgetTrackingProvider.tsx
+++ b/src/providers/WidgetTrackingProvider.tsx
@@ -9,7 +9,8 @@ import type {
   SettingUpdated,
 } from '@lifi/widget';
 import { formatTokenPrice, useWidgetEvents } from '@lifi/widget';
-import { useToken } from 'src/hooks/useToken';
+import type { Address } from 'viem';
+import { useTokens } from 'src/hooks/useTokens';
 import { isEqual, omit } from 'lodash';
 import type { FC, PropsWithChildren } from 'react';
 import {
@@ -40,7 +41,6 @@ import {
   parseFormFieldChangedToTrackingData,
   parseWidgetSettingsToTrackingData,
 } from 'src/utils/tracking/widget';
-import type { Hex } from 'viem';
 
 interface WidgetTrackingState {
   setDestinationChainTokenForTracking: (
@@ -129,21 +129,7 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
   const urlParamsRef = useRef(urlParams);
   urlParamsRef.current = urlParams;
 
-  const { token: sourceTokenData } = useToken(
-    sourceChainToken.current?.chainId ??
-      urlParams.sourceChainToken.chainId ??
-      0,
-    (sourceChainToken.current?.tokenAddress ??
-      urlParams.sourceChainToken.token ??
-      '0x') as Hex,
-    { extended: true },
-  );
-
-  const fromAmountUSDFallback = useRef<number>(0);
-  fromAmountUSDFallback.current =
-    sourceTokenData?.priceUSD && urlParams.fromAmount
-      ? Number(formatTokenPrice(urlParams.fromAmount, sourceTokenData.priceUSD))
-      : 0;
+  const { getToken } = useTokens();
 
   const posthogTracker = useMemo(() => {
     return makePosthogTracker({ trackTransaction, trackEvent });
@@ -178,11 +164,34 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
 
   const availableRoutes = useCallback(
     (availableRoutes: Route[]) => {
+      const firstRoute = availableRoutes[0];
+
+      const fromToken =
+        sourceChainToken.current?.tokenAddress ??
+        urlParamsRef.current.sourceChainToken.token;
+      const fromChainId =
+        sourceChainToken.current?.chainId ??
+        urlParamsRef.current.sourceChainToken.chainId;
+      const toToken =
+        destinationChainToken.current?.tokenAddress ??
+        urlParamsRef.current.destinationChainToken.token;
+      const toChainId =
+        destinationChainToken.current?.chainId ??
+        urlParamsRef.current.destinationChainToken.chainId;
+
       const fromAmount =
-        availableRoutes[0]?.fromAmount ?? urlParamsRef.current.fromAmount;
-      const fromAmountUSD = availableRoutes[0]
-        ? Number(availableRoutes[0].fromAmountUSD)
-        : fromAmountUSDFallback.current;
+        firstRoute?.fromAmount ?? urlParamsRef.current.fromAmount;
+
+      const fallbackToken =
+        fromChainId && fromToken
+          ? getToken(fromChainId, fromToken as Address)
+          : undefined;
+
+      const fromAmountUSD = firstRoute
+        ? Number(firstRoute.fromAmountUSD)
+        : fallbackToken?.priceUSD && fromAmount
+          ? Number(formatTokenPrice(fromAmount, fallbackToken.priceUSD))
+          : 0;
 
       if (currentFromAmount.current !== fromAmount) {
         currentFromAmount.current = fromAmount;
@@ -230,22 +239,10 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
         label: `routes_available`,
         enableAddressable: true,
         data: {
-          [TrackingEventParameter.FromToken]:
-            sourceChainToken.current?.tokenAddress ||
-            urlParamsRef.current.sourceChainToken.token ||
-            '',
-          [TrackingEventParameter.FromChainId]:
-            sourceChainToken.current?.chainId ||
-            urlParamsRef.current.sourceChainToken.chainId ||
-            '',
-          [TrackingEventParameter.ToToken]:
-            destinationChainToken.current?.tokenAddress ||
-            urlParamsRef.current.destinationChainToken.token ||
-            '',
-          [TrackingEventParameter.ToChainId]:
-            destinationChainToken.current?.chainId ||
-            urlParamsRef.current.destinationChainToken.chainId ||
-            '',
+          [TrackingEventParameter.FromToken]: fromToken || '',
+          [TrackingEventParameter.FromChainId]: fromChainId || '',
+          [TrackingEventParameter.ToToken]: toToken || '',
+          [TrackingEventParameter.ToChainId]: toChainId || '',
           [TrackingEventParameter.FromAmountUSD]: fromAmountUSD,
           [TrackingEventParameter.FromAmount]: fromAmount || '',
           [TrackingEventParameter.NbOfSteps]: availableRoutes.length,
@@ -257,7 +254,7 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
       isRoutesForCurrentDestinationTokenTracked.current = true;
       isRoutesForCurrentFromAmountTracked.current = true;
     },
-    [trackEvent, trackingActionKeys.availableRoutes],
+    [trackEvent, trackingActionKeys.availableRoutes, getToken],
   );
 
   const routeExecutionStarted = useCallback(


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-898/add-sending-amount-usd-property-to-action-available-routes-posthog

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved widget tracking accuracy and stability by eliminating stale parameter references in event callbacks.
  * Enhanced URL-parameter handling so token/chain selections and quoted amounts (including USD equivalents) are reported more consistently and reliably in tracking events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->