### PR TITLE
fix: refetch earn opportunity latest on mount - JUM-775

### DIFF
--- a/src/components/EarnDetails/EarnDetailsIntro.tsx
+++ b/src/components/EarnDetails/EarnDetailsIntro.tsx
@@ -16,6 +16,7 @@ import { EarnDetailsActions } from './EarnDetailsActions';
 import { formatDistance } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 import { useZapEarnOpportunitySlugStorage } from '@/providers/hooks';
+import { useEarnOpportunityBySlug } from '@/hooks/earn/useEarnOpportunityBySlug';
 
 interface EarnDetailsIntroProps {
   data: EarnOpportunityWithLatestAnalytics;
@@ -29,15 +30,20 @@ export const EarnDetailsIntro: FC<EarnDetailsIntroProps> = ({
   useZapEarnOpportunitySlugStorage(data.slug);
   const { t } = useTranslation();
   const isMobile = useMediaQuery((theme) => theme.breakpoints.down('md'));
+  // The SSR/ISR snapshot can be served stale by the CDN (JUM-775), so the
+  // prop-level `data.latest.date` may be days old. Prefer the live refetch
+  // for the "Updated at" badge; fall back to the SSR value for first paint.
+  const { data: liveData } = useEarnOpportunityBySlug(data.slug);
+  const liveLatestDate = liveData?.latest?.date ?? data.latest?.date;
   const updateBadgeLabel = useMemo(() => {
-    if (!data.latest.date) {
+    if (!liveLatestDate) {
       return '';
     }
 
     const now = Date.now();
-    const distance = formatDistance(data.latest.date, now);
+    const distance = formatDistance(liveLatestDate, now);
     return t('earn.overview.updated', { time: distance });
-  }, [data.latest.date, t]);
+  }, [liveLatestDate, t]);
 
   return (
     <EarnDetailsRowFlexContainer>

--- a/src/hooks/earn/useEarnOpportunityBySlug.ts
+++ b/src/hooks/earn/useEarnOpportunityBySlug.ts
@@ -8,6 +8,12 @@ export const useEarnOpportunityBySlug = (slug: string) => {
       const result = await getOpportunityBySlug(slug);
       return result.data;
     },
-    enabled: false,
+    // The page renders via SSR/ISR with `revalidate = 300`, which means a CDN
+    // edge may serve a multi-day-old HTML snapshot with a stale `latest.date`
+    // baked in (JUM-775). Refetch on mount so time-sensitive fields are always
+    // pulled live regardless of the served HTML's age.
+    enabled: Boolean(slug),
+    refetchOnMount: 'always',
+    staleTime: 0,
   });
 };


### PR DESCRIPTION
## Summary

The earn detail page renders via SSR/ISR with `revalidate = 300`, so Next.js emits
`Cache-Control: s-maxage=300, stale-while-revalidate=31535700` (~365 day SWR
window). Cloudflare honours the SWR window and serves cold edges multi-day-old
HTML with a stale `latest.date` baked in. The "Updated at" badge is computed
client-side from that frozen value and `useEarnOpportunityBySlug` was
`enabled: false`, so refreshes flip between fresh edges ("Updated 1 day ago")
and cold edges ("Updated 3 days ago"). This PR makes the badge always reflect
the live API by enabling the existing hook and reading its result, while
keeping the SSR prop as the first-paint fallback so the badge isn't blank
during the in-flight request.

## Changes

- `src/hooks/earn/useEarnOpportunityBySlug.ts` — flip `enabled: false` →
  `enabled: Boolean(slug)`, add `refetchOnMount: 'always'` and `staleTime: 0`.
- `src/components/EarnDetails/EarnDetailsIntro.tsx` — call the hook with
  `data.slug` and prefer `liveData?.latest?.date ?? data.latest?.date` for
  the `formatDistance` call that feeds the badge.

## Linked Linear ticket

[JUM-775 — Opportunity "Updated at" is stuck](https://linear.app/lifi-linear/issue/JUM-775/opportunity-updated-at-is-stuck)

## Sister PRs

N/A — backend-only follow-ups (silent stale fallback in
`AnalyticsService.getLatestAnalytics`, IntervalCache failed-interval hot-loop
on intrinsic vaults, Pino `{ error }` serialization) are tracked separately
as architectural debt; they don't cause the user-visible "3 days" symptom but
keep the upstream from drifting more than ~24h.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Updated at" timestamp now refreshes with the latest available data on each visit, ensuring users view current information instead of potentially stale cached values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jumperexchange/jumper-exchange/pull/2876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->