### PR TITLE
fix: partner theme icon color extraction

### DIFF
--- a/src/components/Menus/ThemeModesSubMenu/PartnerThemeIcon.tsx
+++ b/src/components/Menus/ThemeModesSubMenu/PartnerThemeIcon.tsx
@@ -1,0 +1,32 @@
+import { maxBy } from 'lodash';
+import Avatar from '@mui/material/Avatar';
+import { useGetColorsFromImage } from '@/hooks/images/useGetColorsFromImage';
+
+interface PartnerThemeIconProps {
+  src: string;
+  alt: string;
+}
+
+export const PartnerThemeIcon = ({ src, alt }: PartnerThemeIconProps) => {
+  const colors = useGetColorsFromImage(src);
+  const dominantColor = maxBy(
+    colors.filter((c) => c.area > 0.1),
+    'area',
+  );
+  const isLightIcon = (dominantColor?.lightness ?? 0) > 0.5;
+
+  return (
+    <Avatar
+      src={src}
+      alt={alt}
+      sx={(muiTheme) => ({
+        height: 24,
+        width: 24,
+        filter: 'grayscale(1)',
+        ...(isLightIcon
+          ? muiTheme.applyStyles('light', { filter: 'grayscale(1) invert(1)' })
+          : muiTheme.applyStyles('dark', { filter: 'grayscale(1) invert(1)' })),
+      })}
+    />
+  );
+};

--- a/src/components/Menus/ThemeModesSubMenu/useThemeModesMenuContent.tsx
+++ b/src/components/Menus/ThemeModesSubMenu/useThemeModesMenuContent.tsx
@@ -16,8 +16,8 @@ import {
   TrackingEventParameter,
 } from '@/const/trackingKeys';
 import { isDarkOrLightThemeMode } from '@/utils/formatTheme';
-import Avatar from '@mui/material/Avatar';
 import { selectAvailablePartnerThemes } from '@/stores/theme/createThemeStore';
+import { PartnerThemeIcon } from './PartnerThemeIcon';
 import { AB_TEST_NAME } from '@/const/abtests';
 import { useABTest } from '@/hooks/useABTest';
 
@@ -179,15 +179,7 @@ export const useThemeModesMenuContent = () => {
         return {
           label: theme.PartnerName,
           prefixIcon: themeModeIcon ? (
-            <Avatar
-              src={themeModeIcon}
-              alt={theme.PartnerName}
-              sx={{
-                height: 24,
-                width: 24,
-                filter: 'grayscale(100%) contrast(2)',
-              }}
-            />
+            <PartnerThemeIcon src={themeModeIcon} alt={theme.PartnerName} />
           ) : (
             <FlareRoundedIcon />
           ),

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -1088,7 +1088,7 @@ export default interface Resources {
         title: 'Exchange';
       };
       private: {
-        title: 'Anonymous Swap';
+        title: 'Private Swap';
       };
       swapBridge: {
         title: 'Swap & Bridge';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -850,7 +850,7 @@
       "title": "Exchange"
     },
     "private": {
-      "title": "Anonymous Swap"
+      "title": "Private Swap"
     },
     "swapBridge": {
       "title": "Swap & Bridge"


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes JUM-1156

## Testing steps

On develop, if you switch to light mode and open the theme menu, the partner theme icon should be dark, while if you switch to dark theme, the partner theme icon should be light. The auto mode depends on your browser preference, but the partner theme icon should match the previous themes.

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced theme partner icon display with automatic color detection and adaptive styling.

* **Updates**
  * Renamed "Anonymous Swap" to "Private Swap" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->