### PR TITLE
fix(holdings): value filter inconsistency

### DIFF
--- a/src/components/PortfolioFilterBar/hooks.tsx
+++ b/src/components/PortfolioFilterBar/hooks.tsx
@@ -96,8 +96,9 @@ export const useHoldingsFilterCategories = () => {
     [allAssets],
   );
 
-  const valueMin = filter?.minValue ?? allValueRange.min;
-  const valueMax = filter?.maxValue ?? allValueRange.max;
+  const { min: rangeMin, max: rangeMax } = allValueRange;
+  const valueMin = filter?.minValue ?? rangeMin;
+  const valueMax = filter?.maxValue ?? rangeMax;
 
   const sortByOptions = useMemo(
     () => [
@@ -133,8 +134,7 @@ export const useHoldingsFilterCategories = () => {
     filter?.assets,
   ].reduce((count, arr) => count + (arr?.length || 0), 0);
 
-  const hasValueFilterApplied =
-    valueMin !== allValueRange.min || valueMax !== allValueRange.max;
+  const hasValueFilterApplied = valueMin !== rangeMin || valueMax !== rangeMax;
   const valueFilterCount = hasValueFilterApplied ? 1 : 0;
   const filtersCount = arrayFiltersCount + valueFilterCount;
   const hasFilterApplied = filtersCount > 0 && optionsCount > 0;

--- a/src/providers/PortfolioProvider/filtering/HoldingsFilteringContext.tsx
+++ b/src/providers/PortfolioProvider/filtering/HoldingsFilteringContext.tsx
@@ -157,16 +157,9 @@ export const HoldingsFilteringProvider = ({ children }: PropsWithChildren) => {
 
     if (!isEqual(nextFilter, filter)) {
       setFilter(nextFilter);
-      setSearchParamsState(
-        serializeHoldingsFilterForUrl(
-          nextFilter,
-          stats,
-          !!hasExplicitValueRangeRef.current,
-        ),
-      );
+      setSearchParamsState(serializeHoldingsFilterForUrl(nextFilter, stats));
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- mirror Earn: sanitize when stats/loading change
-  }, [stats, isAllBalancesDataLoading, setSearchParamsState]);
+  }, [filter, stats, isAllBalancesDataLoading, setSearchParamsState]);
 
   const balancesData = useMemo(
     () =>
@@ -198,13 +191,7 @@ export const HoldingsFilteringProvider = ({ children }: PropsWithChildren) => {
       });
 
       setFilter(nextFilter);
-      setSearchParamsState(
-        serializeHoldingsFilterForUrl(
-          nextFilter,
-          stats,
-          !!hasExplicitValueRangeRef.current,
-        ),
-      );
+      setSearchParamsState(serializeHoldingsFilterForUrl(nextFilter, stats));
     },
     [filter, setSearchParamsState, stats],
   );

--- a/src/providers/PortfolioProvider/filtering/utils.spec.ts
+++ b/src/providers/PortfolioProvider/filtering/utils.spec.ts
@@ -3,6 +3,9 @@ import { EMPTY_HOLDINGS_FILTERING_PARAMS } from './constants';
 import {
   extractHoldingsFilteringParams,
   filterSortPositionsData,
+  getDefaultHoldingsMinValue,
+  getEffectiveValueRange,
+  isFullHoldingsValueRange,
   resolveHoldingsFilter,
   sanitizeHoldingsFilter,
   serializeHoldingsFilterForUrl,
@@ -33,6 +36,12 @@ const createPosition = (
     rewardTokens: [],
   }) as PortfolioPosition;
 
+const statsAboveOne = {
+  ...EMPTY_HOLDINGS_FILTERING_PARAMS,
+  allAssets: [{ symbol: 'ETH' } as never],
+  allValueRange: { min: 0.00003492862, max: 5000 },
+};
+
 describe('extractHoldingsFilteringParams', () => {
   it('returns empty params when both sources are empty', () => {
     expect(
@@ -57,6 +66,58 @@ describe('extractHoldingsFilteringParams', () => {
   });
 });
 
+describe('getEffectiveValueRange', () => {
+  it('uses a default min of 1 when any asset is above 1', () => {
+    expect(getEffectiveValueRange({ min: 0.05, max: 100 })).toEqual({
+      min: 1,
+      max: 100,
+    });
+  });
+
+  it('returns the portfolio range when all assets are below 1', () => {
+    expect(getEffectiveValueRange({ min: 0.05, max: 0.85 })).toEqual({
+      min: 0.05,
+      max: 0.85,
+    });
+  });
+});
+
+describe('getDefaultHoldingsMinValue', () => {
+  it('returns 1 when the portfolio max is at least 1', () => {
+    expect(getDefaultHoldingsMinValue({ min: 0.05, max: 100 })).toBe(1);
+  });
+
+  it('returns undefined when all holdings are below 1', () => {
+    expect(
+      getDefaultHoldingsMinValue({ min: 0.05, max: 0.85 }),
+    ).toBeUndefined();
+  });
+});
+
+describe('isFullHoldingsValueRange', () => {
+  it('treats an empty value filter as the full range', () => {
+    expect(isFullHoldingsValueRange({}, statsAboveOne)).toBe(true);
+  });
+
+  it('treats explicit portfolio endpoints as the full range', () => {
+    expect(
+      isFullHoldingsValueRange(
+        {
+          minValue: statsAboveOne.allValueRange.min,
+          maxValue: statsAboveOne.allValueRange.max,
+        },
+        statsAboveOne,
+      ),
+    ).toBe(true);
+  });
+
+  it('does not treat the default min filter as the full range', () => {
+    expect(isFullHoldingsValueRange({ minValue: 1 }, statsAboveOne)).toBe(
+      false,
+    );
+  });
+});
+
 describe('resolveHoldingsFilter', () => {
   it('applies the default min value when no explicit range preference exists', () => {
     const stats = {
@@ -73,7 +134,7 @@ describe('resolveHoldingsFilter', () => {
     ).toEqual({ minValue: 1 });
   });
 
-  it('preserves an explicit cleared value range', () => {
+  it('does not re-apply the default min after the value range was cleared', () => {
     const stats = {
       ...EMPTY_HOLDINGS_FILTERING_PARAMS,
       allAssets: [{ symbol: 'ETH' } as never],
@@ -87,15 +148,69 @@ describe('resolveHoldingsFilter', () => {
       }),
     ).toEqual({});
   });
+
+  it('does not apply a default min when stats are still empty', () => {
+    const stats = {
+      ...EMPTY_HOLDINGS_FILTERING_PARAMS,
+      allValueRange: { min: 0, max: 0 },
+    };
+
+    expect(
+      resolveHoldingsFilter({}, stats, {
+        hasExplicitValueRange: false,
+        isAllBalancesDataLoading: false,
+      }),
+    ).toEqual({});
+  });
+
+  it('applies the default min while balances are loading once stats are available', () => {
+    const stats = {
+      ...EMPTY_HOLDINGS_FILTERING_PARAMS,
+      allAssets: [{ symbol: 'ETH' } as never],
+      allValueRange: { min: 0, max: 100 },
+    };
+
+    expect(
+      resolveHoldingsFilter({}, stats, {
+        hasExplicitValueRange: false,
+        isAllBalancesDataLoading: true,
+      }),
+    ).toEqual({ minValue: 1 });
+  });
+
+  it('does not apply a default min when all holdings are below 1', () => {
+    const stats = {
+      ...EMPTY_HOLDINGS_FILTERING_PARAMS,
+      allAssets: [{ symbol: 'ETH' } as never],
+      allValueRange: { min: 0.05, max: 0.85 },
+    };
+
+    expect(
+      resolveHoldingsFilter({}, stats, {
+        hasExplicitValueRange: false,
+        isAllBalancesDataLoading: false,
+      }),
+    ).toEqual({});
+  });
+
+  it('applies the default min alongside other filters when no explicit range exists', () => {
+    const stats = {
+      ...EMPTY_HOLDINGS_FILTERING_PARAMS,
+      allAssets: [{ symbol: 'ETH' } as never],
+      allValueRange: { min: 0, max: 100 },
+    };
+
+    expect(
+      resolveHoldingsFilter({ chains: [1] }, stats, {
+        hasExplicitValueRange: false,
+        isAllBalancesDataLoading: false,
+      }),
+    ).toEqual({ chains: [1], minValue: 1 });
+  });
 });
 
 describe('serializeHoldingsFilterForUrl', () => {
-  const stats = {
-    ...EMPTY_HOLDINGS_FILTERING_PARAMS,
-    allValueRange: { min: 0.00003492862, max: 5000 },
-  };
-
-  it('omits default min, portfolio max, and empty array params', () => {
+  it('persists the default min in the URL when it is applied', () => {
     expect(
       serializeHoldingsFilterForUrl(
         {
@@ -105,12 +220,21 @@ describe('serializeHoldingsFilterForUrl', () => {
           chains: [1],
           assets: [],
         },
-        stats,
-        false,
+        statsAboveOne,
       ),
     ).toEqual({
       holdingsWallets: null,
       holdingsChains: [1],
+      holdingsAssets: null,
+      holdingsMinValue: 1,
+      holdingsMaxValue: null,
+    });
+  });
+
+  it('omits value params when the filter uses the full available range', () => {
+    expect(serializeHoldingsFilterForUrl({}, statsAboveOne)).toEqual({
+      holdingsWallets: null,
+      holdingsChains: null,
       holdingsAssets: null,
       holdingsMinValue: null,
       holdingsMaxValue: null,
@@ -119,26 +243,21 @@ describe('serializeHoldingsFilterForUrl', () => {
 
   it('persists an explicit max below the portfolio top', () => {
     expect(
-      serializeHoldingsFilterForUrl({ maxValue: 100 }, stats, true)
+      serializeHoldingsFilterForUrl({ maxValue: 100 }, statsAboveOne)
         .holdingsMaxValue,
     ).toBe(100);
   });
 
-  it('persists an explicit min opt-out at the portfolio floor', () => {
+  it('persists an explicit min below the default threshold', () => {
     expect(
-      serializeHoldingsFilterForUrl({ minValue: 0 }, stats, true)
+      serializeHoldingsFilterForUrl({ minValue: 0 }, statsAboveOne)
         .holdingsMinValue,
     ).toBe(0);
   });
 });
 
 describe('buildHoldingsFilterPatchFromPending', () => {
-  const stats = {
-    ...EMPTY_HOLDINGS_FILTERING_PARAMS,
-    allValueRange: { min: 0.00003492862, max: 5000 },
-  };
-
-  it('does not include value params when only chains change at default slider', () => {
+  it('does not include value params when only chains change at the default min', () => {
     expect(
       buildHoldingsFilterPatchFromPending(
         {
@@ -147,7 +266,7 @@ describe('buildHoldingsFilterPatchFromPending', () => {
           assets: [],
           value: [1, 5000],
         },
-        stats,
+        statsAboveOne,
         { minValue: 1 },
       ),
     ).toEqual({
@@ -166,7 +285,7 @@ describe('buildHoldingsFilterPatchFromPending', () => {
           assets: [],
           value: [0.00003492862, 5000],
         },
-        stats,
+        statsAboveOne,
         { minValue: 1 },
       ),
     ).toEqual({
@@ -175,6 +294,46 @@ describe('buildHoldingsFilterPatchFromPending', () => {
       assets: null,
       minValue: null,
       maxValue: null,
+    });
+  });
+
+  it('applies the default min after the slider was reset to the full range', () => {
+    expect(
+      buildHoldingsFilterPatchFromPending(
+        {
+          wallets: [],
+          chains: [],
+          assets: [],
+          value: [1, 5000],
+        },
+        statsAboveOne,
+        {},
+      ),
+    ).toEqual({
+      wallets: null,
+      chains: null,
+      assets: null,
+      minValue: 1,
+    });
+  });
+
+  it('resets minValue when the slider returns to the default min from a higher value', () => {
+    expect(
+      buildHoldingsFilterPatchFromPending(
+        {
+          wallets: [],
+          chains: [],
+          assets: [],
+          value: [1, 5000],
+        },
+        statsAboveOne,
+        { minValue: 2 },
+      ),
+    ).toEqual({
+      wallets: null,
+      chains: null,
+      assets: null,
+      minValue: 1,
     });
   });
 });

--- a/src/providers/PortfolioProvider/filtering/utils.ts
+++ b/src/providers/PortfolioProvider/filtering/utils.ts
@@ -237,9 +237,36 @@ export const getEffectiveValueRange = (
   }
 
   return {
-    min: Math.max(defaultMinValue, allValueRange.min),
-    max: Math.max(defaultMinValue, allValueRange.max),
+    min: defaultMinValue,
+    max: allValueRange.max,
   };
+};
+
+export const getDefaultHoldingsMinValue = (allValueRange: {
+  min: number;
+  max: number;
+}): number | undefined => {
+  if (allValueRange.max < DEFAULT_MIN_VALUE) {
+    return undefined;
+  }
+
+  return DEFAULT_MIN_VALUE;
+};
+
+export const isFullHoldingsValueRange = (
+  filter: HoldingsFilter,
+  stats: HoldingsFilteringParams,
+): boolean => {
+  const { min: rangeMin, max: rangeMax } = stats.allValueRange;
+
+  if (filter.minValue === undefined && filter.maxValue === undefined) {
+    return true;
+  }
+
+  const effectiveMin = filter.minValue ?? rangeMin;
+  const effectiveMax = filter.maxValue ?? rangeMax;
+
+  return effectiveMin === rangeMin && effectiveMax === rangeMax;
 };
 
 export interface ExtractHoldingsFilteringParamsInput {
@@ -323,13 +350,18 @@ export const resolveHoldingsFilter = (
     shouldSanitizeChainsAndWallets,
   );
 
-  const withDefaults = context.hasExplicitValueRange
-    ? sanitized
-    : {
+  const defaultMin = getDefaultHoldingsMinValue(stats.allValueRange);
+  const shouldApplyDefaultMin =
+    !context.hasExplicitValueRange &&
+    defaultMin !== undefined &&
+    stats.allValueRange.max > 0;
+
+  const withDefaults = shouldApplyDefaultMin
+    ? {
         ...sanitized,
-        minValue:
-          sanitized.minValue ?? getEffectiveValueRange(stats.allValueRange).min,
-      };
+        minValue: sanitized.minValue ?? defaultMin,
+      }
+    : sanitized;
 
   return removeNullValuesFromFilter<HoldingsFilter>(withDefaults);
 };
@@ -337,18 +369,16 @@ export const resolveHoldingsFilter = (
 export const serializeHoldingsFilterForUrl = (
   filter: HoldingsFilter,
   stats: HoldingsFilteringParams,
-  hasExplicitValueRange: boolean,
 ) => {
-  const { max: rangeMax } = stats.allValueRange;
-  const defaultMin = getEffectiveValueRange(stats.allValueRange).min;
+  const { min: rangeMin, max: rangeMax } = stats.allValueRange;
+  const defaultMin = getDefaultHoldingsMinValue(stats.allValueRange);
 
-  const holdingsMinValue =
-    hasExplicitValueRange && filter.minValue !== undefined
+  const holdingsMinValue = isFullHoldingsValueRange(filter, stats)
+    ? null
+    : filter.minValue !== undefined
       ? filter.minValue
-      : !hasExplicitValueRange &&
-          filter.minValue !== undefined &&
-          filter.minValue !== defaultMin
-        ? filter.minValue
+      : defaultMin !== undefined
+        ? defaultMin
         : null;
 
   const holdingsMaxValue =
@@ -378,7 +408,7 @@ export const buildHoldingsFilterPatchFromPending = (
   const pendingMin = values.value[0] ?? stats.allValueRange.min;
   const pendingMax = values.value[1] ?? stats.allValueRange.max;
   const { min: rangeMin, max: rangeMax } = stats.allValueRange;
-  const defaultMin = getEffectiveValueRange(stats.allValueRange).min;
+  const defaultMin = getDefaultHoldingsMinValue(stats.allValueRange);
   const isFullValueRange = pendingMin === rangeMin && pendingMax === rangeMax;
 
   const patch: NullableFields<HoldingsFilter> = {
@@ -393,9 +423,16 @@ export const buildHoldingsFilterPatchFromPending = (
     return patch;
   }
 
-  if (pendingMin === rangeMin && pendingMin !== defaultMin) {
-    patch.minValue = pendingMin;
-  } else if (pendingMin !== defaultMin) {
+  if (defaultMin !== undefined && pendingMin === defaultMin) {
+    const wasAtFullRange = isFullHoldingsValueRange(currentFilter, stats);
+    if (
+      wasAtFullRange ||
+      (currentFilter.minValue !== undefined &&
+        currentFilter.minValue !== defaultMin)
+    ) {
+      patch.minValue = defaultMin;
+    }
+  } else {
     patch.minValue = pendingMin;
   }
 


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes JUM-1153

## Summary

Fixes portfolio holdings **value range filtering** after the merge of `BalancesFilteringContext` and `PositionsFilteringContext` into `HoldingsFilteringContext` (#2810). The unified context lost several behaviors around the default **$1 minimum** and how clear/apply interacted with that default.

## Problem

When balances and positions filtering were consolidated, the `minValue` logic from the old contexts was not fully preserved. That led to inconsistent filtering and slider behavior:

- **No default min on load** — When any holding was above $1, the filter should start at `minValue: 1` to hide dust. After the merge, this was often not applied and `holdingsMinValue` was missing from the URL.
- **Clear did not reset to the full range** — “Clear all” and the value slider clear button should reset to the **full available portfolio range** (`allValueRange.min` → `allValueRange.max`), including holdings below $1. Instead, the $1 default was re-applied or the explicit-range flag got stuck, so dust filtering could not be removed.
- **Re-selecting $1 after clear did not filter** — After clearing to the full range, moving the slider back to $1 and applying did not emit `minValue` in the filter patch (because `$1 === $1` was treated as “unchanged”). With the explicit-range flag still set, `resolveHoldingsFilter` skipped the default, so holdings were not filtered until a value like $2 was chosen.
- **Portfolios entirely below $1** — When max holding value was below $1, no artificial $1 floor should be applied; the filter should follow the actual holdings range.
- **Slider vs filter mismatch** — The slider should always show the **full available range**, with thumbs at the **current** min/max. “Filter applied” state should compare against the portfolio range, not conflate the default $1 min with the slider floor.

## Solution

- Introduced `getDefaultHoldingsMinValue()` and `isFullHoldingsValueRange()` to separate:
  - **Default filter** ($1 when max ≥ $1)
  - **Full available range** (cleared state)
- Updated `resolveHoldingsFilter()` to apply the $1 default only when the user has not explicitly chosen a value range.
- Updated `serializeHoldingsFilterForUrl()` to persist the active min (including the default $1) and omit params when the filter is the full range.
- Updated `buildHoldingsFilterPatchFromPending()` so clearing to full range clears value params, and selecting $1 after a clear correctly applies `minValue: 1`.
- Adjusted `HoldingsFilteringContext` and filter bar hooks so clear/apply flows respect explicit vs default range correctly.

## Test plan

- [ ] Portfolio with holdings above $1: on load, dust below $1 is hidden and URL includes `holdingsMinValue=1`
- [ ] Value slider shows full range (e.g. $0.15–$4.85) with thumbs at current filter values
- [ ] Clear value / Clear all resets to full range and shows holdings below $1
- [ ] After clear, select $1 and apply — holdings below $1 are hidden again
- [ ] Change min to $2, then back to $1 — filtering still works
- [ ] Portfolio where all holdings are below $1 — no $1 default; full range works without forced min
- [ ] Apply chain/asset filters only while at default $1 min — value filter remains intact
- [ ] `pnpm vitest run src/providers/PortfolioProvider/filtering/utils.spec.ts`

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved holdings filter value range handling for more consistent default minimum application and full-range detection.
  * Enhanced URL synchronization logic for filter persistence.

* **Tests**
  * Expanded test coverage for value range behavior, including edge cases for portfolios with varying asset values and filter reset scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->