### PR TITLE
refactor: unify env/migration label workflows - JUM-1135

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,8 @@
+changelog:
+  categories:
+    - title: Requires Environment Change
+      labels:
+        - env-change
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/label-changes.yml
+++ b/.github/workflows/label-changes.yml
@@ -12,9 +12,10 @@ jobs:
   label-changes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Apply change labels
         shell: bash
         env:

--- a/.github/workflows/label-changes.yml
+++ b/.github/workflows/label-changes.yml
@@ -1,0 +1,59 @@
+name: Label changes
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+  pull-requests: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+jobs:
+  label-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Apply change labels
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          DIFF="$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")"
+
+          # Snapshot current state once. These gh calls must succeed; if auth /
+          # rate-limit / network fails here, the step fails (no error swallowing).
+          repo_labels="$(gh label list --limit 200 --json name --jq '.[].name')"
+          pr_labels="$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')"
+
+          has() { grep -qxF "$2" <<< "$1"; }
+
+          apply() {
+            local name="$1" color="$2" desc="$3" pattern="$4"
+            if grep -qE "$pattern" <<< "$DIFF"; then
+              # Create the label only if the repo doesn't already have it, so we
+              # never rely on swallowing an "already exists" error.
+              if ! has "$repo_labels" "$name"; then
+                gh label create "$name" --color "$color" --description "$desc"
+                repo_labels="$repo_labels"$'\n'"$name"
+              fi
+              # Add only if not already on the PR.
+              if ! has "$pr_labels" "$name"; then
+                gh pr edit "$PR_NUMBER" --add-label "$name"
+              fi
+            else
+              # Remove only if actually on the PR, so --remove-label can never
+              # fail on a missing label.
+              if has "$pr_labels" "$name"; then
+                gh pr edit "$PR_NUMBER" --remove-label "$name"
+              fi
+            fi
+          }
+
+          apply "env-change" "B60205" "PR modifies src/config/env-config.ts" '^src/config/env-config\.ts$'


### PR DESCRIPTION
## Summary

Replaces the separate `env-change-label.yml` with a single `label-changes.yml` that handles all PR labeling in one job. Behavior is unchanged (same label, same trigger — `src/config/env-config.ts`), but the workflow is now:

- A single checkout and diff
- Explicit guard-before-mutate: snapshots `gh label list` and `gh pr view` upfront so every `gh` call is known-valid — no error swallowing via `|| true` or `2>/dev/null`
- `set -euo pipefail` so real failures (auth, rate-limit, network) surface and fail the CI step

Also adds `.github/release.yml` so PRs with the `env-change` label appear under "Requires Environment Change" in auto-generated release notes.

Sister PRs:
- jumper-notifications: https://github.com/jumperexchange/jumper-notifications/pull/57
- jumper-backend: https://github.com/jumperexchange/jumper-backend/pull/956

Closes JUM-1135 (frontend portion).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added GitHub release configuration to organize changelog entries into categorized groups, including an environment-related category.
  * Added an automated GitHub workflow that updates pull request labels based on which files changed, including automatically managing the environment-change label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->