### PR TITLE
feat: filter expired notifications client-side using expiresAt (JUM-1034)

### DIFF
--- a/src/components/Notifications/NotificationBell.spec.tsx
+++ b/src/components/Notifications/NotificationBell.spec.tsx
@@ -12,10 +12,10 @@ const accountState: { account?: { address: string } } = {
 };
 
 const summaryState: {
-  data?: { count: number; latestCreatedAt: string | null };
+  data?: { count: number; expiredCount: number };
   isLoading: boolean;
 } = {
-  data: { count: 0, latestCreatedAt: null },
+  data: { count: 0, expiredCount: 0 },
   isLoading: false,
 };
 
@@ -93,7 +93,7 @@ describe('NotificationBell', () => {
     };
     summaryState.data = {
       count: 5,
-      latestCreatedAt: '2026-04-16T10:30:00.000Z',
+      expiredCount: 0,
     };
     summaryState.isLoading = false;
     useNotificationStore.setState({
@@ -115,7 +115,7 @@ describe('NotificationBell', () => {
   });
 
   it('clamps badge to zero when local dismissed count exceeds server count', () => {
-    summaryState.data = { count: 1, latestCreatedAt: null };
+    summaryState.data = { count: 1, expiredCount: 0 };
     // 1 - 2 readIds - 1 deletedId = -2 → clamped to 0
     render(<NotificationBell />);
     const badge = screen.getByTestId('notification-badge');

--- a/src/hooks/notifications/useFilteredNotifications.ts
+++ b/src/hooks/notifications/useFilteredNotifications.ts
@@ -3,6 +3,7 @@ import { subDays, subWeeks } from 'date-fns';
 import { useMemo, useState } from 'react';
 import { useNotificationStore } from '@/stores/notifications/NotificationStore';
 import type { NotificationCategory } from '@/types/notifications';
+import { isExpired } from '@/utils/notifications/isExpired';
 import { useNotifications } from './useNotifications';
 
 export type DateFilter = 'all' | 'today' | 'week' | 'month';
@@ -56,7 +57,9 @@ export const useFilteredNotifications = ({
     if (!notifications) {
       return [];
     }
-    return notifications.filter((n) => !deletedIds.includes(n.id));
+    return notifications.filter(
+      (n) => !deletedIds.includes(n.id) && !isExpired(n),
+    );
   }, [notifications, deletedIds]);
 
   const unreadCount = useMemo(

--- a/src/hooks/notifications/useNotificationsSummary.spec.ts
+++ b/src/hooks/notifications/useNotificationsSummary.spec.ts
@@ -47,7 +47,7 @@ describe('useNotificationsSummary', () => {
       ok: true,
       json: async () => ({
         count: 2,
-        latestCreatedAt: '2026-04-16T10:30:00.000Z',
+        expiredCount: 1,
       }),
     } as Response);
 
@@ -106,7 +106,7 @@ describe('useNotificationsSummary', () => {
       ok: true,
       json: async () => ({
         count: 3,
-        latestCreatedAt: '2026-04-16T10:30:00.000Z',
+        expiredCount: 0,
       }),
     } as Response);
 

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -25,8 +25,10 @@ export interface Notification {
 }
 
 export interface NotificationSummary {
+  /** Live (non-expired) notification count, computed server-side. */
   count: number;
-  latestCreatedAt: string | null;
+  /** Expired subset of the count, exposed for future client-side use. */
+  expiredCount: number;
 }
 
 export interface NotificationStoreData {

--- a/src/utils/notifications/isExpired.spec.ts
+++ b/src/utils/notifications/isExpired.spec.ts
@@ -20,9 +20,9 @@ describe('isExpired', () => {
     );
   });
 
-  it('treats the exact boundary as expired', () => {
+  it('treats the exact boundary as not yet expired', () => {
     expect(isExpired({ expiresAt: '2026-06-01T12:00:00.000Z' }, NOW)).toBe(
-      true,
+      false,
     );
   });
 

--- a/src/utils/notifications/isExpired.spec.ts
+++ b/src/utils/notifications/isExpired.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { isExpired } from './isExpired';
+
+const NOW = Date.parse('2026-06-01T12:00:00.000Z');
+
+describe('isExpired', () => {
+  it('treats notifications without an expiresAt as never expired', () => {
+    expect(isExpired({ expiresAt: null }, NOW)).toBe(false);
+  });
+
+  it('hides notifications whose expiresAt is in the past', () => {
+    expect(isExpired({ expiresAt: '2026-06-01T11:59:59.999Z' }, NOW)).toBe(
+      true,
+    );
+  });
+
+  it('shows notifications whose expiresAt is in the future', () => {
+    expect(isExpired({ expiresAt: '2026-06-01T12:00:00.001Z' }, NOW)).toBe(
+      false,
+    );
+  });
+
+  it('treats the exact boundary as expired', () => {
+    expect(isExpired({ expiresAt: '2026-06-01T12:00:00.000Z' }, NOW)).toBe(
+      true,
+    );
+  });
+
+  it('treats an unparseable expiresAt as never expired', () => {
+    expect(isExpired({ expiresAt: 'not-a-date' }, NOW)).toBe(false);
+  });
+});

--- a/src/utils/notifications/isExpired.ts
+++ b/src/utils/notifications/isExpired.ts
@@ -1,0 +1,28 @@
+import type { Notification } from '@/types/notifications';
+
+/**
+ * Whether a notification has passed its expiry.
+ *
+ * The backend no longer filters expired rows server-side — it returns every
+ * notification with an `expiresAt` and lets the client decide how to present
+ * them (see JUM-1033/JUM-1034). This helper is the single place that encodes
+ * that policy: today we hide expired notifications to match prior behaviour.
+ * To show them later (greyed-out, behind a toggle, …) change this helper or
+ * its call sites — nothing else needs to move.
+ *
+ * Notifications without an `expiresAt` (or with an unparseable one) never
+ * expire and are always shown.
+ */
+export const isExpired = (
+  notification: Pick<Notification, 'expiresAt'>,
+  now: number = Date.now(),
+): boolean => {
+  if (!notification.expiresAt) {
+    return false;
+  }
+  const expiresAt = new Date(notification.expiresAt).getTime();
+  if (Number.isNaN(expiresAt)) {
+    return false;
+  }
+  return expiresAt <= now;
+};

--- a/src/utils/notifications/isExpired.ts
+++ b/src/utils/notifications/isExpired.ts
@@ -1,15 +1,8 @@
-import { isAfter, isValid, parseISO } from 'date-fns';
+import { isBefore, isValid, parseISO } from 'date-fns';
 import type { Notification } from '@/types/notifications';
 
 /**
  * Whether a notification has passed its expiry.
- *
- * The backend no longer filters expired rows server-side — it returns every
- * notification with an `expiresAt` and lets the client decide how to present
- * them (see JUM-1033/JUM-1034). This helper is the single place that encodes
- * that policy: today we hide expired notifications to match prior behaviour.
- * To show them later (greyed-out, behind a toggle, …) change this helper or
- * its call sites — nothing else needs to move.
  *
  * Notifications without an `expiresAt` (or with an unparseable one) never
  * expire and are always shown.
@@ -25,6 +18,6 @@ export const isExpired = (
   if (!isValid(expiresAt)) {
     return false;
   }
-  // Expired once expiresAt <= now (the exact boundary counts as expired).
-  return !isAfter(expiresAt, now);
+  // Expired once expiresAt is strictly in the past.
+  return isBefore(expiresAt, now);
 };

--- a/src/utils/notifications/isExpired.ts
+++ b/src/utils/notifications/isExpired.ts
@@ -1,3 +1,4 @@
+import { isAfter, isValid, parseISO } from 'date-fns';
 import type { Notification } from '@/types/notifications';
 
 /**
@@ -20,9 +21,10 @@ export const isExpired = (
   if (!notification.expiresAt) {
     return false;
   }
-  const expiresAt = new Date(notification.expiresAt).getTime();
-  if (Number.isNaN(expiresAt)) {
+  const expiresAt = parseISO(notification.expiresAt);
+  if (!isValid(expiresAt)) {
     return false;
   }
-  return expiresAt <= now;
+  // Expired once expiresAt <= now (the exact boundary counts as expired).
+  return !isAfter(expiresAt, now);
 };


### PR DESCRIPTION
## What

Frontend half of [JUM-1034](https://linear.app/lifi-linear/issue/JUM-1034/filter-expired-notifications-client-side-using-expiresat). The notifications backend now stops filtering expired rows server-side and returns `expiresAt` on every notification, leaving presentation to the client.

This moves the expiry decision to the frontend, centralised in a single `isExpired(n)` helper so the policy is trivial to change later (e.g. show expired greyed-out or behind a toggle). **No visible behaviour change in this PR** — expired notifications stay hidden, exactly as today.

## ⚠️ Depends on notifications PR

This requires [jumperexchange/jumper-notifications#43](https://github.com/jumperexchange/jumper-notifications/pull/43) to be **merged and deployed first**. That PR:
- stops filtering expired rows from the list endpoint (returns them with `expiresAt`), and
- changes the summary response from `{ count, latestCreatedAt }` to `{ count, expiredCount }`.

Until it ships, the list won't contain expired rows (so the new filter is a no-op) and the summary type here won't match the live response.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expired notifications are now filtered client-side; unread and badge counts exclude expired items.
  * Notification summary now includes a separate expired-count value.

* **Tests**
  * Added tests covering expiration detection and boundary behavior.
  * Updated notification tests to reflect the new summary shape and badge-visibility logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->