### PR TITLE
fix: localize dust labels using per-request i18next t - JUM-1043

### DIFF
--- a/src/components/EarnDetails/EarnDetailsActionsPosition.tsx
+++ b/src/components/EarnDetails/EarnDetailsActionsPosition.tsx
@@ -62,11 +62,11 @@ export const EarnDetailsActionsPosition: FC<
       let formattedAmountUSD: string;
 
       if (amount) {
-        formattedAmount = extendedToken.formatAmount(amount);
-        formattedAmountUSD = extendedToken.formatAmountUSD(amount);
+        formattedAmount = extendedToken.formatAmount(amount, t);
+        formattedAmountUSD = extendedToken.formatAmountUSD(amount, t);
       } else if (amountUSD) {
-        formattedAmount = extendedToken.formatAmountFromUSD(amountUSD);
-        formattedAmountUSD = formatUSDWithDust(amountUSD);
+        formattedAmount = extendedToken.formatAmountFromUSD(amountUSD, t);
+        formattedAmountUSD = formatUSDWithDust(amountUSD, t);
       } else {
         formattedAmount = extendedToken.formatZeroAmount();
         formattedAmountUSD = extendedToken.formatZeroUSD();
@@ -80,12 +80,12 @@ export const EarnDetailsActionsPosition: FC<
     } else {
       const simpleToken = new SimpleToken(token);
       return {
-        formattedAmount: simpleToken.formatAmount(amount || 0),
+        formattedAmount: simpleToken.formatAmount(amount || 0, t),
         formattedAmountUSD: simpleToken.formatZeroUSD(),
         hasAmount: false,
       };
     }
-  }, [token, extendedToken, amount, amountUSD]);
+  }, [token, extendedToken, amount, amountUSD, t]);
 
   return (
     <Tooltip

--- a/src/components/composite/WalletBalanceCard/__snapshots__/WalletBalanceCard.snapshot.spec.tsx.snap
+++ b/src/components/composite/WalletBalanceCard/__snapshots__/WalletBalanceCard.snapshot.spec.tsx.snap
@@ -646,7 +646,7 @@ exports[`WalletBalanceCard snapshot > without error renders normally 1`] = `
                                       <p
                                         class="MuiTypography-root MuiTypography-bodyXXSmall css-avxtwr-MuiTypography-root"
                                       >
-                                        format.decimal USDC
+                                        format.decimal USDC
                                       </p>
                                     </div>
                                   </div>
@@ -736,7 +736,7 @@ exports[`WalletBalanceCard snapshot > without error renders normally 1`] = `
                                       <p
                                         class="MuiTypography-root MuiTypography-bodyXXSmall css-avxtwr-MuiTypography-root"
                                       >
-                                        format.decimal USDC
+                                        format.decimal USDC
                                       </p>
                                     </div>
                                   </div>

--- a/src/hooks/tokens/usePortfolioFormatters.spec.tsx
+++ b/src/hooks/tokens/usePortfolioFormatters.spec.tsx
@@ -1,6 +1,7 @@
 import type { PortfolioBalance, PricedToken } from '@/types/tokens';
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
+import { NBSP } from '@/utils/formatNumbers';
 import { usePortfolioFormatters } from './usePortfolioFormatters';
 
 const buildBalance = (
@@ -30,7 +31,7 @@ describe('usePortfolioFormatters', () => {
       const balances = [buildBalance(1n, 0)];
 
       expect(result.current.toDisplayAggregatedAmount(balances)).toBe(
-        '<0.0001 ETH',
+        `<0.0001${NBSP}ETH`,
       );
     });
 
@@ -40,7 +41,7 @@ describe('usePortfolioFormatters', () => {
       const balances = [buildBalance(100000000000000n, 0)];
 
       expect(result.current.toDisplayAggregatedAmount(balances)).toBe(
-        'format.decimal ETH',
+        `format.decimal${NBSP}ETH`,
       );
     });
 
@@ -50,7 +51,7 @@ describe('usePortfolioFormatters', () => {
       const balances = [buildBalance(1000000000000000000n, 2000)];
 
       expect(result.current.toDisplayAggregatedAmount(balances)).toBe(
-        'format.decimal ETH',
+        `format.decimal${NBSP}ETH`,
       );
     });
 
@@ -60,7 +61,7 @@ describe('usePortfolioFormatters', () => {
       const balances = [buildBalance(1n, 0), buildBalance(2n, 0)];
 
       expect(result.current.toDisplayAggregatedAmount(balances)).toBe(
-        '<0.0001 ETH',
+        `<0.0001${NBSP}ETH`,
       );
     });
 
@@ -69,7 +70,7 @@ describe('usePortfolioFormatters', () => {
       const balances = [buildBalance(0n, 0)];
 
       expect(result.current.toDisplayAggregatedAmount(balances)).toBe(
-        'format.decimal ETH',
+        `format.decimal${NBSP}ETH`,
       );
     });
   });

--- a/src/hooks/tokens/usePortfolioFormatters.ts
+++ b/src/hooks/tokens/usePortfolioFormatters.ts
@@ -54,7 +54,7 @@ export const usePortfolioFormatters = () => {
     ): string => {
       const totalAmountUSD = toAggregatedAmountUSD(balances);
       if (totalAmountUSD > 0 && totalAmountUSD < DUST_USD_THRESHOLD) {
-        return formatUSDWithDust(totalAmountUSD);
+        return formatUSDWithDust(totalAmountUSD, t);
       }
       const formatKey = options?.compact
         ? 'format.currencyCompact'
@@ -70,7 +70,7 @@ export const usePortfolioFormatters = () => {
       const numeric = Number(amount);
       const symbol = balances[0].token.symbol;
       if (numeric > 0 && numeric < DUST_AMOUNT_THRESHOLD) {
-        return formatTokenAmountWithDust(amount, symbol);
+        return formatTokenAmountWithDust(amount, symbol, t);
       }
       const formatted = t('format.decimal', { value: numeric });
       return `${formatted} ${symbol}`;

--- a/src/hooks/tokens/usePortfolioFormatters.ts
+++ b/src/hooks/tokens/usePortfolioFormatters.ts
@@ -2,6 +2,7 @@ import type { PricedToken, PortfolioBalance } from '@/types/tokens';
 import {
   DUST_AMOUNT_THRESHOLD,
   DUST_USD_THRESHOLD,
+  NBSP,
   formatTokenAmountWithDust,
   formatUSDWithDust,
 } from '@/utils/formatNumbers';
@@ -73,7 +74,7 @@ export const usePortfolioFormatters = () => {
         return formatTokenAmountWithDust(amount, symbol, t);
       }
       const formatted = t('format.decimal', { value: numeric });
-      return `${formatted} ${symbol}`;
+      return `${formatted}${NBSP}${symbol}`;
     },
     [t, toAggregatedAmount],
   );

--- a/src/hooks/tokens/useTokenFormatters.spec.tsx
+++ b/src/hooks/tokens/useTokenFormatters.spec.tsx
@@ -1,6 +1,7 @@
 import type { Balance, PricedToken } from '@/types/tokens';
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
+import { NBSP } from '@/utils/formatNumbers';
 import { useTokenFormatters } from './useTokenFormatters';
 
 const buildBalance = (
@@ -29,7 +30,7 @@ describe('useTokenFormatters', () => {
 
       expect(
         result.current.toDisplayAmount(balance, balance.token.symbol),
-      ).toBe('<0.0001 ETH');
+      ).toBe(`<0.0001${NBSP}ETH`);
     });
 
     it('does not collapse amount exactly at the threshold boundary', () => {
@@ -41,7 +42,7 @@ describe('useTokenFormatters', () => {
       // (mocked t returns the key as-is in tests).
       expect(
         result.current.toDisplayAmount(balance, balance.token.symbol),
-      ).toBe('format.decimal ETH');
+      ).toBe(`format.decimal${NBSP}ETH`);
     });
 
     it('returns localized key + symbol for normal amounts', () => {
@@ -51,7 +52,7 @@ describe('useTokenFormatters', () => {
 
       expect(
         result.current.toDisplayAmount(balance, balance.token.symbol),
-      ).toBe('format.decimal ETH');
+      ).toBe(`format.decimal${NBSP}ETH`);
     });
 
     it('does not collapse zero amount', () => {
@@ -60,14 +61,14 @@ describe('useTokenFormatters', () => {
 
       expect(
         result.current.toDisplayAmount(balance, balance.token.symbol),
-      ).toBe('format.decimal ETH');
+      ).toBe(`format.decimal${NBSP}ETH`);
     });
 
     it('falls back to --- symbol when symbol is missing on dust path', () => {
       const { result } = renderHook(() => useTokenFormatters());
       const balance = buildBalance(1n, { symbol: '' });
 
-      expect(result.current.toDisplayAmount(balance)).toBe('<0.0001 ---');
+      expect(result.current.toDisplayAmount(balance)).toBe(`<0.0001${NBSP}---`);
     });
 
     it('returns localized key without symbol when no symbol is provided on normal path', () => {

--- a/src/hooks/tokens/useTokenFormatters.ts
+++ b/src/hooks/tokens/useTokenFormatters.ts
@@ -45,7 +45,7 @@ export const useTokenFormatters = () => {
     ): string => {
       const value = Number(toAmountUSD(balance));
       if (value > 0 && value < DUST_USD_THRESHOLD) {
-        return formatUSDWithDust(value);
+        return formatUSDWithDust(value, t);
       }
       if (options.compact) {
         return t('format.currencyCompact', { value });
@@ -70,7 +70,7 @@ export const useTokenFormatters = () => {
       const amount = toAmount(balance);
       const numeric = parseFloat(amount);
       if (numeric > 0 && numeric < DUST_AMOUNT_THRESHOLD) {
-        return formatTokenAmountWithDust(amount, symbol ?? '');
+        return formatTokenAmountWithDust(amount, symbol ?? '', t);
       }
       const formatted = t('format.decimal', {
         value: Number(amount),

--- a/src/hooks/tokens/useTokenFormatters.ts
+++ b/src/hooks/tokens/useTokenFormatters.ts
@@ -2,6 +2,7 @@ import type { Balance, PricedToken } from '@/types/tokens';
 import {
   DUST_AMOUNT_THRESHOLD,
   DUST_USD_THRESHOLD,
+  NBSP,
   formatTokenAmountWithDust,
   formatUSDWithDust,
 } from '@/utils/formatNumbers';
@@ -80,7 +81,7 @@ export const useTokenFormatters = () => {
       if (!symbol) {
         return formatted;
       }
-      return `${formatted} ${symbol}`;
+      return `${formatted}${NBSP}${symbol}`;
     },
     [t, toAmount],
   );

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -455,7 +455,7 @@
     "decimal2Digit": "{{value, decimalExt(maximumFractionDigits: 2)}}",
     "date": "{{value, dateExt(month: long)}}",
     "shortDate": "{{value, dateExt(month: short)}}",
-    "dustAmount": "<{{value, decimalExt(maximumFractionDigits: 4)}} {{symbol}}",
+    "dustAmount": "<{{value, decimalExt(maximumFractionDigits: 4)}}\u00a0{{symbol}}",
     "dustUsd": "<{{value, currencyExt(currency: USD)}}"
   },
   "contribution": {

--- a/src/utils/Token.spec.ts
+++ b/src/utils/Token.spec.ts
@@ -2,6 +2,7 @@ import type { StaticToken, Token, TokenExtended } from '@lifi/sdk';
 import { CoinKey, type TokenTag } from '@lifi/widget';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Token as JumperToken } from '@/types/jumper-backend';
+import { NBSP } from './formatNumbers';
 import { ExtendedToken, SimpleToken } from './Token';
 
 const STATIC_TOKEN_FIXTURE: StaticToken = {
@@ -97,7 +98,7 @@ describe('SimpleToken', () => {
 
       const result = token.formatAmount('1000000000000000000');
 
-      expect(result).toBe('1 xDAI');
+      expect(result).toBe(`1${NBSP}xDAI`);
     });
 
     it('should format amount with number input', () => {
@@ -105,7 +106,7 @@ describe('SimpleToken', () => {
 
       const result = token.formatAmount(2500000);
 
-      expect(result).toBe('2.5 xDAI');
+      expect(result).toBe(`2.5${NBSP}xDAI`);
     });
 
     it('should format amount with bigint input', () => {
@@ -113,7 +114,7 @@ describe('SimpleToken', () => {
 
       const result = token.formatAmount(10000000000000000000n);
 
-      expect(result).toBe('10 xDAI');
+      expect(result).toBe(`10${NBSP}xDAI`);
     });
 
     it('should collapse small fractional amount below threshold to <0.0001', () => {
@@ -122,7 +123,7 @@ describe('SimpleToken', () => {
       // 14353125728879 wei with 18 decimals = 0.000014... — below dust threshold
       const result = token.formatAmount('14353125728879');
 
-      expect(result).toBe('<0.0001 xDAI');
+      expect(result).toBe(`<0.0001${NBSP}xDAI`);
     });
 
     it('should collapse dust amount to <0.0001', () => {
@@ -131,7 +132,7 @@ describe('SimpleToken', () => {
       // 1 wei with 18 decimals = 0.000000000000000001 — well below threshold
       const result = token.formatAmount('1');
 
-      expect(result).toBe('<0.0001 xDAI');
+      expect(result).toBe(`<0.0001${NBSP}xDAI`);
     });
 
     it('should not collapse amount exactly at threshold', () => {
@@ -140,7 +141,7 @@ describe('SimpleToken', () => {
       // 1e14 wei with 18 decimals = 0.0001 — exactly at boundary, should render unchanged
       const result = token.formatAmount('100000000000000');
 
-      expect(result).toBe('0.0001 xDAI');
+      expect(result).toBe(`0.0001${NBSP}xDAI`);
     });
 
     it('should handle token with no symbol', () => {
@@ -151,7 +152,7 @@ describe('SimpleToken', () => {
 
       const result = token.formatAmount('1000000000000000000');
 
-      expect(result).toBe('1 ---');
+      expect(result).toBe(`1${NBSP}---`);
     });
 
     it('should collapse dust amount to <0.0001 with no symbol fallback', () => {
@@ -162,7 +163,7 @@ describe('SimpleToken', () => {
 
       const result = token.formatAmount('1');
 
-      expect(result).toBe('<0.0001 ---');
+      expect(result).toBe(`<0.0001${NBSP}---`);
     });
   });
 
@@ -172,7 +173,7 @@ describe('SimpleToken', () => {
 
       const result = token.formatZeroAmount();
 
-      expect(result).toBe('0 xDAI');
+      expect(result).toBe(`0${NBSP}xDAI`);
     });
   });
 
@@ -346,7 +347,7 @@ describe('ExtendedToken', () => {
 
       const result = token.formatAmountFromUSD('1.0');
 
-      expect(result).toBe('1.231527093596059 xDAI');
+      expect(result).toBe(`1.231527093596059${NBSP}xDAI`);
     });
 
     it('should format token amount from USD with number input', () => {
@@ -354,7 +355,7 @@ describe('ExtendedToken', () => {
 
       const result = token.formatAmountFromUSD(2.5);
 
-      expect(result).toBe('3.0788177339901477 xDAI');
+      expect(result).toBe(`3.0788177339901477${NBSP}xDAI`);
     });
 
     it('should format token amount from USD with bigint input', () => {
@@ -362,7 +363,7 @@ describe('ExtendedToken', () => {
 
       const result = token.formatAmountFromUSD(10n);
 
-      expect(result).toBe('12.31527093596059 xDAI');
+      expect(result).toBe(`12.31527093596059${NBSP}xDAI`);
     });
 
     it('should format token amount from USD with high price token', () => {
@@ -370,7 +371,7 @@ describe('ExtendedToken', () => {
 
       const result = token.formatAmountFromUSD('1.0');
 
-      expect(result).toBe('1.0002787076563142 xDAI');
+      expect(result).toBe(`1.0002787076563142${NBSP}xDAI`);
     });
 
     it('should format large USD amount to token amount', () => {
@@ -378,7 +379,7 @@ describe('ExtendedToken', () => {
 
       const result = token.formatAmountFromUSD(1000n);
 
-      expect(result).toBe('1231.527093596059 xDAI');
+      expect(result).toBe(`1231.527093596059${NBSP}xDAI`);
     });
 
     it('should collapse dust token amount from tiny USD input to <0.0001', () => {
@@ -387,7 +388,7 @@ describe('ExtendedToken', () => {
       // 0.00001 USD / 0.812 = ~0.0000123 xDAI — below threshold
       const result = token.formatAmountFromUSD('0.00001');
 
-      expect(result).toBe('<0.0001 xDAI');
+      expect(result).toBe(`<0.0001${NBSP}xDAI`);
     });
   });
 });

--- a/src/utils/Token.ts
+++ b/src/utils/Token.ts
@@ -11,6 +11,7 @@ import {
   formatTokenPrice,
   priceToTokenAmount,
 } from '@lifi/widget';
+import type { TFunction } from 'i18next';
 
 import type { Token as JumperToken } from '@/types/jumper-backend';
 import {
@@ -59,16 +60,17 @@ export class SimpleToken {
     }
   }
 
-  protected formatTokenWithSymbol(amount: string) {
-    return formatTokenAmountWithDust(amount, this.symbol);
+  protected formatTokenWithSymbol(amount: string, t?: TFunction) {
+    return formatTokenAmountWithDust(amount, this.symbol, t);
   }
 
-  formatAmount(amount: string | number | bigint) {
+  formatAmount(amount: string | number | bigint, t?: TFunction) {
     if (typeof amount == 'number' && !Number.isInteger(amount)) {
       console.error(`Token formatAmount: number ${amount} is not an integer`);
     }
     return this.formatTokenWithSymbol(
       formatTokenAmount(BigInt(amount), this.decimals),
+      t,
     );
   }
 
@@ -114,7 +116,10 @@ export class ExtendedToken extends SimpleToken {
     return formatUSD(this.priceUSD);
   }
 
-  formatAmountUSD(amountToken: string | number | bigint): string {
+  formatAmountUSD(
+    amountToken: string | number | bigint,
+    t?: TFunction,
+  ): string {
     if (typeof amountToken == 'number' && !Number.isInteger(amountToken)) {
       console.error(
         `Token formatAmountUSD: number ${amountToken} is not an integer`,
@@ -127,13 +132,13 @@ export class ExtendedToken extends SimpleToken {
           this.priceUSD,
         )
       : 0;
-    return formatUSDWithDust(amount);
+    return formatUSDWithDust(amount, t);
   }
 
-  formatAmountFromUSD(amountUSD: string | number | bigint) {
+  formatAmountFromUSD(amountUSD: string | number | bigint, t?: TFunction) {
     const amount = this.priceUSD
       ? priceToTokenAmount(amountUSD.toString(), this.priceUSD)
       : '0';
-    return this.formatTokenWithSymbol(amount);
+    return this.formatTokenWithSymbol(amount, t);
   }
 }

--- a/src/utils/formatNumbers.spec.ts
+++ b/src/utils/formatNumbers.spec.ts
@@ -1,10 +1,36 @@
+import { createInstance } from 'i18next';
 import { describe, expect, it } from 'vitest';
 import {
+  currencyFormatter,
+  decimalFormatter,
   formatTokenAmountWithDust,
   formatUSDWithDust,
   formatValueWithConfig,
 } from './formatNumbers';
 import { APY_FORMAT_CONFIG } from './numbers/apy';
+
+async function buildFrT() {
+  const i18n = createInstance();
+  await i18n.init({
+    lng: 'fr',
+    resources: {
+      fr: {
+        translation: {
+          format: {
+            dustAmount:
+              '<{{value, decimalExt(maximumFractionDigits: 4)}} {{symbol}}',
+            dustUsd: '<{{value, currencyExt(currency: USD)}}',
+          },
+        },
+      },
+    },
+    defaultNS: 'translation',
+    ns: ['translation'],
+  });
+  i18n.services.formatter?.addCached('decimalExt', decimalFormatter);
+  i18n.services.formatter?.addCached('currencyExt', currencyFormatter);
+  return i18n.t.bind(i18n);
+}
 
 describe('formatTokenAmountWithDust', () => {
   it('should collapse dust amount to <0.0001 SYMBOL', () => {
@@ -59,6 +85,36 @@ describe('formatUSDWithDust', () => {
 
   it('should treat empty string as zero', () => {
     expect(formatUSDWithDust('')).toBe('$0.00');
+  });
+});
+
+describe('formatTokenAmountWithDust with fr locale', () => {
+  it('renders dust amount with fr decimal separator when t is provided', async () => {
+    const t = await buildFrT();
+    const result = formatTokenAmountWithDust(
+      '0.000000000000000001',
+      'WAVAX',
+      t,
+    );
+    expect(result).toBe('<0,0001 WAVAX');
+  });
+
+  it('falls back to en-US literal when t is omitted', () => {
+    expect(formatTokenAmountWithDust('0.000000000000000001', 'WAVAX')).toBe(
+      '<0.0001 WAVAX',
+    );
+  });
+});
+
+describe('formatUSDWithDust with fr locale', () => {
+  it('renders dust USD with fr locale formatting when t is provided', async () => {
+    const t = await buildFrT();
+    const result = formatUSDWithDust(0.001, t);
+    expect(result).toBe('<0,01\u00a0$US');
+  });
+
+  it('falls back to en-US literal when t is omitted', () => {
+    expect(formatUSDWithDust(0.001)).toBe('<$0.01');
   });
 });
 

--- a/src/utils/formatNumbers.spec.ts
+++ b/src/utils/formatNumbers.spec.ts
@@ -1,6 +1,7 @@
 import { createInstance } from 'i18next';
 import { describe, expect, it } from 'vitest';
 import {
+  NBSP,
   currencyFormatter,
   decimalFormatter,
   formatTokenAmountWithDust,
@@ -17,8 +18,7 @@ async function buildFrT() {
       fr: {
         translation: {
           format: {
-            dustAmount:
-              '<{{value, decimalExt(maximumFractionDigits: 4)}} {{symbol}}',
+            dustAmount: `<{{value, decimalExt(maximumFractionDigits: 4)}}${NBSP}{{symbol}}`,
             dustUsd: '<{{value, currencyExt(currency: USD)}}',
           },
         },
@@ -35,29 +35,33 @@ async function buildFrT() {
 describe('formatTokenAmountWithDust', () => {
   it('should collapse dust amount to <0.0001 SYMBOL', () => {
     expect(formatTokenAmountWithDust('0.000000000000000001', 'eETH')).toBe(
-      '<0.0001 eETH',
+      `<0.0001${NBSP}eETH`,
     );
   });
 
   it('should not collapse amount exactly at boundary', () => {
-    expect(formatTokenAmountWithDust('0.0001', 'eETH')).toBe('0.0001 eETH');
+    expect(formatTokenAmountWithDust('0.0001', 'eETH')).toBe(
+      `0.0001${NBSP}eETH`,
+    );
   });
 
   it('should not collapse zero', () => {
-    expect(formatTokenAmountWithDust('0', 'eETH')).toBe('0 eETH');
+    expect(formatTokenAmountWithDust('0', 'eETH')).toBe(`0${NBSP}eETH`);
   });
 
   it('should not collapse normal amount', () => {
-    expect(formatTokenAmountWithDust('12.345', 'eETH')).toBe('12.345 eETH');
+    expect(formatTokenAmountWithDust('12.345', 'eETH')).toBe(
+      `12.345${NBSP}eETH`,
+    );
   });
 
   it('should use --- fallback for missing symbol on normal amount', () => {
-    expect(formatTokenAmountWithDust('1', '')).toBe('1 ---');
+    expect(formatTokenAmountWithDust('1', '')).toBe(`1${NBSP}---`);
   });
 
   it('should use --- fallback for missing symbol on dust amount', () => {
     expect(formatTokenAmountWithDust('0.000000000000000001', '')).toBe(
-      '<0.0001 ---',
+      `<0.0001${NBSP}---`,
     );
   });
 });
@@ -96,12 +100,12 @@ describe('formatTokenAmountWithDust with fr locale', () => {
       'WAVAX',
       t,
     );
-    expect(result).toBe('<0,0001 WAVAX');
+    expect(result).toBe(`<0,0001${NBSP}WAVAX`);
   });
 
   it('falls back to en-US literal when t is omitted', () => {
     expect(formatTokenAmountWithDust('0.000000000000000001', 'WAVAX')).toBe(
-      '<0.0001 WAVAX',
+      `<0.0001${NBSP}WAVAX`,
     );
   });
 });
@@ -110,7 +114,7 @@ describe('formatUSDWithDust with fr locale', () => {
   it('renders dust USD with fr locale formatting when t is provided', async () => {
     const t = await buildFrT();
     const result = formatUSDWithDust(0.001, t);
-    expect(result).toBe('<0,01\u00a0$US');
+    expect(result).toBe(`<0,01${NBSP}$US`);
   });
 
   it('falls back to en-US literal when t is omitted', () => {

--- a/src/utils/formatNumbers.ts
+++ b/src/utils/formatNumbers.ts
@@ -1,4 +1,4 @@
-import i18next from 'i18next';
+import type { TFunction } from 'i18next';
 
 export const decimalFormatter = (
   lng: string | undefined,
@@ -136,11 +136,12 @@ export const DUST_AMOUNT_LABEL = `<${DUST_AMOUNT_THRESHOLD}`;
 export const formatTokenAmountWithDust = (
   amount: string,
   symbol: string,
+  t?: TFunction,
 ): string => {
   const numeric = parseFloat(amount);
   const label = symbol || '---';
   if (numeric > 0 && numeric < DUST_AMOUNT_THRESHOLD) {
-    const translated = i18next.t('format.dustAmount', {
+    const translated = t?.('format.dustAmount', {
       value: DUST_AMOUNT_THRESHOLD,
       symbol: label,
     });
@@ -169,11 +170,14 @@ export const DUST_USD_LABEL = '<$0.01';
  * The collapsed label is locale-aware via `format.dustUsd`; falls back to
  * the en-US literal when i18next hasn't been initialised yet (e.g. tests).
  */
-export const formatUSDWithDust = (amountUSD: number | string): string => {
+export const formatUSDWithDust = (
+  amountUSD: number | string,
+  t?: TFunction,
+): string => {
   const numeric =
     typeof amountUSD === 'number' ? amountUSD : parseFloat(amountUSD as string);
   if (Number.isFinite(numeric) && numeric > 0 && numeric < DUST_USD_THRESHOLD) {
-    const translated = i18next.t('format.dustUsd', {
+    const translated = t?.('format.dustUsd', {
       value: DUST_USD_THRESHOLD,
     });
     return !translated || translated.startsWith('format.dustUsd')

--- a/src/utils/formatNumbers.ts
+++ b/src/utils/formatNumbers.ts
@@ -123,6 +123,8 @@ export const formatValueWithConfig = (
   return new Intl.NumberFormat('en-US', formatOptions).format(numValue);
 };
 
+export const NBSP = '\u00a0'; // non-breaking space
+
 export const DUST_AMOUNT_THRESHOLD = 0.0001;
 export const DUST_AMOUNT_LABEL = `<${DUST_AMOUNT_THRESHOLD}`;
 
@@ -146,10 +148,10 @@ export const formatTokenAmountWithDust = (
       symbol: label,
     });
     return !translated || translated.startsWith('format.dustAmount')
-      ? `${DUST_AMOUNT_LABEL} ${label}`
+      ? `${DUST_AMOUNT_LABEL}${NBSP}${label}`
       : translated;
   }
-  return `${amount} ${label}`;
+  return `${amount}${NBSP}${label}`;
 };
 
 export const formatUSD = currencyFormatter('en-US', {


### PR DESCRIPTION
## Summary

Dust-collapse labels (\`<$0.01\`, \`<0.0001 SYMBOL\`) were hardcoded en-US strings on every locale because \`formatUSDWithDust\` / \`formatTokenAmountWithDust\` called the global \`i18next\` singleton, which has no locale or custom formatters. This routes them through the same per-request \`t\` (from \`useTranslation()\`) that neighbouring values already use, so on \`/fr/\` dust rows now render \`<0,01 $US\` / \`<0,0001 WAVAX\` instead of \`<$0.01\` / \`<0.0001 WAVAX\`.

## Changes

- \`formatNumbers.ts\` — drop global \`i18next\` import; add optional \`t?: TFunction\` param to both helpers; extract \`NBSP\` constant; use NBSP for all number↔symbol joins.
- \`useTokenFormatters.ts\` + \`usePortfolioFormatters.ts\` — pass \`t\` into dust calls; use \`NBSP\` join.
- \`Token.ts\` — thread optional \`t\` through \`formatTokenWithSymbol\`, \`formatAmount\`, \`formatAmountUSD\`, \`formatAmountFromUSD\`.
- \`EarnDetailsActionsPosition.tsx\` — pass \`t\` from \`useTranslation()\` into Token methods and direct \`formatUSDWithDust\` call.
- \`en/translation.json\` — \`dustAmount\` template uses NBSP before \`{{symbol}}\`.
- Tests — fr-locale tests assert exact locale-formatted output; all existing assertions updated for NBSP separator.
- \`WalletBalanceCard\` snapshot regenerated (2 lines, NBSP only).

## Linked Linear ticket

Closes https://linear.app/lifi-linear/issue/JUM-1043/dust-labels-00001-dollar001-dont-follow-locale-number-formatting

## Sister PRs

N/A

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved internationalization for token amounts and dust-threshold labels by using the active language during formatting.

* **Bug Fixes**
  * Updated displayed token amounts and dust/collapsed “threshold” labels to use non-breaking spaces between values and symbols for more consistent, line-break-safe rendering.
  * Ensured dust USD/token labeling respects the active language, with safe en-US-style fallbacks when translations are unavailable.

* **Tests**
  * Updated and expanded unit tests to cover non-breaking-space output and locale-specific dust-label behavior (including French and missing-symbol cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->