### PR TITLE
feat: enable video backgrounds for partner themes

### DIFF
--- a/src/components/Background.tsx
+++ b/src/components/Background.tsx
@@ -24,14 +24,16 @@ function Background() {
   const configTheme = useThemeStore((state) => state.configTheme);
   const { shouldShowForTheme } = useThemeConditionsMet();
 
-  const backgroundImageUrl = useGetPartnerThemeImage();
+  const { url: backgroundImageUrl, mime: backgroundImageMime } =
+    useGetPartnerThemeImage();
 
   return (
     <BackgroundContainer id="background-root">
       <AnimatedBackgroundImage
         src={backgroundImageUrl}
+        mime={backgroundImageMime}
         sx={{
-          '& > img': {
+          '& > img, & > video': {
             objectPosition: configTheme?.backgroundImagePosition ?? 'center',
           },
         }}

--- a/src/components/core/AnimatedBackgroundImage/AnimatedBackgroundImage.tsx
+++ b/src/components/core/AnimatedBackgroundImage/AnimatedBackgroundImage.tsx
@@ -1,15 +1,19 @@
-import { AnimatePresence } from 'motion/react';
-import { AnimatedBackgroundImageContainer } from './AnimatedBackgroundImage.styles';
-import Image from 'next/image';
+import Box from '@mui/material/Box';
 import type { SxProps, Theme } from '@mui/material/styles';
+import { AnimatePresence } from 'motion/react';
+import Image from 'next/image';
+import { isVideoMime } from '@/utils/isVideoMime';
+import { AnimatedBackgroundImageContainer } from './AnimatedBackgroundImage.styles';
 
 export interface AnimatedBackgroundImageProps {
   src?: string | null;
+  mime?: string | null;
   sx?: SxProps<Theme>;
 }
 
 export const AnimatedBackgroundImage = ({
   src,
+  mime,
   sx,
 }: AnimatedBackgroundImageProps) => {
   return (
@@ -26,16 +30,34 @@ export const AnimatedBackgroundImage = ({
           }}
           sx={sx}
         >
-          <Image
-            src={src}
-            alt="Animated background image"
-            fill
-            priority
-            sizes="100vw"
-            style={{
-              objectFit: 'cover',
-            }}
-          />
+          {isVideoMime(mime) ? (
+            <Box
+              component="video"
+              src={src}
+              autoPlay
+              loop
+              playsInline
+              aria-hidden
+              sx={{
+                position: 'absolute',
+                inset: 0,
+                width: '100%',
+                height: '100%',
+                objectFit: 'cover',
+              }}
+            />
+          ) : (
+            <Image
+              src={src}
+              alt="Animated background image"
+              fill
+              priority
+              sizes="100vw"
+              style={{
+                objectFit: 'cover',
+              }}
+            />
+          )}
         </AnimatedBackgroundImageContainer>
       )}
     </AnimatePresence>

--- a/src/components/core/AnimatedBackgroundImage/AnimatedBackgroundImage.tsx
+++ b/src/components/core/AnimatedBackgroundImage/AnimatedBackgroundImage.tsx
@@ -4,8 +4,8 @@ import Box from '@mui/material/Box';
 import type { SxProps, Theme } from '@mui/material/styles';
 import { AnimatePresence } from 'motion/react';
 import Image from 'next/image';
-import { useEffect, useRef } from 'react';
-import { isVideoMime } from '@/utils/isVideoMime';
+import { useEffect, useRef, useState } from 'react';
+import { canBrowserPlayVideoMime, isVideoMime } from '@/utils/isVideoMime';
 import { AnimatedBackgroundImageContainer } from './AnimatedBackgroundImage.styles';
 
 export interface AnimatedBackgroundImageProps {
@@ -14,10 +14,25 @@ export interface AnimatedBackgroundImageProps {
   sx?: SxProps<Theme>;
 }
 
-const AnimatedBackgroundVideo = ({ src }: { src: string }) => {
+interface AnimatedBackgroundVideoProps {
+  src: string;
+  mime: string;
+  onPlaybackUnavailable: () => void;
+}
+
+const AnimatedBackgroundVideo = ({
+  src,
+  mime,
+  onPlaybackUnavailable,
+}: AnimatedBackgroundVideoProps) => {
   const videoRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
+    if (!canBrowserPlayVideoMime(mime)) {
+      onPlaybackUnavailable();
+      return;
+    }
+
     const video = videoRef.current;
 
     if (!video) {
@@ -26,21 +41,27 @@ const AnimatedBackgroundVideo = ({ src }: { src: string }) => {
 
     video.muted = true;
 
-    const playVideo = () => {
-      void video.play().catch(() => undefined);
+    const handlePlaybackFailure = () => {
+      onPlaybackUnavailable();
     };
+
+    const playVideo = () => {
+      void video.play().catch(handlePlaybackFailure);
+    };
+
+    video.addEventListener('error', handlePlaybackFailure);
 
     if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
       playVideo();
-      return;
+    } else {
+      video.addEventListener('loadeddata', playVideo);
     }
 
-    video.addEventListener('loadeddata', playVideo);
-
     return () => {
+      video.removeEventListener('error', handlePlaybackFailure);
       video.removeEventListener('loadeddata', playVideo);
     };
-  }, [src]);
+  }, [mime, onPlaybackUnavailable, src]);
 
   return (
     <Box
@@ -69,6 +90,18 @@ export const AnimatedBackgroundImage = ({
   mime,
   sx,
 }: AnimatedBackgroundImageProps) => {
+  const [isVideoPlaybackUnavailable, setIsVideoPlaybackUnavailable] =
+    useState(false);
+
+  const videoBackground =
+    src && mime && isVideoMime(mime) && !isVideoPlaybackUnavailable
+      ? { src, mime }
+      : null;
+
+  useEffect(() => {
+    setIsVideoPlaybackUnavailable(false);
+  }, [mime, src]);
+
   return (
     <AnimatePresence mode="wait">
       {src && (
@@ -83,9 +116,13 @@ export const AnimatedBackgroundImage = ({
           }}
           sx={sx}
         >
-          {isVideoMime(mime) ? (
-            <AnimatedBackgroundVideo src={src} />
-          ) : (
+          {videoBackground ? (
+            <AnimatedBackgroundVideo
+              src={videoBackground.src}
+              mime={videoBackground.mime}
+              onPlaybackUnavailable={() => setIsVideoPlaybackUnavailable(true)}
+            />
+          ) : !isVideoMime(mime) ? (
             <Image
               src={src}
               alt="Animated background image"
@@ -96,7 +133,7 @@ export const AnimatedBackgroundImage = ({
                 objectFit: 'cover',
               }}
             />
-          )}
+          ) : null}
         </AnimatedBackgroundImageContainer>
       )}
     </AnimatePresence>

--- a/src/components/core/AnimatedBackgroundImage/AnimatedBackgroundImage.tsx
+++ b/src/components/core/AnimatedBackgroundImage/AnimatedBackgroundImage.tsx
@@ -1,7 +1,10 @@
+'use client';
+
 import Box from '@mui/material/Box';
 import type { SxProps, Theme } from '@mui/material/styles';
 import { AnimatePresence } from 'motion/react';
 import Image from 'next/image';
+import { useEffect, useRef } from 'react';
 import { isVideoMime } from '@/utils/isVideoMime';
 import { AnimatedBackgroundImageContainer } from './AnimatedBackgroundImage.styles';
 
@@ -10,6 +13,56 @@ export interface AnimatedBackgroundImageProps {
   mime?: string | null;
   sx?: SxProps<Theme>;
 }
+
+const AnimatedBackgroundVideo = ({ src }: { src: string }) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const video = videoRef.current;
+
+    if (!video) {
+      return;
+    }
+
+    video.muted = true;
+
+    const playVideo = () => {
+      void video.play().catch(() => undefined);
+    };
+
+    if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+      playVideo();
+      return;
+    }
+
+    video.addEventListener('loadeddata', playVideo);
+
+    return () => {
+      video.removeEventListener('loadeddata', playVideo);
+    };
+  }, [src]);
+
+  return (
+    <Box
+      component="video"
+      ref={videoRef}
+      src={src}
+      autoPlay
+      muted
+      loop
+      playsInline
+      preload="auto"
+      aria-hidden
+      sx={{
+        position: 'absolute',
+        inset: 0,
+        width: '100%',
+        height: '100%',
+        objectFit: 'cover',
+      }}
+    />
+  );
+};
 
 export const AnimatedBackgroundImage = ({
   src,
@@ -31,21 +84,7 @@ export const AnimatedBackgroundImage = ({
           sx={sx}
         >
           {isVideoMime(mime) ? (
-            <Box
-              component="video"
-              src={src}
-              autoPlay
-              loop
-              playsInline
-              aria-hidden
-              sx={{
-                position: 'absolute',
-                inset: 0,
-                width: '100%',
-                height: '100%',
-                objectFit: 'cover',
-              }}
-            />
+            <AnimatedBackgroundVideo src={src} />
           ) : (
             <Image
               src={src}

--- a/src/hooks/theme/useGetPartnerThemeImage.ts
+++ b/src/hooks/theme/useGetPartnerThemeImage.ts
@@ -5,9 +5,12 @@ export const useGetPartnerThemeImage = () => {
   const configTheme = useThemeStore((state) => state.configTheme);
   const { shouldShowForTheme } = useThemeConditionsMet();
 
-  const imageUrl = shouldShowForTheme
-    ? configTheme?.backgroundImageUrl?.href
-    : null;
+  if (!shouldShowForTheme) {
+    return { url: null, mime: null };
+  }
 
-  return imageUrl;
+  return {
+    url: configTheme?.backgroundImageUrl?.href ?? null,
+    mime: configTheme?.backgroundImageMime ?? null,
+  };
 };

--- a/src/types/PartnerThemeConfig.ts
+++ b/src/types/PartnerThemeConfig.ts
@@ -11,6 +11,7 @@ export interface PartnerThemeConfig {
   availableThemeModes: string[];
   backgroundColor: string | null;
   backgroundImageUrl: URL | null;
+  backgroundImageMime: string | null;
   backgroundImagePosition: string;
   footerImageUrl: URL | null;
   logo:

--- a/src/utils/formatTheme.ts
+++ b/src/utils/formatTheme.ts
@@ -3,18 +3,33 @@ import { getStrapiUrl } from '@/hooks/useStrapi';
 import type { PartnerThemeConfig } from '@/types/PartnerThemeConfig';
 import type { PartnerThemesAttributes } from '@/types/strapi';
 
+function getThemeMedia(
+  theme: PartnerThemesAttributes,
+  imageType: 'BackgroundImage' | 'FooterImage' | 'Logo',
+  defaultMode: 'light' | 'dark' = 'dark',
+): { url: URL; mime: string } | null {
+  const baseStrapiUrl = getStrapiUrl(STRAPI_PARTNER_THEMES);
+
+  const imageLight = theme[`${imageType}Light`];
+  const imageDark = theme[`${imageType}Dark`];
+  const media = defaultMode === 'light' ? imageLight : imageDark;
+
+  if (!media?.url) {
+    return null;
+  }
+
+  return {
+    url: new URL(media.url, baseStrapiUrl),
+    mime: media.mime,
+  };
+}
+
 function getImageUrl(
   theme: PartnerThemesAttributes,
   imageType: 'BackgroundImage' | 'FooterImage' | 'Logo',
   defaultMode: 'light' | 'dark' = 'dark',
 ): URL | null {
-  const baseStrapiUrl = getStrapiUrl(STRAPI_PARTNER_THEMES);
-
-  const imageLight = theme[`${imageType}Light`];
-  const imageDark = theme[`${imageType}Dark`];
-  const imageUrl = defaultMode === 'light' ? imageLight?.url : imageDark?.url;
-
-  return imageUrl ? new URL(imageUrl, baseStrapiUrl) : null;
+  return getThemeMedia(theme, imageType, defaultMode)?.url ?? null;
 }
 
 export function getAvailableThemeModes(
@@ -68,11 +83,13 @@ export function formatConfig(
 
   const defaultMode = isDarkOrLightThemeMode(theme);
   const themeModes = getAvailableThemeModes(theme);
+  const backgroundMedia = getThemeMedia(theme, 'BackgroundImage', defaultMode);
   const result = {
     availableThemeModes: themeModes,
     backgroundColor:
       theme.BackgroundColorDark || theme.BackgroundColorLight || null,
-    backgroundImageUrl: getImageUrl(theme, 'BackgroundImage', defaultMode),
+    backgroundImageUrl: backgroundMedia?.url ?? null,
+    backgroundImageMime: backgroundMedia?.mime ?? null,
     backgroundImagePosition:
       (theme.lightConfig || theme.darkConfig)?.customization
         ?.backgroundImagePosition || 'center',

--- a/src/utils/formatTheme.ts
+++ b/src/utils/formatTheme.ts
@@ -7,7 +7,7 @@ function getThemeMedia(
   theme: PartnerThemesAttributes,
   imageType: 'BackgroundImage' | 'FooterImage' | 'Logo',
   defaultMode: 'light' | 'dark' = 'dark',
-): { url: URL; mime: string } | null {
+): { url: URL; mime: string | null } | null {
   const baseStrapiUrl = getStrapiUrl(STRAPI_PARTNER_THEMES);
 
   const imageLight = theme[`${imageType}Light`];
@@ -20,7 +20,7 @@ function getThemeMedia(
 
   return {
     url: new URL(media.url, baseStrapiUrl),
-    mime: media.mime,
+    mime: media.mime?.trim() || null,
   };
 }
 

--- a/src/utils/isVideoMime.spec.ts
+++ b/src/utils/isVideoMime.spec.ts
@@ -29,7 +29,10 @@ describe('canBrowserPlayVideoMime', () => {
   });
 
   it('falls back to the playable MIME whitelist when document is unavailable', () => {
+    vi.stubGlobal('document', undefined);
+
     expect(canBrowserPlayVideoMime('video/mp4')).toBe(true);
+    expect(canBrowserPlayVideoMime('video/webm')).toBe(true);
     expect(canBrowserPlayVideoMime('video/quicktime')).toBe(false);
   });
 

--- a/src/utils/isVideoMime.spec.ts
+++ b/src/utils/isVideoMime.spec.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { canBrowserPlayVideoMime, isVideoMime } from './isVideoMime';
+
+describe('isVideoMime', () => {
+  it('returns true for browser-playable video MIME types', () => {
+    expect(isVideoMime('video/mp4')).toBe(true);
+    expect(isVideoMime('video/webm')).toBe(true);
+    expect(isVideoMime('video/ogg')).toBe(true);
+  });
+
+  it('normalizes MIME values before checking', () => {
+    expect(isVideoMime('  VIDEO/MP4  ')).toBe(true);
+    expect(isVideoMime('video/mp4; codecs="avc1.42E01E"')).toBe(true);
+  });
+
+  it('returns false for unsupported or non-video MIME types', () => {
+    expect(isVideoMime('video/quicktime')).toBe(false);
+    expect(isVideoMime('video/x-msvideo')).toBe(false);
+    expect(isVideoMime('image/png')).toBe(false);
+    expect(isVideoMime(null)).toBe(false);
+    expect(isVideoMime(undefined)).toBe(false);
+    expect(isVideoMime('')).toBe(false);
+  });
+});
+
+describe('canBrowserPlayVideoMime', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('falls back to the playable MIME whitelist when document is unavailable', () => {
+    expect(canBrowserPlayVideoMime('video/mp4')).toBe(true);
+    expect(canBrowserPlayVideoMime('video/quicktime')).toBe(false);
+  });
+
+  it('returns false when the browser cannot play the MIME type', () => {
+    const canPlayType = vi.fn().mockReturnValue('');
+
+    vi.stubGlobal('document', {
+      createElement: () => ({ canPlayType }),
+    });
+
+    expect(canBrowserPlayVideoMime('video/mp4')).toBe(false);
+    expect(canPlayType).toHaveBeenCalledWith('video/mp4');
+  });
+
+  it('returns true when the browser reports maybe or probably support', () => {
+    const canPlayType = vi
+      .fn()
+      .mockReturnValueOnce('maybe')
+      .mockReturnValueOnce('probably');
+
+    vi.stubGlobal('document', {
+      createElement: () => ({ canPlayType }),
+    });
+
+    expect(canBrowserPlayVideoMime('video/mp4')).toBe(true);
+    expect(canBrowserPlayVideoMime('video/webm')).toBe(true);
+  });
+});

--- a/src/utils/isVideoMime.ts
+++ b/src/utils/isVideoMime.ts
@@ -1,0 +1,2 @@
+export const isVideoMime = (mime?: string | null): boolean =>
+  typeof mime === 'string' && mime.startsWith('video/');

--- a/src/utils/isVideoMime.ts
+++ b/src/utils/isVideoMime.ts
@@ -1,3 +1,36 @@
-export const isVideoMime = (mime?: string | null): boolean =>
-  typeof mime === 'string' &&
-  mime.trim().toLowerCase().startsWith('video/');
+const PLAYABLE_VIDEO_MIME_TYPES = new Set([
+  'video/mp4',
+  'video/webm',
+  'video/ogg',
+]);
+
+const normalizeMime = (mime: string): string => mime.trim().toLowerCase();
+
+const getBaseMimeType = (mime: string): string =>
+  normalizeMime(mime).split(';')[0]?.trim() ?? '';
+
+export const canBrowserPlayVideoMime = (mime: string): boolean => {
+  if (typeof document === 'undefined') {
+    return PLAYABLE_VIDEO_MIME_TYPES.has(getBaseMimeType(mime));
+  }
+
+  const support = document
+    .createElement('video')
+    .canPlayType(normalizeMime(mime));
+
+  return support === 'probably' || support === 'maybe';
+};
+
+export const isVideoMime = (mime?: string | null): boolean => {
+  if (typeof mime !== 'string' || !mime.trim()) {
+    return false;
+  }
+
+  const baseMime = getBaseMimeType(mime);
+
+  if (!baseMime.startsWith('video/')) {
+    return false;
+  }
+
+  return PLAYABLE_VIDEO_MIME_TYPES.has(baseMime);
+};

--- a/src/utils/isVideoMime.ts
+++ b/src/utils/isVideoMime.ts
@@ -1,2 +1,3 @@
 export const isVideoMime = (mime?: string | null): boolean =>
-  typeof mime === 'string' && mime.startsWith('video/');
+  typeof mime === 'string' &&
+  mime.trim().toLowerCase().startsWith('video/');


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-1080/allow-animated-background-for-partner-themes

## Testing steps

> The default partner theme in Strapi develop env should have an animated bg image

1. Just go to `/`
2. Check the animated background image is displayed


# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partner themes now support video backgrounds that autoplay, loop, play inline and are muted, with automatic image fallback when needed.

* **Refactor**
  * Media selection was improved to include MIME information so the app reliably chooses and renders video or image and stops rendering video when playback isn’t available.

* **Tests**
  * Added tests validating media type detection and playback capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->