### PR TITLE
fix(i18n): rename private swap widget title to "Private Swap" 

### DIFF
--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -1095,7 +1095,7 @@ export default interface Resources {
         title: 'Exchange';
       };
       private: {
-        title: 'Anonymous Swap';
+        title: 'Private Swap';
       };
       swapBridge: {
         title: 'Swap & Bridge';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -857,7 +857,7 @@
       "title": "Exchange"
     },
     "private": {
-      "title": "Anonymous Swap"
+      "title": "Private Swap"
     },
     "swapBridge": {
       "title": "Swap & Bridge"


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-1145

## What

Renames the private-swap widget title from **"Anonymous Swap"** → **"Private Swap"** so the widget header matches the nav tab label (which already reads "Private Swap"). "Anonymous Swap" was a leftover from the original feature name (#2800, "feat: Added anonymous swaps"). Requested by Octave.

## Scope

- **2 lines:** `widget.private.title` in `src/i18n/translations/en/translation.json` + the matching type literal in `src/i18n/resources.d.ts`.
- **EN only** — every other locale falls back to EN for both `widget.private.title` and `navbar.links.private`, so this updates the widget title across all languages at once and keeps it consistent with the tab.
- No logic change, no `@lifi/widget` version bump — Jumper-side string only.
- The private/incognito tab is currently gated off on prod, so this isn't user-visible until the launch reveal — just needs to land in the build before then.

## Note

Did a surgical edit of the `resources.d.ts` type literal rather than a full `pnpm i18next-resources-for-ts` regen — the current tool version reorders the whole file (~2.2k-line churn), which would bury this one-string change. `tsc --noEmit` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the display label for the private swap widget feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->