### PR TITLE
fix: drop entire Solana chain from SSR RPC map

### DIFF
--- a/src/const/rpcList.ts
+++ b/src/const/rpcList.ts
@@ -34,46 +34,29 @@ export const publicRPCList = {
 };
 
 /**
- * RPC providers that must NOT be used during SSR.
+ * Chain IDs whose RPC endpoints are NEVER used from server-side code.
  *
- * These are authenticated, paid endpoints whose quotas are intended to be
- * spent on real user traffic from the browser. Because all SSR traffic exits
- * through a small number of pod IPs, any synchronized burst (e.g. fleet
- * restart, deploy, traffic spike) bunches up on the same source IP and either
- * blows the per-origin quota (triggering tight retry loops that burn CPU and
- * memory) or wastes paid request budget on cluster-warmup pings.
- *
- * On the browser, requests are spread across millions of user IPs, so the
- * per-origin limit is never an issue and the spend goes to actual users.
+ * Any host-by-host blocklist for Solana ends up listing every Solana RPC in
+ * existence: Helius / QuikNode are authenticated paid endpoints that 429,
+ * `*.rpcpool.com` (Triton One — including LiFi's `lifi-mainc49-4c2b.*`) is
+ * origin/IP-locked and 403s, `api.mainnet-beta.solana.com` is itself a
+ * Triton proxy, and even `solana-rpc.publicnode.com` rate-limits server IPs.
+ * In practice nothing rendered on the server actually needs Solana RPC —
+ * wallet UI, balance reads, quote previews, and route execution all run
+ * after hydration. So instead of chasing providers, we drop the entire
+ * Solana chain from the SSR RPC map and leave the browser path untouched.
  */
-const BROWSER_ONLY_RPC_HOSTS = [
-  // Helius rebate endpoints share a per-rebate-address quota across all
-  // callers. SSR concentrates this onto the pod fleet IPs and hits 429.
-  'helius-rpc.com',
-  // QuikNode endpoints are authenticated/paid; we don't want SSR pods
-  // burning the request budget on cluster-warmup pings.
-  'quiknode.pro',
-  // Triton One (rpcpool.com) hosts our private LiFi Solana RPC, which is
-  // origin/IP-restricted and returns 403 when called from pod IPs. This is
-  // what surfaces as `[react-core] cluster warmup failed ... 'Forbidden'`
-  // on SSR after Helius/QuikNode are filtered out.
-  'rpcpool.com',
-];
-
-function isBrowserOnlyRpc(url: string): boolean {
-  try {
-    const host = new URL(url).hostname;
-    return BROWSER_ONLY_RPC_HOSTS.some((needle) => host.includes(needle));
-  } catch {
-    return false;
-  }
-}
+const BROWSER_ONLY_CHAIN_IDS: ReadonlySet<string> = new Set([
+  // Solana mainnet
+  '1151111081099710',
+]);
 
 type RpcMap = Record<string, string[]>;
 
 /**
- * Returns the parsed `NEXT_PUBLIC_CUSTOM_RPCS` map, with browser-only
- * endpoints stripped on the server. On the client it is returned unchanged.
+ * Returns the parsed `NEXT_PUBLIC_CUSTOM_RPCS` map, with chains whose RPCs
+ * must not be exercised from server-side code stripped on SSR. On the
+ * browser it is returned unchanged.
  *
  * Use this everywhere that a component or SDK initializer might run on SSR
  * (LiFi SDK init, widget config, Solana provider, etc.) instead of inlining
@@ -93,12 +76,11 @@ export function getCustomRPCs(): RpcMap {
 
   const filtered: RpcMap = {};
   for (const [chainId, urls] of Object.entries(parsed)) {
-    if (!Array.isArray(urls)) {
+    if (BROWSER_ONLY_CHAIN_IDS.has(chainId)) {
       continue;
     }
-    const safe = urls.filter((url) => !isBrowserOnlyRpc(url));
-    if (safe.length > 0) {
-      filtered[chainId] = safe;
+    if (Array.isArray(urls) && urls.length > 0) {
+      filtered[chainId] = urls;
     }
   }
   return filtered;


### PR DESCRIPTION
## Summary

Replaces the host-by-host `BROWSER_ONLY_RPC_HOSTS` blocklist introduced in #2866 / extended in #2869 (Helius, QuikNode, rpcpool.com) with a chain-level gate:

```ts
const BROWSER_ONLY_CHAIN_IDS = new Set(['1151111081099710']); // Solana mainnet
```

The host-based filter was always going to lose this game. Every Solana RPC we have access to is unusable from server pod IPs:

| Endpoint | Owner | From pod IPs |
|---|---|---|
| `*.helius-rpc.com` | Helius | 429 |
| `*.solana-mainnet.quiknode.pro` | QuikNode | 429 |
| `*.rpcpool.com` | Triton One (incl. LiFi-owned `lifi-mainc49-4c2b.*`) | 403 |
| `api.mainnet-beta.solana.com` | proxied to `pit186.nodes.rpcpool.com` (Triton) | 403/429 |
| `solana-rpc.publicnode.com` | Allnodes | rate-limited |

And nothing rendered on the server actually needs Solana RPC — wallet UI, balance reads, quote previews and route execution all run after hydration. The right abstraction is "no Solana on SSR, period," not a moving list of provider hostnames.

## Behaviour

- **SSR**: `getCustomRPCs()` no longer contains the `1151111081099710` key at all. Anything downstream that asks for a Solana RPC list (`lifiSdkConfig`, `useSharedConfigs`, `SVMProvider`, `getShuffledRPCForChain`) gets nothing for Solana and falls back to the SDK / provider's own no-network handling.
- **Browser**: `getCustomRPCs()` is returned unchanged — all paid + public Solana endpoints stay in rotation, where the per-origin quota is spread across millions of user IPs.
- Other chains (`'10'`, `'42161'`, `'8453'`, `'56'`, `'59140'`, …) unaffected on both sides.

Future Solana RPC provider added to `NEXT_PUBLIC_CUSTOM_RPCS`? Automatically excluded from SSR with no further code change.

## Relationship to #2871

Complementary, not redundant:

- **This PR** stops *our application code* from passing Solana RPC URLs into the LiFi SDK / widget config / `getShuffledRPCForChain` on SSR.
- **#2871** stops `<SolanaProvider>` from calling `@solana/client`'s built-in `getLatestBlockhash` cluster warmup against its hardcoded default endpoint (which is also Triton-backed) on SSR.

Either alone leaves a hole; together they fully close the SSR-Solana loop.

## Test plan

- [x] Verified locally with the staging `NEXT_PUBLIC_CUSTOM_RPCS` value that contains 3 Solana endpoints (Triton, Helius, QuikNode): SSR returns the Solana key dropped entirely; browser returns all 3 unchanged.
- [x] `pnpm typecheck` clean.
- [ ] Deploy to staging; combined with #2871, verify zero `[react-core] cluster warmup failed` and zero outbound traffic to any `*.helius-rpc.com` / `*.quiknode.pro` / `*.rpcpool.com` / `api.mainnet-beta.solana.com` from pod IPs.
- [ ] Confirm Solana wallet connect / quote / sign / route execution all work in browser.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal RPC list filtering logic by switching from URL-based filtering to chain ID-based filtering. No changes to user-facing functionality or available RPC endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jumperexchange/jumper-exchange/pull/2872?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->