### PR TITLE
fix(tests): assert partner-theme bg via canvas/video (qase 49)

### DIFF
--- a/tests/e2e/themeManipulation.spec.ts
+++ b/tests/e2e/themeManipulation.spec.ts
@@ -92,9 +92,14 @@ test.describe('Switch theme — partner themes', () => {
           backgroundElement.evaluate((el, prevBgColor) => {
             const bgColorChanged =
               getComputedStyle(el).backgroundColor !== prevBgColor;
+            // Partner themes render the bg as a <canvas>/<video>
+            // (CanvasBackground/AnimatedBackgroundImage), not just color/<img>.
             const imgElement = el.querySelector('img');
-            const hasBgImage = imgElement !== null && !!imgElement.src;
-            return bgColorChanged || hasBgImage;
+            const hasBackground =
+              (imgElement !== null && !!imgElement.src) ||
+              el.querySelector('video') !== null ||
+              el.querySelector('canvas') !== null;
+            return bgColorChanged || hasBackground;
           }, initialBgColor),
         )
         .toBe(true);


### PR DESCRIPTION
## What
The qase 49 partner-theme test checked the background "applied" by looking only for a **background-color change or an `<img>`**. Partner themes now render their background as a `<canvas>` (`CanvasBackground`) or `<video>` (`AnimatedBackgroundImage`), so a correctly-applied animated theme read as "no background" and hard-failed 0/3. This widens the assertion to also accept `<canvas>`/`<video>`.

## Validation
Passes 5/5 locally against develop.

## Note
CI on this PR may still be red from unrelated chronic CI-environment failures (QR / Telegram / Support, tracked under JUM-1116); this change only addresses qase 49.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced theme verification in E2E tests to more robustly detect when theme backgrounds have been applied, now recognizing additional element types beyond standard image-based backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->