### PR TITLE
feat: normalize position display threshold to $0.10 - JUM-841

### DIFF
--- a/src/app/ui/earn/EarnFilteringContext.tsx
+++ b/src/app/ui/earn/EarnFilteringContext.tsx
@@ -193,7 +193,7 @@ export const EarnFilteringProvider = ({
     accounts: tab === EarnFilterTab.YOUR_POSITIONS && account ? [account] : [],
   });
 
-  const earnSlugWithPositionWorthDisplaying = useMemo(() => {
+  const earnSlugsWithPositionWorthDisplaying = useMemo(() => {
     const positions = yourPositions.data?.data ?? [];
 
     return new Set(
@@ -242,7 +242,7 @@ export const EarnFilteringProvider = ({
     let worthDisplaying = filtered;
     if (tab === EarnFilterTab.YOUR_POSITIONS) {
       worthDisplaying = worthDisplaying.filter((opportunity) =>
-        earnSlugWithPositionWorthDisplaying.has(opportunity.slug),
+        earnSlugsWithPositionWorthDisplaying.has(opportunity.slug),
       );
     }
 
@@ -253,7 +253,7 @@ export const EarnFilteringProvider = ({
     );
 
     return sorted;
-  }, [sourceData, filter, sortBy, tab, earnSlugWithPositionWorthDisplaying]);
+  }, [sourceData, filter, sortBy, tab, earnSlugsWithPositionWorthDisplaying]);
 
   const enrichedData = useMemo(() => {
     const forYouSlugsSet = new Set(

--- a/src/app/ui/earn/EarnFilteringContext.tsx
+++ b/src/app/ui/earn/EarnFilteringContext.tsx
@@ -187,21 +187,20 @@ export const EarnFilteringProvider = ({
     [allNoFilter.data],
   );
 
-  // Summed net USD per earn slug, used to apply the $0.10 display floor on the
-  // "Your positions" tab (the backend filters by hasPositions, not by value).
+  // Per-position $0.10 floor on the "Your positions" tab (the backend filters
+  // by hasPositions, not by value). Consistent with the Portfolio positions list.
   const yourPositions = usePortfolioDeFiPositions({
     accounts: tab === EarnFilterTab.YOUR_POSITIONS && account ? [account] : [],
   });
 
-  const positionValueBySlug = useMemo(() => {
-    const map = new Map<string, number>();
-    for (const position of yourPositions.data?.data ?? []) {
-      if (!position.earn) {
-        continue;
-      }
-      map.set(position.earn, (map.get(position.earn) ?? 0) + position.netUsd);
-    }
-    return map;
+  const displayableEarnSlugs = useMemo(() => {
+    const positions = yourPositions.data?.data ?? [];
+    return new Set(
+      positions
+        .filter(isValueWorthDisplaying)
+        .map((position) => position.earn)
+        .filter((earn): earn is string => !!earn),
+    );
   }, [yourPositions.data?.data]);
 
   const totalMarkets = allNoFilterData.length;
@@ -237,21 +236,19 @@ export const EarnFilteringProvider = ({
 
     const filtered = filterOpportunities(sourceData, filter);
 
-    // Hard floor on the "Your positions" tab: drop opportunities whose summed
-    // position value rounds below $0.10. Opportunities with no matching
-    // position value are dropped too (nothing worth showing).
+    // Hard floor on the "Your positions" tab: keep opportunities where the user
+    // holds at least one position worth displaying (>= $0.10).
     const floored =
       tab === EarnFilterTab.YOUR_POSITIONS
-        ? filtered.filter((opportunity) => {
-            const value = positionValueBySlug.get(opportunity.slug);
-            return value !== undefined && isValueWorthDisplaying(value);
-          })
+        ? filtered.filter((opportunity) =>
+            displayableEarnSlugs.has(opportunity.slug),
+          )
         : filtered;
 
     const sorted = sortOpportunities(floored, sortBy, OrderOptions.DESC);
 
     return sorted;
-  }, [sourceData, filter, sortBy, tab, positionValueBySlug]);
+  }, [sourceData, filter, sortBy, tab, displayableEarnSlugs]);
 
   const enrichedData = useMemo(() => {
     const forYouSlugsSet = new Set(

--- a/src/app/ui/earn/EarnFilteringContext.tsx
+++ b/src/app/ui/earn/EarnFilteringContext.tsx
@@ -193,8 +193,9 @@ export const EarnFilteringProvider = ({
     accounts: tab === EarnFilterTab.YOUR_POSITIONS && account ? [account] : [],
   });
 
-  const displayableEarnSlugs = useMemo(() => {
+  const earnSlugWithPositionWorthDisplaying = useMemo(() => {
     const positions = yourPositions.data?.data ?? [];
+
     return new Set(
       positions
         .filter(isValueWorthDisplaying)
@@ -238,17 +239,21 @@ export const EarnFilteringProvider = ({
 
     // Hard floor on the "Your positions" tab: keep opportunities where the user
     // holds at least one position worth displaying (>= $0.10).
-    const floored =
-      tab === EarnFilterTab.YOUR_POSITIONS
-        ? filtered.filter((opportunity) =>
-            displayableEarnSlugs.has(opportunity.slug),
-          )
-        : filtered;
+    let worthDisplaying = filtered;
+    if (tab === EarnFilterTab.YOUR_POSITIONS) {
+      worthDisplaying = worthDisplaying.filter((opportunity) =>
+        earnSlugWithPositionWorthDisplaying.has(opportunity.slug),
+      );
+    }
 
-    const sorted = sortOpportunities(floored, sortBy, OrderOptions.DESC);
+    const sorted = sortOpportunities(
+      worthDisplaying,
+      sortBy,
+      OrderOptions.DESC,
+    );
 
     return sorted;
-  }, [sourceData, filter, sortBy, tab, displayableEarnSlugs]);
+  }, [sourceData, filter, sortBy, tab, earnSlugWithPositionWorthDisplaying]);
 
   const enrichedData = useMemo(() => {
     const forYouSlugsSet = new Set(

--- a/src/app/ui/earn/EarnFilteringContext.tsx
+++ b/src/app/ui/earn/EarnFilteringContext.tsx
@@ -11,6 +11,8 @@ import {
 } from 'react';
 import { useAccountAddress } from 'src/hooks/earn/useAccountAddress';
 import { useEarnFilterOpportunities } from 'src/hooks/earn/useEarnFilterOpportunities';
+import { usePortfolioDeFiPositions } from '@/hooks/portfolio/usePortfolioDeFiPositions';
+import { isValueWorthDisplaying } from '@/utils/numbers/displayValueThreshold';
 import type { NullableFields } from 'src/types/internal';
 import type { EarnOpportunityWithLatestAnalytics } from 'src/types/jumper-backend';
 import type { StrapiMetaPagination } from 'src/types/strapi';
@@ -185,6 +187,23 @@ export const EarnFilteringProvider = ({
     [allNoFilter.data],
   );
 
+  // Summed net USD per earn slug, used to apply the $0.10 display floor on the
+  // "Your positions" tab (the backend filters by hasPositions, not by value).
+  const yourPositions = usePortfolioDeFiPositions({
+    accounts: tab === EarnFilterTab.YOUR_POSITIONS && account ? [account] : [],
+  });
+
+  const positionValueBySlug = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const position of yourPositions.data?.data ?? []) {
+      if (!position.earn) {
+        continue;
+      }
+      map.set(position.earn, (map.get(position.earn) ?? 0) + position.netUsd);
+    }
+    return map;
+  }, [yourPositions.data?.data]);
+
   const totalMarkets = allNoFilterData.length;
 
   const { sourceData, error, updatedAt } = useMemo(() => {
@@ -218,10 +237,21 @@ export const EarnFilteringProvider = ({
 
     const filtered = filterOpportunities(sourceData, filter);
 
-    const sorted = sortOpportunities(filtered, sortBy, OrderOptions.DESC);
+    // Hard floor on the "Your positions" tab: drop opportunities whose summed
+    // position value rounds below $0.10. Opportunities with no matching
+    // position value are dropped too (nothing worth showing).
+    const floored =
+      tab === EarnFilterTab.YOUR_POSITIONS
+        ? filtered.filter((opportunity) => {
+            const value = positionValueBySlug.get(opportunity.slug);
+            return value !== undefined && isValueWorthDisplaying(value);
+          })
+        : filtered;
+
+    const sorted = sortOpportunities(floored, sortBy, OrderOptions.DESC);
 
     return sorted;
-  }, [sourceData, filter, sortBy, tab]);
+  }, [sourceData, filter, sortBy, tab, positionValueBySlug]);
 
   const enrichedData = useMemo(() => {
     const forYouSlugsSet = new Set(

--- a/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
+++ b/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
@@ -67,7 +67,7 @@ export const WalletBalanceCard: FC<WalletBalanceCardProps> = ({
       .map(
         ([symbol, group]): BalanceGroup => [
           symbol,
-          group.filter((balance) => isValueWorthDisplaying(balance)),
+          group.filter(isValueWorthDisplaying),
         ],
       )
       .filter(([, group]) => group.length > 0);

--- a/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
+++ b/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
@@ -24,11 +24,10 @@ import { useSettingsStore } from '@/stores/settings';
 import { BalanceCardSize } from '../BalanceCard/types';
 import { BalanceCardSkeleton } from '../BalanceCard/components/BalanceCardSkeleton';
 import { BalanceCard } from '../BalanceCard/BalanceCard';
-import { flatMap } from 'lodash';
+import { flatMap, mapValues, pickBy } from 'lodash';
 import {
   balanceGroupSortAccessors,
   sortPortfolioItems,
-  type BalanceGroup,
 } from '@/providers/PortfolioProvider/filtering/utils';
 import { isValueWorthDisplaying } from '@/utils/numbers/displayValueThreshold';
 import { BaseAlert } from '@/components/Alerts/BaseAlert/BaseAlert';
@@ -63,17 +62,16 @@ export const WalletBalanceCard: FC<WalletBalanceCardProps> = ({
   const balanceGroups = useMemo(() => {
     // Hard floor: hide dust below the $0.10 display threshold and drop emptied
     // groups. The per-wallet total below stays computed from unfiltered data.
-    const displayableEntries = Object.entries(data)
-      .map(
-        ([symbol, group]): BalanceGroup => [
-          symbol,
-          group.filter(isValueWorthDisplaying),
-        ],
-      )
-      .filter(([, group]) => group.length > 0);
+    const worthDisplaying = mapValues(data, (group) =>
+      group.filter(isValueWorthDisplaying),
+    );
+    const worthDisplayingAndNonEmpty = pickBy(
+      worthDisplaying,
+      (group) => group.length > 0,
+    );
 
     return sortPortfolioItems(
-      displayableEntries,
+      Object.entries(worthDisplayingAndNonEmpty),
       'value',
       'desc',
       balanceGroupSortAccessors,

--- a/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
+++ b/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
@@ -67,7 +67,7 @@ export const WalletBalanceCard: FC<WalletBalanceCardProps> = ({
       .map(
         ([symbol, group]): BalanceGroup => [
           symbol,
-          group.filter((balance) => isValueWorthDisplaying(balance.amountUSD)),
+          group.filter((balance) => isValueWorthDisplaying(balance)),
         ],
       )
       .filter(([, group]) => group.length > 0);

--- a/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
+++ b/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
@@ -28,7 +28,9 @@ import { flatMap } from 'lodash';
 import {
   balanceGroupSortAccessors,
   sortPortfolioItems,
+  type BalanceGroup,
 } from '@/providers/PortfolioProvider/filtering/utils';
+import { isValueWorthDisplaying } from '@/utils/numbers/displayValueThreshold';
 import { BaseAlert } from '@/components/Alerts/BaseAlert/BaseAlert';
 import { BaseAlertVariant } from '@/components/Alerts/BaseAlert/BaseAlert.styles';
 import { AppPaths } from '@/const/urls';
@@ -59,8 +61,19 @@ export const WalletBalanceCard: FC<WalletBalanceCardProps> = ({
   const { setWalletMenuState } = useMenuStore((state) => state);
 
   const balanceGroups = useMemo(() => {
+    // Hard floor: hide dust below the $0.10 display threshold and drop emptied
+    // groups. The per-wallet total below stays computed from unfiltered data.
+    const displayableEntries = Object.entries(data)
+      .map(
+        ([symbol, group]): BalanceGroup => [
+          symbol,
+          group.filter((balance) => isValueWorthDisplaying(balance.amountUSD)),
+        ],
+      )
+      .filter(([, group]) => group.length > 0);
+
     return sortPortfolioItems(
-      Object.entries(data),
+      displayableEntries,
       'value',
       'desc',
       balanceGroupSortAccessors,

--- a/src/providers/PortfolioProvider/filtering/utils.spec.ts
+++ b/src/providers/PortfolioProvider/filtering/utils.spec.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import type { PortfolioBalance, WalletToken } from '@/types/tokens';
+import type { PortfolioPosition } from '../types';
+import { OrderOptions, SortByOptions } from './types';
+import type { BalancesFilter, PositionsFilter } from './types';
+import {
+  filterSortBalancesData,
+  filterSortPositionsData,
+  sanitizeValue,
+} from './utils';
+
+const makePosition = (
+  protocol: string,
+  chainId: number,
+  netUsd: number,
+): PortfolioPosition =>
+  ({
+    source: 'chain',
+    protocol: { name: protocol },
+    chain: { chainId },
+    netUsd,
+  }) as unknown as PortfolioPosition;
+
+const makeBalance = (
+  symbol: string,
+  chainId: number,
+  amountUSD: number,
+): PortfolioBalance<WalletToken> =>
+  ({
+    amountUSD,
+    token: { symbol, chainId, chainKey: `chain-${chainId}` },
+  }) as unknown as PortfolioBalance<WalletToken>;
+
+const positionValues = (
+  grouped: Record<string, PortfolioPosition[]>,
+): number[] =>
+  Object.values(grouped)
+    .flat()
+    .map((p) => p.netUsd)
+    .sort((a, b) => a - b);
+
+const balanceValues = (
+  grouped: Record<string, PortfolioBalance<WalletToken>[]>,
+): number[] =>
+  Object.values(grouped)
+    .flat()
+    .map((b) => b.amountUSD)
+    .sort((a, b) => a - b);
+
+describe('sanitizeValue', () => {
+  it('rounds to two decimals and passes non-finite through', () => {
+    expect(sanitizeValue(0.099)).toBe(0.1);
+    expect(sanitizeValue(Infinity)).toBe(Infinity);
+    expect(sanitizeValue(NaN)).toBeNaN();
+  });
+});
+
+describe('filterSortPositionsData $0.10 hard floor', () => {
+  it('hides positions that round below $0.10 with no slider filter', () => {
+    const positions = [
+      makePosition('aave', 1, 0.05),
+      makePosition('compound', 1, 0.099),
+      makePosition('yearn', 1, 0.1),
+      makePosition('morpho', 1, 5),
+    ];
+    const filter: PositionsFilter = {};
+
+    const result = filterSortPositionsData(
+      positions,
+      filter,
+      SortByOptions.VALUE,
+      OrderOptions.DESC,
+    );
+
+    expect(positionValues(result)).toEqual([0.099, 0.1, 5]);
+  });
+
+  it('applies the floor beneath a $0 slider minimum', () => {
+    const positions = [
+      makePosition('aave', 1, 0.05),
+      makePosition('yearn', 1, 2),
+    ];
+    const filter: PositionsFilter = { minValue: 0 };
+
+    const result = filterSortPositionsData(
+      positions,
+      filter,
+      SortByOptions.VALUE,
+      OrderOptions.DESC,
+    );
+
+    expect(positionValues(result)).toEqual([2]);
+  });
+});
+
+describe('filterSortBalancesData $0.10 hard floor', () => {
+  it('hides balances that round below $0.10 with no slider filter', () => {
+    const balancesByAddress = {
+      '0xabc': {
+        ETH: [makeBalance('ETH', 1, 0.05)],
+        USDC: [makeBalance('USDC', 1, 0.099)],
+        DAI: [makeBalance('DAI', 1, 0.1)],
+        WBTC: [makeBalance('WBTC', 1, 100)],
+      },
+    };
+    const filter: BalancesFilter = {};
+
+    const result = filterSortBalancesData(
+      balancesByAddress,
+      filter,
+      SortByOptions.VALUE,
+      OrderOptions.DESC,
+    );
+
+    expect(balanceValues(result)).toEqual([0.099, 0.1, 100]);
+  });
+
+  it('applies the floor beneath a $0 slider minimum', () => {
+    const balancesByAddress = {
+      '0xabc': {
+        ETH: [makeBalance('ETH', 1, 0.05)],
+        WBTC: [makeBalance('WBTC', 1, 100)],
+      },
+    };
+    const filter: BalancesFilter = { minValue: 0 };
+
+    const result = filterSortBalancesData(
+      balancesByAddress,
+      filter,
+      SortByOptions.VALUE,
+      OrderOptions.DESC,
+    );
+
+    expect(balanceValues(result)).toEqual([100]);
+  });
+});

--- a/src/providers/PortfolioProvider/filtering/utils.ts
+++ b/src/providers/PortfolioProvider/filtering/utils.ts
@@ -20,17 +20,17 @@ import { DEFAULT_POSITIONS_MIN_VALUE } from './constants';
 import type { PortfolioPosition } from '../types';
 import { balanceAccessors, positionAccessors } from '../utils';
 import type { PortfolioBalance, WalletToken } from '@/types/tokens';
+import {
+  isValueWorthDisplaying,
+  roundDisplayValueUsd,
+} from '@/utils/numbers/displayValueThreshold';
 
 export type SortAccessors<T> = Partial<
   Record<SortByEnum, (item: T) => string | number>
 >;
 
-export const sanitizeValue = (value: number): number => {
-  if (!isFinite(value)) {
-    return value;
-  }
-  return Number(value.toFixed(2));
-};
+export const sanitizeValue = (value: number): number =>
+  roundDisplayValueUsd(value);
 
 export const sortPortfolioItems = <T>(
   items: T[],
@@ -181,6 +181,11 @@ export const filterSortBalancesData = (
     );
   }
 
+  // Hard floor: hide dust below the $0.10 display threshold regardless of slider
+  allBalances = allBalances.filter((balance) =>
+    isValueWorthDisplaying(balance.amountUSD),
+  );
+
   if (filter.minValue !== undefined || filter.maxValue !== undefined) {
     allBalances = allBalances.filter((balance) => {
       return isWithinValueRange(
@@ -282,7 +287,10 @@ export const filterSortPositionsData = (
   sortByValue: SortByEnum,
   order: OrderEnum,
 ): Record<string, PortfolioPosition[]> => {
-  let result = [...positions];
+  // Hard floor: hide dust below the $0.10 display threshold regardless of slider
+  let result = positions.filter((position) =>
+    isValueWorthDisplaying(position.netUsd),
+  );
 
   if (filter.minValue !== undefined || filter.maxValue !== undefined) {
     result = result.filter((position) => {

--- a/src/providers/PortfolioProvider/filtering/utils.ts
+++ b/src/providers/PortfolioProvider/filtering/utils.ts
@@ -182,9 +182,7 @@ export const filterSortBalancesData = (
   }
 
   // Hard floor: hide dust below the $0.10 display threshold regardless of slider
-  allBalances = allBalances.filter((balance) =>
-    isValueWorthDisplaying(balance),
-  );
+  allBalances = allBalances.filter(isValueWorthDisplaying);
 
   if (filter.minValue !== undefined || filter.maxValue !== undefined) {
     allBalances = allBalances.filter((balance) => {
@@ -288,7 +286,7 @@ export const filterSortPositionsData = (
   order: OrderEnum,
 ): Record<string, PortfolioPosition[]> => {
   // Hard floor: hide dust below the $0.10 display threshold regardless of slider
-  let result = positions.filter((position) => isValueWorthDisplaying(position));
+  let result = positions.filter(isValueWorthDisplaying);
 
   if (filter.minValue !== undefined || filter.maxValue !== undefined) {
     result = result.filter((position) => {

--- a/src/providers/PortfolioProvider/filtering/utils.ts
+++ b/src/providers/PortfolioProvider/filtering/utils.ts
@@ -183,7 +183,7 @@ export const filterSortBalancesData = (
 
   // Hard floor: hide dust below the $0.10 display threshold regardless of slider
   allBalances = allBalances.filter((balance) =>
-    isValueWorthDisplaying(balance.amountUSD),
+    isValueWorthDisplaying(balance),
   );
 
   if (filter.minValue !== undefined || filter.maxValue !== undefined) {
@@ -288,9 +288,7 @@ export const filterSortPositionsData = (
   order: OrderEnum,
 ): Record<string, PortfolioPosition[]> => {
   // Hard floor: hide dust below the $0.10 display threshold regardless of slider
-  let result = positions.filter((position) =>
-    isValueWorthDisplaying(position.netUsd),
-  );
+  let result = positions.filter((position) => isValueWorthDisplaying(position));
 
   if (filter.minValue !== undefined || filter.maxValue !== undefined) {
     result = result.filter((position) => {

--- a/src/utils/numbers/displayValueThreshold.spec.ts
+++ b/src/utils/numbers/displayValueThreshold.spec.ts
@@ -41,4 +41,24 @@ describe('isValueWorthDisplaying', () => {
     expect(isValueWorthDisplaying(Infinity)).toBe(true);
     expect(isValueWorthDisplaying(NaN)).toBe(false);
   });
+
+  it('accepts a balance object { amountUSD } and applies the same floor', () => {
+    expect(isValueWorthDisplaying({ amountUSD: 0 })).toBe(false);
+    expect(isValueWorthDisplaying({ amountUSD: 0.094 })).toBe(false);
+    expect(isValueWorthDisplaying({ amountUSD: 0.099 })).toBe(true);
+    expect(isValueWorthDisplaying({ amountUSD: MIN_DISPLAY_VALUE_USD })).toBe(
+      true,
+    );
+    expect(isValueWorthDisplaying({ amountUSD: 1 })).toBe(true);
+  });
+
+  it('accepts a position object { netUsd } and applies the same floor', () => {
+    expect(isValueWorthDisplaying({ netUsd: 0 })).toBe(false);
+    expect(isValueWorthDisplaying({ netUsd: 0.094 })).toBe(false);
+    expect(isValueWorthDisplaying({ netUsd: 0.099 })).toBe(true);
+    expect(isValueWorthDisplaying({ netUsd: MIN_DISPLAY_VALUE_USD })).toBe(
+      true,
+    );
+    expect(isValueWorthDisplaying({ netUsd: 1 })).toBe(true);
+  });
 });

--- a/src/utils/numbers/displayValueThreshold.spec.ts
+++ b/src/utils/numbers/displayValueThreshold.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MIN_DISPLAY_VALUE_USD,
+  isValueWorthDisplaying,
+  roundDisplayValueUsd,
+} from './displayValueThreshold';
+
+describe('roundDisplayValueUsd', () => {
+  it('rounds to two decimals', () => {
+    expect(roundDisplayValueUsd(0.099)).toBe(0.1);
+    expect(roundDisplayValueUsd(0.094)).toBe(0.09);
+    expect(roundDisplayValueUsd(1.005)).toBe(1);
+  });
+
+  it('passes through non-finite values unchanged', () => {
+    expect(roundDisplayValueUsd(Infinity)).toBe(Infinity);
+    expect(roundDisplayValueUsd(-Infinity)).toBe(-Infinity);
+    expect(roundDisplayValueUsd(NaN)).toBeNaN();
+  });
+});
+
+describe('isValueWorthDisplaying', () => {
+  it('hides values below the $0.10 floor', () => {
+    expect(isValueWorthDisplaying(0)).toBe(false);
+    expect(isValueWorthDisplaying(0.09)).toBe(false);
+    expect(isValueWorthDisplaying(0.094)).toBe(false);
+  });
+
+  it('shows values that round up to the inclusive boundary', () => {
+    expect(isValueWorthDisplaying(0.099)).toBe(true);
+    expect(isValueWorthDisplaying(MIN_DISPLAY_VALUE_USD)).toBe(true);
+    expect(isValueWorthDisplaying(0.1)).toBe(true);
+  });
+
+  it('shows values comfortably above the floor', () => {
+    expect(isValueWorthDisplaying(1)).toBe(true);
+    expect(isValueWorthDisplaying(1234.56)).toBe(true);
+  });
+
+  it('shows Infinity and hides NaN', () => {
+    expect(isValueWorthDisplaying(Infinity)).toBe(true);
+    expect(isValueWorthDisplaying(NaN)).toBe(false);
+  });
+});

--- a/src/utils/numbers/displayValueThreshold.ts
+++ b/src/utils/numbers/displayValueThreshold.ts
@@ -1,0 +1,8 @@
+export const MIN_DISPLAY_VALUE_USD = 0.1;
+
+export const roundDisplayValueUsd = (value: number): number =>
+  isFinite(value) ? Number(value.toFixed(2)) : value;
+
+// "worth showing" — boundary is inclusive ($0.10 shows; below hides)
+export const isValueWorthDisplaying = (value: number): boolean =>
+  roundDisplayValueUsd(value) >= MIN_DISPLAY_VALUE_USD;

--- a/src/utils/numbers/displayValueThreshold.ts
+++ b/src/utils/numbers/displayValueThreshold.ts
@@ -3,6 +3,18 @@ export const MIN_DISPLAY_VALUE_USD = 0.1;
 export const roundDisplayValueUsd = (value: number): number =>
   isFinite(value) ? Number(value.toFixed(2)) : value;
 
-// "worth showing" — boundary is inclusive ($0.10 shows; below hides)
-export const isValueWorthDisplaying = (value: number): boolean =>
-  roundDisplayValueUsd(value) >= MIN_DISPLAY_VALUE_USD;
+type UsdValued = { amountUSD: number } | { netUsd: number };
+export type DisplayValueInput = number | UsdValued;
+
+const toUsd = (input: DisplayValueInput): number =>
+  typeof input === 'number'
+    ? input
+    : 'netUsd' in input
+      ? input.netUsd
+      : input.amountUSD;
+
+// "worth showing" — boundary is inclusive ($0.10 shows; below hides).
+// Accepts a raw number, a balance object ({ amountUSD }), or a position
+// object ({ netUsd }) so call sites don't need to reach into the field.
+export const isValueWorthDisplaying = (input: DisplayValueInput): boolean =>
+  roundDisplayValueUsd(toUsd(input)) >= MIN_DISPLAY_VALUE_USD;


### PR DESCRIPTION
## Summary

Introduces a single shared $0.10 minimum display-value helper and applies it as a hard floor across every list of user positions and balances, so dust below ten cents is hidden consistently regardless of the slider or filter settings. Header and overview totals stay unfiltered.

## Changes

- Add `src/utils/numbers/displayValueThreshold.ts` (`roundDisplayValueUsd`, `isValueWorthDisplaying`) as the single source of truth for the $0.10 floor, with colocated vitest spec.
- Apply the floor in `filterSortPositionsData` (netUsd) and `filterSortBalancesData` (amountUSD) before the slider; `sanitizeValue` now delegates to `roundDisplayValueUsd`. Adds `filtering/utils.spec.ts`.
- Filter wallet drawer groups in `WalletBalanceCard` and drop emptied groups, while the per-wallet total stays computed from unfiltered data.
- Drop sub-$0.10 / no-match opportunities on the Earn "Your positions" tab in `EarnFilteringContext`.

## Linked Linear ticket

JUM-841 — https://linear.app/lifi-linear/issue/JUM-841

## Sister PRs

N/A

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Wallet balance card now hides low-value balance entries using a consistent **$0.10** threshold with USD rounding, reducing visual clutter.
  * Portfolio filtering now applies a hard **$0.10** floor to both DeFi positions and earn opportunities, including the **YOUR_POSITIONS** tab.
* **Tests**
  * Added unit tests covering **$0.10** threshold behavior and USD rounding (including **Infinity** and **NaN**) plus coverage for related filtering utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->