### PR TITLE
fix: guard null notification ctaUrl to prevent crash - JUM-1144

### DIFF
--- a/src/components/Notifications/NotificationItem.spec.tsx
+++ b/src/components/Notifications/NotificationItem.spec.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '../../../vitest.setup';
+import { NotificationItem } from './NotificationItem';
+import type { Notification } from '@/types/notifications';
+import { NotificationCategory } from '@/types/notifications';
+import { useNotificationStore } from '@/stores/notifications/NotificationStore';
+import type * as ZustandMiddleware from 'zustand/middleware';
+
+const accountState: { account?: { address: string } } = {
+  account: {
+    address: '0x1111111111111111111111111111111111111111',
+  },
+};
+
+vi.mock('@lifi/wallet-management', () => ({
+  useAccount: () => accountState,
+}));
+
+vi.mock('motion/react', () => ({
+  useInView: () => false,
+}));
+
+const contentState: { ctaLabel?: string | null } = { ctaLabel: 'Open' };
+
+vi.mock('@/hooks/notifications/useNotificationContent', () => ({
+  useNotificationContent: (notification: Notification) => ({
+    title: notification.title,
+    body: notification.body,
+    ctaLabel: contentState.ctaLabel,
+  }),
+}));
+
+vi.mock('@/hooks/userTracking/useNotificationTracking', () => ({
+  useNotificationTracking: () => ({
+    trackSeen: vi.fn(),
+    trackClicked: vi.fn(),
+    trackDismissed: vi.fn(),
+  }),
+}));
+
+// Prevent zustand's persist from writing to localStorage during tests
+vi.mock('zustand/middleware', async () => {
+  const actual =
+    await vi.importActual<typeof ZustandMiddleware>('zustand/middleware');
+  return {
+    ...actual,
+    persist:
+      (config: Parameters<typeof actual.persist>[0]) =>
+      (...args: Parameters<ReturnType<typeof actual.persist>>) =>
+        config(...args),
+  };
+});
+
+const makeNotification = (
+  overrides: Partial<Notification> = {},
+): Notification => ({
+  id: '1',
+  title: 'STORED TITLE',
+  body: 'STORED BODY',
+  category: NotificationCategory.Earn,
+  ctaLabel: 'STORED CTA',
+  ctaUrl: '/earn',
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-01T00:00:00.000Z',
+  expiresAt: null,
+  isGlobal: false,
+  metadata: {},
+  priority: 5,
+  sourceRuleId: '',
+  status: 'pending',
+  userAddress: '0xabc',
+  ...overrides,
+});
+
+describe('NotificationItem', () => {
+  beforeEach(() => {
+    accountState.account = {
+      address: '0x1111111111111111111111111111111111111111',
+    };
+    contentState.ctaLabel = 'Open';
+    useNotificationStore.setState({
+      readNotificationIdsByAccount: {},
+      deletedNotificationIdsByAccount: {},
+    });
+  });
+
+  it('renders without a CTA link when ctaUrl is null (JUM-1144 regression)', () => {
+    const notification = makeNotification({ ctaUrl: null, ctaLabel: null });
+    contentState.ctaLabel = null;
+
+    expect(() =>
+      render(
+        <NotificationItem notification={notification} onCtaClick={vi.fn()} />,
+      ),
+    ).not.toThrow();
+
+    expect(screen.getByText('STORED TITLE')).toBeInTheDocument();
+    expect(screen.queryByText('Open')).not.toBeInTheDocument();
+  });
+
+  it('renders an internal CTA link for a relative ctaUrl', () => {
+    render(
+      <NotificationItem
+        notification={makeNotification({ ctaUrl: '/earn' })}
+        onCtaClick={vi.fn()}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: /open/i });
+    expect(link).toHaveAttribute('href', '/earn');
+    expect(link).not.toHaveAttribute('target', '_blank');
+  });
+
+  it('renders an external CTA link for an absolute ctaUrl', () => {
+    render(
+      <NotificationItem
+        notification={makeNotification({ ctaUrl: 'https://example.com' })}
+        onCtaClick={vi.fn()}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: /open/i });
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+});

--- a/src/components/Notifications/NotificationItem.tsx
+++ b/src/components/Notifications/NotificationItem.tsx
@@ -60,6 +60,7 @@ export const NotificationItem: FC<NotificationItemProps> = ({
 
   const isRead = readIds.includes(notification.id);
   const isInternal =
+    !!notification.ctaUrl &&
     notification.ctaUrl.startsWith('/') &&
     !notification.ctaUrl.startsWith('//');
 

--- a/src/hooks/notifications/useNotificationContent.ts
+++ b/src/hooks/notifications/useNotificationContent.ts
@@ -10,7 +10,7 @@ import type { Notification } from '@/types/notifications';
 export interface NotificationContent {
   title: string;
   body: string;
-  ctaLabel: string;
+  ctaLabel?: string | null;
 }
 
 /**

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -11,8 +11,8 @@ export interface Notification {
   title: string;
   body: string;
   category: NotificationCategory;
-  ctaLabel: string;
-  ctaUrl: string;
+  ctaLabel?: string | null;
+  ctaUrl?: string | null;
   createdAt: string;
   updatedAt: string;
   expiresAt: string | null;


### PR DESCRIPTION
## Summary

Clicking the notification bell crashed the entire app to a white "An error occurred" screen whenever the notification list contained a notification with a `null` `ctaUrl`. `NotificationItem` computed `isInternal` by calling `notification.ctaUrl.startsWith('/')` unconditionally — before the existing `ctaUrl &&` guard in the JSX — so a `null` URL threw `TypeError: Cannot read properties of null (reading 'startsWith')` and unmounted the app.

The backend (`jumper-notifications`) legitimately returns `null` for `cta_url`/`cta_label` (both are nullable columns), but the frontend types declared them as non-nullable `string`, which hid the case from TypeScript.

## Changes

- `NotificationItem.tsx`: guard `isInternal` with `!!notification.ctaUrl` so the `startsWith` checks only run when a URL is present. Notifications without a CTA now render without a CTA link instead of crashing.
- `types/notifications.ts`: `ctaUrl` / `ctaLabel` are now `?: string | null`, matching the nullable backend schema.
- `useNotificationContent.ts`: propagate the nullable `ctaLabel` type downstream.
- `NotificationItem.spec.tsx`: new unit coverage, including the null-`ctaUrl` regression case.

## Verification

- `vitest` unit tests: 3/3 pass
- `tsc --noEmit`: clean
- `eslint`: clean

## Linked Linear ticket

Fixes JUM-1144

## Sister PRs

N/A — frontend-only fix. The backend nullable schema is intentional and unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification CTA handling so notifications render safely when CTA label and/or CTA URL are missing or empty, and internal/external link behavior remains correct.

* **Tests**
  * Added React Testing Library + Vitest coverage for notification rendering, including cases with no CTA, relative CTA URLs (internal links), and absolute CTA URLs (external links).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->