### PR TITLE
fix: Strapi v5 media URLs and feature-card documentId filter

### DIFF
--- a/src/app/[lng]/(infos)/learn/[slug]/page.tsx
+++ b/src/app/[lng]/(infos)/learn/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { sliceStrToXChar } from '@/utils/splitStringToXChar';
 import { learnSlugSchema } from '@/utils/validation-schemas';
 import type { Metadata } from 'next';
 import { notFound, permanentRedirect } from 'next/navigation';
-import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
+import { resolveStrapiMediaUrl } from 'src/utils/strapi/strapiHelper';
 import { getArticleBySlug } from '../../../../lib/getArticleBySlug';
 import { getArticlesByTag } from '../../../../lib/getArticlesByTag';
 
@@ -20,9 +20,8 @@ const FALLBACK_METADATA: Metadata = {
 
 function getStrapiImageUrl(
   image: StrapiMediaData | undefined,
-  baseUrl: string,
 ): string | undefined {
-  return image?.url ? `${baseUrl}${image.url}` : undefined;
+  return resolveStrapiMediaUrl(image?.url);
 }
 
 function getPageTitle(title: string) {
@@ -71,11 +70,10 @@ export async function generateMetadata({
   const seo = articleData.seo;
 
   const pageUrl = `${getSiteUrl()}/learn/${validatedSlug}`;
-  const baseUrl = getStrapiBaseUrl();
 
   const ogImage =
     seo?.openGraph?.ogImage ?? seo?.metaImage ?? articleData.Image;
-  const ogImageUrl = getStrapiImageUrl(ogImage, baseUrl);
+  const ogImageUrl = getStrapiImageUrl(ogImage);
 
   const title = getPageTitle(
     seo?.metaTitle ?? sliceStrToXChar(articleData.Title, 45),

--- a/src/app/[lng]/missions/[slug]/page.tsx
+++ b/src/app/[lng]/missions/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { getQuestBySlug } from 'src/app/lib/getQuestBySlug';
 import { getQuestsWithNoCampaignAttached } from 'src/app/lib/getQuestsWithNoCampaignAttached';
 import { siteName } from 'src/app/lib/metadata';
 import { sliceStrToXChar } from 'src/utils/splitStringToXChar';
-import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
+import { resolveStrapiMediaUrl } from 'src/utils/strapi/strapiHelper';
 import { questSlugSchema } from 'src/utils/validation-schemas';
 import { AppPaths, getSiteUrl } from 'src/const/urls';
 import { MissionPageSkeleton } from 'src/app/ui/mission/MissionPageSkeleton';
@@ -81,7 +81,7 @@ export async function generateMetadata({
     }
 
     const missionData = mission.data;
-    const baseUrl = getStrapiBaseUrl();
+    const imageUrl = resolveStrapiMediaUrl(missionData.Image?.url);
 
     const pageUrl = `${getSiteUrl()}${AppPaths.Missions}/${slug}`;
 
@@ -90,14 +90,16 @@ export async function generateMetadata({
       description: `${sliceStrToXChar(missionData.Information || 'Mission description', 60)}`,
       siteName: siteName,
       url: pageUrl,
-      images: [
-        {
-          url: `${baseUrl}${missionData.Image?.url}`,
-          width: 900,
-          height: 450,
-          alt: 'banner image',
-        },
-      ],
+      images: imageUrl
+        ? [
+            {
+              url: imageUrl,
+              width: 900,
+              height: 450,
+              alt: 'banner image',
+            },
+          ]
+        : undefined,
       type: 'article',
     };
 

--- a/src/app/[lng]/zap/[slug]/page.tsx
+++ b/src/app/[lng]/zap/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { siteName } from 'src/app/lib/metadata';
 import ZapPage from 'src/app/ui/zap/ZapPage';
 import { getSiteUrl } from 'src/const/urls';
 import { sliceStrToXChar } from 'src/utils/splitStringToXChar';
-import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
+import { resolveStrapiMediaUrl } from 'src/utils/strapi/strapiHelper';
 
 type Params = Promise<{ slug: string }>;
 
@@ -23,20 +23,22 @@ export async function generateMetadata({
     if (!quest || !questData) {
       throw new Error();
     }
-    const baseUrl = getStrapiBaseUrl();
+    const imageUrl = resolveStrapiMediaUrl(questData.Image?.url);
     const openGraph: Metadata['openGraph'] = {
       title: `Jumper | Zaps - ${sliceStrToXChar(questData.Title, 45)}`,
       description: `${sliceStrToXChar(questData.Information || 'Zap description', 60)}`,
       siteName: siteName,
       url: `${getSiteUrl()}/zap/${slug}`,
-      images: [
-        {
-          url: `${baseUrl}${questData.Image?.url}`,
-          width: 900,
-          height: 450,
-          alt: 'banner image',
-        },
-      ],
+      images: imageUrl
+        ? [
+            {
+              url: imageUrl,
+              width: 900,
+              height: 450,
+              alt: 'banner image',
+            },
+          ]
+        : undefined,
       type: 'article',
     };
 

--- a/src/app/ui/learn/LearnPageSearchSection/LearnPageSearchArticleList.tsx
+++ b/src/app/ui/learn/LearnPageSearchSection/LearnPageSearchArticleList.tsx
@@ -4,14 +4,11 @@ import type { BlogArticleData } from '@/types/strapi';
 import Link from 'next/link';
 import type { FC } from 'react';
 import { LearnPageSearchArticleListShell } from './LearnPageSearchArticleListShell';
-import { getStrapiBaseUrl } from '@/utils/strapi/strapiHelper';
 
 interface LearnPageSearchArticleListProps {
   articles: BlogArticleData[];
   highlight?: string;
 }
-
-const baseUrl = getStrapiBaseUrl();
 
 export const LearnPageSearchArticleList: FC<
   LearnPageSearchArticleListProps
@@ -28,7 +25,6 @@ export const LearnPageSearchArticleList: FC<
         <BlogArticleCard
           variant="preview"
           data={article}
-          baseUrl={baseUrl}
           highlight={highlight}
         />
       </Link>

--- a/src/components/Blog/BlogArticle/BlogArticle.tsx
+++ b/src/components/Blog/BlogArticle/BlogArticle.tsx
@@ -22,7 +22,7 @@ import {
 } from './BlogArticle.style';
 
 import type { BlogArticleData } from '@/types/strapi';
-import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
+import { resolveStrapiMediaUrl } from 'src/utils/strapi/strapiHelper';
 import { ShareArticleIcons } from './ShareArticleIcons';
 import { RichBlocks } from '@/components/RichBlocks/RichBlocks';
 import { RichBlocksVariant } from '@/components/RichBlocks/types';
@@ -79,7 +79,6 @@ export const BlogArticle = ({ article }: BlogArticleProps) => {
     faq_items,
     popup,
   } = article;
-  const baseUrl = getStrapiBaseUrl();
   const scrollHidesAppBar = useScrollTrigger(navbarHideOnScrollTriggerOptions);
   const { trackBlogArticleOpenPopupEvent } = useBlogArticleTracking();
 
@@ -205,7 +204,7 @@ export const BlogArticle = ({ article }: BlogArticleProps) => {
       <BlogArticleImageContainer>
         <WithSkeleton show={!!image} skeleton={<BlogArticleImageSkeleton />}>
           <BlogArticleImage
-            src={`${baseUrl}${image!.url}`}
+            src={resolveStrapiMediaUrl(image!.url)!}
             alt={image?.alternativeText ?? title}
             priority
             width={1200}

--- a/src/components/Blog/BlogArticle/BlogArticleAuthor.tsx
+++ b/src/components/Blog/BlogArticle/BlogArticleAuthor.tsx
@@ -3,7 +3,7 @@ import type { FC, PropsWithChildren } from 'react';
 import { BlogAuthorSocials } from './BlogAuthorSocials';
 import Typography from '@mui/material/Typography';
 import { BaseBlogArticleSkeleton, BlogAuthorAvatar } from './BlogArticle.style';
-import { getStrapiBaseUrl } from '@/utils/strapi/strapiHelper';
+import { resolveStrapiMediaUrl } from '@/utils/strapi/strapiHelper';
 import Box from '@mui/material/Box';
 import { WithSkeleton } from './WithSkeleton';
 
@@ -22,8 +22,6 @@ export const BlogArticleAuthor: FC<BlogArticleAuthorProps> = ({
   source,
   showRole = false,
 }) => {
-  const baseUrl = getStrapiBaseUrl();
-
   return (
     <Box sx={{ display: 'flex', flexDirection: 'row', gap: 3 }}>
       <WithSkeleton
@@ -39,7 +37,7 @@ export const BlogArticleAuthor: FC<BlogArticleAuthorProps> = ({
         <BlogAuthorAvatar
           width={avatarSize}
           height={avatarSize}
-          src={`${baseUrl}${author?.Avatar?.url}`}
+          src={resolveStrapiMediaUrl(author?.Avatar?.url)}
           alt={`${author?.Name || 'Author'}'s avatar`}
         />
       </WithSkeleton>

--- a/src/components/Blog/BlogArticle/BlogArticleAuthor.tsx
+++ b/src/components/Blog/BlogArticle/BlogArticleAuthor.tsx
@@ -37,7 +37,7 @@ export const BlogArticleAuthor: FC<BlogArticleAuthorProps> = ({
         <BlogAuthorAvatar
           width={avatarSize}
           height={avatarSize}
-          src={resolveStrapiMediaUrl(author?.Avatar?.url)}
+          src={resolveStrapiMediaUrl(author?.Avatar?.url) ?? ''}
           alt={`${author?.Name || 'Author'}'s avatar`}
         />
       </WithSkeleton>

--- a/src/components/Blog/BlogArticleCard/BlogArticleCard.tsx
+++ b/src/components/Blog/BlogArticleCard/BlogArticleCard.tsx
@@ -7,7 +7,7 @@ import type { SxProps, Theme } from '@mui/material/styles';
 import { Skeleton } from '@mui/material';
 import Link from 'next/link';
 import useClient from 'src/hooks/useClient';
-import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
+import { resolveStrapiMediaUrl } from 'src/utils/strapi/strapiHelper';
 import {
   BlogArticleCardContainer,
   BlogArticleCardContent,
@@ -30,7 +30,6 @@ export const BlogArticleCard = ({
   sx,
 }: BlogArticleCardProps) => {
   const { trackEvent } = useUserTracking();
-  const baseUrl = getStrapiBaseUrl();
   const { closeAllMenus } = useMenuStore((state) => state);
   const isClient = useClient();
   const handleClick = () => {
@@ -55,9 +54,11 @@ export const BlogArticleCard = ({
         onClick={handleClick}
         sx={sx}
       >
-        {article?.Image && baseUrl ? (
+        {article?.Image ? (
           <BlogArticleCardImage
-            src={`${baseUrl}${article?.Image?.formats.small.url || article?.Image?.url}`}
+            src={resolveStrapiMediaUrl(
+              article?.Image?.formats.small.url || article?.Image?.url,
+            )}
             alt={article?.Image?.alternativeText ?? article?.Title}
             // read the following to understand why width and height are set to 0, https://github.com/vercel/next.js/discussions/18474#discussioncomment-5501724
             width={0}

--- a/src/components/Blog/BlogArticleCard/BlogArticleCard.tsx
+++ b/src/components/Blog/BlogArticleCard/BlogArticleCard.tsx
@@ -56,9 +56,11 @@ export const BlogArticleCard = ({
       >
         {article?.Image ? (
           <BlogArticleCardImage
-            src={resolveStrapiMediaUrl(
-              article?.Image?.formats.small.url || article?.Image?.url,
-            )}
+            src={
+              resolveStrapiMediaUrl(
+                article?.Image?.formats.small.url || article?.Image?.url,
+              ) ?? ''
+            }
             alt={article?.Image?.alternativeText ?? article?.Title}
             // read the following to understand why width and height are set to 0, https://github.com/vercel/next.js/discussions/18474#discussioncomment-5501724
             width={0}

--- a/src/components/Blog/FeaturedArticle/FeaturedArticle.tsx
+++ b/src/components/Blog/FeaturedArticle/FeaturedArticle.tsx
@@ -11,7 +11,7 @@ import type { BlogArticleData } from '@/types/strapi';
 import RouterLink from 'next/link';
 import { JUMPER_LEARN_PATH } from 'src/const/urls';
 import useClient from 'src/hooks/useClient';
-import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
+import { resolveStrapiMediaUrl } from 'src/utils/strapi/strapiHelper';
 import {
   FeaturedArticleContent,
   FeaturedArticleDetails,
@@ -35,7 +35,6 @@ interface FeaturedArticleProps {
 export const FeaturedArticle = ({ featuredArticle }: FeaturedArticleProps) => {
   const { trackEvent } = useUserTracking();
   const isClient = useClient();
-  const baseUrl = getStrapiBaseUrl();
 
   const cardRef = useRef<HTMLAnchorElement>(null);
   const rawX = useMotionValue(0);
@@ -94,7 +93,12 @@ export const FeaturedArticle = ({ featuredArticle }: FeaturedArticleProps) => {
             height={0}
             sizes="100vw"
             priority
-            src={`${baseUrl}${featuredArticle?.Image?.formats?.medium.url || featuredArticle?.Image?.url}`}
+            src={
+              resolveStrapiMediaUrl(
+                featuredArticle?.Image?.formats?.medium.url ||
+                  featuredArticle?.Image?.url,
+              ) ?? ''
+            }
             alt={
               featuredArticle?.Image?.alternativeText ?? featuredArticle?.Title
             }

--- a/src/components/FeatureCards/hooks.ts
+++ b/src/components/FeatureCards/hooks.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
 import type { FeatureCardData } from '@/types/strapi';
-import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
+import { resolveStrapiMediaUrl } from 'src/utils/strapi/strapiHelper';
 import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
 import { isSpindlTrackData } from '@/types/spindl';
 import { trackSpindl } from '@/hooks/feature-cards/spindl/trackSpindl';
@@ -155,18 +155,18 @@ export const useFeatureCardImage = (data: FeatureCardData): URL | null => {
   const { mode: themeMode } = useColorScheme();
   return useMemo(() => {
     const mode = data?.DisplayConditions?.mode || themeMode;
-    const baseUrl = getStrapiBaseUrl();
 
     if (!data?.BackgroundImageDark?.url || !data?.BackgroundImageLight?.url) {
       return null;
     }
 
-    const imageUrl =
+    const rawImageUrl =
       mode === 'dark'
         ? data.BackgroundImageDark.url
         : data.BackgroundImageLight.url;
 
-    return new URL(imageUrl, baseUrl);
+    const resolved = resolveStrapiMediaUrl(rawImageUrl);
+    return resolved ? new URL(resolved) : null;
   }, [
     data?.BackgroundImageDark?.url,
     data?.BackgroundImageLight?.url,

--- a/src/components/Lightbox/Lightbox.tsx
+++ b/src/components/Lightbox/Lightbox.tsx
@@ -10,11 +10,10 @@ import { LightboxToolbar } from './LightboxToolbar';
 import { useLightbox } from './useLightbox';
 
 interface LightboxProps {
-  baseUrl: string;
   imageData: StrapiMediaAttributes;
 }
 
-export const Lightbox = ({ baseUrl, imageData }: LightboxProps) => {
+export const Lightbox = ({ imageData }: LightboxProps) => {
   const {
     open,
     scale,

--- a/src/components/RichBlocks/blocks/ImageBlock.tsx
+++ b/src/components/RichBlocks/blocks/ImageBlock.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
+import { resolveStrapiMediaUrl } from 'src/utils/strapi/strapiHelper';
 import type { CommonBlockProps, ImageProps } from '../types';
 import { RichBlocksVariant } from '../types';
 
@@ -16,9 +16,9 @@ export const ImageBlock: FC<ImageBlockProps> = ({ image, variant }) => {
     return null;
   }
 
-  const baseUrl = getStrapiBaseUrl();
-  if (!baseUrl) {
+  const resolvedUrl = resolveStrapiMediaUrl(image?.url);
+  if (!resolvedUrl) {
     return null;
   }
-  return <Lightbox imageData={image} baseUrl={baseUrl} />;
+  return <Lightbox imageData={{ ...image, url: resolvedUrl }} />;
 };

--- a/src/components/composite/cards/BlogArticleCard/BlogArticleCard.stories.tsx
+++ b/src/components/composite/cards/BlogArticleCard/BlogArticleCard.stories.tsx
@@ -1,7 +1,6 @@
 import { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { BlogArticleCard } from './BlogArticleCard';
 import { blogArticle } from './fixtures';
-import { JUMPER_STRAPI_URL } from '@/const/urls';
 
 const meta: Meta<typeof BlogArticleCard> = {
   title: 'components/composite/BlogArticleCard',
@@ -21,7 +20,6 @@ export const BlogArticleSearchPreview: Story = {
   args: {
     variant: 'preview',
     data: blogArticle,
-    baseUrl: JUMPER_STRAPI_URL,
     highlight: 'APY',
   },
 };

--- a/src/components/composite/cards/BlogArticleCard/types.ts
+++ b/src/components/composite/cards/BlogArticleCard/types.ts
@@ -5,13 +5,11 @@ export type BlogArticleVariant = 'default' | 'preview' | 'featured';
 interface LoadingBlogArticleCardProps {
   isLoading: true;
   data?: null;
-  baseUrl?: never;
 }
 
 interface LoadedBlogArticleCardProps {
   isLoading?: false;
   data: BlogArticleData;
-  baseUrl: string;
 }
 
 export type BaseBlogArticleCardProps =

--- a/src/components/composite/cards/BlogArticleCard/variants/PreviewBlogArticleCard.tsx
+++ b/src/components/composite/cards/BlogArticleCard/variants/PreviewBlogArticleCard.tsx
@@ -48,9 +48,11 @@ export const PreviewBlogArticleCard: FC<PreviewBlogArticleCardProps> = ({
     <BlogArticleCardContainer>
       {data?.Image && (
         <BlogArticleCardImage
-          src={resolveStrapiMediaUrl(
-            data?.Image?.formats.small.url || data?.Image?.url,
-          )}
+          src={
+            resolveStrapiMediaUrl(
+              data?.Image?.formats.small.url || data?.Image?.url,
+            ) ?? ''
+          }
           alt={data?.Image?.alternativeText ?? data?.Title}
           width={0}
           height={0}

--- a/src/components/composite/cards/BlogArticleCard/variants/PreviewBlogArticleCard.tsx
+++ b/src/components/composite/cards/BlogArticleCard/variants/PreviewBlogArticleCard.tsx
@@ -8,6 +8,7 @@ import {
 } from '../BlogArticleCard.styles';
 
 import { getTextEllipsisStyles } from '@/utils/styles/getTextEllipsisStyles';
+import { resolveStrapiMediaUrl } from '@/utils/strapi/strapiHelper';
 import { PreviewBlogArticleCardSkeleton } from './PreviewBlogArticleCardSkeleton';
 
 const highlightText = (text: string, highlight: string) => {
@@ -35,7 +36,6 @@ const highlightText = (text: string, highlight: string) => {
 export const PreviewBlogArticleCard: FC<PreviewBlogArticleCardProps> = ({
   isLoading,
   data,
-  baseUrl,
   highlight = '',
 }) => {
   if (!data || isLoading) {
@@ -48,7 +48,9 @@ export const PreviewBlogArticleCard: FC<PreviewBlogArticleCardProps> = ({
     <BlogArticleCardContainer>
       {data?.Image && (
         <BlogArticleCardImage
-          src={`${baseUrl}${data?.Image?.formats.small.url || data?.Image?.url}`}
+          src={resolveStrapiMediaUrl(
+            data?.Image?.formats.small.url || data?.Image?.url,
+          )}
           alt={data?.Image?.alternativeText ?? data?.Title}
           width={0}
           height={0}

--- a/src/hooks/campaigns/useCampaignDisplayData.ts
+++ b/src/hooks/campaigns/useCampaignDisplayData.ts
@@ -2,12 +2,10 @@ import { useMemo } from 'react';
 import { MissionHeroStatsCardVariant } from 'src/components/Cards/MissionHeroStatsCard/MissionHeroStatsCard.style';
 import { AppPaths } from 'src/const/urls';
 import { BenefitCardColorMode, CampaignData } from 'src/types/strapi';
-import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
+import { resolveStrapiMediaUrl } from 'src/utils/strapi/strapiHelper';
 
 export const useCampaignDisplayData = (campaign: CampaignData) => {
   return useMemo(() => {
-    const apiBaseUrl = getStrapiBaseUrl();
-
     const getStatsCardVariant = (colorMode?: BenefitCardColorMode) =>
       colorMode === BenefitCardColorMode.Dark
         ? MissionHeroStatsCardVariant.Inverted
@@ -23,9 +21,9 @@ export const useCampaignDisplayData = (campaign: CampaignData) => {
       rewardChainIds: campaign.merkl_rewards
         ?.map((reward) => reward.ChainId)
         .filter((rewardChainId) => rewardChainId !== null),
-      background: `${apiBaseUrl}${campaign.Background?.url || ''}`,
-      icon: `${apiBaseUrl}${campaign.Icon?.url || ''}`,
-      bannerImage: `${apiBaseUrl}${campaign.ProfileBannerImage?.url || ''}`,
+      background: resolveStrapiMediaUrl(campaign.Background?.url) ?? '',
+      icon: resolveStrapiMediaUrl(campaign.Icon?.url) ?? '',
+      bannerImage: resolveStrapiMediaUrl(campaign.ProfileBannerImage?.url) ?? '',
       bannerTitle: campaign.ProfileBannerTitle || '',
       bannerDescription: campaign.ProfileBannerDescription || '',
       link:

--- a/src/hooks/feature-cards/usePersonalizedFeatureCardsQuery.ts
+++ b/src/hooks/feature-cards/usePersonalizedFeatureCardsQuery.ts
@@ -29,9 +29,7 @@ export const usePersonalizedFeatureCardsQuery =
           throw new Error('Account address must be set');
         }
 
-        const response = await fetch(
-          getFeatureCardsEndpoint(account?.address),
-        );
+        const response = await fetch(getFeatureCardsEndpoint(account?.address));
 
         if (!response.ok) {
           throw new Error('Failed to fetch data');
@@ -52,9 +50,10 @@ export const usePersonalizedFeatureCardsQuery =
     apiUrl.searchParams.set('populate[1]', 'BackgroundImageDark');
     apiUrl.searchParams.set('populate[2]', 'featureCardsExclusions');
     apiUrl.searchParams.set('filters[PersonalizedFeatureCard]', 'true');
-    fcCardData?.map((id: number) =>
-      apiUrl.searchParams.set('filters[id][]', id.toString()),
-    );
+
+    fcCardData?.forEach((documentId: string, i: number) => {
+      apiUrl.searchParams.append(`filters[documentId][$in][${i}]`, documentId);
+    });
 
     config.NEXT_PUBLIC_ENVIRONMENT !== 'production' &&
       apiUrl.searchParams.set('status', 'draft');

--- a/src/hooks/perks/useFormatDisplayPerkData.ts
+++ b/src/hooks/perks/useFormatDisplayPerkData.ts
@@ -1,10 +1,9 @@
 import { useMemo } from 'react';
 import { PerksDataAttributes } from 'src/types/strapi';
-import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
+import { resolveStrapiMediaUrl } from 'src/utils/strapi/strapiHelper';
 
 export const useFormatDisplayPerkData = (perk: PerksDataAttributes) => {
   return useMemo(() => {
-    const baseStrapiUrl = getStrapiBaseUrl();
     const {
       documentId,
       Title,
@@ -23,15 +22,8 @@ export const useFormatDisplayPerkData = (perk: PerksDataAttributes) => {
       NextStepsDescription,
     } = perk;
 
-    let bannerImageUrl = '';
-    if (BannerImage?.url) {
-      bannerImageUrl = `${baseStrapiUrl}${BannerImage?.url}`;
-    }
-
-    let imageUrl = '';
-    if (Image?.url) {
-      imageUrl = `${baseStrapiUrl}${Image?.url}`;
-    }
+    const bannerImageUrl = resolveStrapiMediaUrl(BannerImage?.url) ?? '';
+    const imageUrl = resolveStrapiMediaUrl(Image?.url) ?? '';
 
     return {
       id: documentId,

--- a/src/hooks/quests/useFormatDisplayQuestData.ts
+++ b/src/hooks/quests/useFormatDisplayQuestData.ts
@@ -6,7 +6,7 @@ import type {
   RewardGroup,
 } from 'src/types/loyaltyPass';
 import { capitalizeString } from 'src/utils/capitalizeString';
-import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
+import { resolveStrapiMediaUrl } from 'src/utils/strapi/strapiHelper';
 import { useFormatDisplayRewardsData } from './useFormatDisplayRewardsData';
 import type { QuestData } from 'src/types/strapi';
 import type { Chain } from 'src/types/questDetails';
@@ -62,7 +62,6 @@ export function useFormatDisplayQuestData(
   );
 
   return useMemo(() => {
-    const baseStrapiUrl = getStrapiBaseUrl();
     const {
       id,
       Title,
@@ -90,14 +89,10 @@ export function useFormatDisplayQuestData(
 
     if (useBannerImage) {
       imageUrl = isQuest(quest)
-        ? quest.BannerImage?.[0]?.url
-          ? `${baseStrapiUrl}${quest.BannerImage[0].url}`
-          : undefined
-        : quest.BannerImage?.url
-          ? `${baseStrapiUrl}${quest.BannerImage?.url}`
-          : undefined;
+        ? resolveStrapiMediaUrl(quest.BannerImage?.[0]?.url)
+        : resolveStrapiMediaUrl(quest.BannerImage?.url);
     } else {
-      imageUrl = quest.Image ? `${baseStrapiUrl}${quest.Image.url}` : undefined;
+      imageUrl = resolveStrapiMediaUrl(quest.Image?.url);
     }
 
     return {

--- a/src/hooks/useAnnouncements.ts
+++ b/src/hooks/useAnnouncements.ts
@@ -6,7 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getAnnouncements } from '@/app/lib/getAnnouncements';
 import { useAnnouncementStore } from '@/stores/announcements/AnnouncementStore';
 import { useEffect, useMemo } from 'react';
-import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
+import { resolveStrapiMediaUrl } from 'src/utils/strapi/strapiHelper';
 import { TEN_MINUTES_MS, THIRTY_MINUTES_MS } from 'src/const/time';
 
 interface UseAnnouncementsProps {
@@ -20,7 +20,6 @@ interface UseAnnouncementsProps {
 const mapToDisplayFormat = (
   announcement: AnnouncementData,
 ): AnnouncementDisplay => {
-  const baseStrapiUrl = getStrapiBaseUrl();
   return {
     id: announcement.id,
     documentId: announcement.documentId,
@@ -32,7 +31,7 @@ const mapToDisplayFormat = (
     logo: announcement.Logo
       ? {
           ...announcement.Logo,
-          url: `${baseStrapiUrl}${announcement.Logo?.url}`,
+          url: resolveStrapiMediaUrl(announcement.Logo?.url) ?? '',
         }
       : undefined,
     dismissible: announcement.Dismissible,

--- a/src/utils/articles/buildArticleSchema.ts
+++ b/src/utils/articles/buildArticleSchema.ts
@@ -1,13 +1,10 @@
 import { getSiteUrl } from '@/const/urls';
 import type { BlogArticleData } from '@/types/strapi';
-import { getStrapiBaseUrl } from '../strapi/strapiHelper';
+import { resolveStrapiMediaUrl } from '../strapi/strapiHelper';
 
 export function buildArticleSchema(articleData: BlogArticleData) {
-  const baseUrl = getStrapiBaseUrl();
   const pageUrl = `${getSiteUrl()}/learn/${articleData.Slug}`;
-  const imageUrl = articleData.Image?.url
-    ? `${baseUrl}${articleData.Image.url}`
-    : undefined;
+  const imageUrl = resolveStrapiMediaUrl(articleData.Image?.url);
 
   return (
     articleData.seo?.structuredData ?? {

--- a/src/utils/sitemaps/learn.ts
+++ b/src/utils/sitemaps/learn.ts
@@ -2,7 +2,7 @@ import { AppPaths } from '@/const/urls';
 import { getArticles } from '@/app/lib/getArticles';
 import type { BlogArticleData } from '@/types/strapi';
 import { buildUrl, toSitemapDate } from '@/utils/sitemap';
-import { getStrapiBaseUrl } from '@/utils/strapi/strapiHelper';
+import { resolveStrapiMediaUrl } from '@/utils/strapi/strapiHelper';
 import type { SitemapXmlEntry } from '@/utils/sitemaps/xml';
 import { isProduction } from '@/utils/isProduction';
 
@@ -11,7 +11,6 @@ export const dynamic = 'force-static';
 const SITEMAP_LIMIT = 50_000;
 const ARTICLES_PAGE_SIZE = 100;
 const DEV_CHUNK_SIZE = 20;
-const strapiUrl = getStrapiBaseUrl();
 const chunkSize = isProduction ? SITEMAP_LIMIT : DEV_CHUNK_SIZE;
 
 const getArticlesTotal = async (): Promise<number> => {
@@ -55,11 +54,14 @@ export const getLearnSitemapEntriesForChunk = async (
 ): Promise<SitemapXmlEntry[]> => {
   const articles = await fetchArticlesChunk(chunkId);
 
-  return articles.map(({ Slug, updatedAt, publishedAt, Image }) => ({
-    loc: buildUrl(AppPaths.Learn, Slug),
-    lastModified: toSitemapDate(updatedAt ?? publishedAt ?? Date.now()),
-    changeFrequency: 'weekly',
-    priority: 0.8,
-    images: Image?.url && strapiUrl ? [`${strapiUrl}${Image.url}`] : undefined,
-  }));
+  return articles.map(({ Slug, updatedAt, publishedAt, Image }) => {
+    const imageUrl = resolveStrapiMediaUrl(Image?.url);
+    return {
+      loc: buildUrl(AppPaths.Learn, Slug),
+      lastModified: toSitemapDate(updatedAt ?? publishedAt ?? Date.now()),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+      images: imageUrl ? [imageUrl] : undefined,
+    };
+  });
 };

--- a/src/utils/strapi/strapiHelper.ts
+++ b/src/utils/strapi/strapiHelper.ts
@@ -17,3 +17,23 @@ export function getStrapiApiAccessToken() {
   }
   return config.NEXT_PUBLIC_STRAPI_API_TOKEN;
 }
+
+/**
+ * Resolve a Strapi media URL.
+ *
+ * Newer Strapi versions return absolute URLs (e.g. https://cdn.example.com/...)
+ * while older / local Strapi instances return relative paths (e.g. /uploads/...).
+ * This helper prefixes the configured Strapi base URL only when the value is a
+ * relative path, keeping consumers backward compatible with both formats.
+ */
+export function resolveStrapiMediaUrl(
+  url: string | null | undefined,
+): string | undefined {
+  if (!url) {
+    return undefined;
+  }
+  if (url.startsWith('http')) {
+    return url;
+  }
+  return `${getStrapiBaseUrl()}${url}`;
+}


### PR DESCRIPTION
## Summary

Strapi v5 migration follow-ups for the frontend:

- **Image / media URLs.** Strapi v5 now returns absolute URLs from its CDN, while older / local instances still return relative `/uploads/...` paths. Introduce `resolveStrapiMediaUrl(url)` in `src/utils/strapi/strapiHelper.ts` that passes absolute URLs through and prefixes relative ones with the configured Strapi base URL. All blog, learn, mission, zap, lightbox, campaign, perk, quest, announcement, sitemap and rich-block image consumers updated to use it.
- **Type fixes.** Tighten image types in `BlogArticleCard`, `BlogArticleAuthor`, and the `composite/cards/BlogArticleCard` variants to compile cleanly against the v5 response shape.
- **Feature cards lookup.** `usePersonalizedFeatureCardsQuery` now filters by `documentId` (Strapi v5's stable identifier) instead of legacy numeric `id`, using `filters[documentId][$in][i]` with `searchParams.append` so the full list of ids is preserved (the previous `.set` in a loop silently kept only the last one).

## Test plan

- [ ] Blog article list, featured article, and individual article images render on both prod-like (absolute CDN URLs) and local Strapi (relative paths).
- [ ] Mission / Zap / Learn detail pages: hero images and rich-block images load.
- [ ] Lightbox opens the correct full-size image.
- [ ] Personalized feature cards: connect a wallet that has feature-card assignments and confirm the matching cards render (backend must return `documentId` strings).
- [ ] Network tab: request to `/api/feature-cards` contains `filters[documentId][$in][...]` entries for every assigned card, not just the last one.
- [ ] No regressions in campaign banners, perks, quests, announcements, sitemap generation, or article JSON-LD schema output.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image URL resolution consistency across the application, ensuring proper image display for both newer and legacy server configurations.

* **Refactor**
  * Streamlined internal image URL handling to use a unified resolution system, removing redundant configuration parameters from components and improving code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jumperexchange/jumper-exchange/pull/2887?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->