### PR TITLE
feat: translate notifications via i18next - JUM-1032

### DIFF
--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -4,6 +4,10 @@ import { initReactI18next } from 'react-i18next/initReactI18next';
 import resourcesToBackend from 'i18next-resources-to-backend';
 import i18nConfig from '../../i18n-config';
 import {
+  chainNameFormatter,
+  chainNamesFormatter,
+} from '@/utils/chains/chainNameFormatter';
+import {
   currencyFormatter,
   decimalFormatter,
   percentFormatter,
@@ -47,6 +51,14 @@ export default async function initTranslations(
   i18nInstance.services.formatter?.addCached('decimalExt', decimalFormatter);
   i18nInstance.services.formatter?.addCached('currencyExt', currencyFormatter);
   i18nInstance.services.formatter?.addCached('dateExt', dateFormatter);
+  i18nInstance.services.formatter?.addCached(
+    'chainNameExt',
+    chainNameFormatter,
+  );
+  i18nInstance.services.formatter?.addCached(
+    'chainNamesExt',
+    chainNamesFormatter,
+  );
 
   return {
     i18n: i18nInstance,

--- a/src/components/Notifications/NotificationItem.tsx
+++ b/src/components/Notifications/NotificationItem.tsx
@@ -11,6 +11,7 @@ import { Badge } from '@/components/Badge/Badge';
 import { BadgeSize, BadgeVariant } from '@/components/Badge/Badge.styles';
 import { IconButton } from '@/components/core/buttons/IconButton/IconButton';
 import { Variant, Size } from '@/components/core/buttons/types';
+import { useNotificationContent } from '@/hooks/notifications/useNotificationContent';
 import { useNotificationStore } from '@/stores/notifications/NotificationStore';
 import type { Notification } from '@/types/notifications';
 import { NotificationCategory } from '@/types/notifications';
@@ -44,6 +45,7 @@ export const NotificationItem: FC<NotificationItemProps> = ({
   alwaysShowDelete,
 }) => {
   const { t } = useTranslation();
+  const { title, body, ctaLabel } = useNotificationContent(notification);
   const { account } = useAccount();
   const address = account?.address ?? '';
   const [readIds, markAsRead, deleteNotif] = useNotificationStore((state) => [
@@ -80,7 +82,7 @@ export const NotificationItem: FC<NotificationItemProps> = ({
     <NotificationItemContainer onClick={handleClick} isRead={isRead}>
       <UnreadDot sx={{ visibility: isRead ? 'hidden' : 'visible' }} />
       <NotificationContent>
-        <NotificationTitle>{notification.title}</NotificationTitle>
+        <NotificationTitle>{title}</NotificationTitle>
         <Stack
           direction="row"
           sx={{
@@ -100,20 +102,18 @@ export const NotificationItem: FC<NotificationItemProps> = ({
           />
         </Stack>
 
-        <NotificationBody title={notification.body}>
-          {notification.body}
-        </NotificationBody>
+        <NotificationBody title={body}>{body}</NotificationBody>
 
         <NotificationFooter>
           {notification.ctaUrl &&
-            notification.ctaLabel &&
+            ctaLabel &&
             (isInternal ? (
               <CtaLink
                 as={NextLink}
                 href={notification.ctaUrl}
                 onClick={handleCtaClick}
               >
-                {notification.ctaLabel}
+                {ctaLabel}
                 <OpenInNewRounded />
               </CtaLink>
             ) : (
@@ -123,7 +123,7 @@ export const NotificationItem: FC<NotificationItemProps> = ({
                 rel="noopener noreferrer"
                 onClick={handleCtaClick}
               >
-                {notification.ctaLabel}
+                {ctaLabel}
                 <OpenInNewRounded />
               </CtaLink>
             ))}

--- a/src/hooks/notifications/useNotificationContent.spec.ts
+++ b/src/hooks/notifications/useNotificationContent.spec.ts
@@ -1,0 +1,122 @@
+import type { i18n as I18nInstance, TFunction } from 'i18next';
+import { beforeAll, describe, expect, it } from 'vitest';
+import initTranslations from '@/app/i18n';
+import type { Notification } from '@/types/notifications';
+import { NotificationCategory } from '@/types/notifications';
+import { resolveNotificationContent } from './useNotificationContent';
+
+const makeNotification = (
+  overrides: Partial<Notification> = {},
+): Notification => ({
+  id: '1',
+  title: 'STORED TITLE',
+  body: 'STORED BODY',
+  category: NotificationCategory.Earn,
+  ctaLabel: 'STORED CTA',
+  ctaUrl: '/earn',
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-01T00:00:00.000Z',
+  expiresAt: null,
+  isGlobal: false,
+  metadata: {},
+  priority: 5,
+  sourceRuleId: '',
+  status: 'pending',
+  userAddress: '0xabc',
+  ...overrides,
+});
+
+describe('resolveNotificationContent', () => {
+  let t: TFunction;
+  let i18n: I18nInstance;
+
+  beforeAll(async () => {
+    const init = await initTranslations('en', ['translation', 'language']);
+    t = init.t;
+    i18n = init.i18n;
+  });
+
+  const resolve = (notification: Notification) =>
+    resolveNotificationContent(notification, { t, i18n });
+
+  it('translates idleAssets, formatting raw APY/USD and resolving the chain', () => {
+    const content = resolve(
+      makeNotification({
+        sourceRuleId: 'idleAssets',
+        metadata: {
+          apy: '0.0441',
+          symbol: 'USDC',
+          amountUsd: '5000',
+          chainId: 137,
+          opportunityName: 'Aave USDC',
+        },
+      }),
+    );
+
+    expect(content.title).toBe('Earn 4.41% APY on your idle USDC');
+    expect(content.body).toBe(
+      'You have $5,000.00 USDC on Polygon sitting idle. Deposit into Aave USDC to earn 4.41% APY.',
+    );
+    expect(content.ctaLabel).toBe('Start Earning');
+  });
+
+  it('translates apyDrop, formatting both fractional APYs as percentages', () => {
+    const content = resolve(
+      makeNotification({
+        sourceRuleId: 'apyDrop',
+        metadata: {
+          opportunityName: 'Aave USDC',
+          previousApy: '0.05',
+          currentApy: '0.03',
+        },
+      }),
+    );
+
+    expect(content.title).toBe('Aave USDC: APY dropped');
+    expect(content.body).toBe(
+      'The APY for Aave USDC dropped from 5.00% to 3.00%. Consider reviewing your position on Jumper Earn.',
+    );
+  });
+
+  it('translates userLevelUp with raw level numbers', () => {
+    const content = resolve(
+      makeNotification({
+        sourceRuleId: 'userLevelUp',
+        metadata: { oldLevel: 2, newLevel: 3 },
+      }),
+    );
+
+    expect(content.title).toBe('You reached Level 3!');
+    expect(content.body).toBe(
+      'Your Jumper Pass leveled up from Level 2 to Level 3. Keep earning XP to unlock more.',
+    );
+  });
+
+  it('derives the verb (nesting) and joins chain names for newToolLaunch', () => {
+    const content = resolve(
+      makeNotification({
+        sourceRuleId: 'newToolLaunch',
+        metadata: { toolName: 'Acme', toolType: 'BRIDGE', chainIds: [137, 10] },
+      }),
+    );
+
+    expect(content.body).toBe(
+      'Acme is now live on Jumper. You recently bridged on Polygon, OP Mainnet — try it now.',
+    );
+  });
+
+  it('falls back to stored copy for an unknown rule id', () => {
+    const content = resolve(
+      makeNotification({
+        sourceRuleId: 'mysteryRule',
+        metadata: { foo: 'bar' },
+      }),
+    );
+
+    expect(content).toEqual({
+      title: 'STORED TITLE',
+      body: 'STORED BODY',
+      ctaLabel: 'STORED CTA',
+    });
+  });
+});

--- a/src/hooks/notifications/useNotificationContent.ts
+++ b/src/hooks/notifications/useNotificationContent.ts
@@ -1,0 +1,66 @@
+import type { i18n as I18nInstance, TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
+import type { Notification } from '@/types/notifications';
+
+/**
+ * Rendered notification copy. Either the i18next-translated strings (when the
+ * notification's `sourceRuleId` has a catalogue entry) or the backend-rendered
+ * English fallback.
+ */
+export interface NotificationContent {
+  title: string;
+  body: string;
+  ctaLabel: string;
+}
+
+/**
+ * Translate a notification's copy via i18next keyed by `sourceRuleId`,
+ * interpolating from `metadata`. Falls back to the stored
+ * `title`/`body`/`ctaLabel` when the rule has no catalogue entry. Pure; the
+ * hook below wires the i18n context.
+ */
+export function resolveNotificationContent(
+  notification: Notification,
+  ctx: { t: TFunction; i18n: I18nInstance },
+): NotificationContent {
+  const fallback: NotificationContent = {
+    title: notification.title,
+    body: notification.body,
+    ctaLabel: notification.ctaLabel,
+  };
+
+  const ruleId = notification.sourceRuleId;
+  const titleKey = `notifications.${ruleId}.title`;
+  const bodyKey = `notifications.${ruleId}.body`;
+  if (!ruleId || !ctx.i18n.exists(titleKey) || !ctx.i18n.exists(bodyKey)) {
+    return fallback;
+  }
+
+  // Dynamic union keys carrying interpolation options can't be narrowed by the
+  // typed-resources `t()`; the keys are validated above with `i18n.exists`.
+  const translate = ctx.t as unknown as (
+    key: string,
+    options?: Record<string, unknown>,
+  ) => string;
+  const params = notification.metadata ?? {};
+  const ctaKey = `notifications.${ruleId}.cta`;
+
+  return {
+    title: translate(titleKey, params),
+    body: translate(bodyKey, params),
+    ctaLabel: ctx.i18n.exists(ctaKey)
+      ? translate(ctaKey, params)
+      : notification.ctaLabel,
+  };
+}
+
+/**
+ * Hook form of {@link resolveNotificationContent}, wired to the active i18n
+ * instance.
+ */
+export function useNotificationContent(
+  notification: Notification,
+): NotificationContent {
+  const { t, i18n } = useTranslation();
+  return resolveNotificationContent(notification, { t, i18n });
+}

--- a/src/hooks/notifications/useNotificationContent.ts
+++ b/src/hooks/notifications/useNotificationContent.ts
@@ -23,34 +23,30 @@ export function resolveNotificationContent(
   notification: Notification,
   ctx: { t: TFunction; i18n: I18nInstance },
 ): NotificationContent {
-  const fallback: NotificationContent = {
-    title: notification.title,
-    body: notification.body,
-    ctaLabel: notification.ctaLabel,
-  };
-
   const ruleId = notification.sourceRuleId;
-  const titleKey = `notifications.${ruleId}.title`;
-  const bodyKey = `notifications.${ruleId}.body`;
-  if (!ruleId || !ctx.i18n.exists(titleKey) || !ctx.i18n.exists(bodyKey)) {
-    return fallback;
+  if (!ruleId) {
+    return {
+      title: notification.title,
+      body: notification.body,
+      ctaLabel: notification.ctaLabel,
+    };
   }
 
   // Dynamic union keys carrying interpolation options can't be narrowed by the
-  // typed-resources `t()`; the keys are validated above with `i18n.exists`.
+  // typed-resources `t()`; the keys are validated below with `i18n.exists`.
   const translate = ctx.t as unknown as (
     key: string,
     options?: Record<string, unknown>,
   ) => string;
   const params = notification.metadata ?? {};
-  const ctaKey = `notifications.${ruleId}.cta`;
+
+  const resolve = (key: string, fallbackValue: string): string =>
+    ctx.i18n.exists(key) ? translate(key, params) : fallbackValue;
 
   return {
-    title: translate(titleKey, params),
-    body: translate(bodyKey, params),
-    ctaLabel: ctx.i18n.exists(ctaKey)
-      ? translate(ctaKey, params)
-      : notification.ctaLabel,
+    title: resolve(`notifications.${ruleId}.title`, notification.title),
+    body: resolve(`notifications.${ruleId}.body`, notification.body),
+    ctaLabel: resolve(`notifications.${ruleId}.cta`, notification.ctaLabel),
   };
 }
 

--- a/src/i18n/i18next.d.ts
+++ b/src/i18n/i18next.d.ts
@@ -9,6 +9,10 @@ declare module 'i18next' {
       [K in `currencyExt${string}` | `decimalExt${string}` | `percentExt${string}`]: number;
     } & {
       [K in `dateExt${string}`]: Date;
+    } & {
+      [K in `chainNameExt${string}`]: number;
+    } & {
+      [K in `chainNamesExt${string}`]: number[];
     };
   }
 }

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -710,9 +710,19 @@ export default interface Resources {
       };
     };
     notifications: {
+      apyDrop: {
+        body: 'The APY for {{opportunityName}} dropped from {{previousApy, percentExt}} to {{currentApy, percentExt}}. Consider reviewing your position on Jumper Earn.';
+        cta: 'View Position';
+        title: '{{opportunityName}}: APY dropped';
+      };
       aria: {
         deleteNotification: 'Delete notification';
         openPanel: 'Notifications';
+      };
+      bridgeToEarn: {
+        body: 'You just bridged {{amountUsd, currencyExt(currency: USD)}} {{symbol}} to {{chainId, chainNameExt}}. Earn {{apy, percentExt}} APY by depositing into {{opportunityName}} on Jumper Earn!';
+        cta: 'Start Earning';
+        title: 'Earn {{apy, percentExt}} APY on your {{symbol}}';
       };
       categories: {
         all: 'All Categories';
@@ -728,10 +738,34 @@ export default interface Resources {
         week: 'Past Week';
       };
       emptyState: 'No notifications';
+      idleAssets: {
+        body: 'You have {{amountUsd, currencyExt(currency: USD)}} {{symbol}} on {{chainId, chainNameExt}} sitting idle. Deposit into {{opportunityName}} to earn {{apy, percentExt}} APY.';
+        cta: 'Start Earning';
+        title: 'Earn {{apy, percentExt}} APY on your idle {{symbol}}';
+      };
+      newOpportunity: {
+        body: 'Earn {{apy, percentExt}} APY on {{protocol}} ({{chainId, chainNameExt}}). You hold stablecoins on this chain — check it out!';
+        cta: 'Start Earning';
+        title: 'New Earn Opportunity: {{opportunityName}}';
+      };
+      newToolLaunch: {
+        body: '{{toolName}} is now live on Jumper. You recently $t(notifications.toolVerb.{{toolType}}) on {{chainIds, chainNamesExt}} — try it now.';
+        cta: 'Try it';
+        title: 'New on Jumper: {{toolName}}';
+      };
       title: 'Notifications';
+      toolVerb: {
+        BRIDGE: 'bridged';
+        SWAP: 'swapped';
+      };
       unread_one: '{{count}} unread notification';
       unread_other: '{{count}} unread notifications';
       unread_zero: 'No unread notifications';
+      userLevelUp: {
+        body: 'Your Jumper Pass leveled up from Level {{oldLevel}} to Level {{newLevel}}. Keep earning XP to unlock more.';
+        cta: 'View Jumper Pass';
+        title: 'You reached Level {{newLevel}}!';
+      };
     };
     portfolio: {
       assetOverviewCard: {

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -1062,6 +1062,40 @@
     "aria": {
       "openPanel": "Notifications",
       "deleteNotification": "Delete notification"
+    },
+    "toolVerb": {
+      "BRIDGE": "bridged",
+      "SWAP": "swapped"
+    },
+    "idleAssets": {
+      "title": "Earn {{apy, percentExt}} APY on your idle {{symbol}}",
+      "body": "You have {{amountUsd, currencyExt(currency: USD)}} {{symbol}} on {{chainId, chainNameExt}} sitting idle. Deposit into {{opportunityName}} to earn {{apy, percentExt}} APY.",
+      "cta": "Start Earning"
+    },
+    "bridgeToEarn": {
+      "title": "Earn {{apy, percentExt}} APY on your {{symbol}}",
+      "body": "You just bridged {{amountUsd, currencyExt(currency: USD)}} {{symbol}} to {{chainId, chainNameExt}}. Earn {{apy, percentExt}} APY by depositing into {{opportunityName}} on Jumper Earn!",
+      "cta": "Start Earning"
+    },
+    "apyDrop": {
+      "title": "{{opportunityName}}: APY dropped",
+      "body": "The APY for {{opportunityName}} dropped from {{previousApy, percentExt}} to {{currentApy, percentExt}}. Consider reviewing your position on Jumper Earn.",
+      "cta": "View Position"
+    },
+    "newOpportunity": {
+      "title": "New Earn Opportunity: {{opportunityName}}",
+      "body": "Earn {{apy, percentExt}} APY on {{protocol}} ({{chainId, chainNameExt}}). You hold stablecoins on this chain — check it out!",
+      "cta": "Start Earning"
+    },
+    "newToolLaunch": {
+      "title": "New on Jumper: {{toolName}}",
+      "body": "{{toolName}} is now live on Jumper. You recently $t(notifications.toolVerb.{{toolType}}) on {{chainIds, chainNamesExt}} — try it now.",
+      "cta": "Try it"
+    },
+    "userLevelUp": {
+      "title": "You reached Level {{newLevel}}!",
+      "body": "Your Jumper Pass leveled up from Level {{oldLevel}} to Level {{newLevel}}. Keep earning XP to unlock more.",
+      "cta": "View Jumper Pass"
     }
   }
 }

--- a/src/utils/chains/chainNameFormatter.ts
+++ b/src/utils/chains/chainNameFormatter.ts
@@ -1,0 +1,27 @@
+import { findChain } from '@/utils/chains/findChain';
+
+const resolveChainName = (value: unknown): string => {
+  const id = Number(value);
+  return Number.isFinite(id) ? (findChain(id)?.name ?? String(value)) : '';
+};
+
+/**
+ * i18next formatter resolving a single EVM chain id to its brand name, e.g.
+ * `{{chainId, chainNameExt}}` → "Polygon". Chain names are not translated.
+ */
+export const chainNameFormatter = () => (value: unknown) =>
+  resolveChainName(value);
+
+/**
+ * i18next formatter resolving an array of chain ids to a joined list of brand
+ * names, e.g. `{{chainIds, chainNamesExt}}` → "Polygon, OP Mainnet". The
+ * separator can be overridden via the format option `separator`.
+ */
+export const chainNamesFormatter =
+  (_lng: string | undefined, options: { separator?: string } = {}) =>
+  (value: unknown) => {
+    if (!Array.isArray(value)) {
+      return '';
+    }
+    return value.map(resolveChainName).join(options.separator ?? ', ');
+  };


### PR DESCRIPTION
## Summary

Notifications arrive from the backend as English `title`/`body`/`ctaLabel` strings plus a `sourceRuleId` and a `metadata` bag. This renders them through an i18next catalogue keyed by `sourceRuleId`, interpolating directly from `metadata`, so notification copy is localizable. The stored English strings remain the fallback for any rule without a catalogue entry, so notifications are always displayable.

Frontend half of [JUM-835](https://linear.app/lifi-linear/issue/JUM-835); the backend per-rule metadata contract shipped in jumperexchange/jumper-notifications#47.

## Changes

- Add `notifications.<ruleId>.{title,body,cta}` catalogue entries for the six rules in the backend metadata contract (`idleAssets`, `bridgeToEarn`, `apyDrop`, `newOpportunity`, `newToolLaunch`, `userLevelUp`).
- Add `chainNameExt`/`chainNamesExt` i18next formatters (backed by `findChain`) so chain ids render as brand names; resolve the tool verb via `$t()` nesting. Interpolation is fully declarative — no per-rule JS.
- Reuse the existing `percentExt`/`currencyExt` formatters for raw-fractional APY and raw USD values.
- Resolve copy in `useNotificationContent`, render it in `NotificationItem`.
- Unit test covering formatting, chain/verb resolution, and the unknown-rule fallback.

## Linked Linear ticket

Fixes JUM-1032 (frontend half of JUM-835).

## Sister PRs

- jumperexchange/jumper-notifications#47 — backend per-rule metadata contract (JUM-835)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now resolve content via translations with localized CTA labels and safe fallbacks; CTA buttons show translated text.
  * Chain-name formatting added for human-friendly chain names in notification copy.
  * New notification templates: APY drops, new tool launches, user level progression, idle assets, and bridge opportunities.

* **Tests**
  * Added tests covering notification content resolution, translation formatting, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->