### PR TITLE
fix(tests): scope tab-label assertion to navbar button (qase 2 flake)

### DIFF
--- a/tests/e2e/pages/LandingPage.ts
+++ b/tests/e2e/pages/LandingPage.ts
@@ -113,17 +113,19 @@ export class LandingPage {
     await this.page.waitForLoadState('domcontentloaded');
   }
 
-  // RegExp form is for AB-tested labels (see `EXCHANGE_TAB_LABEL_PATTERN`).
   async navigateAndExpectTab(
     tabKey: number | string,
     expected: RegExp | string,
   ): Promise<void> {
     await this.page.waitForLoadState('domcontentloaded');
     await this.page.getByTestId(`tab-key-${tabKey}`).click();
+    // The RegExp form targets the AB-tested Exchange label; scope it to the
+    // navbar button so it can't collide with the widget header, which renders
+    // the same "Swap & Bridge" text page-wide.
     const label =
       typeof expected === 'string'
         ? this.page.getByText(expected, { exact: true })
-        : this.page.getByText(expected);
+        : this.page.getByTestId('navbar-exchange-button').getByText(expected);
     await expect(label).toBeVisible();
   }
 


### PR DESCRIPTION
## What
`navigateAndExpectTab` now scopes the AB-tested Exchange label to `navbar-exchange-button` instead of a page-wide `getByText`.

## Why
The RegExp `/^(Exchange|Swap & Bridge|Trade)$/` matched both the navbar tab label **and** the LI.FI widget header (`<p>Swap & Bridge</p>`), so a strict-mode violation fired whenever the widget header rendered before the assertion. This is the chronic landingPage qase 2 flake ("passes on retry" in CI). Only the RegExp branch is scoped; the exact-string branch is unchanged.

## Validation
Local CI-parity (`--repeat-each=30 --retries=0 --workers=4`, raw flake rate):
- **Before:** qase 2 failed **18/30 (60%)**
- **After:** qase 2 **0/30** — full file ** passed**

## Scope
JUM-1116 sub-task 4 (chronic landingPage flakes) — fixes the qase 2 locator collision. connectWallet qase 36 and the welcome-overlay race (sub-task 2) are separate and unaffected.

JUM-1116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of the navigation test helper by preventing element lookup collisions in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->