### PR TITLE
fix(tests): assert collapsed settings value via summary, not Tab button

### DIFF
--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -44,7 +44,9 @@ for (const { name, size } of [
 
           await settings.clickItem(SETTINGS_MENU.ROUTE_PRIORITY.FASTEST);
           await settings.clickItem(SETTINGS_MENU.ROUTE_PRIORITY.LABEL);
-          await settings.expectItem(SETTINGS_MENU.ROUTE_PRIORITY.FASTEST, {
+          // Collapsing the submenu renders the chosen value as a summary <p>,
+          // not a Tab button (cf. the slippage step below).
+          await settings.expectSetting(SETTINGS_MENU.ROUTE_PRIORITY.FASTEST, {
             visible: true,
           });
           await settings.expectInfoBadgeVisible();
@@ -61,7 +63,8 @@ for (const { name, size } of [
 
           await settings.clickItem(SETTINGS_MENU.GAS_PRICE.SLOW);
           await settings.clickItem(SETTINGS_MENU.GAS_PRICE.LABEL);
-          await settings.expectItem(SETTINGS_MENU.GAS_PRICE.SLOW, {
+          // Same as route priority: the collapsed value is a summary <p>.
+          await settings.expectSetting(SETTINGS_MENU.GAS_PRICE.SLOW, {
             visible: true,
           });
         });


### PR DESCRIPTION
## What
Route-priority + gas-price re-checks now assert the collapsed summary value via `expectSetting` (the `<p>`), not `expectItem` (`//button`).

## Why
These settings sections are accordion headers whose options are MUI Tabs. After selecting an option then clicking the header to collapse it, the chosen value renders as the summary `<p>` — but the re-check looked for a `<button>` with that text, racing the collapse animation (~50% flake on the Fastest / Slow re-check). The slippage step already does this correctly with `expectSetting`; route-priority + gas-price now match.

Grounded in the actual rendered DOM (a DOM dump through the flow), not the a11y snapshot. Fixing route-priority exposed gas-price (identical bug, previously masked because the earlier failure aborted the test).

## Validation
Local CI-parity (`--repeat-each=10 --retries=0 --workers=4`):
- Before: route-priority/gas-price locator failures **10/20 (50%)**
- After: **0/20** locator failures (19/20 overall; the 1 was an unrelated 120s timeout on a load-heavy run, not this bug)

## Scope
JUM-1116 sub-task 4 (chronic flakes). Fixes settings qase 7/8 'Fastest'/'Slow' reopen race. Confirmed **not** a #2932 regression.

JUM-1116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Settings menu test to verify selected values in collapsed submenus are displayed correctly. Enhanced test documentation with clarifications on submenu behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->