### PR TITLE
feat: Storybook tooling to preview all Strapi pop-cards - JUM-973

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,6 @@
 import type { Preview } from '@storybook/nextjs-vite';
 import { sb } from 'storybook/test';
+import i18nConfig from '../i18n-config';
 import { withProviders } from './withProviders';
 
 sb.mock(import('@lifi/wallet-management'), { spy: true });
@@ -27,10 +28,24 @@ const preview: Preview = {
         dynamicTitle: true,
       },
     },
+    locale: {
+      name: 'Locale',
+      description: 'UI language',
+      defaultValue: 'en',
+      toolbar: {
+        icon: 'globe',
+        items: i18nConfig.locales.map((l) => ({
+          value: l,
+          title: l.toUpperCase(),
+        })),
+        dynamicTitle: true,
+      },
+    },
   },
   parameters: {
     globals: {
       theme: 'light',
+      locale: 'en',
     },
 
     controls: {

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -48,6 +48,12 @@ const preview: Preview = {
       locale: 'en',
     },
 
+    options: {
+      storySort: {
+        order: ['Preview', '*'],
+      },
+    },
+
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/.storybook/withProviders.tsx
+++ b/.storybook/withProviders.tsx
@@ -1,4 +1,4 @@
-import type { StoryContext } from '@storybook/react';
+import type { Decorator } from '@storybook/react';
 import type { Resource } from 'i18next';
 import { type ReactNode, useEffect, useState } from 'react';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
@@ -30,10 +30,7 @@ const ThemeBridge = ({
   return <>{children}</>;
 };
 
-export const withProviders = (
-  Story: () => ReactNode,
-  context: StoryContext,
-) => {
+export const withProviders: Decorator = (Story, context) => {
   const [resources, setResources] = useState<Resource | null>(null);
 
   const activeLocale = (context.globals.locale as string) || fallbackLng;

--- a/.storybook/withProviders.tsx
+++ b/.storybook/withProviders.tsx
@@ -18,7 +18,7 @@ const ThemeBridge = ({
   children,
   theme,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
   theme: string;
 }) => {
   const { setMode } = useColorScheme();

--- a/.storybook/withProviders.tsx
+++ b/.storybook/withProviders.tsx
@@ -1,4 +1,6 @@
-import React, { ReactNode, useEffect, useState } from 'react';
+import type { StoryContext } from '@storybook/react';
+import type { Resource } from 'i18next';
+import { type ReactNode, useEffect, useState } from 'react';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
 import { ReactQueryProvider } from '../src/providers/ReactQueryProvider';
 import { DefaultThemeProvider } from '../src/providers/ThemeProvider/DefaultThemeProvider';
@@ -28,17 +30,24 @@ const ThemeBridge = ({
   return <>{children}</>;
 };
 
-export const withProviders = (Story: () => ReactNode, context) => {
-  const [resources, setResources] = useState<any>(null);
+export const withProviders = (
+  Story: () => ReactNode,
+  context: StoryContext,
+) => {
+  const [resources, setResources] = useState<Resource | null>(null);
 
   const activeLocale = (context.globals.locale as string) || fallbackLng;
 
   useEffect(() => {
+    let cancelled = false;
     setResources(null);
     (async () => {
       const { resources } = await initTranslations(activeLocale, namespaces);
-      setResources(resources);
+      if (!cancelled) setResources(resources);
     })();
+    return () => {
+      cancelled = true;
+    };
   }, [activeLocale]);
 
   if (!resources) return <div>Loading...</div>;
@@ -49,6 +58,7 @@ export const withProviders = (Story: () => ReactNode, context) => {
     <NuqsAdapter>
       <ReactQueryProvider>
         <TranslationsProvider
+          key={activeLocale}
           namespaces={[defaultNS]}
           locale={activeLocale}
           resources={resources}

--- a/.storybook/withProviders.tsx
+++ b/.storybook/withProviders.tsx
@@ -31,12 +31,15 @@ const ThemeBridge = ({
 export const withProviders = (Story: () => ReactNode, context) => {
   const [resources, setResources] = useState<any>(null);
 
+  const activeLocale = (context.globals.locale as string) || fallbackLng;
+
   useEffect(() => {
+    setResources(null);
     (async () => {
-      const { resources } = await initTranslations(fallbackLng, namespaces);
+      const { resources } = await initTranslations(activeLocale, namespaces);
       setResources(resources);
     })();
-  }, []);
+  }, [activeLocale]);
 
   if (!resources) return <div>Loading...</div>;
 
@@ -47,7 +50,7 @@ export const withProviders = (Story: () => ReactNode, context) => {
       <ReactQueryProvider>
         <TranslationsProvider
           namespaces={[defaultNS]}
-          locale={fallbackLng}
+          locale={activeLocale}
           resources={resources}
         >
           <DefaultThemeProvider themes={mockThemes} activeTheme={activeTheme}>

--- a/src/components/FeatureCards/FeatureCards.stories.spindl.ts
+++ b/src/components/FeatureCards/FeatureCards.stories.spindl.ts
@@ -1,0 +1,108 @@
+import { useQuery } from '@tanstack/react-query';
+import { getSpindlConfig } from 'src/hooks/feature-cards/spindl/spindlConfig';
+import { spindlItemToCardData } from 'src/hooks/feature-cards/spindl/spindlMapper';
+import type { SpindlCardData, SpindlFetchData } from 'src/types/spindl';
+import { isSpindlFetchResponse } from 'src/types/spindl';
+import { callRequest } from 'src/utils/callRequest';
+
+// Chain IDs matching @lifi/sdk ChainId enum values (ETH, ARB, OPT, POL, Base)
+const ETH = 1;
+const ARB = 42161;
+const OPT = 10;
+const POL = 137;
+const BAS = 8453;
+
+// Well-known USDC contract addresses per chain
+const USDC: Record<number, string> = {
+  [ETH]: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  [ARB]: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
+  [OPT]: '0x7F5c764cBc14f9669B88837ca1490cCa17c31607',
+  [BAS]: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+};
+
+// Native token sentinel used by the LI.FI ecosystem
+const NATIVE = '0x0000000000000000000000000000000000000000';
+
+interface MatrixEntry {
+  chainId: number;
+  tokenAddress: string;
+  label: string;
+}
+
+export const SPINDL_STORYBOOK_MATRIX: MatrixEntry[] = [
+  { chainId: ETH, tokenAddress: USDC[ETH], label: 'ETH / USDC' },
+  { chainId: ETH, tokenAddress: NATIVE, label: 'ETH / native' },
+  { chainId: ARB, tokenAddress: USDC[ARB], label: 'ARB / USDC' },
+  { chainId: ARB, tokenAddress: NATIVE, label: 'ARB / native' },
+  { chainId: OPT, tokenAddress: USDC[OPT], label: 'OPT / USDC' },
+  { chainId: OPT, tokenAddress: NATIVE, label: 'OPT / native' },
+  { chainId: BAS, tokenAddress: USDC[BAS], label: 'Base / USDC' },
+  { chainId: BAS, tokenAddress: NATIVE, label: 'Base / native' },
+  { chainId: POL, tokenAddress: NATIVE, label: 'POL / native' },
+];
+
+const FETCH_SPINDL_PATH = '/render/jumper';
+const STALE_TIME_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Fans out Spindl /render/jumper calls across the curated matrix,
+ * flattens and deduplicates by item.id (first occurrence wins).
+ * Storybook-only — not used in production.
+ */
+export const useSpindlMatrixCards = (
+  country: string,
+): { cards: SpindlCardData[]; isLoading: boolean; errorCount: number } => {
+  const { data, isLoading } = useQuery({
+    queryKey: ['spindl-storybook-matrix', country],
+    queryFn: async () => {
+      const spindlConfig = getSpindlConfig();
+
+      const results = await Promise.allSettled(
+        SPINDL_STORYBOOK_MATRIX.map(({ chainId, tokenAddress }) =>
+          callRequest<SpindlFetchData>({
+            method: 'GET',
+            path: FETCH_SPINDL_PATH,
+            apiUrl: spindlConfig.apiUrl,
+            headers: spindlConfig.headers,
+            queryParams: {
+              placement_id: 'notify_message',
+              limit: '3',
+              country,
+              chain_id: String(chainId),
+              token_address: tokenAddress,
+            },
+          }),
+        ),
+      );
+
+      const errorCount = results.filter((r) => r.status === 'rejected').length;
+
+      const seen = new Set<string>();
+      const cards: SpindlCardData[] = [];
+      let flatIndex = 0;
+
+      for (const result of results) {
+        if (
+          result.status === 'fulfilled' &&
+          isSpindlFetchResponse(result.value)
+        ) {
+          for (const item of result.value.items) {
+            if (!seen.has(item.id)) {
+              seen.add(item.id);
+              cards.push(spindlItemToCardData(item, flatIndex++));
+            }
+          }
+        }
+      }
+
+      return { cards, errorCount };
+    },
+    staleTime: STALE_TIME_MS,
+  });
+
+  return {
+    cards: data?.cards ?? [],
+    isLoading,
+    errorCount: data?.errorCount ?? 0,
+  };
+};

--- a/src/components/FeatureCards/FeatureCards.stories.spindl.ts
+++ b/src/components/FeatureCards/FeatureCards.stories.spindl.ts
@@ -59,17 +59,18 @@ export const useSpindlMatrixCards = (
         ),
       );
 
-      const errorCount = results.filter((r) => r.status === 'rejected').length;
+      let errorCount = results.filter((r) => r.status === 'rejected').length;
 
       const seen = new Set<string>();
       const cards: SpindlCardData[] = [];
       let flatIndex = 0;
 
       for (const result of results) {
-        if (
-          result.status === 'fulfilled' &&
-          isSpindlFetchResponse(result.value)
-        ) {
+        if (result.status === 'fulfilled') {
+          if (!isSpindlFetchResponse(result.value)) {
+            errorCount += 1;
+            continue;
+          }
           for (const item of result.value.items) {
             if (!seen.has(item.id)) {
               seen.add(item.id);

--- a/src/components/FeatureCards/FeatureCards.stories.spindl.ts
+++ b/src/components/FeatureCards/FeatureCards.stories.spindl.ts
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetchSpindlCards } from 'src/hooks/feature-cards/spindl/fetchSpindlCards';
-import { spindlItemToCardData } from 'src/hooks/feature-cards/spindl/spindlMapper';
-import type { SpindlCardData } from 'src/types/spindl';
-import { isSpindlFetchResponse } from 'src/types/spindl';
+import { fetchSpindlCards } from '@/hooks/feature-cards/spindl/fetchSpindlCards';
+import { spindlItemToCardData } from '@/hooks/feature-cards/spindl/spindlMapper';
+import type { SpindlCardData } from '@/types/spindl';
+import { isSpindlFetchResponse } from '@/types/spindl';
 
 // Chain IDs matching @lifi/sdk ChainId enum values (ETH, ARB, OPT, POL, Base)
 const ETH = 1;

--- a/src/components/FeatureCards/FeatureCards.stories.spindl.ts
+++ b/src/components/FeatureCards/FeatureCards.stories.spindl.ts
@@ -1,9 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
-import { getSpindlConfig } from 'src/hooks/feature-cards/spindl/spindlConfig';
+import { fetchSpindlCards } from 'src/hooks/feature-cards/spindl/fetchSpindlCards';
 import { spindlItemToCardData } from 'src/hooks/feature-cards/spindl/spindlMapper';
-import type { SpindlCardData, SpindlFetchData } from 'src/types/spindl';
+import type { SpindlCardData } from 'src/types/spindl';
 import { isSpindlFetchResponse } from 'src/types/spindl';
-import { callRequest } from 'src/utils/callRequest';
 
 // Chain IDs matching @lifi/sdk ChainId enum values (ETH, ARB, OPT, POL, Base)
 const ETH = 1;
@@ -41,7 +40,6 @@ export const SPINDL_STORYBOOK_MATRIX: MatrixEntry[] = [
   { chainId: POL, tokenAddress: NATIVE, label: 'POL / native' },
 ];
 
-const FETCH_SPINDL_PATH = '/render/jumper';
 const STALE_TIME_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
@@ -55,23 +53,9 @@ export const useSpindlMatrixCards = (
   const { data, isLoading } = useQuery({
     queryKey: ['spindl-storybook-matrix', country],
     queryFn: async () => {
-      const spindlConfig = getSpindlConfig();
-
       const results = await Promise.allSettled(
         SPINDL_STORYBOOK_MATRIX.map(({ chainId, tokenAddress }) =>
-          callRequest<SpindlFetchData>({
-            method: 'GET',
-            path: FETCH_SPINDL_PATH,
-            apiUrl: spindlConfig.apiUrl,
-            headers: spindlConfig.headers,
-            queryParams: {
-              placement_id: 'notify_message',
-              limit: '3',
-              country,
-              chain_id: String(chainId),
-              token_address: tokenAddress,
-            },
-          }),
+          fetchSpindlCards({ chainId, tokenAddress, country }),
         ),
       );
 

--- a/src/components/FeatureCards/FeatureCards.stories.tsx
+++ b/src/components/FeatureCards/FeatureCards.stories.tsx
@@ -338,7 +338,7 @@ const AllCardsPreview = ({ globals }: AllCardsPreviewProps) => {
 };
 
 const meta: Meta<typeof AllCardsPreview> = {
-  title: 'Components/FeatureCards/All Cards',
+  title: 'Preview/FeatureCards',
   component: AllCardsPreview,
   tags: ['autodocs'],
 };

--- a/src/components/FeatureCards/FeatureCards.stories.tsx
+++ b/src/components/FeatureCards/FeatureCards.stories.tsx
@@ -7,7 +7,7 @@ import Divider from '@mui/material/Divider';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 import sortBy from 'lodash/sortBy';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import config from '@/config/env-config';
 import { STRAPI_FEATURE_CARDS } from '@/const/strapiContentKeys';
 import { useStrapi } from '@/hooks/useStrapi';
@@ -149,7 +149,7 @@ const CardGrid = ({ cards, otherIds, group }: CardGridProps) => (
       justifyItems: 'center',
     }}
   >
-    {cards.map((cardData, index) => {
+    {cards.map((cardData) => {
       const isInOtherGroup = otherIds.has(cardData.documentId);
       const chip: CardHeaderProps['chip'] =
         group === 'draft'
@@ -159,7 +159,7 @@ const CardGrid = ({ cards, otherIds, group }: CardGridProps) => (
           : { label: 'PUBLISHED', color: 'success' };
 
       return (
-        <Box key={`${group}-${cardData.id ?? index}`} sx={{ width: 384 }}>
+        <Box key={`${group}-${cardData.documentId}`} sx={{ width: 384 }}>
           <CardHeader cardData={cardData} chip={chip} />
           <FeatureCard data={cardData} />
         </Box>
@@ -181,8 +181,8 @@ const SpindlCardGrid = ({ cards }: { cards: SpindlCardData[] }) => (
       justifyItems: 'center',
     }}
   >
-    {cards.map((card, index) => (
-      <Box key={`spindl-${card.id ?? index}`} sx={{ width: 384 }}>
+    {cards.map((card) => (
+      <Box key={`spindl-${card.id}`} sx={{ width: 384 }}>
         <SpindlCardHeader card={card} />
         <FeatureCard data={card} />
       </Box>
@@ -231,6 +231,8 @@ const AllCardsPreview = ({ globals }: AllCardsPreviewProps) => {
     useStrapi<StrapiFeatureCardData>({
       contentType: STRAPI_FEATURE_CARDS,
       status: 'draft',
+      includePersonalized: true,
+      ignoreCampaignDates: true,
       queryKey: ['feature-cards', 'storybook', 'draft'],
     });
 
@@ -238,6 +240,8 @@ const AllCardsPreview = ({ globals }: AllCardsPreviewProps) => {
     useStrapi<StrapiFeatureCardData>({
       contentType: STRAPI_FEATURE_CARDS,
       status: 'published',
+      includePersonalized: true,
+      ignoreCampaignDates: true,
       queryKey: ['feature-cards', 'storybook', 'published'],
     });
 
@@ -247,35 +251,20 @@ const AllCardsPreview = ({ globals }: AllCardsPreviewProps) => {
     errorCount: spindlErrorCount,
   } = useSpindlMatrixCards(country);
 
-  const draftIds = useMemo(
-    () => new Set((draftCards ?? []).map((c) => c.documentId)),
-    [draftCards],
-  );
+  const draftIds = new Set((draftCards ?? []).map((c) => c.documentId));
 
-  const publishedIds = useMemo(
-    () => new Set((publishedCards ?? []).map((c) => c.documentId)),
-    [publishedCards],
-  );
+  const publishedIds = new Set((publishedCards ?? []).map((c) => c.documentId));
 
-  const sortedSpindlCards = useMemo(
-    () => sortBy(spindlCards, (c) => c.Title.toLowerCase()),
-    [spindlCards],
-  );
+  const sortedSpindlCards = sortBy(spindlCards, (c) => c.Title.toLowerCase());
 
-  const sortedDraftCards = useMemo(
-    () =>
-      sortBy(draftCards ?? [], [
-        (c) => (publishedIds.has(c.documentId) ? 0 : 1),
-        (c) => (c.uid || c.Title).toLowerCase(),
-      ]),
-    [draftCards, publishedIds],
-  );
+  const sortedDraftCards = sortBy(draftCards ?? [], [
+    (c) => (publishedIds.has(c.documentId) ? 0 : 1),
+    (c) => (c.uid || c.Title).toLowerCase(),
+  ]);
 
-  const sortedPublishedCards = useMemo(
-    () =>
-      sortBy(publishedCards ?? [], [(c) => (c.uid || c.Title).toLowerCase()]),
-    [publishedCards],
-  );
+  const sortedPublishedCards = sortBy(publishedCards ?? [], [
+    (c) => (c.uid || c.Title).toLowerCase(),
+  ]);
 
   if (draftLoading || publishedLoading || spindlLoading) {
     return (

--- a/src/components/FeatureCards/FeatureCards.stories.tsx
+++ b/src/components/FeatureCards/FeatureCards.stories.tsx
@@ -2,9 +2,12 @@
 
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
-import { useEffect } from 'react';
+import sortBy from 'lodash/sortBy';
+import { useEffect, useMemo } from 'react';
 import config from '@/config/env-config';
 import { STRAPI_FEATURE_CARDS } from '@/const/strapiContentKeys';
 import { useStrapi } from '@/hooks/useStrapi';
@@ -12,19 +15,178 @@ import { useAdCooldownStore } from '@/stores/adCooldown/AdCooldownStore';
 import type { StrapiFeatureCardData } from '@/types/strapi';
 import { FeatureCard } from './FeatureCard';
 
+// ---------------------------------------------------------------------------
+// Shared header above each card cell
+// ---------------------------------------------------------------------------
+
+interface CardHeaderProps {
+  cardData: StrapiFeatureCardData;
+  /** Chip shown to flag publication state within this group */
+  chip: { label: string; color: 'success' | 'warning' | 'error' | 'info' };
+}
+
+const CardHeader = ({ cardData, chip }: CardHeaderProps) => {
+  const strapiBase = config.NEXT_PUBLIC_STRAPI_URL;
+  const adminUrl = `${strapiBase}/admin/content-manager/collection-types/api::feature-card.feature-card/${cardData.documentId}`;
+  const label = cardData.uid || cardData.Title;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'baseline',
+        justifyContent: 'space-between',
+        gap: 1,
+        mb: 0.5,
+        px: 0.5,
+      }}
+    >
+      <Box sx={{ minWidth: 0 }}>
+        <Box
+          sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 0.25 }}
+        >
+          <Chip
+            label={chip.label}
+            color={chip.color}
+            size="small"
+            variant="outlined"
+          />
+          <Typography
+            variant="bodySmallStrong"
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {label}
+          </Typography>
+        </Box>
+        <Typography variant="bodyXSmall" sx={{ color: 'text.secondary' }}>
+          {cardData.documentId}
+        </Typography>
+      </Box>
+      <Link
+        href={adminUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        variant="bodyXSmall"
+        sx={{ flexShrink: 0 }}
+      >
+        View in Strapi ↗
+      </Link>
+    </Box>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Card grid
+// ---------------------------------------------------------------------------
+
+interface CardGridProps {
+  cards: StrapiFeatureCardData[];
+  /** documentIds present in the *other* group — used to cross-reference */
+  otherIds: Set<string>;
+  group: 'draft' | 'published';
+}
+
+const CardGrid = ({ cards, otherIds, group }: CardGridProps) => (
+  <Box
+    sx={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(auto-fill, minmax(384px, 1fr))',
+      gap: 3,
+      justifyItems: 'center',
+    }}
+  >
+    {cards.map((cardData, index) => {
+      const isInOtherGroup = otherIds.has(cardData.documentId);
+
+      const chip: CardHeaderProps['chip'] =
+        group === 'draft'
+          ? isInOtherGroup
+            ? { label: 'LIVE', color: 'success' }
+            : { label: 'DRAFT ONLY', color: 'warning' }
+          : isInOtherGroup
+            ? { label: 'PUBLISHED', color: 'success' }
+            : { label: 'PUBLISHED', color: 'success' };
+
+      return (
+        <Box key={`${group}-${cardData.id ?? index}`} sx={{ width: 384 }}>
+          <CardHeader cardData={cardData} chip={chip} />
+          <FeatureCard data={cardData} />
+        </Box>
+      );
+    })}
+  </Box>
+);
+
+// ---------------------------------------------------------------------------
+// Section heading
+// ---------------------------------------------------------------------------
+
+const SectionHeading = ({ title, count }: { title: string; count: number }) => (
+  <Box sx={{ mb: 2 }}>
+    <Typography variant="headerMedium">
+      {title}{' '}
+      <Typography component="span" variant="bodyMedium" color="text.secondary">
+        ({count})
+      </Typography>
+    </Typography>
+  </Box>
+);
+
+// ---------------------------------------------------------------------------
+// Main story component
+// ---------------------------------------------------------------------------
+
 const AllCardsPreview = () => {
   useEffect(() => {
-    // Bypass the production cooldown gate and ensure the store reports hydrated
-    // so every FeatureCard will paint — without touching production code.
+    // Bypass the production cooldown gate so every FeatureCard will paint.
     useAdCooldownStore.setState({ adSession: {}, _hasHydrated: true });
   }, []);
 
-  const { data: cards, isLoading } = useStrapi<StrapiFeatureCardData>({
-    contentType: STRAPI_FEATURE_CARDS,
-    queryKey: ['feature-cards', 'storybook'],
-  });
+  const { data: draftCards, isLoading: draftLoading } =
+    useStrapi<StrapiFeatureCardData>({
+      contentType: STRAPI_FEATURE_CARDS,
+      status: 'draft',
+      queryKey: ['feature-cards', 'storybook', 'draft'],
+    });
 
-  if (isLoading) {
+  const { data: publishedCards, isLoading: publishedLoading } =
+    useStrapi<StrapiFeatureCardData>({
+      contentType: STRAPI_FEATURE_CARDS,
+      status: 'published',
+      queryKey: ['feature-cards', 'storybook', 'published'],
+    });
+
+  const draftIds = useMemo(
+    () => new Set((draftCards ?? []).map((c) => c.documentId)),
+    [draftCards],
+  );
+
+  const publishedIds = useMemo(
+    () => new Set((publishedCards ?? []).map((c) => c.documentId)),
+    [publishedCards],
+  );
+
+  const sortedDraftCards = useMemo(
+    () =>
+      sortBy(draftCards ?? [], [
+        (c) => (publishedIds.has(c.documentId) ? 0 : 1),
+        (c) => (c.uid || c.Title).toLowerCase(),
+      ]),
+    [draftCards, publishedIds],
+  );
+
+  const sortedPublishedCards = useMemo(
+    () =>
+      sortBy(publishedCards ?? [], [(c) => (c.uid || c.Title).toLowerCase()]),
+    [publishedCards],
+  );
+
+  if (draftLoading || publishedLoading) {
     return (
       <Box sx={{ p: 4 }}>
         <Typography variant="bodyMedium">Loading cards…</Typography>
@@ -32,7 +194,7 @@ const AllCardsPreview = () => {
     );
   }
 
-  if (!cards || cards.length === 0) {
+  if (!draftCards?.length && !publishedCards?.length) {
     return (
       <Box sx={{ p: 4 }}>
         <Typography variant="bodyMedium">
@@ -42,68 +204,36 @@ const AllCardsPreview = () => {
     );
   }
 
-  const strapiBase = config.NEXT_PUBLIC_STRAPI_URL;
-
   return (
-    <Box
-      sx={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fill, minmax(384px, 1fr))',
-        gap: 3,
-        padding: 3,
-        justifyItems: 'center',
-      }}
-    >
-      {cards.map((cardData, index) => {
-        const adminUrl = `${strapiBase}/admin/content-manager/collection-types/api::feature-card.feature-card/${cardData.documentId}`;
-        const label = cardData.uid || cardData.Title;
+    <Box sx={{ padding: 3, bgcolor: 'background.default', minHeight: '100vh' }}>
+      {!!sortedPublishedCards.length && (
+        <Box sx={{ mb: 5 }}>
+          <SectionHeading
+            title="Published"
+            count={sortedPublishedCards.length}
+          />
+          <CardGrid
+            cards={sortedPublishedCards}
+            otherIds={draftIds}
+            group="published"
+          />
+        </Box>
+      )}
 
-        return (
-          <Box key={`feature-card-${cardData.id ?? index}`} sx={{ width: 384 }}>
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'baseline',
-                justifyContent: 'space-between',
-                gap: 1,
-                mb: 0.5,
-                px: 0.5,
-              }}
-            >
-              <Box sx={{ minWidth: 0 }}>
-                <Typography
-                  variant="bodySmallStrong"
-                  sx={{
-                    display: 'block',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                  }}
-                >
-                  {label}
-                </Typography>
-                <Typography
-                  variant="bodyXSmall"
-                  sx={{ color: 'text.secondary' }}
-                >
-                  {cardData.documentId}
-                </Typography>
-              </Box>
-              <Link
-                href={adminUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={(e) => e.stopPropagation()}
-                variant="bodyXSmall"
-                sx={{ flexShrink: 0 }}
-              >
-                View in Strapi ↗
-              </Link>
-            </Box>
-            <FeatureCard data={cardData} />
-          </Box>
-        );
-      })}
+      {!!sortedPublishedCards.length && !!sortedDraftCards.length && (
+        <Divider sx={{ mb: 5 }} />
+      )}
+
+      {!!sortedDraftCards.length && (
+        <Box>
+          <SectionHeading title="Draft" count={sortedDraftCards.length} />
+          <CardGrid
+            cards={sortedDraftCards}
+            otherIds={publishedIds}
+            group="draft"
+          />
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/components/FeatureCards/FeatureCards.stories.tsx
+++ b/src/components/FeatureCards/FeatureCards.stories.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { useEffect } from 'react';
+import { STRAPI_FEATURE_CARDS } from '@/const/strapiContentKeys';
+import { useStrapi } from '@/hooks/useStrapi';
+import { useAdCooldownStore } from '@/stores/adCooldown/AdCooldownStore';
+import type { StrapiFeatureCardData } from '@/types/strapi';
+import { FeatureCard } from './FeatureCard';
+
+const AllCardsPreview = () => {
+  useEffect(() => {
+    // Bypass the production cooldown gate and ensure the store reports hydrated
+    // so every FeatureCard will paint — without touching production code.
+    useAdCooldownStore.setState({ adSession: {}, _hasHydrated: true });
+  }, []);
+
+  const { data: cards, isLoading } = useStrapi<StrapiFeatureCardData>({
+    contentType: STRAPI_FEATURE_CARDS,
+    queryKey: ['feature-cards', 'storybook'],
+  });
+
+  if (isLoading) {
+    return (
+      <Box sx={{ p: 4 }}>
+        <Typography variant="bodyMedium">Loading cards…</Typography>
+      </Box>
+    );
+  }
+
+  if (!cards || cards.length === 0) {
+    return (
+      <Box sx={{ p: 4 }}>
+        <Typography variant="bodyMedium">
+          No feature cards found in Strapi.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-end',
+        width: 408,
+        padding: 1.5,
+        margin: '0 auto',
+      }}
+    >
+      {cards.map((cardData, index) => (
+        <FeatureCard
+          data={cardData}
+          key={`feature-card-${cardData.id ?? index}`}
+        />
+      ))}
+    </Box>
+  );
+};
+
+const meta: Meta<typeof AllCardsPreview> = {
+  title: 'Components/FeatureCards/All Cards',
+  component: AllCardsPreview,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AllCardsPreview>;
+
+export const Default: Story = {};

--- a/src/components/FeatureCards/FeatureCards.stories.tsx
+++ b/src/components/FeatureCards/FeatureCards.stories.tsx
@@ -2,8 +2,10 @@
 
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import Box from '@mui/material/Box';
+import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 import { useEffect } from 'react';
+import config from '@/config/env-config';
 import { STRAPI_FEATURE_CARDS } from '@/const/strapiContentKeys';
 import { useStrapi } from '@/hooks/useStrapi';
 import { useAdCooldownStore } from '@/stores/adCooldown/AdCooldownStore';
@@ -40,23 +42,68 @@ const AllCardsPreview = () => {
     );
   }
 
+  const strapiBase = config.NEXT_PUBLIC_STRAPI_URL;
+
   return (
     <Box
       sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-end',
-        width: 408,
-        padding: 1.5,
-        margin: '0 auto',
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(384px, 1fr))',
+        gap: 3,
+        padding: 3,
+        justifyItems: 'center',
       }}
     >
-      {cards.map((cardData, index) => (
-        <FeatureCard
-          data={cardData}
-          key={`feature-card-${cardData.id ?? index}`}
-        />
-      ))}
+      {cards.map((cardData, index) => {
+        const adminUrl = `${strapiBase}/admin/content-manager/collection-types/api::feature-card.feature-card/${cardData.documentId}`;
+        const label = cardData.uid || cardData.Title;
+
+        return (
+          <Box key={`feature-card-${cardData.id ?? index}`} sx={{ width: 384 }}>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'baseline',
+                justifyContent: 'space-between',
+                gap: 1,
+                mb: 0.5,
+                px: 0.5,
+              }}
+            >
+              <Box sx={{ minWidth: 0 }}>
+                <Typography
+                  variant="bodySmallStrong"
+                  sx={{
+                    display: 'block',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {label}
+                </Typography>
+                <Typography
+                  variant="bodyXSmall"
+                  sx={{ color: 'text.secondary' }}
+                >
+                  {cardData.documentId}
+                </Typography>
+              </Box>
+              <Link
+                href={adminUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
+                variant="bodyXSmall"
+                sx={{ flexShrink: 0 }}
+              >
+                View in Strapi ↗
+              </Link>
+            </Box>
+            <FeatureCard data={cardData} />
+          </Box>
+        );
+      })}
     </Box>
   );
 };

--- a/src/components/FeatureCards/FeatureCards.stories.tsx
+++ b/src/components/FeatureCards/FeatureCards.stories.tsx
@@ -13,15 +13,16 @@ import { STRAPI_FEATURE_CARDS } from '@/const/strapiContentKeys';
 import { useStrapi } from '@/hooks/useStrapi';
 import { useAdCooldownStore } from '@/stores/adCooldown/AdCooldownStore';
 import type { StrapiFeatureCardData } from '@/types/strapi';
+import type { SpindlCardData } from '@/types/spindl';
+import { useSpindlMatrixCards } from './FeatureCards.stories.spindl';
 import { FeatureCard } from './FeatureCard';
 
 // ---------------------------------------------------------------------------
-// Shared header above each card cell
+// Strapi card header (with Strapi admin link)
 // ---------------------------------------------------------------------------
 
 interface CardHeaderProps {
   cardData: StrapiFeatureCardData;
-  /** Chip shown to flag publication state within this group */
   chip: { label: string; color: 'success' | 'warning' | 'error' | 'info' };
 }
 
@@ -81,12 +82,60 @@ const CardHeader = ({ cardData, chip }: CardHeaderProps) => {
 };
 
 // ---------------------------------------------------------------------------
-// Card grid
+// Spindl card header (no Strapi admin link, links to CTA instead)
+// ---------------------------------------------------------------------------
+
+const SpindlCardHeader = ({ card }: { card: SpindlCardData }) => (
+  <Box
+    sx={{
+      display: 'flex',
+      alignItems: 'baseline',
+      justifyContent: 'space-between',
+      gap: 1,
+      mb: 0.5,
+      px: 0.5,
+    }}
+  >
+    <Box sx={{ minWidth: 0 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 0.25 }}>
+        <Chip label="SPINDL" color="info" size="small" variant="outlined" />
+        <Typography
+          variant="bodySmallStrong"
+          sx={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {card.Title}
+        </Typography>
+      </Box>
+      <Typography variant="bodyXSmall" sx={{ color: 'text.secondary' }}>
+        creative: {card.spindlData.ad_creative_id} · impression:{' '}
+        {card.spindlData.impression_id}
+      </Typography>
+    </Box>
+    {card.URL && (
+      <Link
+        href={card.URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        variant="bodyXSmall"
+        sx={{ flexShrink: 0 }}
+      >
+        Preview CTA ↗
+      </Link>
+    )}
+  </Box>
+);
+
+// ---------------------------------------------------------------------------
+// Strapi card grid
 // ---------------------------------------------------------------------------
 
 interface CardGridProps {
   cards: StrapiFeatureCardData[];
-  /** documentIds present in the *other* group — used to cross-reference */
   otherIds: Set<string>;
   group: 'draft' | 'published';
 }
@@ -102,15 +151,12 @@ const CardGrid = ({ cards, otherIds, group }: CardGridProps) => (
   >
     {cards.map((cardData, index) => {
       const isInOtherGroup = otherIds.has(cardData.documentId);
-
       const chip: CardHeaderProps['chip'] =
         group === 'draft'
           ? isInOtherGroup
             ? { label: 'LIVE', color: 'success' }
             : { label: 'DRAFT ONLY', color: 'warning' }
-          : isInOtherGroup
-            ? { label: 'PUBLISHED', color: 'success' }
-            : { label: 'PUBLISHED', color: 'success' };
+          : { label: 'PUBLISHED', color: 'success' };
 
       return (
         <Box key={`${group}-${cardData.id ?? index}`} sx={{ width: 384 }}>
@@ -119,6 +165,28 @@ const CardGrid = ({ cards, otherIds, group }: CardGridProps) => (
         </Box>
       );
     })}
+  </Box>
+);
+
+// ---------------------------------------------------------------------------
+// Spindl card grid
+// ---------------------------------------------------------------------------
+
+const SpindlCardGrid = ({ cards }: { cards: SpindlCardData[] }) => (
+  <Box
+    sx={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(auto-fill, minmax(384px, 1fr))',
+      gap: 3,
+      justifyItems: 'center',
+    }}
+  >
+    {cards.map((card, index) => (
+      <Box key={`spindl-${card.id ?? index}`} sx={{ width: 384 }}>
+        <SpindlCardHeader card={card} />
+        <FeatureCard data={card} />
+      </Box>
+    ))}
   </Box>
 );
 
@@ -141,11 +209,23 @@ const SectionHeading = ({ title, count }: { title: string; count: number }) => (
 // Main story component
 // ---------------------------------------------------------------------------
 
-const AllCardsPreview = () => {
+interface AllCardsPreviewProps {
+  /** Injected by the withProviders decorator via context spread */
+  globals?: { locale?: string };
+}
+
+const AllCardsPreview = ({ globals }: AllCardsPreviewProps) => {
   useEffect(() => {
     // Bypass the production cooldown gate so every FeatureCard will paint.
     useAdCooldownStore.setState({ adSession: {}, _hasHydrated: true });
   }, []);
+
+  // Derive a country code from the active locale for Spindl targeting.
+  // Locale format is either 'en' or 'en-US'; fallback to 'US' when no region.
+  const locale = globals?.locale || 'en';
+  const country = locale.includes('-')
+    ? locale.split('-')[1].toUpperCase()
+    : 'US';
 
   const { data: draftCards, isLoading: draftLoading } =
     useStrapi<StrapiFeatureCardData>({
@@ -161,6 +241,12 @@ const AllCardsPreview = () => {
       queryKey: ['feature-cards', 'storybook', 'published'],
     });
 
+  const {
+    cards: spindlCards,
+    isLoading: spindlLoading,
+    errorCount: spindlErrorCount,
+  } = useSpindlMatrixCards(country);
+
   const draftIds = useMemo(
     () => new Set((draftCards ?? []).map((c) => c.documentId)),
     [draftCards],
@@ -169,6 +255,11 @@ const AllCardsPreview = () => {
   const publishedIds = useMemo(
     () => new Set((publishedCards ?? []).map((c) => c.documentId)),
     [publishedCards],
+  );
+
+  const sortedSpindlCards = useMemo(
+    () => sortBy(spindlCards, (c) => c.Title.toLowerCase()),
+    [spindlCards],
   );
 
   const sortedDraftCards = useMemo(
@@ -186,7 +277,7 @@ const AllCardsPreview = () => {
     [publishedCards],
   );
 
-  if (draftLoading || publishedLoading) {
+  if (draftLoading || publishedLoading || spindlLoading) {
     return (
       <Box sx={{ p: 4 }}>
         <Typography variant="bodyMedium">Loading cards…</Typography>
@@ -194,18 +285,37 @@ const AllCardsPreview = () => {
     );
   }
 
-  if (!draftCards?.length && !publishedCards?.length) {
+  if (!spindlCards.length && !draftCards?.length && !publishedCards?.length) {
     return (
       <Box sx={{ p: 4 }}>
-        <Typography variant="bodyMedium">
-          No feature cards found in Strapi.
-        </Typography>
+        <Typography variant="bodyMedium">No cards found.</Typography>
       </Box>
     );
   }
 
   return (
     <Box sx={{ padding: 3, bgcolor: 'background.default', minHeight: '100vh' }}>
+      {!!sortedSpindlCards.length && (
+        <Box sx={{ mb: 5 }}>
+          <SectionHeading title="Spindl" count={sortedSpindlCards.length} />
+          {spindlErrorCount > 0 && (
+            <Typography
+              variant="bodyXSmall"
+              sx={{ color: 'warning.main', mb: 2 }}
+            >
+              {spindlErrorCount} matrix call(s) failed — results may be
+              incomplete.
+            </Typography>
+          )}
+          <SpindlCardGrid cards={sortedSpindlCards} />
+        </Box>
+      )}
+
+      {!!sortedSpindlCards.length &&
+        !!(sortedPublishedCards.length || sortedDraftCards.length) && (
+          <Divider sx={{ mb: 5 }} />
+        )}
+
       {!!sortedPublishedCards.length && (
         <Box sx={{ mb: 5 }}>
           <SectionHeading

--- a/src/hooks/feature-cards/spindl/fetchSpindlCards.ts
+++ b/src/hooks/feature-cards/spindl/fetchSpindlCards.ts
@@ -21,7 +21,7 @@ export const fetchSpindlCards = ({
     queryParams: {
       placement_id: PLACEMENT_ID,
       limit: DEFAULT_LIMIT,
-      address,
+      ...(address !== undefined && { address }),
       country,
       chain_id: chainId !== undefined ? String(chainId) : undefined,
       token_address: tokenAddress,

--- a/src/hooks/feature-cards/spindl/fetchSpindlCards.ts
+++ b/src/hooks/feature-cards/spindl/fetchSpindlCards.ts
@@ -1,0 +1,30 @@
+import type { SpindlFetchData, SpindlFetchParams } from 'src/types/spindl';
+import { callRequest } from 'src/utils/callRequest';
+import { getSpindlConfig } from './spindlConfig';
+
+const FETCH_SPINDL_PATH = '/render/jumper';
+const PLACEMENT_ID = 'notify_message';
+const DEFAULT_LIMIT = '3';
+
+export const fetchSpindlCards = ({
+  country,
+  chainId,
+  tokenAddress,
+  address,
+}: SpindlFetchParams): Promise<SpindlFetchData> => {
+  const { apiUrl, headers } = getSpindlConfig();
+  return callRequest<SpindlFetchData>({
+    method: 'GET',
+    path: FETCH_SPINDL_PATH,
+    apiUrl,
+    headers,
+    queryParams: {
+      placement_id: PLACEMENT_ID,
+      limit: DEFAULT_LIMIT,
+      address,
+      country,
+      chain_id: chainId !== undefined ? String(chainId) : undefined,
+      token_address: tokenAddress,
+    },
+  });
+};

--- a/src/hooks/feature-cards/spindl/fetchSpindlCards.ts
+++ b/src/hooks/feature-cards/spindl/fetchSpindlCards.ts
@@ -1,5 +1,5 @@
-import type { SpindlFetchData, SpindlFetchParams } from 'src/types/spindl';
-import { callRequest } from 'src/utils/callRequest';
+import type { SpindlFetchData, SpindlFetchParams } from '@/types/spindl';
+import { callRequest } from '@/utils/callRequest';
 import { getSpindlConfig } from './spindlConfig';
 
 const FETCH_SPINDL_PATH = '/render/jumper';

--- a/src/hooks/feature-cards/spindl/spindlMapper.ts
+++ b/src/hooks/feature-cards/spindl/spindlMapper.ts
@@ -2,7 +2,7 @@ import type {
   SpindlCardData,
   SpindlMediaAttributes,
   SpindlItem,
-} from 'src/types/spindl';
+} from '@/types/spindl';
 
 export function spindlItemToCardData(
   item: SpindlItem,

--- a/src/hooks/feature-cards/spindl/spindlMapper.ts
+++ b/src/hooks/feature-cards/spindl/spindlMapper.ts
@@ -1,0 +1,50 @@
+import type {
+  SpindlCardData,
+  SpindlMediaAttributes,
+  SpindlItem,
+} from 'src/types/spindl';
+
+export function spindlItemToCardData(
+  item: SpindlItem,
+  index: number,
+): SpindlCardData {
+  return {
+    id: item.id,
+    Title: item.title,
+    Subtitle: item.description,
+    CTACall: item.ctas[0]?.title || 'Learn more',
+    URL: item.ctas[0]?.href || '',
+    DisplayConditions: { mode: item.mode || 'dark' },
+    TitleColor: item.titleColor,
+    SubtitleColor: item.descriptionColor,
+    CTAColor: item.ctas[0]?.color,
+    createdAt: Date.now().toString(),
+    updatedAt: Date.now().toString(),
+    PersonalizedFeatureCard: true,
+    publishedAt: Date.now().toString(),
+    uid: item.id,
+    // TODO: Needs to be refactored
+    BackgroundImageLight: {
+      id: index.toString(), // Change this to a number
+      name: `${item.imageAltText || item.advertiser?.name || ''} image`,
+      alternativeText: `${item.imageAltText || item.advertiser?.name || ''} image`,
+      width: 384,
+      height: 160,
+      formats: {},
+      url: item.imageUrl,
+    } as SpindlMediaAttributes,
+    BackgroundImageDark: {
+      id: index.toString(), // Change this to a number
+      name: `${item.imageAltText || item.advertiser?.name || ''} image`,
+      alternativeText: `${item.imageAltText || item.advertiser?.name || ''} image`,
+      width: 384,
+      height: 160,
+      formats: {},
+      url: item.imageUrl,
+    } as SpindlMediaAttributes,
+    spindlData: {
+      impression_id: item.impressionId,
+      ad_creative_id: item.advertiserId,
+    },
+  };
+}

--- a/src/hooks/feature-cards/spindl/useSpindlCards.ts
+++ b/src/hooks/feature-cards/spindl/useSpindlCards.ts
@@ -4,47 +4,33 @@ import {
   WidgetEvent,
   type RouteExecutionUpdate,
 } from '@lifi/widget';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useCallRequest } from 'src/hooks/useCallRequest';
 import {
   isSpindlFetchResponse,
-  type SpindlFetchData,
   type SpindlFetchParams,
 } from 'src/types/spindl';
-import { callRequest } from 'src/utils/callRequest';
 import { getLocale } from 'src/utils/getLocale';
-import { getSpindlConfig } from './spindlConfig';
+import { fetchSpindlCards } from './fetchSpindlCards';
 import { useSpindlProcessData } from './useSpindlProcessData';
-
-const FETCH_SPINDL_PATH = '/render/jumper';
 
 export const useSpindlCards = () => {
   const { account } = useAccount();
   const widgetEvents = useWidgetEvents();
   const processSpindlData = useSpindlProcessData();
-  const spindlConfig = getSpindlConfig();
   const { fetchData } = useCallRequest();
 
   const fetchSpindlData = useCallback(
     async ({ country, chainId, tokenAddress, address }: SpindlFetchParams) => {
       const locale = getLocale().split('-');
-      const queryParams: Record<string, string | undefined> = {
-        placement_id: 'notify_message',
-        limit: '3',
-        address,
+      const queryParams: SpindlFetchParams = {
         country: country || locale[1],
-        chain_id: chainId?.toString(),
-        token_address: tokenAddress,
+        chainId,
+        tokenAddress,
+        address,
       };
 
-      const queryFn = async () =>
-        callRequest<SpindlFetchData>({
-          method: 'GET',
-          path: FETCH_SPINDL_PATH,
-          apiUrl: spindlConfig.apiUrl,
-          headers: spindlConfig.headers,
-          queryParams,
-        });
+      const queryFn = () => fetchSpindlCards(queryParams);
 
       try {
         const response = await fetchData(queryFn, queryParams);
@@ -57,7 +43,7 @@ export const useSpindlCards = () => {
         console.error('Error fetching Spindl data:', error);
       }
     },
-    [fetchData, processSpindlData, spindlConfig.apiUrl, spindlConfig.headers],
+    [fetchData, processSpindlData],
   );
 
   useEffect(() => {

--- a/src/hooks/feature-cards/spindl/useSpindlCards.ts
+++ b/src/hooks/feature-cards/spindl/useSpindlCards.ts
@@ -5,12 +5,9 @@ import {
   type RouteExecutionUpdate,
 } from '@lifi/widget';
 import { useCallback, useEffect } from 'react';
-import { useCallRequest } from 'src/hooks/useCallRequest';
-import {
-  isSpindlFetchResponse,
-  type SpindlFetchParams,
-} from 'src/types/spindl';
-import { getLocale } from 'src/utils/getLocale';
+import { useCallRequest } from '@/hooks/useCallRequest';
+import { isSpindlFetchResponse, type SpindlFetchParams } from '@/types/spindl';
+import { getLocale } from '@/utils/getLocale';
 import { fetchSpindlCards } from './fetchSpindlCards';
 import { useSpindlProcessData } from './useSpindlProcessData';
 

--- a/src/hooks/feature-cards/spindl/useSpindlProcessData.ts
+++ b/src/hooks/feature-cards/spindl/useSpindlProcessData.ts
@@ -1,6 +1,6 @@
-import { useSettingsStore } from 'src/stores/settings';
-import { useSpindlStore } from 'src/stores/spindl';
-import type { SpindlFetchData, SpindlItem } from 'src/types/spindl';
+import { useSettingsStore } from '@/stores/settings';
+import { useSpindlStore } from '@/stores/spindl';
+import type { SpindlFetchData, SpindlItem } from '@/types/spindl';
 import { shallow } from 'zustand/shallow';
 import { spindlItemToCardData } from './spindlMapper';
 

--- a/src/hooks/feature-cards/spindl/useSpindlProcessData.ts
+++ b/src/hooks/feature-cards/spindl/useSpindlProcessData.ts
@@ -1,11 +1,8 @@
 import { useSettingsStore } from 'src/stores/settings';
 import { useSpindlStore } from 'src/stores/spindl';
-import type {
-  SpindlFetchData,
-  SpindlItem,
-  SpindlMediaAttributes,
-} from 'src/types/spindl';
+import type { SpindlFetchData, SpindlItem } from 'src/types/spindl';
 import { shallow } from 'zustand/shallow';
+import { spindlItemToCardData } from './spindlMapper';
 
 export const useSpindlProcessData = () => {
   const setSpindl = useSpindlStore((state) => state.setSpindl);
@@ -18,45 +15,7 @@ export const useSpindlProcessData = () => {
     if (Array.isArray(data?.items) && data.items.length > 0) {
       const items = data.items
         .filter((item: SpindlItem) => !disabledFeatureCards.includes(item.id))
-        .map((item: SpindlItem, index: number) => ({
-          id: item.id,
-          Title: item.title,
-          Subtitle: item.description,
-          CTACall: item.ctas[0]?.title || 'Learn more',
-          URL: item.ctas[0]?.href || '',
-          DisplayConditions: { mode: item.mode || 'dark' },
-          TitleColor: item.titleColor,
-          SubtitleColor: item.descriptionColor,
-          CTAColor: item.ctas[0]?.color,
-          createdAt: Date.now().toString(),
-          updatedAt: Date.now().toString(),
-          PersonalizedFeatureCard: true,
-          publishedAt: Date.now().toString(),
-          uid: item.id,
-          // TODO: Needs to be refactored
-          BackgroundImageLight: {
-            id: index.toString(), // Change this to a number
-            name: `${item.imageAltText || item.advertiser?.name || ''} image`,
-            alternativeText: `${item.imageAltText || item.advertiser?.name || ''} image`,
-            width: 384,
-            height: 160,
-            formats: {},
-            url: item.imageUrl,
-          } as SpindlMediaAttributes,
-          BackgroundImageDark: {
-            id: index.toString(), // Change this to a number
-            name: `${item.imageAltText || item.advertiser?.name || ''} image`,
-            alternativeText: `${item.imageAltText || item.advertiser?.name || ''} image`,
-            width: 384,
-            height: 160,
-            formats: {},
-            url: item.imageUrl,
-          } as SpindlMediaAttributes,
-          spindlData: {
-            impression_id: item.impressionId,
-            ad_creative_id: item.advertiserId,
-          },
-        }));
+        .map(spindlItemToCardData);
       setSpindl(items.length ? items.slice(0, 1) : []);
     }
   };

--- a/src/hooks/useStrapi.ts
+++ b/src/hooks/useStrapi.ts
@@ -207,6 +207,8 @@ export const useStrapi = <T>({
       queryKey,
       filterPersonalFeatureCards?.account?.isConnected,
       effectiveStatus,
+      includePersonalized ?? false,
+      ignoreCampaignDates ?? false,
     ],
     queryFn: async () => {
       const response = await fetch(decodeURIComponent(apiUrl.href));

--- a/src/hooks/useStrapi.ts
+++ b/src/hooks/useStrapi.ts
@@ -46,6 +46,9 @@ interface ContentTypeProps {
   pagination?: PaginationProps;
   filterFeaturedFaq?: boolean;
   queryKey?: (string | number | undefined)[];
+  /** Override the Strapi publication status filter. When omitted the default
+   *  env-based rule applies: 'draft' on non-production, nothing on production. */
+  status?: 'draft' | 'published';
 }
 
 export function getStrapiUrl(contentType: string): URL {
@@ -65,6 +68,7 @@ export const useStrapi = <T>({
   pagination,
   filterFeaturedFaq,
   queryKey,
+  status,
 }: ContentTypeProps): UseStrapiProps<T> => {
   // account needed to filter personalized feature cards
 
@@ -175,14 +179,23 @@ export const useStrapi = <T>({
       apiUrl.searchParams.set('filters[uid][$eq]', filterUid);
     }
   }
-  // show drafts ONLY on development env
-  config.NEXT_PUBLIC_ENVIRONMENT !== 'production' &&
-    apiUrl.searchParams.set('status', 'draft');
-  config.NEXT_PUBLIC_ENVIRONMENT === 'development' &&
+  // Explicit `status` prop wins; otherwise show drafts on non-production envs.
+  const defaultStatus =
+    config.NEXT_PUBLIC_ENVIRONMENT !== 'production' ? 'draft' : undefined;
+  const effectiveStatus = status ?? defaultStatus;
+  if (effectiveStatus) {
+    apiUrl.searchParams.set('status', effectiveStatus);
+  }
+  if (config.NEXT_PUBLIC_ENVIRONMENT === 'development') {
     apiUrl.searchParams.set('pagination[pageSize]', '50');
+  }
 
   const { data, isSuccess, isLoading, isRefetching, isFetching } = useQuery({
-    queryKey: [queryKey, filterPersonalFeatureCards?.account?.isConnected],
+    queryKey: [
+      queryKey,
+      filterPersonalFeatureCards?.account?.isConnected,
+      effectiveStatus,
+    ],
     queryFn: async () => {
       const response = await fetch(decodeURIComponent(apiUrl.href));
       const result = await response.json();

--- a/src/hooks/useStrapi.ts
+++ b/src/hooks/useStrapi.ts
@@ -49,6 +49,10 @@ interface ContentTypeProps {
   /** Override the Strapi publication status filter. When omitted the default
    *  env-based rule applies: 'draft' on non-production, nothing on production. */
   status?: 'draft' | 'published';
+  /** When true, skips the PersonalizedFeatureCard exclusion filter (feature-cards only). */
+  includePersonalized?: boolean;
+  /** When true, skips the campaignStart/campaignEnd date-window filters (feature-cards only). */
+  ignoreCampaignDates?: boolean;
 }
 
 export function getStrapiUrl(contentType: string): URL {
@@ -69,6 +73,8 @@ export const useStrapi = <T>({
   filterFeaturedFaq,
   queryKey,
   status,
+  includePersonalized,
+  ignoreCampaignDates,
 }: ContentTypeProps): UseStrapiProps<T> => {
   // account needed to filter personalized feature cards
 
@@ -153,16 +159,22 @@ export const useStrapi = <T>({
     apiUrl.searchParams.set('populate[0]', 'BackgroundImageLight');
     apiUrl.searchParams.set('populate[1]', 'BackgroundImageDark');
     apiUrl.searchParams.set('populate[2]', 'featureCardsExclusions');
-    apiUrl.searchParams.set('filters[PersonalizedFeatureCard][$nei]', 'true');
-    //filter url
-    const currentDate = new Date(Date.now()).toISOString().split('T')[0];
-    apiUrl.searchParams.set(
-      'filters[$or][0][campaignStart][$lte]',
-      currentDate,
-    );
-    apiUrl.searchParams.set('filters[$or][1][campaignStart][$null]', 'true');
-    apiUrl.searchParams.set('filters[$or][0][campaignEnd][$gte]', currentDate);
-    apiUrl.searchParams.set('filters[$or][1][campaignEnd][$null]', 'true');
+    if (!includePersonalized) {
+      apiUrl.searchParams.set('filters[PersonalizedFeatureCard][$nei]', 'true');
+    }
+    if (!ignoreCampaignDates) {
+      const currentDate = new Date(Date.now()).toISOString().split('T')[0];
+      apiUrl.searchParams.set(
+        'filters[$or][0][campaignStart][$lte]',
+        currentDate,
+      );
+      apiUrl.searchParams.set('filters[$or][1][campaignStart][$null]', 'true');
+      apiUrl.searchParams.set(
+        'filters[$or][0][campaignEnd][$gte]',
+        currentDate,
+      );
+      apiUrl.searchParams.set('filters[$or][1][campaignEnd][$null]', 'true');
+    }
   }
 
   // partner-themes -->


### PR DESCRIPTION
## Summary

Adds a Storybook story that fetches all feature cards (the bottom-right ad pop-ups) directly from Strapi and renders them in one place — so the marketing team can review every card without having to stumble upon them in production. Includes a grid layout, per-card Strapi admin links, and a global locale switcher.

End goal is to serve this in the preview release: https://jumper-exchange-storybook-git-develop-jumper-exchange.vercel.app so the team can check and review all cards.

## Changes

- `src/components/FeatureCards/FeatureCards.stories.tsx` — new story that:
  - Calls `useStrapi` directly to fetch the full card list (bypasses the production 1-card slice and ad-cooldown gate via an on-mount store reset — no production code touched)
  - Renders cards in a responsive CSS grid (`auto-fill, minmax(384px, 1fr)`)
  - Shows a header above each card with the Strapi `uid`, `documentId`, and a "View in Strapi ↗" deep link to the admin entry
- `.storybook/preview.ts` — adds a global **Locale** toolbar (globe icon) backed by `i18n-config.ts` (14 locales: bn, en, es, fr, id, it, ja, ko, pt, th, tr, uk, vi, zh)
- `.storybook/withProviders.tsx` — wires the active locale into `initTranslations` and `TranslationsProvider`; re-inits i18next on each locale change; composes independently with the existing Light/Dark theme switcher
- `src/hooks/feature-cards/spindl/fetchSpindlCards.ts` — new shared fetcher extracted from the duplicated `callRequest` blocks in `useSpindlCards` and `FeatureCards.stories.spindl.ts`; owns path, placement, limit, and config

## Linked Linear ticket

JUM-973: https://linear.app/lifi-linear/issue/JUM-973/experiment-ad-cards-review

## Future Upgrades

- Pass the active Storybook locale to `useStrapi` so Strapi-side card text (Title/Subtitle/CTACall) also localises — requires a small change to the `useStrapi` hook and its callers in the app

## Sister PRs

N/A — all changes are frontend-only in `jumper-exchange`.

Made with [Cursor](https://cursor.com)

Examples:

https://linear.app/lifi-linear/issue/JUM-973/experiment-ad-cards-review#comment-e5ae8058

with spindl, published, draft:

<img width="5344" height="3054" alt="CleanShot 2026-05-19 at 10 43 21@2x" src="https://github.com/user-attachments/assets/b9615480-36db-4e6b-9192-40e87e9b6623" />

(you can change theme and local as well in the top bar)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Storybook adds a locale selector (default "en") and reinitializes translations when locale changes.
* **New Features**
  * New FeatureCards stories showing draft vs published groups, admin "View" links, conditional preview CTAs, combined loading/empty states, and an external-error banner.
  * Added Spindl storybook matrix utility, Spindl fetcher and mapper for matrix-driven card data.
  * Strapi hook accepts optional status, includePersonalized, and ignoreCampaignDates flags.
* **Refactor**
  * Card fetching/mapping reorganized for deduplication, safer loading, and clearer error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jumperexchange/jumper-exchange/pull/2865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->