### PR TITLE
feat: translate perkLevelUp notification via i18next (JUM-1058)

### DIFF
--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -12,6 +12,7 @@ import {
   decimalFormatter,
   percentFormatter,
 } from '@/utils/formatNumbers';
+import { listFormatter } from '@/utils/formatList';
 import { dateFormatter } from 'src/utils/formatDate';
 
 export default async function initTranslations(
@@ -59,6 +60,7 @@ export default async function initTranslations(
     'chainNamesExt',
     chainNamesFormatter,
   );
+  i18nInstance.services.formatter?.addCached('listExt', listFormatter);
 
   return {
     i18n: i18nInstance,

--- a/src/hooks/notifications/useNotificationContent.spec.ts
+++ b/src/hooks/notifications/useNotificationContent.spec.ts
@@ -92,6 +92,75 @@ describe('resolveNotificationContent', () => {
     );
   });
 
+  it('translates perkLevelUp (single) with the perk name and singular copy', () => {
+    const content = resolve(
+      makeNotification({
+        sourceRuleId: 'perkLevelUp',
+        ctaLabel: 'STORED CTA',
+        metadata: {
+          oldLevel: 4,
+          newLevel: 5,
+          count: 1,
+          perks: [
+            { name: 'Fee discount', slug: 'fee-discount', unlockLevel: 5 },
+          ],
+        },
+      }),
+    );
+
+    expect(content.title).toBe('Perk unlocked: Fee discount');
+    expect(content.body).toBe(
+      'Reaching Level 5 unlocked Fee discount. Check it out in your Jumper Pass.',
+    );
+    expect(content.ctaLabel).toBe('View Jumper Pass');
+  });
+
+  it('translates perkLevelUp (multiple) with a joined name list and plural copy', () => {
+    const content = resolve(
+      makeNotification({
+        sourceRuleId: 'perkLevelUp',
+        metadata: {
+          oldLevel: 4,
+          newLevel: 7,
+          count: 2,
+          perks: [
+            { name: 'Fee discount', slug: 'fee-discount', unlockLevel: 5 },
+            {
+              name: 'Priority support',
+              slug: 'priority-support',
+              unlockLevel: 7,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(content.title).toBe('You unlocked 2 new perks!');
+    expect(content.body).toBe(
+      'Reaching Level 7 unlocked Fee discount, Priority support. Check them out in your Jumper Pass.',
+    );
+  });
+
+  it('falls back to stored copy for perkLevelUp when count is absent', () => {
+    const content = resolve(
+      makeNotification({
+        sourceRuleId: 'perkLevelUp',
+        metadata: {
+          newLevel: 5,
+          perks: [
+            { name: 'Fee discount', slug: 'fee-discount', unlockLevel: 5 },
+          ],
+        },
+      }),
+    );
+
+    expect(content).toEqual({
+      title: 'STORED TITLE',
+      body: 'STORED BODY',
+      ctaLabel: 'STORED CTA',
+    });
+  });
+
   it('derives the verb (nesting) and joins chain names for newToolLaunch', () => {
     const content = resolve(
       makeNotification({

--- a/src/hooks/notifications/useNotificationContent.ts
+++ b/src/hooks/notifications/useNotificationContent.ts
@@ -23,30 +23,41 @@ export function resolveNotificationContent(
   notification: Notification,
   ctx: { t: TFunction; i18n: I18nInstance },
 ): NotificationContent {
+  const fallback: NotificationContent = {
+    title: notification.title,
+    body: notification.body,
+    ctaLabel: notification.ctaLabel,
+  };
+
   const ruleId = notification.sourceRuleId;
-  if (!ruleId) {
-    return {
-      title: notification.title,
-      body: notification.body,
-      ctaLabel: notification.ctaLabel,
-    };
+  const params = notification.metadata ?? {};
+  const titleKey = `notifications.${ruleId}.title`;
+  const bodyKey = `notifications.${ruleId}.body`;
+  // Pass `params` to `exists` so rules whose catalogue entry is plural-only
+  // (`_one`/`_other`, resolved via `params.count`) are detected. A rule missing
+  // its `count` resolves no plural form, so it falls back to the stored copy.
+  if (
+    !ruleId ||
+    !ctx.i18n.exists(titleKey, params) ||
+    !ctx.i18n.exists(bodyKey, params)
+  ) {
+    return fallback;
   }
 
   // Dynamic union keys carrying interpolation options can't be narrowed by the
-  // typed-resources `t()`; the keys are validated below with `i18n.exists`.
+  // typed-resources `t()`; the keys are validated above with `i18n.exists`.
   const translate = ctx.t as unknown as (
     key: string,
     options?: Record<string, unknown>,
   ) => string;
-  const params = notification.metadata ?? {};
-
-  const resolve = (key: string, fallbackValue: string): string =>
-    ctx.i18n.exists(key) ? translate(key, params) : fallbackValue;
+  const ctaKey = `notifications.${ruleId}.cta`;
 
   return {
-    title: resolve(`notifications.${ruleId}.title`, notification.title),
-    body: resolve(`notifications.${ruleId}.body`, notification.body),
-    ctaLabel: resolve(`notifications.${ruleId}.cta`, notification.ctaLabel),
+    title: translate(titleKey, params),
+    body: translate(bodyKey, params),
+    ctaLabel: ctx.i18n.exists(ctaKey, params)
+      ? translate(ctaKey, params)
+      : notification.ctaLabel,
   };
 }
 

--- a/src/i18n/i18next.d.ts
+++ b/src/i18n/i18next.d.ts
@@ -13,6 +13,8 @@ declare module 'i18next' {
       [K in `chainNameExt${string}`]: number;
     } & {
       [K in `chainNamesExt${string}`]: number[];
+    } & {
+      [K in `listExt${string}`]: unknown[];
     };
   }
 }

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -757,6 +757,13 @@ export default interface Resources {
         cta: 'Try it';
         title: 'New on Jumper: {{toolName}}';
       };
+      perkLevelUp: {
+        body_one: 'Reaching Level {{newLevel}} unlocked {{perks, listExt(prop: name)}}. Check it out in your Jumper Pass.';
+        body_other: 'Reaching Level {{newLevel}} unlocked {{perks, listExt(prop: name)}}. Check them out in your Jumper Pass.';
+        cta: 'View Jumper Pass';
+        title_one: 'Perk unlocked: {{perks, listExt(prop: name)}}';
+        title_other: 'You unlocked {{count}} new perks!';
+      };
       title: 'Notifications';
       toolVerb: {
         BRIDGE: 'bridged';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -1098,6 +1098,13 @@
       "title": "You reached Level {{newLevel}}!",
       "body": "Your Jumper Pass leveled up from Level {{oldLevel}} to Level {{newLevel}}. Keep earning XP to unlock more.",
       "cta": "View Jumper Pass"
+    },
+    "perkLevelUp": {
+      "title_one": "Perk unlocked: {{perks, listExt(prop: name)}}",
+      "title_other": "You unlocked {{count}} new perks!",
+      "body_one": "Reaching Level {{newLevel}} unlocked {{perks, listExt(prop: name)}}. Check it out in your Jumper Pass.",
+      "body_other": "Reaching Level {{newLevel}} unlocked {{perks, listExt(prop: name)}}. Check them out in your Jumper Pass.",
+      "cta": "View Jumper Pass"
     }
   },
   "alerts": {

--- a/src/utils/chains/chainNameFormatter.ts
+++ b/src/utils/chains/chainNameFormatter.ts
@@ -1,4 +1,5 @@
 import { findChain } from '@/utils/chains/findChain';
+import { listFormatter } from '@/utils/formatList';
 
 const resolveChainName = (value: unknown): string => {
   const id = Number(value);
@@ -15,13 +16,14 @@ export const chainNameFormatter = () => (value: unknown) =>
 /**
  * i18next formatter resolving an array of chain ids to a joined list of brand
  * names, e.g. `{{chainIds, chainNamesExt}}` → "Polygon, OP Mainnet". The
- * separator can be overridden via the format option `separator`.
+ * separator can be overridden via the format option `separator`. Resolves ids
+ * to names, then delegates joining to {@link listFormatter}.
  */
 export const chainNamesFormatter =
-  (_lng: string | undefined, options: { separator?: string } = {}) =>
+  (lng: string | undefined, options: { separator?: string } = {}) =>
   (value: unknown) => {
     if (!Array.isArray(value)) {
       return '';
     }
-    return value.map(resolveChainName).join(options.separator ?? ', ');
+    return listFormatter(lng, options)(value.map(resolveChainName));
   };

--- a/src/utils/formatList.ts
+++ b/src/utils/formatList.ts
@@ -1,6 +1,9 @@
 const toDisplayString = (item: unknown, prop?: string): string => {
-  if (prop && item !== null && typeof item === 'object' && prop in item) {
-    return String((item as Record<string, unknown>)[prop]);
+  if (prop) {
+    if (item !== null && typeof item === 'object' && prop in item) {
+      return String((item as Record<string, unknown>)[prop]);
+    }
+    return '';
   }
   return item == null ? '' : String(item);
 };

--- a/src/utils/formatList.ts
+++ b/src/utils/formatList.ts
@@ -1,0 +1,28 @@
+const toDisplayString = (item: unknown, prop?: string): string => {
+  if (prop && item !== null && typeof item === 'object' && prop in item) {
+    return String((item as Record<string, unknown>)[prop]);
+  }
+  return item == null ? '' : String(item);
+};
+
+/**
+ * i18next formatter joining an array into a string, e.g.
+ * `{{items, listExt}}` → "a, b, c". Pass `prop` to pluck a field from an array
+ * of objects (`{{perks, listExt(prop: name)}}` → "Fee discount, Priority
+ * support") and `separator` to override the default `", "`. Non-arrays and
+ * empty items render as nothing.
+ */
+export const listFormatter =
+  (
+    _lng: string | undefined,
+    options: { prop?: string; separator?: string } = {},
+  ) =>
+  (value: unknown) => {
+    if (!Array.isArray(value)) {
+      return '';
+    }
+    return value
+      .map((item) => toDisplayString(item, options.prop))
+      .filter(Boolean)
+      .join(options.separator ?? ', ');
+  };


### PR DESCRIPTION
Adds the frontend i18next translation for the new `perkLevelUp` notification rule (jumperexchange/jumper-notifications#49, JUM-998), following the pattern from #2904. Stacked on top of #2904 (JUM-1032).

## Changes

- Add `notifications.perkLevelUp` catalogue entry with `_one`/`_other` plural variants driven by `count`, interpolating `newLevel` and the perk names.
- Add a generic `listExt` i18next formatter (`{{items, listExt(prop: name)}}`) that joins an array, optionally plucking a property; `chainNamesFormatter` now delegates its join to it.
- Make `resolveNotificationContent` pass `metadata` into `i18n.exists()` so plural-only entries resolve, falling back to the stored English copy when `count` is absent.
- Unit tests for the single-perk, multi-perk, and missing-`count` fallback cases.

## Backend pairing

Translation activates once the `perkLevelUp` metadata carries `count` (alongside the existing `perks`). Until then it safely falls back to the backend-rendered English string.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Perk level-up notifications with pluralized title/body and a localized CTA.
  * Consistent, locale-aware list formatting for multi-item displays; new formatter exposed to translations.

* **Tests**
  * Added tests covering single/multiple perk unlocks and fallback behavior.

* **Bug Fixes**
  * Improved translation existence checks and CTA fallbacks to ensure correct notification content.

* **Docs/Types**
  * Typing updates to support the new list-format interpolation keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->