### PR TITLE
fix: update jumper-backend types for earn call-data endpoints

### DIFF
--- a/src/components/composite/RequestRedeemModal/RequestRedeemModal.tsx
+++ b/src/components/composite/RequestRedeemModal/RequestRedeemModal.tsx
@@ -72,10 +72,10 @@ export const RequestRedeemModal: FC<RequestRedeemModalProps> = ({
         earnOpportunity.slug,
         {
           address: accountAddress as Hex,
-          amount: selectedClaim.assetAmount ?? '0',
         },
       );
 
+      // @ts-expect-error: see LF-15589 - we are transforming data in the backend
       return data.data;
     }
     const { data } = await client.v1.earnControllerGetRequestRedeemCallDataV1(
@@ -83,14 +83,9 @@ export const RequestRedeemModal: FC<RequestRedeemModalProps> = ({
       { address: accountAddress as Hex, amount },
     );
 
+    // @ts-expect-error: see LF-15589 - we are transforming data in the backend
     return data.data;
-  }, [
-    isClaimFlow,
-    earnOpportunity.slug,
-    accountAddress,
-    selectedClaim,
-    amount,
-  ]);
+  }, [isClaimFlow, earnOpportunity.slug, accountAddress, amount]);
 
   const transactionForm = useTransactionForm({
     chainId: earnOpportunity.lpToken.chain.chainId,

--- a/src/types/jumper-backend.ts
+++ b/src/types/jumper-backend.ts
@@ -1047,23 +1047,28 @@ export interface FullRequestParams extends Omit<RequestInit, 'body'> {
   cancelToken?: CancelToken;
 }
 
-export type VaultSpecificData = Record<string, any> | null;
-
-export type VaultsFYICallDataResponse = {
-  currentActionIndex: number;
-  actions: VaultsFYICallDataActionResponse[];
-};
-
-export type VaultsFYICallDataActionResponse = {
-  name: string;
-  tx: WalletCall;
-};
-
-export interface WalletCall {
+export interface CallDataTxDto {
+  /** Address of the transaction recipient */
   to: Hex;
+  /** Hex-encoded calldata, 0x-prefixed */
   data: `0x${string}`;
+  /** Value (in wei) to send with the transaction */
   value?: string;
+  /** Chain ID of the transaction */
   chainId: number;
+}
+
+export interface CallDataActionDto {
+  /** Name of the action step */
+  name: string;
+  tx: CallDataTxDto;
+}
+
+export interface CallDataResponseDto {
+  /** Index of the current action in the actions array */
+  currentActionIndex: number;
+  /** Ordered list of transaction steps to execute */
+  actions: CallDataActionDto[];
 }
 
 export type RequestParams = Omit<
@@ -1451,8 +1456,8 @@ export class JumperBackend<
      *
      * @tags Earn, Public
      * @name earnControllerGetVaultSpecificDataV1
-     * @summary Get an earn opportunity by slug
-     * @request GET:/v1/earn/items/{slug}
+     * @summary Get the vault specific data for a user in a given earn opportunity
+     * @request GET:/v1/earn/items/{slug}/vault-specific-data
      */
     earnControllerGetVaultSpecificDataV1: (
       slug: string,
@@ -1461,7 +1466,7 @@ export class JumperBackend<
       },
       params: RequestParams = {},
     ) =>
-      this.request<VaultSpecificData, any>({
+      this.request<Record<string, any> | null, any>({
         path: `/v1/earn/items/${slug}/vault-specific-data`,
         method: 'GET',
         query: query,
@@ -1474,7 +1479,7 @@ export class JumperBackend<
      *
      * @tags Earn, Public
      * @name earnControllerGetRequestRedeemCallDataV1
-     * @summary Get an earn opportunity by slug
+     * @summary Get request-redeem calldata for an earn opportunity
      * @request GET:/v1/earn/items/{slug}/request-redeem/call-data
      */
     earnControllerGetRequestRedeemCallDataV1: (
@@ -1485,7 +1490,7 @@ export class JumperBackend<
       },
       params: RequestParams = {},
     ) =>
-      this.request<{ data: VaultsFYICallDataResponse }, any>({
+      this.request<CallDataResponseDto, any>({
         path: `/v1/earn/items/${slug}/request-redeem/call-data`,
         method: 'GET',
         query: query,
@@ -1498,18 +1503,17 @@ export class JumperBackend<
      *
      * @tags Earn, Public
      * @name earnControllerGetClaimRedeemCalldataV1
-     * @summary Get an earn opportunity by slug
+     * @summary Get claim-redeem calldata for an earn opportunity
      * @request GET:/v1/earn/items/{slug}/claim-redeem/call-data
      */
     earnControllerGetClaimRedeemCalldataV1: (
       slug: string,
       query?: {
         address: Hex;
-        amount: string;
       },
       params: RequestParams = {},
     ) =>
-      this.request<{ data: VaultsFYICallDataResponse }, any>({
+      this.request<CallDataResponseDto, any>({
         path: `/v1/earn/items/${slug}/claim-redeem/call-data`,
         method: 'GET',
         query: query,


### PR DESCRIPTION
## Summary

- Replace the hand-crafted `VaultsFYICallDataResponse` / `VaultSpecificData` / `WalletCall` ambient types with proper DTO interfaces (`CallDataTxDto`, `CallDataActionDto`, `CallDataResponseDto`) that mirror the backend Swagger output
- `earnControllerGetVaultSpecificDataV1` now returns `Record<string,any>|null` (the upstream API exposes ~17 protocol-specific shapes with no discriminator)
- `earnControllerGetRequestRedeemCallDataV1` and `earnControllerGetClaimRedeemCalldataV1` now return `CallDataResponseDto` directly
- `earnControllerGetClaimRedeemCalldataV1` query no longer carries `amount` (the backend `ClaimRedeemCalldataQueryDto` only has `address`)
- `RequestRedeemModal`: return response body directly instead of `.data`; drop `amount` from the claim-redeem call; tidy up `useCallback` deps

## Sister PR

jumperexchange/jumper-backend#841

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Claim flow now sends only the wallet address for claim requests (no claim amount included).
  * Client call logic updated to remove now-unused claim selection dependency.
  * Backend calldata responses consolidated to a unified response shape for request and claim redeem endpoints; vault-specific calldata type removed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jumperexchange/jumper-exchange/pull/2873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->