### PR TITLE
fix: redirect from wallet drawer on token selection

### DIFF
--- a/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
+++ b/src/components/composite/WalletBalanceCard/WalletBalanceCard.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/providers/PortfolioProvider/filtering/utils';
 import { BaseAlert } from '@/components/Alerts/BaseAlert/BaseAlert';
 import { BaseAlertVariant } from '@/components/Alerts/BaseAlert/BaseAlert.styles';
+import { AppPaths } from '@/const/urls';
 
 export const WalletBalanceCard: FC<WalletBalanceCardProps> = ({
   walletAddress,
@@ -94,7 +95,7 @@ export const WalletBalanceCard: FC<WalletBalanceCardProps> = ({
     setWelcomeScreenClosed(true);
 
     if (!isMainPaths) {
-      router.push('/');
+      router.push(AppPaths.Main);
     }
   };
   return (

--- a/src/const/urls.ts
+++ b/src/const/urls.ts
@@ -16,6 +16,7 @@ export const TERMS_CONDITIONS_URL = 'https://li.fi/legal/terms-and-conditions';
 export const DEFI_REACHER_API_URL = 'https://defireacher.com/api';
 export const JUMPER_MAIN_PATH = '/';
 export const JUMPER_GAS_PATH = '/gas';
+export const JUMPER_BUY_PATH = '/buy';
 export const JUMPER_LEARN_PATH = '/learn';
 export const JUMPER_PROFILE_PATH = '/profile';
 export const JUMPER_MISSIONS_PATH = '/missions';
@@ -51,6 +52,7 @@ export function getSiteUrl() {
 export enum AppPaths {
   Main = JUMPER_MAIN_PATH,
   Gas = JUMPER_GAS_PATH,
+  Buy = JUMPER_BUY_PATH,
   Learn = JUMPER_LEARN_PATH,
   Profile = JUMPER_PROFILE_PATH,
   Missions = JUMPER_MISSIONS_PATH,

--- a/src/hooks/useMainPaths.ts
+++ b/src/hooks/useMainPaths.ts
@@ -8,9 +8,12 @@ interface useMainPathsProps {
 export const useMainPaths = (): useMainPathsProps => {
   const pathname = usePathnameWithoutLocale();
 
-  const isGas = pathname?.includes(AppPaths.Gas);
-  const isBuy = pathname?.includes(AppPaths.Buy);
-  const isPrivate = pathname?.includes(AppPaths.Private);
+  const matchesPath = (route: AppPaths) =>
+    pathname === route || pathname?.startsWith(`${route}/`);
+
+  const isGas = matchesPath(AppPaths.Gas);
+  const isBuy = matchesPath(AppPaths.Buy);
+  const isPrivate = matchesPath(AppPaths.Private);
   const isExchange = pathname === AppPaths.Main;
 
   return {

--- a/src/hooks/useMainPaths.ts
+++ b/src/hooks/useMainPaths.ts
@@ -1,36 +1,17 @@
-import { usePathname } from 'next/navigation';
-import {
-  AppPaths,
-  JUMPER_BRIDGE_PATH,
-  JUMPER_LEARN_PATH,
-  JUMPER_PROFILE_PATH,
-  JUMPER_SCAN_PATH,
-  JUMPER_SWAP_PATH,
-  JUMPER_ZAP_PATH,
-} from '@/const/urls';
+import { AppPaths } from '@/const/urls';
+import { usePathnameWithoutLocale } from './routing/usePathnameWithoutLocale';
 
 interface useMainPathsProps {
   isMainPaths: boolean;
 }
 
 export const useMainPaths = (): useMainPathsProps => {
-  const pathname = usePathname();
+  const pathname = usePathnameWithoutLocale();
 
   const isGas = pathname?.includes(AppPaths.Gas);
-  const isBuy = pathname?.includes('/buy');
+  const isBuy = pathname?.includes(AppPaths.Buy);
   const isPrivate = pathname?.includes(AppPaths.Private);
-  //Todo: find better way to check
-  const isExchange =
-    !pathname?.includes(JUMPER_SWAP_PATH) &&
-    !pathname?.includes(JUMPER_PROFILE_PATH) &&
-    !pathname?.includes(JUMPER_LEARN_PATH) &&
-    !pathname?.includes(JUMPER_SCAN_PATH) &&
-    !pathname?.includes(JUMPER_ZAP_PATH) &&
-    !pathname?.includes(JUMPER_SWAP_PATH) &&
-    !pathname?.includes(JUMPER_BRIDGE_PATH) &&
-    (pathname === '/' ||
-      pathname?.split('/').length === 3 ||
-      pathname?.split('/').length === 2);
+  const isExchange = pathname === AppPaths.Main;
 
   return {
     isMainPaths: isGas || isBuy || isPrivate || isExchange,


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-991/token-selection-from-wallet-panel-does-not-navigate-after-route-change

## Testing steps

1. Go to `/`
2. Open wallet menu and click on a simple (non-aggregated) token
3. Check the widget get populated with the correct chain and token in the source field
4. Behaviour should remain the same also for the `/gas` and `/private` routes
5. Now go to any other page (missions, earn etc)
6. Perform step 2.
7. Check you're redirected to the main page
8. Check the widget gets populated with the correct source chain and token

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Buy route for in-app purchasing.

* **Bug Fixes**
  * Wallet balance card now navigates correctly into the main app context when selecting a token.
  * Routing logic improved for consistent, locale-agnostic path handling and more accurate route detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->