### PR TITLE
fix(theme): partner theme menu visibility and feature-flag gating

### DIFF
--- a/src/components/Menus/ThemeModesSubMenu/useThemeModesMenuContent.tsx
+++ b/src/components/Menus/ThemeModesSubMenu/useThemeModesMenuContent.tsx
@@ -18,6 +18,8 @@ import {
 import { isDarkOrLightThemeMode } from '@/utils/formatTheme';
 import Avatar from '@mui/material/Avatar';
 import { selectAvailablePartnerThemes } from '@/stores/theme/createThemeStore';
+import { AB_TEST_NAME } from '@/const/abtests';
+import { useABTest } from '@/hooks/useABTest';
 
 interface SubmenuItem {
   label: string;
@@ -54,11 +56,18 @@ export const useThemeModesMenuContent = () => {
     state.configThemeStates,
   ]);
   const availablePartnerThemes = useThemeStore(selectAvailablePartnerThemes);
+  const { isEnabled: isThemePartnerDefaultEnabled } = useABTest({
+    feature: AB_TEST_NAME.THEME_PARTNER_DEFAULT,
+  });
 
   const defaultMode = isMainPaths ? 'system' : 'light';
   const selectedThemeMode = mode ?? defaultMode;
 
   const { activeConfigThemeUid, activeConfigTheme } = useMemo(() => {
+    if (!isThemePartnerDefaultEnabled) {
+      return { activeConfigThemeUid: undefined, activeConfigTheme: undefined };
+    }
+
     for (const [uid, state] of Object.entries(configThemeStates)) {
       if (state.isSelected) {
         const theme = availablePartnerThemes.find((t) => t.uid === uid);
@@ -66,7 +75,17 @@ export const useThemeModesMenuContent = () => {
       }
     }
     return { activeConfigThemeUid: undefined, activeConfigTheme: undefined };
-  }, [configThemeStates, availablePartnerThemes]);
+  }, [configThemeStates, availablePartnerThemes, isThemePartnerDefaultEnabled]);
+
+  useEffect(() => {
+    if (!isThemePartnerDefaultEnabled) {
+      for (const [uid, state] of Object.entries(configThemeStates)) {
+        if (state.isSelected) {
+          setConfigThemeState(uid, { isSelected: false });
+        }
+      }
+    }
+  }, [isThemePartnerDefaultEnabled, configThemeStates, setConfigThemeState]);
 
   useEffect(() => {
     if (!activeConfigTheme) {
@@ -132,8 +151,12 @@ export const useThemeModesMenuContent = () => {
 
   const displayablePartnerThemes = useMemo(
     () =>
-      availablePartnerThemes.filter((t) => t.SelectableInMenu && t.PartnerName),
-    [availablePartnerThemes],
+      isThemePartnerDefaultEnabled
+        ? availablePartnerThemes.filter(
+            (t) => t.SelectableInMenu && t.PartnerName,
+          )
+        : [],
+    [availablePartnerThemes, isThemePartnerDefaultEnabled],
   );
 
   const standardModeItems = useMemo<SubmenuItem[]>(

--- a/src/stores/theme/createThemeStore.spec.ts
+++ b/src/stores/theme/createThemeStore.spec.ts
@@ -77,7 +77,7 @@ describe('createThemeStore', () => {
   });
 
   describe('selectAvailablePartnerThemes', () => {
-    it('returns only themes whose uid has isSelected: true', () => {
+    it('returns themes that have a configThemeStates entry regardless of isSelected', () => {
       const state = {
         partnerThemes: [
           makePartnerTheme('a'),
@@ -87,21 +87,21 @@ describe('createThemeStore', () => {
         configThemeStates: {
           a: { isSelected: true },
           b: { isSelected: false },
-          c: { isSelected: true },
         },
       } as unknown as ThemeState;
 
       const result = selectAvailablePartnerThemes(state);
-      expect(result.map((t) => t.uid)).toEqual(['a', 'c']);
+      expect(result.map((t) => t.uid)).toEqual(['a', 'b']);
     });
 
-    it('returns empty array when no theme is selected', () => {
+    it('keeps partner themes visible after deselecting (isSelected: false)', () => {
+      const partnerTheme = makePartnerTheme('a');
       const state = {
-        partnerThemes: [makePartnerTheme('a')],
+        partnerThemes: [partnerTheme],
         configThemeStates: { a: { isSelected: false } },
       } as unknown as ThemeState;
 
-      expect(selectAvailablePartnerThemes(state)).toEqual([]);
+      expect(selectAvailablePartnerThemes(state)).toEqual([partnerTheme]);
     });
 
     it('returns empty array when configThemeStates is empty', () => {

--- a/src/stores/theme/createThemeStore.tsx
+++ b/src/stores/theme/createThemeStore.tsx
@@ -18,13 +18,9 @@ import { createWithEqualityFn } from 'zustand/traditional';
 export const selectAvailablePartnerThemes = (
   state: ThemeState,
 ): PartnerThemesData[] => {
-  const selectedUids = Object.entries(state.configThemeStates)
-    .filter(([_, themeState]) => themeState.isSelected)
-    .map(([uid]) => uid);
+  const availableUids = new Set(Object.keys(state.configThemeStates));
 
-  return state.partnerThemes.filter((theme) =>
-    selectedUids.some((uid) => uid === theme.uid),
-  );
+  return state.partnerThemes.filter((theme) => availableUids.has(theme.uid));
 };
 
 const getLocalStorage = () =>


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Contributes to https://linear.app/lifi-linear/issue/JUM-1060/add-background-theme-for-private-swaps-launch

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental control over partner theme selection. When disabled, partner theme selections are cleared and unavailable.

* **Refactor**
  * Updated partner theme availability filtering based on configuration state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->