### PR TITLE
fix: skip Solana cluster warmup entirely on SSR

### DIFF
--- a/src/providers/WalletProvider/SVMProvider.tsx
+++ b/src/providers/WalletProvider/SVMProvider.tsx
@@ -10,10 +10,11 @@ import {
   useMemo,
   useRef,
 } from 'react';
-import type { SolanaClientConfig } from '@solana/client';
+import type { SolanaClient, SolanaClientConfig } from '@solana/client';
 import envConfig from '@/config/env-config';
 import { getCustomRPCs } from '@/const/rpcList';
 import { useHydrated } from '@/hooks/useHydrated';
+import { createSsrSolanaClient } from './ssrSolanaClient';
 
 const SOLANA_CHAIN_ID = '1151111081099710';
 
@@ -56,6 +57,13 @@ const SolanaWalletSync: FC<PropsWithChildren> = ({ children }) => {
   return children;
 };
 
+// Pre-hydration stub client built once per process. Satisfies the
+// `<SolanaProvider client={...}>` contract without calling `createClient(...)`,
+// which is what triggers the `getLatestBlockhash` cluster warmup against
+// rate-limited / IP-restricted Solana RPCs from the pod fleet on every SSR
+// render. See `./ssrSolanaClient.ts` for the rationale.
+const ssrSolanaClient: SolanaClient = createSsrSolanaClient();
+
 export const SVMProvider: FC<PropsWithChildren> = ({ children }) => {
   const isHydrated = useHydrated();
   const solanaConfig = useMemo<SolanaClientConfig>(() => {
@@ -66,9 +74,18 @@ export const SVMProvider: FC<PropsWithChildren> = ({ children }) => {
     };
   }, []);
 
+  // Provide a no-warmup stub on SSR + the first client render (so hydration
+  // matches), then swap to a real config-driven client once hydrated. The
+  // `<SolanaProvider>` wrapper is kept identical across both paths so children
+  // do NOT unmount when the underlying client is replaced — only the
+  // `SolanaClientContext` value changes, which is exactly what we want.
+  const providerProps = isHydrated
+    ? { config: solanaConfig }
+    : { client: ssrSolanaClient };
+
   return (
     <SolanaProvider
-      config={solanaConfig}
+      {...providerProps}
       walletPersistence={{
         autoConnect: isHydrated,
         storageKey: 'jumper-solana',

--- a/src/providers/WalletProvider/SVMProvider.tsx
+++ b/src/providers/WalletProvider/SVMProvider.tsx
@@ -79,18 +79,28 @@ export const SVMProvider: FC<PropsWithChildren> = ({ children }) => {
   // `<SolanaProvider>` wrapper is kept identical across both paths so children
   // do NOT unmount when the underlying client is replaced — only the
   // `SolanaClientContext` value changes, which is exactly what we want.
+  //
+  // `walletPersistence` is also gated on `isHydrated`. Pre-hydration we pass
+  // `false`, which fully short-circuits `<SolanaProvider>`'s persistence path:
+  // no `localStorage` read, no `<WalletPersistence>` child mounted, and no
+  // `subscribeSolanaState(...)` against the stub client (which has no actions
+  // wired up). Once hydrated we install the real persistence config, at which
+  // point auto-connect runs against the real client.
   const providerProps = isHydrated
-    ? { config: solanaConfig }
-    : { client: ssrSolanaClient };
+    ? {
+        config: solanaConfig,
+        walletPersistence: {
+          autoConnect: true,
+          storageKey: 'jumper-solana',
+        },
+      }
+    : {
+        client: ssrSolanaClient,
+        walletPersistence: false as const,
+      };
 
   return (
-    <SolanaProvider
-      {...providerProps}
-      walletPersistence={{
-        autoConnect: isHydrated,
-        storageKey: 'jumper-solana',
-      }}
-    >
+    <SolanaProvider {...providerProps}>
       <SolanaWalletSync>{children}</SolanaWalletSync>
     </SolanaProvider>
   );

--- a/src/providers/WalletProvider/ssrSolanaClient.ts
+++ b/src/providers/WalletProvider/ssrSolanaClient.ts
@@ -1,0 +1,73 @@
+import {
+  createClientStore,
+  createInitialClientState,
+  type SolanaClient,
+} from '@solana/client';
+
+/**
+ * Build a SolanaClient suitable for use during SSR / pre-hydration only.
+ *
+ * We can't use the real `<SolanaProvider config={...}>` pathway on the server
+ * because internally it calls `createClient(config)` which immediately fires a
+ * `getLatestBlockhash` "cluster warmup" against the configured (or defaulted)
+ * Solana endpoint. Every public Solana RPC we have access to is either:
+ *
+ *   - an authenticated/paid endpoint (Helius, QuikNode) whose quota is meant
+ *     to be spent on real user traffic, or
+ *   - a Triton-backed endpoint (`*.rpcpool.com`, `api.mainnet-beta.solana.com`,
+ *     even `solana-rpc.publicnode.com` ultimately) that 403s or 429s when hit
+ *     from the small set of pod fleet IPs.
+ *
+ * SSR doesn't actually need any of that — wallet connections, signing, quotes,
+ * route execution and every other Solana hook consumer in the app is
+ * conditionally rendered AFTER hydration. So on the server we install this
+ * lightweight stub via `<SolanaProvider client={ssrSolanaClient}>`, which
+ * skips the `createClient` warmup path entirely while still providing a real
+ * zustand store so `useWallet()` / `useWalletSession()` return a sensible
+ * "disconnected" state instead of throwing.
+ *
+ * Once `useHydrated()` flips to true, `<SVMProvider>` re-renders with
+ * `config={...}` instead of `client={...}`, and the real client is created
+ * inside the SolanaClientProvider with the full RPC + persistence behaviour.
+ * The JSX structure is unchanged across the swap, so children don't unmount.
+ */
+export function createSsrSolanaClient(): SolanaClient {
+  const store = createClientStore(
+    createInitialClientState({
+      commitment: 'confirmed',
+      // These URLs are never actually hit from the SSR path — the stub never
+      // calls `setCluster` or invokes `runtime.rpc`. They're only here to
+      // satisfy the initial client state shape.
+      endpoint: 'https://api.mainnet-beta.solana.com',
+      websocketEndpoint: 'wss://api.mainnet-beta.solana.com',
+    }),
+  );
+
+  const noopAsync = async () => undefined;
+  const noop = () => undefined;
+
+  // The fields below are never invoked on SSR. The handful of consumers that
+  // would dispatch wallet actions, hit `runtime.rpc`, or read helpers
+  // (`MissionVerifyWallet`, `GoldenRouteModal`, `ClaimPerkModal`) are all
+  // conditionally rendered only after the user reaches a state that requires
+  // a connected wallet — which only happens post-hydration. They're stubbed
+  // out purely to satisfy the structural `SolanaClient` type.
+  return {
+    store,
+    actions: {
+      setCluster: noopAsync,
+      connectWallet: noopAsync,
+      disconnectWallet: noopAsync,
+    },
+    config: {},
+    connectors: { all: () => [], byId: () => undefined },
+    destroy: noop,
+    helpers: {},
+    runtime: {},
+    solTransfer: {},
+    stake: {},
+    transaction: {},
+    splToken: {},
+    wsol: {},
+  } as unknown as SolanaClient;
+}


### PR DESCRIPTION
## Summary

Follow-up to #2866 and #2869. After both shipped, the `Skipping wallet initializer` Sui error is gone, but staging logs still show:

```
[react-core] cluster warmup failed { endpoint: 'https://lifi-mainc49-4c2b.mainnet.rpcpool.com/', ... 'Forbidden', statusCode: 403 }
```

Reality check on Solana RPCs from pod-fleet IPs:

| Endpoint | Owner | From pod IPs |
|---|---|---|
| `*.helius-rpc.com` | Helius | 429 (paid quota) |
| `*.solana-mainnet.quiknode.pro` | QuikNode | 429 (paid quota) |
| `lifi-mainc49-4c2b.mainnet.rpcpool.com` | Triton One (LiFi-owned) | 403 (origin/IP locked) |
| `api.mainnet-beta.solana.com` | proxied to `pit186.nodes.rpcpool.com` (Triton) | 403/429 |
| `solana-rpc.publicnode.com` | Allnodes | rate-limited from server IPs |

There is no Solana RPC we can warm up from SSR that won't either fail or burn quota the moment we have any traffic. The previous PRs were filtering provider-by-provider in `NEXT_PUBLIC_CUSTOM_RPCS`, but the `<SolanaProvider config={...}>` mount path inside `@solana/react-hooks` calls `createClient(...)` on every SSR render, which unconditionally fires a `getLatestBlockhash` cluster warmup against *whichever* endpoint survives filtering.

## What this changes

`SVMProvider` now provides a tiny stub Solana client via `<SolanaProvider client={...}>` on SSR + first client render, and only swaps to the `config={...}` (real-client) path once `useHydrated()` flips. Mechanism:

- `<SolanaProvider>` short-circuits `createClient(...)` when a `client` prop is provided, so passing the stub means **no `getLatestBlockhash` is ever issued from a server pod**.
- The stub still ships a real `createClientStore(createInitialClientState({...}))` zustand store seeded with `wallet: { status: 'disconnected' }`, so any SSR-rendered consumer of `useWallet()` / `useWalletSession()` gets a sane disconnected state instead of a context-missing throw.
- The outer `<SolanaProvider>` JSX is **identical** across the SSR-stub and post-hydration paths — only the `client` vs `config` prop swaps. So when the client is replaced after hydration, only the `SolanaClientContext` value changes; children (i.e. the entire wallet provider tree below `SVMProvider`) do **not** unmount.
- `walletPersistence.autoConnect` stays gated on `isHydrated`, so no reconnect attempt fires before the real client exists.

## Files

- `src/providers/WalletProvider/ssrSolanaClient.ts` — new helper that builds the SSR-only stub client.
- `src/providers/WalletProvider/SVMProvider.tsx` — switches between `client={ssrStub}` and `config={real}` based on `useHydrated()`.

## Test plan

- [x] `pnpm typecheck` passes (clean run, no errors).
- [ ] Deploy to staging. `[react-core] cluster warmup failed` warnings should drop to **zero**.
- [ ] Confirm Solana wallet connect / disconnect / sign-message still works in browser.
- [ ] Confirm a connected Solana wallet survives a page reload (autoConnect path is exercised post-hydration).
- [ ] Spot-check the SSR-rendered `MissionVerifyWallet`, `GoldenRouteModal`, and `ClaimPerkModal` paths don't crash on initial render.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SSR-safe Solana wallet support that keeps the wallet provider mounted across SSR→hydration, enabling a seamless client swap without remounting.
  * Introduced an SSR stub client so the app presents a disconnected-style wallet state on the server and then transitions to full wallet persistence and auto-connect after hydration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jumperexchange/jumper-exchange/pull/2871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->