### PR TITLE
feat: remove deprecated rewardsApy from frontend types - JUM-989

### DIFF
--- a/src/types/jumper-backend.ts
+++ b/src/types/jumper-backend.ts
@@ -915,8 +915,6 @@ export interface EarnOpportunityWithLatestAnalytics {
   lockupDays?: number | null;
   /** The cap in dollar */
   capInDollar?: string;
-  /** @deprecated */
-  rewardsApy?: number;
   forYou: boolean;
   interactionFlags: EarnInteractionFlags;
   rewardApiLinks?: RewardApiLink[];
@@ -1333,8 +1331,6 @@ export interface EarnOpportunityWithScore {
   lockupDays?: number | null;
   /** The cap in dollar */
   capInDollar?: string;
-  /** @deprecated */
-  rewardsApy?: number;
   forYou: boolean;
   interactionFlags: EarnInteractionFlags;
   rewardApiLinks?: RewardApiLink[];


### PR DESCRIPTION
## Summary

Drop the deprecated `rewardsApy?: number` field from both `EarnOpportunityWithLatestAnalytics` and `EarnOpportunityWithScore` interfaces in the auto-generated `jumper-backend.ts` types. This mirrors the backend change (JUM-989) that stops exposing the field on the public earn API. No runtime UI code reads this field — `useFormatDisplayEarnOpportunityData` and `filterOpportunities` both read `latest.apy.jumperReward` instead.

## Changes

- `src/types/jumper-backend.ts` — remove `/** @deprecated */ rewardsApy?: number;` from two interfaces

## Linked Linear ticket

JUM-989

## Sister PRs

- jumperexchange/jumper-backend: https://github.com/jumperexchange/jumper-backend/pull/898

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Earn opportunity listings now include a lock-up period (months) and a dollar cap value.
* **Changes**
  * Removed the deprecated rewards APY field from earn opportunity data to reduce confusion and reflect updated API fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->