### PR TITLE
chore(ci): upgrade GitHub Actions to Node.js 24 and latest action versions - JUM-1137

### DIFF
--- a/.github/actions/init-gcp/action.yaml
+++ b/.github/actions/init-gcp/action.yaml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Authenticate to Google Cloud
       id: gcpauth
-      uses: google-github-actions/auth@v3
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
         create_credentials_file: 'true'
         workload_identity_provider: ${{ inputs.workload_identity_provider }}

--- a/.github/actions/init-gcp/action.yaml
+++ b/.github/actions/init-gcp/action.yaml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Authenticate to Google Cloud
       id: gcpauth
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@v3
       with:
         create_credentials_file: 'true'
         workload_identity_provider: ${{ inputs.workload_identity_provider }}

--- a/.github/workflows/build-and-push-multitag.yaml
+++ b/.github/workflows/build-and-push-multitag.yaml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Init GCP
         id: build-init
@@ -114,7 +114,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - name: Init GCP
         id: build-init
         uses: ./.github/actions/init-gcp
@@ -190,7 +190,7 @@ jobs:
 
       # Step 2: Checkout the repository for the build context
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       # Step 3: Initialize Docker build
       - name: Init GCP secrets
@@ -228,7 +228,7 @@ jobs:
       # Step 4: Build and push the Docker image
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: true
@@ -246,7 +246,7 @@ jobs:
 
       # Step 6: Upload the image digest as an artifact
       - name: Upload digest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
@@ -265,7 +265,7 @@ jobs:
         shell: bash
         run: echo "UNIQ_ID=$(date +'%y%m%d')-${GITHUB_SHA:0:7}" >> $GITHUB_ENV
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Init GCP
         id: build-init
@@ -275,7 +275,7 @@ jobs:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       # Step 2: Download image digests uploaded by the build job
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: /tmp/digests
           pattern: digests-*
@@ -283,7 +283,7 @@ jobs:
 
       # Step 3: Set up Docker Buildx for multi-platform builds
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       # Step 4: Generate Docker image metadata
       - name: Docker meta

--- a/.github/workflows/build-and-push-multitag.yaml
+++ b/.github/workflows/build-and-push-multitag.yaml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Init GCP
         id: build-init
@@ -114,7 +114,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Init GCP
         id: build-init
         uses: ./.github/actions/init-gcp
@@ -190,7 +190,7 @@ jobs:
 
       # Step 2: Checkout the repository for the build context
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       # Step 3: Initialize Docker build
       - name: Init GCP secrets
@@ -228,7 +228,7 @@ jobs:
       # Step 4: Build and push the Docker image
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -246,7 +246,7 @@ jobs:
 
       # Step 6: Upload the image digest as an artifact
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
@@ -265,7 +265,7 @@ jobs:
         shell: bash
         run: echo "UNIQ_ID=$(date +'%y%m%d')-${GITHUB_SHA:0:7}" >> $GITHUB_ENV
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Init GCP
         id: build-init
@@ -275,7 +275,7 @@ jobs:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       # Step 2: Download image digests uploaded by the build job
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-*
@@ -283,7 +283,7 @@ jobs:
 
       # Step 3: Set up Docker Buildx for multi-platform builds
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Step 4: Generate Docker image metadata
       - name: Docker meta

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,13 +17,13 @@ jobs:
           git config --global user.name github-actions[bot]
           git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
       - &checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - &pnpm-setup
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
       - &node-setup
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "pnpm"
@@ -55,13 +55,13 @@ jobs:
           SOURCE_NAME: ${{ github.base_ref || 'base-branch' }}
       - name: Comment on PR in case of failure
         if: failure()
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: "Lint-staged"
           path: DIFF.txt
       - name: Hide the Comment in case of success
         if: success()
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: "Lint-staged"
           hide: true
@@ -99,7 +99,7 @@ jobs:
         run: pnpm test:snapshots
       - name: Post snapshot comment
         if: always() && github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: Snapshot Tests Summary
           message: ${{ steps.test.outcome == 'success' && '✅ All snapshot tests passed' || '❌ Some snapshot tests failed. Check the logs for details.' }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,13 +17,13 @@ jobs:
           git config --global user.name github-actions[bot]
           git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
       - &checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           fetch-depth: 0
       - &pnpm-setup
         uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
       - &node-setup
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "pnpm"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -88,9 +88,9 @@ jobs:
         shard: [1, 2, 3, 4, 5]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "pnpm"
@@ -123,7 +123,7 @@ jobs:
           fi
       - name: Upload blob report to Github Actions Artifacts
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: blob-report-${{ matrix.shard }}
           path: blob-report
@@ -138,16 +138,16 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install
       - name: Download blob reports from GitHub Actions Articfacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: all-blob-reports
           pattern: blob-report-*
@@ -162,7 +162,7 @@ jobs:
           report-file: ./report.json
           create-comment: false
       - name: Upload HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: html-report--attempt-${{ github.run_attempt }}
           path: playwright-report
@@ -195,7 +195,7 @@ jobs:
     if: ${{ !cancelled() && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           message: |
             ${{ needs.merge-reports.outputs.summary }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -88,9 +88,9 @@ jobs:
         shard: [1, 2, 3, 4, 5]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "pnpm"
@@ -123,7 +123,7 @@ jobs:
           fi
       - name: Upload blob report to Github Actions Artifacts
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: blob-report-${{ matrix.shard }}
           path: blob-report
@@ -138,16 +138,16 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install
       - name: Download blob reports from GitHub Actions Articfacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: all-blob-reports
           pattern: blob-report-*
@@ -162,7 +162,7 @@ jobs:
           report-file: ./report.json
           create-comment: false
       - name: Upload HTML report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: html-report--attempt-${{ github.run_attempt }}
           path: playwright-report
@@ -290,7 +290,7 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
       
       - name: Send Slack notification
-        uses: slackapi/slack-github-action@v2
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_UI_TESTS }}

--- a/.github/workflows/tag-notify.yml
+++ b/.github/workflows/tag-notify.yml
@@ -7,7 +7,7 @@ jobs:
   slack-notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with: { fetch-depth: 0 }          # we need full history for diff
 
       # Detect the previous tag (if any)

--- a/.github/workflows/tag-notify.yml
+++ b/.github/workflows/tag-notify.yml
@@ -7,7 +7,7 @@ jobs:
   slack-notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with: { fetch-depth: 0 }          # we need full history for diff
 
       # Detect the previous tag (if any)


### PR DESCRIPTION
## Summary
- Bump official GitHub Actions to Node.js 24 runtime (`actions/checkout@v6`, `actions/setup-node@v6`) with `node-version: 24` on all Node/pnpm jobs
- Upgrade outdated action majors in Docker build (`checkout` v3→v6, `docker/build-push-action` v3→v7, `setup-buildx-action` v3→v4, artifact actions v4→v7/v8)
- Refresh third-party pins: `pnpm/action-setup` v6.0.9, `marocchino/sticky-pull-request-comment` v3.0.4, `google-github-actions/auth` v3

Closes [JUM-1137](https://linear.app/lifi-linear/issue/JUM-1137/upgrade-github-actions-to-nodejs-24-and-latest-action-versions).

## Test plan
- [ ] PR Checks workflow passes (lint-staged, unit, snapshots, dupcheck)
- [ ] Playwright workflow passes on this PR (all 5 shards + merge-reports)
- [ ] Docker build/push workflow succeeds on next staging/production tag (or manual `workflow_dispatch` if available)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated and pinned GitHub Actions across CI/CD workflows and composite steps, including Google Cloud authentication, multi-tag Docker build/push, Playwright testing/report merging, general checks, and tag notifications.
  * Upgraded key actions for source checkout, Node/pnpm setup, artifact upload/download, build tooling, and sticky PR comment updates to newer stable revisions to improve reliability and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->