### PR TITLE
fix: stop SSR memory leak from Sui dapp-kit + Solana RPC retries

### DIFF
--- a/src/components/Widgets/variants/widgetConfig/useSharedConfigs.ts
+++ b/src/components/Widgets/variants/widgetConfig/useSharedConfigs.ts
@@ -1,7 +1,7 @@
 import { ChainType } from '@lifi/sdk';
 import type { WidgetConfig } from '@lifi/widget';
 import { useMemo } from 'react';
-import { publicRPCList } from 'src/const/rpcList';
+import { getCustomRPCs, publicRPCList } from 'src/const/rpcList';
 import type { LanguageKey } from 'src/types/i18n';
 import { TaskType } from 'src/types/strapi';
 import getApiUrl from 'src/utils/getApiUrl';
@@ -68,7 +68,7 @@ export function useSharedRPCConfig(
           isPrivateVariant: params.isPrivateVariant,
         }),
         rpcUrls: {
-          ...JSON.parse(envConfig.NEXT_PUBLIC_CUSTOM_RPCS ?? '{}'),
+          ...getCustomRPCs(),
           ...publicRPCList,
         },
         routeOptions: {

--- a/src/const/rpcList.ts
+++ b/src/const/rpcList.ts
@@ -33,7 +33,79 @@ export const publicRPCList = {
   '8453': shuffleArray(basRPCList),
 };
 
-export const mergedRPCList = {
-  ...JSON.parse(config.NEXT_PUBLIC_CUSTOM_RPCS ?? '{}'),
-  ...publicRPCList,
-};
+/**
+ * RPC providers that must NOT be used during SSR.
+ *
+ * These are authenticated, paid endpoints whose quotas are intended to be
+ * spent on real user traffic from the browser. Because all SSR traffic exits
+ * through a small number of pod IPs, any synchronized burst (e.g. fleet
+ * restart, deploy, traffic spike) bunches up on the same source IP and either
+ * blows the per-origin quota (triggering tight retry loops that burn CPU and
+ * memory) or wastes paid request budget on cluster-warmup pings.
+ *
+ * On the browser, requests are spread across millions of user IPs, so the
+ * per-origin limit is never an issue and the spend goes to actual users.
+ */
+const BROWSER_ONLY_RPC_HOSTS = [
+  // Helius rebate endpoints share a per-rebate-address quota across all
+  // callers. SSR concentrates this onto the pod fleet IPs and hits 429.
+  'helius-rpc.com',
+  // QuikNode endpoints are authenticated/paid; we don't want SSR pods
+  // burning the request budget on cluster-warmup pings.
+  'quiknode.pro',
+];
+
+function isBrowserOnlyRpc(url: string): boolean {
+  try {
+    const host = new URL(url).hostname;
+    return BROWSER_ONLY_RPC_HOSTS.some((needle) => host.includes(needle));
+  } catch {
+    return false;
+  }
+}
+
+type RpcMap = Record<string, string[]>;
+
+/**
+ * Returns the parsed `NEXT_PUBLIC_CUSTOM_RPCS` map, with browser-only
+ * endpoints stripped on the server. On the client it is returned unchanged.
+ *
+ * Use this everywhere that a component or SDK initializer might run on SSR
+ * (LiFi SDK init, widget config, Solana provider, etc.) instead of inlining
+ * `JSON.parse(config.NEXT_PUBLIC_CUSTOM_RPCS ?? '{}')`.
+ */
+export function getCustomRPCs(): RpcMap {
+  let parsed: RpcMap;
+  try {
+    parsed = JSON.parse(config.NEXT_PUBLIC_CUSTOM_RPCS ?? '{}');
+  } catch {
+    return {};
+  }
+
+  if (typeof window !== 'undefined') {
+    return parsed;
+  }
+
+  const filtered: RpcMap = {};
+  for (const [chainId, urls] of Object.entries(parsed)) {
+    if (!Array.isArray(urls)) {
+      continue;
+    }
+    const safe = urls.filter((url) => !isBrowserOnlyRpc(url));
+    if (safe.length > 0) {
+      filtered[chainId] = safe;
+    }
+  }
+  return filtered;
+}
+
+/**
+ * Lazy getter so the merge happens after `getCustomRPCs()` has decided
+ * what to include for the current execution context (SSR vs browser).
+ */
+export function getMergedRPCList(): RpcMap {
+  return {
+    ...getCustomRPCs(),
+    ...publicRPCList,
+  };
+}

--- a/src/providers/WalletProvider/SVMProvider.tsx
+++ b/src/providers/WalletProvider/SVMProvider.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react';
 import type { SolanaClientConfig } from '@solana/client';
 import envConfig from '@/config/env-config';
+import { getCustomRPCs } from '@/const/rpcList';
 import { useHydrated } from '@/hooks/useHydrated';
 
 const SOLANA_CHAIN_ID = '1151111081099710';
@@ -20,14 +21,11 @@ function getSolanaRpcUrl(): string | undefined {
   if (envConfig.NEXT_PUBLIC_SOLANA_RPC_URI) {
     return envConfig.NEXT_PUBLIC_SOLANA_RPC_URI;
   }
-  try {
-    const customRpcs = JSON.parse(envConfig.NEXT_PUBLIC_CUSTOM_RPCS || '{}');
-    const solanaRpcs = customRpcs[SOLANA_CHAIN_ID];
-    if (Array.isArray(solanaRpcs) && solanaRpcs.length > 0) {
-      return solanaRpcs[0];
-    }
-  } catch {
-    // ignore parse errors
+  // getCustomRPCs() strips browser-only endpoints (e.g. Helius) on SSR so
+  // we never warm up an authenticated, rate-limited RPC from the pod fleet.
+  const solanaRpcs = getCustomRPCs()[SOLANA_CHAIN_ID];
+  if (Array.isArray(solanaRpcs) && solanaRpcs.length > 0) {
+    return solanaRpcs[0];
   }
   return undefined;
 }

--- a/src/providers/WalletProvider/SuiProvider.tsx
+++ b/src/providers/WalletProvider/SuiProvider.tsx
@@ -6,34 +6,34 @@ import {
 } from '@mysten/dapp-kit-react';
 import { SuiGrpcClient } from '@mysten/sui/grpc';
 import { getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc';
-import { type FC, type PropsWithChildren, useEffect, useState } from 'react';
+import type { FC, PropsWithChildren } from 'react';
 
-// Module-level singleton so createDAppKit is called at most once
-// (guards against React StrictMode double-invoking effects).
-let dappKitSingleton: DefaultExpectedDppKit | null = null;
+// Module-level singleton: createDAppKit is called at most once per Node.js
+// process (SSR) or browser tab.
+//
+// Why this matters:
+//   1. SSR memory leak — without a singleton, each SSR request would call
+//      createDAppKit and allocate a fresh SuiGrpcClient + nanostores graph
+//      that is never released after the response.
+//   2. Slush wallet's default `getDefaultAppName()` reads `document.title`,
+//      which throws "ReferenceError: document is not defined" on SSR. Passing
+//      `appName` explicitly bypasses that branch and keeps Slush registered
+//      on both server and client.
+//   3. Establishing DAppKitContext eagerly stops @lifi/widget-provider-sui's
+//      SuiWidgetProvider from falling through to its own SuiBaseProvider,
+//      which has the same per-render `createDAppKit` anti-pattern internally.
+const dappKit: DefaultExpectedDppKit = createDAppKit({
+  networks: ['mainnet'],
+  createClient: (network) =>
+    new SuiGrpcClient({
+      network,
+      baseUrl: getJsonRpcFullnodeUrl('mainnet'),
+    }),
+  autoConnect: true,
+  storageKey: 'jumper-sui-wallet-connection',
+  slushWalletConfig: { appName: 'Jumper' },
+});
 
 export const SuiProvider: FC<PropsWithChildren> = ({ children }) => {
-  const [dappKit, setDappKit] = useState<DefaultExpectedDppKit | null>(null);
-
-  useEffect(() => {
-    if (!dappKitSingleton) {
-      dappKitSingleton = createDAppKit({
-        networks: ['mainnet'],
-        createClient: (network) =>
-          new SuiGrpcClient({
-            network,
-            baseUrl: getJsonRpcFullnodeUrl('mainnet'),
-          }),
-        autoConnect: true,
-        storageKey: 'jumper-sui-wallet-connection',
-      });
-    }
-    setDappKit(dappKitSingleton);
-  }, []);
-
-  if (!dappKit) {
-    return <>{children}</>;
-  }
-
   return <DAppKitProvider dAppKit={dappKit}>{children}</DAppKitProvider>;
 };

--- a/src/utils/instrumentation/lifiSdkConfig.ts
+++ b/src/utils/instrumentation/lifiSdkConfig.ts
@@ -1,5 +1,5 @@
 import config from '@/config/env-config';
-import { publicRPCList } from '@/const/rpcList';
+import { getCustomRPCs, publicRPCList } from '@/const/rpcList';
 import { createClient, type SDKProvider } from '@lifi/sdk';
 import { EthereumProvider } from '@lifi/sdk-provider-ethereum';
 import { BitcoinProvider } from '@lifi/sdk-provider-bitcoin';
@@ -25,7 +25,7 @@ function initClient() {
       apiUrl: getApiUrl(),
       integrator: config.NEXT_PUBLIC_WIDGET_INTEGRATOR || 'jumper.exchange',
       rpcUrls: {
-        ...JSON.parse(config.NEXT_PUBLIC_CUSTOM_RPCS ?? '{}'),
+        ...getCustomRPCs(),
         ...publicRPCList,
       },
       preloadChains: true,

--- a/src/utils/rpc/getShuffledRPCForChain.ts
+++ b/src/utils/rpc/getShuffledRPCForChain.ts
@@ -1,8 +1,8 @@
 import { shuffle } from 'lodash';
-import { mergedRPCList } from 'src/const/rpcList';
+import { getMergedRPCList } from 'src/const/rpcList';
 
 export const getShuffledRPCForChain = (chainId: string | number) => {
-  const rpcUrls = mergedRPCList[chainId];
+  const rpcUrls = getMergedRPCList()[chainId];
   if (!rpcUrls?.length) {
     return;
   }


### PR DESCRIPTION
## Summary

Two compounding SSR bugs were causing pods to leak ~30Mi/h, throttle CPU at 1500m/limit, and fail liveness probes — repeating the May 17 incident on a slower curve.

### Bug 1 — Sui dapp-kit re-instantiated per SSR request

Our `SuiProvider` returned `<>{children}</>` on the server, so no `DAppKitContext` was established. `@lifi/widget-provider-sui` then fell through to its own `SuiBaseProvider`, which calls `createDAppKit` in the render body — allocating a fresh `SuiGrpcClient` and nanostores graph **per SSR request**, never released.

The Slush wallet's default `getDefaultAppName()` reads `document.title` inside `registerAdditionalWallets`, so each SSR request also threw `ReferenceError: document is not defined` (~10/min/pod, ~9,600 retained errors over 16h) and held onto the error context (cookies, headers).

**Fix**: create the dapp-kit instance once at module level with an explicit `appName`, so:
- one `createDAppKit` per Node.js process / browser tab
- the `document.title` fallback is never reached
- `DAppKitContext` is provided on SSR, bypassing `SuiBaseProvider`
- Slush still works on the client (we don't disable it)

### Bug 2 — Authenticated Solana RPCs called from SSR

`NEXT_PUBLIC_CUSTOM_RPCS` contains paid Helius and QuikNode endpoints. When the LiFi SDK initialized on the server (`preloadChains: true`), it warmed up these endpoints from the small set of pod IPs. Because Helius rebate links share a per-rebate-address quota across callers, any synchronized burst (fleet restart, deploy) blew the quota and triggered a tight 429 retry loop — burning CPU and amplifying the leak with retained error/cookie payloads.

**Fix**: introduce `getCustomRPCs()` in `src/const/rpcList.ts` that filters `BROWSER_ONLY_RPC_HOSTS` (`helius-rpc.com`, `quiknode.pro`) when `typeof window === 'undefined'`. All four SSR call sites now use the helper:
- `lifiSdkConfig.ts` — LiFi SDK client init
- `useSharedConfigs.ts` — widget RPC config
- `SVMProvider.tsx` — `@solana/react-hooks` provider
- `getShuffledRPCForChain.ts` — via `getMergedRPCList()`

Browsers continue to see the full RPC list and spend the paid quota on real user traffic.

## Why this was missed in the May 18 patch

The May 18 SuiProvider fix moved `createDAppKit` into `useEffect` to skip SSR — which correctly stopped *our* provider from running on the server, but inadvertently caused `@lifi/widget-provider-sui`'s `SuiWidgetProvider` to fall through to `SuiBaseProvider` (`useInSuiContext()` returns false without our context) — and that internal fallback still calls `createDAppKit` in the render body. Net effect: the leak moved one stack frame deeper instead of going away.

## Verification

Smoke tested in pure Node.js (no `document`/`window`):
- `createDAppKit({ slushWalletConfig: { appName: 'Jumper' } })` succeeds and returns a working dapp-kit
- `getCustomRPCs()` returns only public Infura on SSR; returns the full list (Helius + QuikNode) on the client
- TypeScript and ESLint clean for the 6 changed files

## Test plan

- [ ] Deploy to staging, observe pod logs for **zero** `Skipping wallet initializer: "ReferenceError: document is not defined"` (was ~10/min/pod)
- [ ] Observe pod logs for **zero** `cluster warmup failed` / Helius 429 errors (was ~20/min/pod)
- [ ] Watch Prometheus `avg(container_memory_working_set_bytes{namespace="jumper-exchange",container="jumper-exchange"})/1024/1024` — expect flat trend (was +30 Mi/h)
- [ ] Smoke test Sui wallet connection via Slush in the browser to confirm no regression
- [ ] Smoke test Solana wallet connection in the browser to confirm Helius+QuikNode are still used client-side

## Follow-ups (not in this PR)

- Pod fleet still has restarts pending from the previous incident; after deploy, do one rolling restart of `jumper-exchange-prod-europe-west4` to seed the fleet on the patched image
- Consider lowering CPU limit back from `1500m` to `750m` once memory growth is confirmed flat
- The `useMainWidgetConfig.ts` `_tokens.allow = ...` mutation (separate, smaller leak on memecoins-variant pages) — fix in a follow-up PR

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved custom RPC URL error handling with graceful fallback mechanisms when parsing fails.
  * Enhanced RPC endpoint filtering to properly support server-side rendering with provider-specific allowlisting.

* **Improvements**
  * Optimized Sui provider initialization for faster load times and improved overall user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jumperexchange/jumper-exchange/pull/2866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->