### PR TITLE
fix(tests): point e2e hosts at jumper.xyz

### DIFF
--- a/tests/.env.test
+++ b/tests/.env.test
@@ -1,9 +1,7 @@
 NEXT_PUBLIC_ENVIRONMENT=development
-# NEXT_PUBLIC_SITE_URL=https://develop.jumper.xyz
-NEXT_PUBLIC_SITE_URL=https://develop.jumper.exchange
+NEXT_PUBLIC_SITE_URL=https://develop.jumper.xyz
 NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID=G-T6ZDXLLXB5
-# NEXT_PUBLIC_LIFI_BACKEND_URL=https://api-develop.jumper.xyz/pipeline
-NEXT_PUBLIC_LIFI_BACKEND_URL=https://api-develop.jumper.exchange/pipeline
+NEXT_PUBLIC_LIFI_BACKEND_URL=https://api-develop.jumper.xyz/pipeline
 NEXT_PUBLIC_WIDGET_INTEGRATOR=dev.jumper.exchange
 NEXT_PUBLIC_WIDGET_INTEGRATOR_REFUEL=dev.jumper.exchange.gas
 NEXT_PUBLIC_WIDGET_INTEGRATOR_BLOG=dev.jumper.exchange.blog
@@ -11,8 +9,7 @@ NEXT_PUBLIC_WIDGET_INTEGRATOR_EARN=jumper.exchange.earndev
 NEXT_PUBLIC_ADDRESSABLE_TID=0d48165d8b544e029b816f54c3371ae8
 NEXT_PUBLIC_CUSTOM_RPCS={ "59140": ["https://consensys-zkevm-goerli-prealpha.infura.io/v3/faf4bc4ea7344e5da5e56c55de087480"], "1151111081099710": ["https://chaotic-restless-putty.solana-mainnet.quiknode.pro/", "https://dacey-pp61jd-fast-mainnet.helius-rpc.com/"] }
 NEXT_PUBLIC_DKEY=AmE4rjRHH0aLksP_-Nym-DCL_5qOHBYR77m7svbGyHm5
-# NEXT_PUBLIC_BACKEND_URL=https://api-develop.jumper.xyz/v1
-NEXT_PUBLIC_BACKEND_URL=https://api-develop.jumper.exchange/v1
+NEXT_PUBLIC_BACKEND_URL=https://api-develop.jumper.xyz/v1
 
 # NEXT_PUBLIC_STRAPI_URL=https://strapi-staging.jumper.xyz
 NEXT_PUBLIC_STRAPI_URL=https://strapi-develop.jumper.xyz


### PR DESCRIPTION
**What** — Aligns the e2e env with the ongoing `*.jumper.exchange` → `.xyz` decommission. `tests/.env.test` still pointed the Playwright build at `*-develop.jumper.exchange`, which stopped resolving in DNS around Jun-4 and broke every e2e run. Switches `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_LIFI_BACKEND_URL`, `NEXT_PUBLIC_BACKEND_URL` to the `.xyz` hosts. Integrator IDs (`NEXT_PUBLIC_WIDGET_INTEGRATOR=*`) are identifiers, not hosts — left as-is.

**Why CI went red**
- Failure trace: every widget data call dies — `api-develop.jumper.exchange/pipeline/v1/tokens` → `net::ERR_NAME_NOT_RESOLVED` (same `/chains`, `/tools`).
- No token list → widget never preselects From/To (stays "Select…") → no route request → "Best Return" never renders → `swapActions` + homepage-stat specs (`mobileView` qase 5) fail.
- Not a code change: `tests/.env.test` is byte-identical at the last green run (Jun-4 07:09) and first red (13:25). Host had been `.exchange` since #2713 (Mar 3) and passed for 3 months — only DNS changed. `jumper.exchange` apex + all `.xyz` hosts still resolve.

**Verification**
- Repro: `swapActions` ARB Desktop (qase 27) fails on `.exchange`, passes on `.xyz`.
- Full no-wallet suite locally on this branch: **30 passed, 4 skipped** (the 4 are pre-existing `test.fixme`/`test.skip`).

Linear: JUM-1072

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment configuration to reference new development infrastructure endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->