### PR TITLE
fix: block Triton (rpcpool.com) Solana RPC on SSR

### DIFF
--- a/src/const/rpcList.ts
+++ b/src/const/rpcList.ts
@@ -53,6 +53,11 @@ const BROWSER_ONLY_RPC_HOSTS = [
   // QuikNode endpoints are authenticated/paid; we don't want SSR pods
   // burning the request budget on cluster-warmup pings.
   'quiknode.pro',
+  // Triton One (rpcpool.com) hosts our private LiFi Solana RPC, which is
+  // origin/IP-restricted and returns 403 when called from pod IPs. This is
+  // what surfaces as `[react-core] cluster warmup failed ... 'Forbidden'`
+  // on SSR after Helius/QuikNode are filtered out.
+  'rpcpool.com',
 ];
 
 function isBrowserOnlyRpc(url: string): boolean {


### PR DESCRIPTION
## Summary

Follow-up to #2866. After that PR shipped to staging, the `Skipping wallet initializer` Sui error stopped firing (good), but the Solana cluster warmup is still failing on SSR — this time against `lifi-mainc49-4c2b.mainnet.rpcpool.com` which 403s from the pod IPs:

```
[react-core] cluster warmup failed {
  endpoint: 'https://lifi-mainc49-4c2b.mainnet.rpcpool.com/',
  ... statusCode: 403, message: 'Forbidden' ...
}
```

The reason is that the Solana entry in `NEXT_PUBLIC_CUSTOM_RPCS` on staging actually contains **three** private endpoints, and the previous filter only matched two of them:

```jsonc
"1151111081099710": [
  "https://lifi-mainc49-4c2b.mainnet.rpcpool.com/",                 // Triton — NOT filtered before
  "https://dacey-pp61jd-fast-mainnet.helius-rpc.com/?rebate-...",   // Helius — filtered
  "https://practical-side-snow.solana-mainnet.quiknode.pro/..."     // QuikNode — filtered
]
```

Triton (`rpcpool.com`) is origin/IP-restricted to browser traffic, so SSR pods fall straight through to it once the other two are stripped and get a 403, which retries and adds back exactly the kind of pressure #2866 was meant to remove.

This patch adds `rpcpool.com` to `BROWSER_ONLY_RPC_HOSTS` in `src/const/rpcList.ts`. With it:

- **SSR**: Solana entry in `getCustomRPCs()` is dropped entirely. The SDK falls back to the public RPCs returned by the LiFi `/v1/chains` API (`api.mainnet-beta.solana.com`, `solana-rpc.publicnode.com`), which work fine for the lightweight calls the SSR path needs.
- **Browser**: unchanged — all three private endpoints stay in rotation, where the per-origin quota is spread across millions of user IPs.

## Test plan

- [x] Verified locally with the actual staging `NEXT_PUBLIC_CUSTOM_RPCS` value: SSR map drops `1151111081099710` entirely; browser map keeps all 3 endpoints.
- [ ] Deploy to staging, watch logs for `[react-core] cluster warmup failed` — expected to drop to zero.
- [ ] Confirm Solana wallet connection / quote / route still works in browser.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Solana RPC host configuration to ensure proper server-side behavior and prevent potential compatibility issues during server-side rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jumperexchange/jumper-exchange/pull/2869?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->