### PR TITLE
fix(tron): disable auto-connect on load to prevent Ledger modal persistence

### DIFF
--- a/src/providers/WalletProvider/TronProvider.tsx
+++ b/src/providers/WalletProvider/TronProvider.tsx
@@ -16,7 +16,11 @@ export const TronProvider: FC<PropsWithChildren> = ({ children }) => {
   );
 
   return (
-    <WalletProvider adapters={adapters} autoConnect={true}>
+    <WalletProvider
+      adapters={adapters}
+      autoConnect={true}
+      disableAutoConnectOnLoad
+    >
       {children}
     </WalletProvider>
   );


### PR DESCRIPTION
## Summary
- Add `disableAutoConnectOnLoad` to Tron `WalletProvider` to prevent `LedgerAdapter.connect()` from firing on every page load
- Prevents Ledger modal DOM nodes from leaking when connection fails (device unplugged, HID denied)
- Auto-connect still works after manual wallet selection

Mirrors [lifinance/widget#790](https://github.com/lifinance/widget/pull/790).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified wallet provider's auto-connect behavior on application load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->