### PR TITLE
fix(sitemap): cap learn sitemap Strapi fetches to avoid CI ETIMEDOUT (JUM-1136)

### DIFF
--- a/src/app/lib/getArticles.ts
+++ b/src/app/lib/getArticles.ts
@@ -1,6 +1,63 @@
 import type { BlogArticleData, StrapiResponse } from '@/types/strapi';
 import { ArticleStrapiApi } from '@/utils/strapi/StrapiApi';
+
 const DEFAULT_PAGE_SIZE = 20;
+const SITEMAP_FETCH_RETRIES = 3;
+
+const fetchWithRetry = async (
+  url: string,
+  init: RequestInit,
+): Promise<Response> => {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < SITEMAP_FETCH_RETRIES; attempt++) {
+    try {
+      return await fetch(url, init);
+    } catch (error) {
+      lastError = error;
+      if (attempt < SITEMAP_FETCH_RETRIES - 1) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, 500 * (attempt + 1)),
+        );
+      }
+    }
+  }
+
+  throw lastError;
+};
+
+export async function getSitemapArticles(
+  page: number,
+  pageSize: number,
+  withCount = false,
+): Promise<StrapiResponse<BlogArticleData>> {
+  const urlParams = new ArticleStrapiApi({
+    includeFields: ['Slug', 'publishedAt', 'updatedAt'],
+    populate: ['Image'],
+  })
+    .sort('desc')
+    .addPaginationParams({
+      page,
+      pageSize,
+      withCount,
+    });
+  const apiUrl = decodeURIComponent(urlParams.getApiUrl());
+  const res = await fetchWithRetry(apiUrl, {
+    next: {
+      revalidate: 60 * 5,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch sitemap articles');
+  }
+
+  const responseData = await res.json();
+  return {
+    meta: responseData.meta,
+    data: responseData.data,
+  };
+}
 
 export async function getArticles(
   excludeId?: number,

--- a/src/utils/sitemaps/learn.spec.ts
+++ b/src/utils/sitemaps/learn.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { getLearnSitemapPageRange } from '@/utils/sitemaps/learn';
+
+describe('getLearnSitemapPageRange', () => {
+  it('returns only the pages needed for a production-sized chunk', () => {
+    expect(getLearnSitemapPageRange(0, 771, 50_000, 100)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8,
+    ]);
+  });
+
+  it('returns a single page for a dev-sized chunk', () => {
+    expect(getLearnSitemapPageRange(0, 771, 20, 100)).toEqual([1]);
+  });
+
+  it('returns an empty range when the chunk starts past the total', () => {
+    expect(getLearnSitemapPageRange(1, 771, 50_000, 100)).toEqual([]);
+  });
+
+  it('returns an empty range when there are no articles', () => {
+    expect(getLearnSitemapPageRange(0, 0, 50_000, 100)).toEqual([]);
+  });
+});

--- a/src/utils/sitemaps/learn.ts
+++ b/src/utils/sitemaps/learn.ts
@@ -10,7 +10,7 @@ export const dynamic = 'force-static';
 
 const SITEMAP_LIMIT = 50_000;
 const ARTICLES_PAGE_SIZE = 100;
-const DEV_CHUNK_SIZE = 100;
+const DEV_CHUNK_SIZE = 20;
 const FETCH_CONCURRENCY = 5;
 const chunkSize = isProduction ? SITEMAP_LIMIT : DEV_CHUNK_SIZE;
 

--- a/src/utils/sitemaps/learn.ts
+++ b/src/utils/sitemaps/learn.ts
@@ -1,5 +1,5 @@
+import { getSitemapArticles } from '@/app/lib/getArticles';
 import { AppPaths } from '@/const/urls';
-import { getArticles } from '@/app/lib/getArticles';
 import type { BlogArticleData } from '@/types/strapi';
 import { buildUrl, toSitemapDate } from '@/utils/sitemap';
 import { resolveStrapiMediaUrl } from '@/utils/strapi/strapiHelper';
@@ -10,33 +10,73 @@ export const dynamic = 'force-static';
 
 const SITEMAP_LIMIT = 50_000;
 const ARTICLES_PAGE_SIZE = 100;
-const DEV_CHUNK_SIZE = 20;
+const DEV_CHUNK_SIZE = 100;
+const FETCH_CONCURRENCY = 5;
 const chunkSize = isProduction ? SITEMAP_LIMIT : DEV_CHUNK_SIZE;
 
+export const getLearnSitemapPageRange = (
+  chunkId: number,
+  total: number,
+  articlesChunkSize: number,
+  pageSize: number,
+): number[] => {
+  const start = chunkId * articlesChunkSize;
+  if (start >= total) {
+    return [];
+  }
+
+  const articlesInChunk = Math.min(articlesChunkSize, total - start);
+  const firstPage = Math.floor(start / pageSize) + 1;
+  const lastPage = Math.ceil((start + articlesInChunk) / pageSize);
+
+  return Array.from(
+    { length: lastPage - firstPage + 1 },
+    (_, index) => firstPage + index,
+  );
+};
+
 const getArticlesTotal = async (): Promise<number> => {
-  const { meta } = await getArticles(undefined, 1, 1, true);
+  const { meta } = await getSitemapArticles(1, 1, true);
   return meta.pagination.total;
+};
+
+const fetchArticlesPage = async (page: number): Promise<BlogArticleData[]> => {
+  const { data } = await getSitemapArticles(page, ARTICLES_PAGE_SIZE, false);
+  return data;
+};
+
+const fetchInBatches = async (
+  pages: number[],
+  concurrency: number,
+): Promise<BlogArticleData[]> => {
+  const articles: BlogArticleData[] = [];
+
+  for (let index = 0; index < pages.length; index += concurrency) {
+    const batch = pages.slice(index, index + concurrency);
+    const batchArticles = await Promise.all(batch.map(fetchArticlesPage));
+    articles.push(...batchArticles.flat());
+  }
+
+  return articles;
 };
 
 const fetchArticlesChunk = async (
   chunkId: number,
 ): Promise<BlogArticleData[]> => {
-  const start = chunkId * chunkSize;
-  const firstPage = Math.floor(start / ARTICLES_PAGE_SIZE) + 1;
-  const lastPage = Math.ceil((start + chunkSize) / ARTICLES_PAGE_SIZE);
-  const pageRange = [...Array(lastPage - firstPage + 1).keys()].map(
-    (index) => firstPage + index,
+  const total = await getArticlesTotal();
+  const pageRange = getLearnSitemapPageRange(
+    chunkId,
+    total,
+    chunkSize,
+    ARTICLES_PAGE_SIZE,
   );
 
-  const pages = await Promise.all(
-    pageRange.map((page) =>
-      getArticles(undefined, ARTICLES_PAGE_SIZE, page, false).then(
-        ({ data }) => data,
-      ),
-    ),
-  );
+  if (pageRange.length === 0) {
+    return [];
+  }
 
-  return pages.flat().slice(0, chunkSize);
+  const articles = await fetchInBatches(pageRange, FETCH_CONCURRENCY);
+  return articles.slice(0, chunkSize);
 };
 
 export const getLearnSitemapChunkIds = async (): Promise<string[]> => {

--- a/src/utils/strapi/StrapiApi.ts
+++ b/src/utils/strapi/StrapiApi.ts
@@ -485,15 +485,18 @@ class ArticleStrapiApi extends StrapiApi {
   constructor({
     includeFields,
     excludeFields,
+    populate,
   }: {
     includeFields?: ArticleField[];
     excludeFields?: ArticleField[];
+    populate?: string[];
   } = {}) {
     super({ contentType: 'blog-articles' }); // Set content type to "blog-articles" automatically
     const articleParams = new ArticleParams(this.apiUrl);
     this.apiUrl = articleParams.addParams({
       includeFields,
       excludeFields,
+      populate,
     });
   }
 


### PR DESCRIPTION
## Summary

- Fixes flaky Release Docker builds that failed on `/learn/sitemap/0.xml` prerender with `ETIMEDOUT` ([failed job](https://github.com/jumperexchange/jumper-exchange/actions/runs/27553513979/job/81464174198))
- Caps learn sitemap Strapi pagination to the actual article count instead of firing 500 parallel requests per chunk
- Batches fetches (concurrency 5), uses a lightweight sitemap query, and retries transient fetch failures
- Adds unit tests for sitemap page-range calculation

Linear: [JUM-1136](https://linear.app/lifi-linear/issue/JUM-1136/fix-flaky-release-docker-build-on-learn-sitemap-prerender)

## Test plan

- [x] `pnpm vitest run --project unit src/utils/sitemaps/learn.spec.ts`
- [ ] Release workflow `build-and-push` completes without retrying on `pnpm build`
- [ ] `/learn/sitemap/0.xml` includes expected article URLs in preview/production


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sitemap-specific article retrieval with optional total-count support.
  * Enabled configurable relation population for article queries.

* **Improvements**
  * Enhanced Learn sitemap generation with retry logic, exponential backoff, and resilient error handling.
  * Optimized sitemap article fetching by calculating page ranges and fetching in fixed-size concurrent batches.

* **Tests**
  * Added test coverage for sitemap page-range calculations (including edge cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->