### PR TITLE
fix(ci): complete Qase run once via dedicated job - JUM-1050

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -168,6 +168,28 @@ jobs:
           path: playwright-report
           retention-days: 2
 
+  # Closes the shared run once after all shards report; always() also rescues runs orphaned by cancellation.
+  complete-qase-run:
+    needs: [create-qase-run, test]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Complete Qase Test Run
+        env:
+          QASE_TOKEN: ${{ secrets.QASE_TOKEN }}
+          QASE_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
+        run: |
+          if [ -z "$QASE_TOKEN" ] || [ -z "$QASE_RUN_ID" ]; then
+            echo "No Qase token or run id available, nothing to complete"
+            exit 0
+          fi
+
+          curl --silent --fail --show-error --request POST \
+            --url "https://api.qase.io/v1/run/WJ/$QASE_RUN_ID/complete" \
+            --header "Token: $QASE_TOKEN" \
+            --header 'accept: application/json'
+
   post-comment:
     needs: [create-qase-run, merge-reports]
     if: ${{ !cancelled() && github.event_name == 'pull_request' }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,7 +32,8 @@ const qaseReporter = [
       project: 'WJ',
       uploadAttachments: true,
       run: {
-        complete: true,
+        // completed once by the complete-qase-run CI job, not per-shard (avoids status races)
+        complete: false,
       },
     },
   },


### PR DESCRIPTION
## What

Fixes two Qase TestOps anomalies on our CI runs:

1. Runs badged **"Passed" despite real test failures** (e.g. `27 passed / 1 failed` shows green).
2. Runs stuck **"In Progress" forever** — these are the ones from cancelled workflows.

## Why

CI shares **one** Qase run across **5 shards**, with `run.complete: true`. So each shard races to close the run — whichever finishes last stamps the status, and if it held only passing tests, the whole run reads "passed". Cancelled workflows never run the shards at all, so nobody closes the run → stuck in-progress.

## Change

Move completion out of the shards into one dedicated job (Qase's documented sharding pattern):

- `playwright.config.ts`: `run.complete: false` — shards no longer self-complete.
- `.github/workflows/playwright.yml`: new `complete-qase-run` job (`needs: [create-qase-run, test]`, `if: always()`) that closes the run once via the API. `always()` also rescues cancelled-workflow orphans.

## Verification

CI-behaviour change — only verifiable in CI. Expect: a sharded run with any failure now shows run status **failed**, and a cancelled workflow leaves its Qase run **closed**, not stuck.

Linear: JUM-1050

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test infrastructure to improve test run completion tracking in the CI/CD pipeline, preventing race conditions during automated test reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->