### PR TITLE
fix: blog article tags show duplicates and only first tag

### DIFF
--- a/src/components/Blog/BlogArticleCard/BlogArticleCard.tsx
+++ b/src/components/Blog/BlogArticleCard/BlogArticleCard.tsx
@@ -83,7 +83,7 @@ export const BlogArticleCard = ({
           </BlogArticleCardTitle>
           <BlogArticleCardDetails>
             {isClient ? (
-              <BlogArticleMetadata article={article} />
+              <BlogArticleMetadata article={article} maxVisibleTags={2} />
             ) : (
               <BlogArticleMetadataSkeleton />
             )}

--- a/src/components/Blog/BlogArticleMetadata/BlogArticleMetadata.tsx
+++ b/src/components/Blog/BlogArticleMetadata/BlogArticleMetadata.tsx
@@ -6,12 +6,14 @@ import { BlogArticleMetaProperty } from './BlogArticleMetadata.style';
 import { useTranslation } from 'react-i18next';
 import { Badge } from '@/components/Badge/Badge';
 import { BadgeSize, BadgeVariant } from '@/components/Badge/Badge.styles';
+import { Tooltip } from '@/components/core/Tooltip/Tooltip';
 import type { TypographyProps } from '@mui/material/Typography';
 import Stack from '@mui/material/Stack';
 import type { SxProps, Theme } from '@mui/material/styles';
 
 interface BlogArticleMetadataProps {
   article: BlogArticleData;
+  maxVisibleTags?: number;
   tagSize?: BadgeSize;
   tagVariant?: BadgeVariant;
   metaVariant?: TypographyProps['variant'];
@@ -20,6 +22,7 @@ interface BlogArticleMetadataProps {
 
 export const BlogArticleMetadata: FC<BlogArticleMetadataProps> = ({
   article,
+  maxVisibleTags,
   tagSize = BadgeSize.MD,
   tagVariant = BadgeVariant.Alpha,
   metaVariant = 'bodyXSmall',
@@ -29,13 +32,19 @@ export const BlogArticleMetadata: FC<BlogArticleMetadataProps> = ({
   },
 }) => {
   const { t } = useTranslation();
-  const firstTag = article?.tags?.[0];
   const now = Date.now();
   const publishDate = article.publishedAt || article.createdAt || now;
   const updateDate = article.updatedAt || publishDate;
   const isUpdateAfterPublish =
     Boolean(article.updatedAt) && differenceInDays(updateDate, publishDate) > 0;
   const minRead = readingTime(article?.WordCount);
+  const tags = article.tags || [];
+  const hasTags = tags.length > 0;
+  const visibleTags =
+    maxVisibleTags !== undefined ? tags.slice(0, maxVisibleTags) : tags;
+  const hiddenTags =
+    maxVisibleTags !== undefined ? tags.slice(maxVisibleTags) : [];
+  const remainingCount = hiddenTags.length;
 
   return (
     <Stack useFlexGap sx={sx}>
@@ -82,8 +91,21 @@ export const BlogArticleMetadata: FC<BlogArticleMetadataProps> = ({
         </BlogArticleMetaProperty>
       </Stack>
 
-      {firstTag && (
-        <Badge label={firstTag.Title} size={tagSize} variant={tagVariant} />
+      {hasTags && (
+        <Stack sx={{ flexDirection: 'row', gap: 1, overflow: 'hidden' }}>
+          {visibleTags.map((tag) => (
+            <Badge label={tag.Title} size={tagSize} variant={tagVariant} />
+          ))}
+          {remainingCount > 0 && (
+            <Tooltip title={hiddenTags.map((tag) => tag.Title).join(', ')}>
+              <Badge
+                label={`+${remainingCount}`}
+                size={tagSize}
+                variant={tagVariant}
+              />
+            </Tooltip>
+          )}
+        </Stack>
       )}
     </Stack>
   );

--- a/src/components/Blog/BlogArticleMetadata/BlogArticleMetadata.tsx
+++ b/src/components/Blog/BlogArticleMetadata/BlogArticleMetadata.tsx
@@ -94,7 +94,12 @@ export const BlogArticleMetadata: FC<BlogArticleMetadataProps> = ({
       {hasTags && (
         <Stack sx={{ flexDirection: 'row', gap: 1, overflow: 'hidden' }}>
           {visibleTags.map((tag) => (
-            <Badge label={tag.Title} size={tagSize} variant={tagVariant} />
+            <Badge
+              key={tag.id}
+              label={tag.Title}
+              size={tagSize}
+              variant={tagVariant}
+            />
           ))}
           {remainingCount > 0 && (
             <Tooltip title={hiddenTags.map((tag) => tag.Title).join(', ')}>

--- a/src/providers/LearnProvider/filtering/LearnFilteringContext.tsx
+++ b/src/providers/LearnProvider/filtering/LearnFilteringContext.tsx
@@ -38,7 +38,7 @@ import {
   sortBlogArticles,
   tagAccessors,
 } from './utils';
-import { isEqual } from 'lodash';
+import { isEqual, uniqBy } from 'lodash';
 
 const PAGE_SIZE = 6;
 
@@ -161,7 +161,7 @@ export const LearnFilteringProvider = ({
       return [];
     }
     if (tab === TAG_ALL) {
-      return allData.map(tagAccessors.articles).flat();
+      return uniqBy(allData.map(tagAccessors.articles).flat(), 'documentId');
     }
     const selectedTag = allData.find((tag) => tag.Title === tab);
     if (


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-948/blog-article-tags-show-duplicates-and-only-first-tag

## Testing steps
1. Connect to strapi prod
2. Go to `/learn`
3. Check on "All" tab in the bottom section that `How to Stake Ethereum in 2026` is rendered only once
4. Also check both `Tutorial` and `Earn` tags are rendered
5. If an article has more than 2 tags, an overflow counter will be shown
6. Go to `/learn/ethereum-staking`
7. Check in the header section all tags are shown

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blog article cards now display up to 2 tags with a "+N" indicator for remaining tags, accessible via tooltip on hover.

* **Bug Fixes**
  * Fixed duplicate articles appearing in the "all tags" filter view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jumperexchange/jumper-exchange/pull/2857)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->