### PR TITLE
fix(feature-cards): query Strapi v5 by documentId

### DIFF
--- a/src/hooks/feature-cards/usePersonalizedFeatureCardsQuery.ts
+++ b/src/hooks/feature-cards/usePersonalizedFeatureCardsQuery.ts
@@ -29,9 +29,7 @@ export const usePersonalizedFeatureCardsQuery =
           throw new Error('Account address must be set');
         }
 
-        const response = await fetch(
-          getFeatureCardsEndpoint(account?.address),
-        );
+        const response = await fetch(getFeatureCardsEndpoint(account?.address));
 
         if (!response.ok) {
           throw new Error('Failed to fetch data');
@@ -52,9 +50,10 @@ export const usePersonalizedFeatureCardsQuery =
     apiUrl.searchParams.set('populate[1]', 'BackgroundImageDark');
     apiUrl.searchParams.set('populate[2]', 'featureCardsExclusions');
     apiUrl.searchParams.set('filters[PersonalizedFeatureCard]', 'true');
-    fcCardData?.map((id: number) =>
-      apiUrl.searchParams.set('filters[id][]', id.toString()),
-    );
+
+    fcCardData?.forEach((documentId: string, i: number) => {
+      apiUrl.searchParams.append(`filters[documentId][$in][${i}]`, documentId);
+    });
 
     config.NEXT_PUBLIC_ENVIRONMENT !== 'production' &&
       apiUrl.searchParams.set('status', 'draft');


### PR DESCRIPTION
## Summary

- Migrate `usePersonalizedFeatureCardsQuery` to filter feature cards by Strapi v5's stable `documentId` instead of the legacy numeric `id`.
- Emit the filter as `filters[documentId][$in][i]=<id>` using `searchParams.append` so every id is preserved — the previous `.set('filters[id][]', …)` inside a `.map()` silently kept only the last id because `URLSearchParams.set` overwrites.

JUM-1008.

## Test plan

- [ ] Connect a wallet whose `/wallets/{address}/feature-cards` payload returns multiple `documentId`s.
- [ ] In the network tab, confirm the Strapi request contains one `filters[documentId][$in][i]` entry per id (not just the last one).
- [ ] Confirm the matching personalized feature card(s) render in the UI.
- [ ] Confirm a wallet with no assigned cards still falls back to `usePersonalizedFeatureOnLevel` without errors.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized personalized feature card data retrieval and query filtering for improved efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jumperexchange/jumper-exchange/pull/2888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->