### PR TITLE
ci(e2e): serve a prod build in CI to fix dev-server boot timeouts

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -108,6 +108,7 @@ jobs:
           QASE_TESTOPS_RUN_ID: ${{ needs.create-qase-run.outputs.run_id || '' }}
           QASE_TESTOPS_API_TOKEN: ${{ secrets.QASE_TOKEN }}
           SHARD: ${{ matrix.shard }}/${{ strategy.job-total }}
+          E2E_PROD_BUILD: "1" # serve a plain prod build (not the dev server) — JUM-1116
           TEST_WALLET_SEED_PHRASE: ${{ secrets.TEST_WALLET_SEED_PHRASE }}
           TEST_WALLET_PASSWORD: ${{ secrets.TEST_WALLET_PASSWORD }}
         if: ${{ !cancelled()}} # Always attempt to run the tests even if cache setup failed

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -81,7 +81,7 @@ jobs:
     # 25 min headroom — `swapActions.spec.ts` and `mainMenu.spec.ts` use
     # `test.slow()` (3× per-test timeout) and one Hyperliquid case has
     # `timeoutMs: 90_000`. 20 min was tight against worst-case shard timing.
-    timeout-minutes: 25
+    timeout-minutes: 40 # +cold prod build per shard (e2e now serves a prod build; see playwright.config webServer)
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -107,7 +107,7 @@ jobs:
           QASE_TESTOPS_RUN_ID: ${{ needs.create-qase-run.outputs.run_id || '' }}
           QASE_TESTOPS_API_TOKEN: ${{ secrets.QASE_TOKEN }}
           SHARD: ${{ matrix.shard }}/${{ strategy.job-total }}
-          E2E_PROD_BUILD: "1" # serve a plain prod build (not the dev server) — JUM-1116
+          E2E_PROD_BUILD: "1" # serve a plain prod build (not the dev server)
           TEST_WALLET_SEED_PHRASE: ${{ secrets.TEST_WALLET_SEED_PHRASE }}
           TEST_WALLET_PASSWORD: ${{ secrets.TEST_WALLET_PASSWORD }}
         if: ${{ !cancelled()}} # Always attempt to run the tests even if cache setup failed

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -78,10 +78,9 @@ jobs:
     needs: [create-qase-run]
     name: Test (${{ matrix.shard }} / ${{ strategy.job-total}})
     continue-on-error: false # Instead we use fail-fast to forward the failure state to subsequent jobs
-    # 25 min headroom — `swapActions.spec.ts` and `mainMenu.spec.ts` use
-    # `test.slow()` (3× per-test timeout) and one Hyperliquid case has
-    # `timeoutMs: 90_000`. 20 min was tight against worst-case shard timing.
-    timeout-minutes: 40 # +cold prod build per shard (e2e now serves a prod build; see playwright.config webServer)
+    # 40 min: per-shard cold prod build (~5-8 min) on top of the existing headroom
+    # for `test.slow()` specs (swapActions/mainMenu) + a 90s Hyperliquid case.
+    timeout-minutes: 40
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,7 +3,9 @@ import withBundleAnalyzer from '@next/bundle-analyzer';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'standalone',
+  // Standalone is for the Docker image; for the e2e prod-build server we want a
+  // plain build that `next start` serves cleanly (E2E_PROD_BUILD). See JUM-1116.
+  output: process.env.E2E_PROD_BUILD ? undefined : 'standalone',
   trailingSlash: false,
   reactCompiler: true,
   productionBrowserSourceMaps: false,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,7 +4,7 @@ import withBundleAnalyzer from '@next/bundle-analyzer';
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Standalone is for the Docker image; for the e2e prod-build server we want a
-  // plain build that `next start` serves cleanly (E2E_PROD_BUILD). See JUM-1116.
+  // plain build that `next start` serves cleanly (E2E_PROD_BUILD).
   output: process.env.E2E_PROD_BUILD ? undefined : 'standalone',
   trailingSlash: false,
   reactCompiler: true,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -74,10 +74,8 @@ export default defineConfig({
   webServer: process.env.BASE_URL
     ? undefined
     : {
-        // Under CI (or local E2E_PROD_BUILD) serve a production build, not the
-        // Turbopack dev server: dev-mode compilation starves React re-renders on
-        // the loaded runner, dropping the settings slippage warning (JUM-1116).
-        // Mirrors playwright.perf.config.
+        // Serve a prod build under CI/E2E_PROD_BUILD — the Turbopack dev server
+        // intermittently boot-hangs on CI runners (300s webServer timeout). JUM-1116.
         command:
           process.env.E2E_PROD_BUILD || process.env.CI
             ? 'pnpm run build && pnpm run start'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -75,7 +75,7 @@ export default defineConfig({
     ? undefined
     : {
         // Serve a prod build under CI/E2E_PROD_BUILD — the Turbopack dev server
-        // intermittently boot-hangs on CI runners (300s webServer timeout). JUM-1116.
+        // intermittently boot-hangs on CI runners (300s webServer timeout).
         command:
           process.env.E2E_PROD_BUILD || process.env.CI
             ? 'pnpm run build && pnpm run start'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -74,9 +74,17 @@ export default defineConfig({
   webServer: process.env.BASE_URL
     ? undefined
     : {
-        command: 'pnpm run dev',
+        // Under CI (or local E2E_PROD_BUILD) serve a production build, not the
+        // Turbopack dev server: dev-mode compilation starves React re-renders on
+        // the loaded runner, dropping the settings slippage warning (JUM-1116).
+        // Mirrors playwright.perf.config.
+        command:
+          process.env.E2E_PROD_BUILD || process.env.CI
+            ? 'pnpm run build && pnpm run start'
+            : 'pnpm run dev',
         url: 'http://localhost:3000',
-        timeout: 300 * 1000,
+        timeout:
+          (process.env.E2E_PROD_BUILD || process.env.CI ? 900 : 300) * 1000,
         reuseExistingServer: !process.env.CI,
       },
 


### PR DESCRIPTION
> Branch name is historical — it began as the settings-qase-8 investigation. The actual change here is the CI infra win below; it does **not** fix qase 8.

## What
Under CI (and local `E2E_PROD_BUILD=1`), serve a **production build** (`pnpm build && pnpm start`) instead of the Turbopack **dev** server, and bump shard `timeout-minutes` 25 → 40 for the added cold-build time. Also gates `output: 'standalone'` off for the e2e build so `next start` serves cleanly. Mirrors `playwright.perf.config.ts`.

## Why
The Turbopack dev server intermittently **boot-hangs on CI runners** → `config.webServer` 300s timeout → an entire shard fails with **0 tests run** (seen on multiple recent runs, 1–2 shards each). A pre-built prod server avoids the on-demand-compile boot hang. A dispatched run on this branch had **0 boot-timeouts** (vs dev-server runs with 1–2), and shard 1 — which gets timeout-cancelled at 25 min on the heavy wallet/earn specs — passed with the 40-min bump.

## Trade-off
Adds a per-shard cold `next build` (~5–8 min), offset by faster/more-stable test runs (no compile stalls mid-test). Worth your call: per-shard build vs build-once-and-share-artifact.

## Note
Does **not** fix settings qase 8 Desktop (a separate CI-environment issue under JUM-1116). The value here is CI **stability** — removing the boot-timeout + shard-cancel class of red.

Relates to JUM-1116.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased end-to-end test job timeouts to accommodate production build testing.
  * Updated test environment to validate against production builds instead of development server.

* **Chores**
  * Adjusted build configuration for test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->