### PR TITLE
fix(next): remove dead Strapi .exchange image hosts

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -80,18 +80,6 @@ const nextConfig = {
       },
       {
         protocol: 'https',
-        hostname: 'strapi-develop.jumper.exchange',
-        port: '',
-        pathname: '/uploads/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'strapi.jumper.exchange',
-        port: '',
-        pathname: '/uploads/**',
-      },
-      {
-        protocol: 'https',
         hostname: 'strapi.jumper.xyz',
         port: '',
         pathname: '/uploads/**',


### PR DESCRIPTION
## What
Removes two dead image `remotePatterns` hosts from `next.config.mjs`: **`strapi-develop.jumper.exchange`** and **`strapi.jumper.exchange`** — both fail DNS resolution (the `ENOTFOUND strapi.jumper.exchange` seen in CI logs). The correct `.xyz` equivalents (`strapi-develop.jumper.xyz`, `strapi.jumper.xyz`) are already present, so nothing is lost.

## Note
This cleans up the next/image allowlist. If `.exchange` media URLs are still emitted by Strapi data, the deeper source is CMS-side. Relates to JUM-1116 (CI external-reachability noise).