### PR TITLE
chore: update earn apy copy

### DIFF
--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -1034,7 +1034,7 @@ export default interface Resources {
     };
     tooltips: {
       apr: 'Expected yearly return rate of the tokens invested (incl. rewards if available).';
-      apy: 'Expected yearly return rate of the tokens invested.';
+      apy: 'Expected yearly return rate of the tokens invested on a 7 day trailing basis, incl. temporary rewards.';
       assets_one: 'The asset you will earn from';
       assets_other: 'The assets you will earn from';
       assets_other_one: 'The asset you will earn from';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -366,7 +366,7 @@
   },
   "tooltips": {
     "tvl": "Total value of crypto assets deposited in this market.",
-    "apy": "Expected yearly return rate of the tokens invested.",
+    "apy": "Expected yearly return rate of the tokens invested on a 7 day trailing basis, incl. temporary rewards.",
     "apr": "Expected yearly return rate of the tokens invested (incl. rewards if available).",
     "rewardsApy": "Expected yearly return rate distributed in reward token.",
     "deposit": "The token on which the market is defined and yield accrues on.",


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-834/earn-change-copy-on-earn-apy-hover

## Testing steps
1. Go to `/earn`
2. For any earn card that has an `APY` value hover over the question mark and check the tooltip copy
3. Go to an earn details page
4. Perform same check on the overview card

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the APY tooltip in English: it now states APY is based on a 7‑day trailing basis and that temporary rewards are included, replacing the prior generic “expected yearly return rate” wording. Only this tooltip text was updated; no other UI copy or functionality changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->