### PR TITLE
feat(earn): consume lockupDays, unify on formatLockupPeriod [JUM-842]

### DIFF
--- a/src/components/Cards/EarnCard/EarnCard.snapshot.spec.tsx
+++ b/src/components/Cards/EarnCard/EarnCard.snapshot.spec.tsx
@@ -155,7 +155,7 @@ describe('EarnCard snapshot', () => {
         {...commonArgs}
         data={{
           ...commonArgs.data,
-          lockupMonths: undefined,
+          lockupDays: undefined,
           capInDollar: undefined,
           latest: {
             date: '2021-01-01',
@@ -185,22 +185,22 @@ describe('EarnCard snapshot', () => {
     );
     expect(container).toMatchSnapshot();
   });
-  it('compact card with lockup months matches snapshot', async () => {
+  it('compact card with lockup days matches snapshot', async () => {
     const { container } = render(
       <EarnCard
         {...commonArgs}
         variant="compact"
-        data={{ ...commonArgs.data, lockupMonths: 2 }}
+        data={{ ...commonArgs.data, lockupDays: 60 }}
       />,
     );
     expect(container).toMatchSnapshot();
   });
-  it('compact card with lockup months and cap in dollar matches snapshot', async () => {
+  it('compact card with lockup days and cap in dollar matches snapshot', async () => {
     const { container } = render(
       <EarnCard
         {...commonArgs}
         variant="compact"
-        data={{ ...commonArgs.data, lockupMonths: 2, capInDollar: '1000000' }}
+        data={{ ...commonArgs.data, lockupDays: 60, capInDollar: '1000000' }}
       />,
     );
     expect(container).toMatchSnapshot();
@@ -263,22 +263,22 @@ describe('EarnCard snapshot', () => {
     );
     expect(container).toMatchSnapshot();
   });
-  it('list item card with lockup months matches snapshot', async () => {
+  it('list item card with lockup days matches snapshot', async () => {
     const { container } = render(
       <EarnCard
         {...commonArgs}
         variant="list-item"
-        data={{ ...commonArgs.data, lockupMonths: 2 }}
+        data={{ ...commonArgs.data, lockupDays: 60 }}
       />,
     );
     expect(container).toMatchSnapshot();
   });
-  it('list item card with lockup months and cap in dollar matches snapshot', async () => {
+  it('list item card with lockup days and cap in dollar matches snapshot', async () => {
     const { container } = render(
       <EarnCard
         {...commonArgs}
         variant="list-item"
-        data={{ ...commonArgs.data, lockupMonths: 2, capInDollar: '1000000' }}
+        data={{ ...commonArgs.data, lockupDays: 60, capInDollar: '1000000' }}
       />,
     );
     expect(container).toMatchSnapshot();
@@ -318,7 +318,7 @@ describe('EarnCard snapshot', () => {
         variant="overview"
         data={{
           ...commonArgs.data,
-          lockupMonths: undefined,
+          lockupDays: undefined,
           capInDollar: '1000000',
         }}
       />,
@@ -326,23 +326,23 @@ describe('EarnCard snapshot', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('overview card with lockup months matches snapshot', async () => {
+  it('overview card with lockup days matches snapshot', async () => {
     const { container } = render(
       <EarnCard
         {...commonArgs}
         variant="overview"
-        data={{ ...commonArgs.data, lockupMonths: 2 }}
+        data={{ ...commonArgs.data, lockupDays: 60 }}
       />,
     );
     expect(container).toMatchSnapshot();
   });
 
-  it('overview card with lockup months and cap in dollar matches snapshot', async () => {
+  it('overview card with lockup days and cap in dollar matches snapshot', async () => {
     const { container } = render(
       <EarnCard
         {...commonArgs}
         variant="overview"
-        data={{ ...commonArgs.data, lockupMonths: 2, capInDollar: '1000000' }}
+        data={{ ...commonArgs.data, lockupDays: 60, capInDollar: '1000000' }}
       />,
     );
     expect(container).toMatchSnapshot();

--- a/src/components/Cards/EarnCard/EarnCard.stories.tsx
+++ b/src/components/Cards/EarnCard/EarnCard.stories.tsx
@@ -72,7 +72,7 @@ export const CompactWithTwoItems: Story = {
     ...commonArgs,
     data: {
       ...commonArgs.data,
-      lockupMonths: undefined,
+      lockupDays: undefined,
       capInDollar: undefined,
       isRedeemable: true,
       latest: {

--- a/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
+++ b/src/components/Cards/EarnCard/__snapshots__/EarnCard.snapshot.spec.tsx.snap
@@ -209,7 +209,7 @@ exports[`EarnCard snapshot > compact card matches snapshot 1`] = `
           </div>
           <div
             class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
-            data-testid="lockupPeriod-2"
+            data-testid="lockupPeriod-60"
           >
             <div
               class="MuiBox-root css-5ul7dk"
@@ -531,7 +531,7 @@ exports[`EarnCard snapshot > compact card with cap in dollar matches snapshot 1`
           </div>
           <div
             class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
-            data-testid="lockupPeriod-2"
+            data-testid="lockupPeriod-60"
           >
             <div
               class="MuiBox-root css-5ul7dk"
@@ -857,7 +857,7 @@ exports[`EarnCard snapshot > compact card with href matches snapshot 1`] = `
             </div>
             <div
               class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
-              data-testid="lockupPeriod-2"
+              data-testid="lockupPeriod-60"
             >
               <div
                 class="MuiBox-root css-5ul7dk"
@@ -1054,7 +1054,7 @@ exports[`EarnCard snapshot > compact card with loading matches snapshot 1`] = `
 </div>
 `;
 
-exports[`EarnCard snapshot > compact card with lockup months and cap in dollar matches snapshot 1`] = `
+exports[`EarnCard snapshot > compact card with lockup days and cap in dollar matches snapshot 1`] = `
 <div>
   <div
     class="MuiBox-root css-1tyjne1"
@@ -1237,7 +1237,7 @@ exports[`EarnCard snapshot > compact card with lockup months and cap in dollar m
           </div>
           <div
             class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
-            data-testid="lockupPeriod-2"
+            data-testid="lockupPeriod-60"
           >
             <div
               class="MuiBox-root css-5ul7dk"
@@ -1376,7 +1376,7 @@ exports[`EarnCard snapshot > compact card with lockup months and cap in dollar m
 </div>
 `;
 
-exports[`EarnCard snapshot > compact card with lockup months matches snapshot 1`] = `
+exports[`EarnCard snapshot > compact card with lockup days matches snapshot 1`] = `
 <div>
   <div
     class="MuiBox-root css-1tyjne1"
@@ -1559,7 +1559,7 @@ exports[`EarnCard snapshot > compact card with lockup months matches snapshot 1`
           </div>
           <div
             class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
-            data-testid="lockupPeriod-2"
+            data-testid="lockupPeriod-60"
           >
             <div
               class="MuiBox-root css-5ul7dk"
@@ -1876,7 +1876,7 @@ exports[`EarnCard snapshot > compact card with no recommendation matches snapsho
           </div>
           <div
             class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
-            data-testid="lockupPeriod-2"
+            data-testid="lockupPeriod-60"
           >
             <div
               class="MuiBox-root css-5ul7dk"
@@ -2224,7 +2224,7 @@ exports[`EarnCard snapshot > compact card with single asset matches snapshot 1`]
           </div>
           <div
             class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
-            data-testid="lockupPeriod-2"
+            data-testid="lockupPeriod-60"
           >
             <div
               class="MuiBox-root css-5ul7dk"
@@ -2793,7 +2793,7 @@ exports[`EarnCard snapshot > list item card matches snapshot 1`] = `
           >
             <p
               class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
-              data-testid="lockupPeriod-2"
+              data-testid="lockupPeriod-60"
             >
               2 months
             </p>
@@ -3027,7 +3027,7 @@ exports[`EarnCard snapshot > list item card with cap in dollar matches snapshot 
           >
             <p
               class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
-              data-testid="lockupPeriod-2"
+              data-testid="lockupPeriod-60"
             >
               2 months
             </p>
@@ -3239,7 +3239,7 @@ exports[`EarnCard snapshot > list item card with href matches snapshot 1`] = `
             >
               <p
                 class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
-                data-testid="lockupPeriod-2"
+                data-testid="lockupPeriod-60"
               >
                 2 months
               </p>
@@ -3356,7 +3356,7 @@ exports[`EarnCard snapshot > list item card with loading matches snapshot 1`] = 
 </div>
 `;
 
-exports[`EarnCard snapshot > list item card with lockup months and cap in dollar matches snapshot 1`] = `
+exports[`EarnCard snapshot > list item card with lockup days and cap in dollar matches snapshot 1`] = `
 <div>
   <div
     class="MuiBox-root css-nhh3oc"
@@ -3510,7 +3510,7 @@ exports[`EarnCard snapshot > list item card with lockup months and cap in dollar
           >
             <p
               class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
-              data-testid="lockupPeriod-2"
+              data-testid="lockupPeriod-60"
             >
               2 months
             </p>
@@ -3564,7 +3564,7 @@ exports[`EarnCard snapshot > list item card with lockup months and cap in dollar
 </div>
 `;
 
-exports[`EarnCard snapshot > list item card with lockup months matches snapshot 1`] = `
+exports[`EarnCard snapshot > list item card with lockup days matches snapshot 1`] = `
 <div>
   <div
     class="MuiBox-root css-nhh3oc"
@@ -3718,7 +3718,7 @@ exports[`EarnCard snapshot > list item card with lockup months matches snapshot 
           >
             <p
               class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
-              data-testid="lockupPeriod-2"
+              data-testid="lockupPeriod-60"
             >
               2 months
             </p>
@@ -3895,7 +3895,7 @@ exports[`EarnCard snapshot > list item card with no recommendation matches snaps
           >
             <p
               class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
-              data-testid="lockupPeriod-2"
+              data-testid="lockupPeriod-60"
             >
               2 months
             </p>
@@ -4129,7 +4129,7 @@ exports[`EarnCard snapshot > list item card with single asset matches snapshot 1
           >
             <p
               class="MuiTypography-root MuiTypography-body1 css-jc816d-MuiTypography-root"
-              data-testid="lockupPeriod-2"
+              data-testid="lockupPeriod-60"
             >
               2 months
             </p>
@@ -4241,7 +4241,7 @@ exports[`EarnCard snapshot > overview card matches snapshot 1`] = `
         </div>
         <div
           class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
-          data-testid="lockupPeriod-2"
+          data-testid="lockupPeriod-60"
         >
           <div
             class="MuiBox-root css-5ul7dk"
@@ -4625,7 +4625,7 @@ exports[`EarnCard snapshot > overview card with badge matches snapshot 1`] = `
         </div>
         <div
           class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
-          data-testid="lockupPeriod-2"
+          data-testid="lockupPeriod-60"
         >
           <div
             class="MuiBox-root css-5ul7dk"
@@ -5363,7 +5363,7 @@ exports[`EarnCard snapshot > overview card with loading matches snapshot 1`] = `
 </div>
 `;
 
-exports[`EarnCard snapshot > overview card with lockup months and cap in dollar matches snapshot 1`] = `
+exports[`EarnCard snapshot > overview card with lockup days and cap in dollar matches snapshot 1`] = `
 <div>
   <div
     class="MuiBox-root css-4gp3vo"
@@ -5421,7 +5421,7 @@ exports[`EarnCard snapshot > overview card with lockup months and cap in dollar 
         </div>
         <div
           class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
-          data-testid="lockupPeriod-2"
+          data-testid="lockupPeriod-60"
         >
           <div
             class="MuiBox-root css-5ul7dk"
@@ -5744,7 +5744,7 @@ exports[`EarnCard snapshot > overview card with lockup months and cap in dollar 
 </div>
 `;
 
-exports[`EarnCard snapshot > overview card with lockup months matches snapshot 1`] = `
+exports[`EarnCard snapshot > overview card with lockup days matches snapshot 1`] = `
 <div>
   <div
     class="MuiBox-root css-4gp3vo"
@@ -5802,7 +5802,7 @@ exports[`EarnCard snapshot > overview card with lockup months matches snapshot 1
         </div>
         <div
           class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 css-13xb3fr-MuiGrid-root"
-          data-testid="lockupPeriod-2"
+          data-testid="lockupPeriod-60"
         >
           <div
             class="MuiBox-root css-5ul7dk"

--- a/src/components/Cards/EarnCard/fixtures.tsx
+++ b/src/components/Cards/EarnCard/fixtures.tsx
@@ -40,7 +40,7 @@ export const commonArgs = {
       },
     },
     slug: 'moonwell-flagship-usdc-on-base',
-    lockupMonths: 2,
+    lockupDays: 60,
     capInDollar: '1000000000000000000',
     featured: true,
     forYou: true,

--- a/src/components/Cards/HeroEarnCard/fixtures.tsx
+++ b/src/components/Cards/HeroEarnCard/fixtures.tsx
@@ -40,7 +40,7 @@ export const commonArgs = {
       },
     },
     slug: 'moonwell-flagship-usdc-on-base',
-    lockupMonths: 2,
+    lockupDays: 60,
     capInDollar: '1000000000000000000',
     featured: true,
     forYou: true,

--- a/src/components/Cards/ProtocolCard/fixtures.ts
+++ b/src/components/Cards/ProtocolCard/fixtures.ts
@@ -38,7 +38,7 @@ export const commonArgs = {
       },
     },
     slug: 'moonwell-flagship-usdc-on-base',
-    lockupMonths: 2,
+    lockupDays: 60,
     capInDollar: '1000000000000000000',
     featured: true,
     forYou: true,

--- a/src/hooks/earn/useFormatDisplayEarnOpportunityData.tsx
+++ b/src/hooks/earn/useFormatDisplayEarnOpportunityData.tsx
@@ -18,7 +18,7 @@ import type {
   Token,
 } from 'src/types/jumper-backend';
 import { capitalizeString } from 'src/utils/capitalizeString';
-import { formatLockupPeriod } from 'src/utils/formatLockupPeriod';
+import { formatLockupPeriod } from '@/utils/formatLockupPeriod';
 import { formatApy } from 'src/utils/numbers/apy';
 import { formatTvl } from 'src/utils/numbers/tvl';
 import { isZeroApprox } from 'src/utils/numbers/utils';

--- a/src/hooks/earn/useFormatDisplayEarnOpportunityData.tsx
+++ b/src/hooks/earn/useFormatDisplayEarnOpportunityData.tsx
@@ -1,7 +1,15 @@
+import { EntityStack } from '@/components/composite/EntityStack/EntityStack';
+import { EntityStackWithBadge } from '@/components/composite/EntityStackWithBadge/EntityStackWithBadge';
+import { SECONDS_IN_A_DAY } from '@/const/time';
+import { useChains } from '@/hooks/useChains';
+import { getChainName } from '@/utils/chains/getChainName';
+import { formatCapInDollar } from '@/utils/numbers/capInDollar';
+import type { TFunction } from 'i18next';
 import uniqBy from 'lodash/uniqBy';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { formatLockupPeriod } from 'src/utils/formatLockupPeriod';
+import type { EarnCardVariant } from 'src/components/Cards/EarnCard/EarnCard.types';
+import { AvatarSize } from 'src/components/core/AvatarStack/AvatarStack.types';
 import type {
   APYItem,
   Chain,
@@ -9,18 +17,11 @@ import type {
   Protocol,
   Token,
 } from 'src/types/jumper-backend';
+import { capitalizeString } from 'src/utils/capitalizeString';
+import { formatLockupPeriod } from 'src/utils/formatLockupPeriod';
 import { formatApy } from 'src/utils/numbers/apy';
 import { formatTvl } from 'src/utils/numbers/tvl';
 import { isZeroApprox } from 'src/utils/numbers/utils';
-import type { EarnCardVariant } from 'src/components/Cards/EarnCard/EarnCard.types';
-import { AvatarSize } from 'src/components/core/AvatarStack/AvatarStack.types';
-import { capitalizeString } from 'src/utils/capitalizeString';
-import type { TFunction } from 'i18next';
-import { useChains } from '@/hooks/useChains';
-import { getChainName } from '@/utils/chains/getChainName';
-import { formatCapInDollar } from '@/utils/numbers/capInDollar';
-import { EntityStackWithBadge } from '@/components/composite/EntityStackWithBadge/EntityStackWithBadge';
-import { EntityStack } from '@/components/composite/EntityStack/EntityStack';
 
 interface EarnCardOverviewItem {
   key: string;
@@ -89,8 +90,6 @@ const buildRewardsApyItem = (
   };
 };
 
-const SECONDS_PER_DAY = 86400;
-
 const buildLockupItem = (
   lockupDays: number | string | undefined,
   variant: EarnCardVariant,
@@ -102,7 +101,7 @@ const buildLockupItem = (
   }
 
   const { value, unit } = formatLockupPeriod(
-    lockupDaysNumber * SECONDS_PER_DAY,
+    lockupDaysNumber * SECONDS_IN_A_DAY,
   );
   const formatted = `${value} ${unit}`;
   return {

--- a/src/hooks/earn/useFormatDisplayEarnOpportunityData.tsx
+++ b/src/hooks/earn/useFormatDisplayEarnOpportunityData.tsx
@@ -1,7 +1,7 @@
 import uniqBy from 'lodash/uniqBy';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { formatLockupDuration } from 'src/utils/earn/utils';
+import { formatLockupPeriod } from 'src/utils/formatLockupPeriod';
 import type {
   APYItem,
   Chain,
@@ -89,20 +89,25 @@ const buildRewardsApyItem = (
   };
 };
 
+const SECONDS_PER_DAY = 86400;
+
 const buildLockupItem = (
-  lockupMonths: number | string | undefined,
+  lockupDays: number | string | undefined,
   variant: EarnCardVariant,
   t: TFunction,
 ): EarnCardOverviewItem | null => {
-  const lockupMonthsNumber = Number(lockupMonths);
-  if (isNaN(lockupMonthsNumber) || !lockupMonthsNumber) {
+  const lockupDaysNumber = Number(lockupDays);
+  if (isNaN(lockupDaysNumber) || !lockupDaysNumber) {
     return null;
   }
 
-  const formatted = formatLockupDuration(lockupMonthsNumber);
+  const { value, unit } = formatLockupPeriod(
+    lockupDaysNumber * SECONDS_PER_DAY,
+  );
+  const formatted = `${value} ${unit}`;
   return {
     key: 'lockupPeriod',
-    dataTestId: `lockupPeriod-${lockupMonthsNumber}`,
+    dataTestId: `lockupPeriod-${lockupDaysNumber}`,
     label: t('labels.lockupPeriod'),
     value: formatted,
     tooltip: t('tooltips.lockupPeriod', {
@@ -254,7 +259,7 @@ export const useFormatDisplayEarnOpportunityData = (
   const { getChainById } = useChains();
 
   return useMemo(() => {
-    const lockupMonths = earnOpportunity?.lockupMonths;
+    const lockupDays = earnOpportunity?.lockupDays;
     const capInDollar = earnOpportunity?.capInDollar;
     const protocol = earnOpportunity?.protocol;
     const assets = earnOpportunity?.asset ? [earnOpportunity.asset] : [];
@@ -275,8 +280,8 @@ export const useFormatDisplayEarnOpportunityData = (
     // Build all items, passing variant to each builder
     const overviewItems = [
       apyItem,
-      lockupMonths
-        ? buildLockupItem(lockupMonths, variant, t)
+      lockupDays
+        ? buildLockupItem(lockupDays, variant, t)
         : capInDollar
           ? buildCapInDollarItem(capInDollar, variant, t)
           : buildRewardsApyItem(rewardsApy, variant, t),

--- a/src/types/jumper-backend.ts
+++ b/src/types/jumper-backend.ts
@@ -912,7 +912,7 @@ export interface EarnOpportunityWithLatestAnalytics {
   lpToken: Token;
   slug: string;
   featured: boolean;
-  lockupMonths?: number | null;
+  lockupDays?: number | null;
   /** The cap in dollar */
   capInDollar?: string;
   /** @deprecated */
@@ -1330,7 +1330,7 @@ export interface EarnOpportunityWithScore {
   lpToken: Token;
   slug: string;
   featured: boolean;
-  lockupMonths?: number | null;
+  lockupDays?: number | null;
   /** The cap in dollar */
   capInDollar?: string;
   /** @deprecated */

--- a/src/utils/earn/utils.ts
+++ b/src/utils/earn/utils.ts
@@ -15,14 +15,3 @@ export const AtLeastNWhenLoading = <T>(
   const result = [...d, ...filler].slice(0, maxN);
   return result;
 };
-
-export const formatLockupDuration = (lockupMonths: number) => {
-  const duration = lockupMonths.toLocaleString();
-
-  if (lockupMonths === 0) {
-    return 'None';
-  } else if (lockupMonths <= 1) {
-    return `${duration} month`;
-  }
-  return `${duration} months`;
-};


### PR DESCRIPTION
## Summary
Reads earnOpportunity.lockupDays from the regenerated DTO type. Replaces the months-only formatLockupDuration helper with a days*86400 adapter over the existing seconds-based formatLockupPeriod (date-fns multi-unit), and deletes the old helper. Linked to JUM-842.

## Design
Final piece of the cross-repo lockupMonths -> lockupDays rename. Translation keys (labels.lockupPeriod, tooltips.lockupPeriod) are unit-agnostic per architect verification - no copy/i18n edits.

## Behavioural change worth flagging to editorial
formatLockupPeriod uses date-fns intervalToDuration, which picks the most-significant unit. So an entry with LockupDays=30 renders as '30 days', NOT '1 month'. When editorial migrates LockupMonths=1 entries they should be aware the rendered string changes. LockupDays=60 renders '2 months' (verified via fixture). (Reviewer finding d.)

## Tests
test:unit (123), test:unit-components (10), test:snapshots (132 - 18 snapshot entries regenerated cleanly). pnpm typecheck clean. src/types/jumper-backend.ts hand-edited (2 occurrences) instead of pnpm api regen (which requires a running backend); reviewer finding e.

Resolves JUM-842 (frontend portion).

Sister PRs:
- strapi-cms: https://github.com/jumperexchange/strapi-cms/pull/116
- jumper-backend: https://github.com/jumperexchange/jumper-backend/pull/916


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched lockup period display from months to days across the UI — lockups now show day-based values (e.g., 60 days) and handle undefined cases consistently.
* **Tests & Stories**
  * Updated component examples and snapshot coverage to reflect day-based lockup scenarios and corresponding display variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->