### PR TITLE
feat: enable request redeem flow on all environments - JUM-627

### DIFF
--- a/src/components/EarnDetails/EarnDetailsActions.tsx
+++ b/src/components/EarnDetails/EarnDetailsActions.tsx
@@ -30,7 +30,6 @@ import { Variant as IconButtonVariant } from '@/components/core/buttons/types';
 import CheckIcon from '@mui/icons-material/Check';
 import ScheduleIcon from '@mui/icons-material/Schedule';
 import { useChainTypeData } from '@/hooks/chains/useChainTypeData';
-import { isProduction } from '@/utils/isProduction';
 
 interface EarnDetailsActionsProps {
   earnOpportunity: EarnOpportunityExtended;
@@ -199,7 +198,7 @@ export const EarnDetailsActions = ({
             sx={{ flex: 1 }}
           />
         )}
-        {hasDeposited && !earnOpportunity.isRedeemable && !isProduction && (
+        {hasDeposited && !earnOpportunity.isRedeemable && (
           <RequestRedeemFlowButton
             earnOpportunity={earnOpportunity}
             size="large"
@@ -246,7 +245,7 @@ export const EarnDetailsActions = ({
         <Typography variant="bodyXSmall" color="textSecondary">
           {t('earn.position.label')}
         </Typography>
-        {!isProduction && claimRedeemButton}
+        {claimRedeemButton}
       </EarnDetailsActionsHeaderContainer>
       <EarnDetailsActionsPosition
         token={earnOpportunity.lpToken}


### PR DESCRIPTION
:bomb: do not merge until https://linear.app/lifi-linear/issue/JUM-715/claim-success-screen-shows-dollar0-instead-of-actual-claimed-amount is fixed

## Summary

- Removes `isProduction` guards from `EarnDetailsActions` that were blocking the request redeem flow in production
- Users with deposits in non-redeemable vaults (e.g. Lido stETH, Ethena sUSDe) can now see the Withdraw button on all environments
- The claim redeem icon buttons (check / clock) in the earn position header are now also visible on all environments

Closes [JUM-627](https://linear.app/lifi-linear/issue/JUM-627/request-redeem-remove-production-feature-flag)

## Changes

`src/components/EarnDetails/EarnDetailsActions.tsx`
- Remove `isProduction` import
- Remove `&& !isProduction` condition on `RequestRedeemFlowButton`
- Remove `!isProduction &&` guard on `claimRedeemButton`

## Test plan

For each environment (develop, staging, production):

- [ ] Visit a non-redeemable earn opportunity (e.g. Lido stETH, Ethena sUSDe) - https://develop.jumper.exchange/fr/earn/covered-smokehouse-usdc-on-mainnet
- [ ] Connect a wallet with an existing deposit
- [ ] Verify the "Withdraw" button appears
- [ ] Verify claim redeem icons (check/clock) appear in the header when there are pending/accepted claims
- [ ] Verify the request redeem modal opens and functions correctly

---


[JUM-627]: https://lifi.atlassian.net/browse/JUM-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redeem controls are now visible to all users: the "request redeem" footer appears when you have deposited and the opportunity isn't redeemable, and the claim/redeem action remains visible in the header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->