### PR TITLE
fix: Strapi fetch observability and cache tags for on-demand invalidation

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,7 +16,8 @@ const nextConfig = {
     '@opentelemetry/exporter-metrics-otlp-grpc',
     '@opentelemetry/host-metrics',
   ],
-  expireTime: 86400, // one day in seconds
+  // expireTime: 86400, // one day in seconds
+  expireTime: 900, // 15 minutes in seconds
   experimental: {
     serverSourceMaps: false,
     optimizePackageImports: [],

--- a/src/app/[lng]/missions/[slug]/page.tsx
+++ b/src/app/[lng]/missions/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next/types';
-import { getQuestBySlug } from 'src/app/lib/getQuestBySlug';
 import { getQuestsWithNoCampaignAttached } from 'src/app/lib/getQuestsWithNoCampaignAttached';
+import { fetchQuestBySlugForPage } from 'src/app/lib/missions/cachedMissionsFetch';
 import { siteName } from 'src/app/lib/metadata';
 import { sliceStrToXChar } from 'src/utils/splitStringToXChar';
 import { resolveStrapiMediaUrl } from 'src/utils/strapi/strapiHelper';
@@ -73,13 +73,13 @@ export async function generateMetadata({
       throw new Error('Invalid mission slug');
     }
 
-    const mission = await getQuestBySlug(slugResult.data);
+    const mission = await fetchQuestBySlugForPage(slugResult.data);
 
-    if (!mission || !mission.data) {
+    if (!mission) {
       throw new Error('Mission not found');
     }
 
-    const missionData = mission.data;
+    const missionData = mission;
     const imageUrl = resolveStrapiMediaUrl(missionData.Image?.url);
 
     const pageUrl = `${getSiteUrl()}${AppPaths.Missions}/${slug}`;

--- a/src/app/lib/fetchStrapi.ts
+++ b/src/app/lib/fetchStrapi.ts
@@ -1,0 +1,35 @@
+import { logger } from '@/utils/logger';
+import { recordFetchCacheMetric } from '@/utils/telemetry/recordFetchCacheMetric';
+
+export async function fetchStrapi(
+  url: string,
+  options: RequestInit,
+  endpoint: string,
+): Promise<Response> {
+  const res = await fetch(url, options);
+
+  try {
+    const cfCacheStatus = res.headers.get('cf-cache-status') ?? 'none';
+    const ageRaw = res.headers.get('age');
+    const ageSeconds = ageRaw !== null ? Number(ageRaw) : null;
+    const cacheControl = res.headers.get('cache-control') ?? 'none';
+
+    recordFetchCacheMetric({ endpoint, cfCacheStatus, ageSeconds });
+
+    logger.info(
+      {
+        endpoint,
+        cfCacheStatus,
+        age: ageSeconds,
+        cacheControl,
+        status: res.status,
+        url,
+      },
+      'strapi fetch',
+    );
+  } catch (error) {
+    console.error(error, 'Error instrumenting Strapi fetch.');
+  }
+
+  return res;
+}

--- a/src/app/lib/fetchStrapi.ts
+++ b/src/app/lib/fetchStrapi.ts
@@ -11,7 +11,9 @@ export async function fetchStrapi(
   try {
     const cfCacheStatus = res.headers.get('cf-cache-status') ?? 'none';
     const ageRaw = res.headers.get('age');
-    const ageSeconds = ageRaw !== null ? Number(ageRaw) : null;
+    const ageParsed = ageRaw !== null ? Number(ageRaw) : NaN;
+    const ageSeconds =
+      Number.isFinite(ageParsed) && ageParsed >= 0 ? ageParsed : null;
     const cacheControl = res.headers.get('cache-control') ?? 'none';
 
     recordFetchCacheMetric({ endpoint, cfCacheStatus, ageSeconds });

--- a/src/app/lib/getPartnerThemes.ts
+++ b/src/app/lib/getPartnerThemes.ts
@@ -1,16 +1,18 @@
 import type { PartnerThemesData, StrapiResponse } from '@/types/strapi';
 import { PartnerThemeStrapiApi } from '@/utils/strapi/StrapiApi';
+import { fetchStrapi } from '@/app/lib/fetchStrapi';
+
 export async function getPartnerThemes(): Promise<
   StrapiResponse<PartnerThemesData>
 > {
   const urlParams = new PartnerThemeStrapiApi();
   const apiUrl = urlParams.getApiUrl();
 
-  const res = await fetch(decodeURIComponent(apiUrl), {
-    next: {
-      revalidate: 60 * 5, // revalidate every 5 minutes
-    },
-  });
+  const res = await fetchStrapi(
+    decodeURIComponent(apiUrl),
+    { next: { revalidate: 60 * 5, tags: ['partner-themes'] } },
+    'partner-themes',
+  );
 
   if (!res.ok) {
     throw new Error('Failed to fetch data');

--- a/src/app/lib/getQuestsBy.ts
+++ b/src/app/lib/getQuestsBy.ts
@@ -2,23 +2,30 @@ import { cache } from 'react';
 import { QuestStrapiApi } from '@/utils/strapi/StrapiApi';
 import type { Quest } from 'src/types/loyaltyPass';
 import type { StrapiResponse } from 'src/types/strapi';
+import { fetchStrapi } from '@/app/lib/fetchStrapi';
+
 export const getQuestsBy = cache(async (key: string, value: string) => {
   const urlParams = new QuestStrapiApi()
     .filterBy(key, value)
     .populateCampaign();
   const apiUrl = urlParams.getApiUrl();
 
-  const res = await fetch(decodeURIComponent(apiUrl), {
-    next: {
-      revalidate: 60 * 5, // revalidate every 5 minutes
+  const res = await fetchStrapi(
+    decodeURIComponent(apiUrl),
+    {
+      next: {
+        revalidate: 60 * 5,
+        tags: [`quest:${key.toLowerCase()}:${value}`],
+      },
     },
-  });
+    'quests',
+  );
 
   if (!res.ok) {
     throw new Error('Failed to fetch data');
   }
 
-  const data: StrapiResponse<Quest> = await res.json(); // Use the defined type here
+  const data: StrapiResponse<Quest> = await res.json();
 
-  return { data }; // Return a plain object
+  return { data };
 });

--- a/src/app/lib/getQuestsWithNoCampaignAttached.ts
+++ b/src/app/lib/getQuestsWithNoCampaignAttached.ts
@@ -1,6 +1,8 @@
 import type { PaginationProps } from '@/utils/strapi/StrapiApi';
 import { QuestStrapiApi } from '@/utils/strapi/StrapiApi';
 import type { QuestData, StrapiResponse } from 'src/types/strapi';
+import { fetchStrapi } from '@/app/lib/fetchStrapi';
+
 export async function getQuestsWithNoCampaignAttached(
   pagination: PaginationProps = {
     page: 1,
@@ -19,11 +21,11 @@ export async function getQuestsWithNoCampaignAttached(
     });
   const apiUrl = urlParams.getApiUrl();
 
-  const res = await fetch(decodeURIComponent(apiUrl), {
-    next: {
-      revalidate: 60 * 5, // revalidate every 5 minutes
-    },
-  });
+  const res = await fetchStrapi(
+    decodeURIComponent(apiUrl),
+    { next: { revalidate: 60 * 5 } },
+    'quests',
+  );
 
   if (!res.ok) {
     throw new Error('Failed to fetch data');

--- a/src/app/lib/missions/cachedMissionsFetch.ts
+++ b/src/app/lib/missions/cachedMissionsFetch.ts
@@ -21,7 +21,10 @@ export const fetchQuestBySlugForPage = (slug: string) =>
   unstable_cache(
     () => fetchQuestBySlug(slug),
     ['missions-page-quest-by-slug', slug],
-    { revalidate: MISSIONS_PAGE_REVALIDATE_SECONDS },
+    {
+      revalidate: MISSIONS_PAGE_REVALIDATE_SECONDS,
+      tags: [`quest:slug:${slug}`],
+    },
   )();
 
 export const fetchProfileBannerCampaignsForPage = () =>

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,3 @@
+import pino from 'pino';
+
+export const logger = pino({ level: process.env.LOG_LEVEL ?? 'info' });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,3 +1,15 @@
 import pino from 'pino';
 
-export const logger = pino({ level: process.env.LOG_LEVEL ?? 'info' });
+const VALID_LEVELS = new Set([
+  'trace',
+  'debug',
+  'info',
+  'warn',
+  'error',
+  'fatal',
+  'silent',
+]);
+const rawLevel = (process.env.LOG_LEVEL ?? '').toLowerCase();
+const level = VALID_LEVELS.has(rawLevel) ? rawLevel : 'info';
+
+export const logger = pino({ level });

--- a/src/utils/telemetry/recordFetchCacheMetric.ts
+++ b/src/utils/telemetry/recordFetchCacheMetric.ts
@@ -1,6 +1,22 @@
 import { metrics } from '@opentelemetry/api';
 
-const METER_NAME = 'jumper-exchange';
+const meter = metrics.getMeter('jumper-exchange');
+
+const cacheStatusCounter = meter.createCounter(
+  'strapi_fetch_cf_cache_status_total',
+  {
+    description: 'Count of Strapi fetches by Cloudflare cache status.',
+  },
+);
+
+const cacheAgeHistogram = meter.createHistogram(
+  'strapi_fetch_cf_cache_age_seconds',
+  {
+    description:
+      'Age in seconds of CF-cached Strapi API responses at fetch time.',
+    unit: 's',
+  },
+);
 
 export const recordFetchCacheMetric = ({
   endpoint,
@@ -12,22 +28,13 @@ export const recordFetchCacheMetric = ({
   ageSeconds: number | null;
 }) => {
   try {
-    const meter = metrics.getMeter(METER_NAME);
-
-    meter
-      .createCounter('strapi_fetch_cf_cache_status_total', {
-        description: 'Count of Strapi fetches by Cloudflare cache status.',
-      })
-      .add(1, { endpoint, cf_cache_status: cfCacheStatus });
+    cacheStatusCounter.add(1, { endpoint, cf_cache_status: cfCacheStatus });
 
     if (ageSeconds !== null) {
-      meter
-        .createHistogram('strapi_fetch_cf_cache_age_seconds', {
-          description:
-            'Age in seconds of CF-cached Strapi API responses at fetch time.',
-          unit: 's',
-        })
-        .record(ageSeconds, { endpoint, cf_cache_status: cfCacheStatus });
+      cacheAgeHistogram.record(ageSeconds, {
+        endpoint,
+        cf_cache_status: cfCacheStatus,
+      });
     }
   } catch (error) {
     console.error(error, 'Error recording fetch cache metric.');

--- a/src/utils/telemetry/recordFetchCacheMetric.ts
+++ b/src/utils/telemetry/recordFetchCacheMetric.ts
@@ -1,0 +1,35 @@
+import { metrics } from '@opentelemetry/api';
+
+const METER_NAME = 'jumper-exchange';
+
+export const recordFetchCacheMetric = ({
+  endpoint,
+  cfCacheStatus,
+  ageSeconds,
+}: {
+  endpoint: string;
+  cfCacheStatus: string;
+  ageSeconds: number | null;
+}) => {
+  try {
+    const meter = metrics.getMeter(METER_NAME);
+
+    meter
+      .createCounter('strapi_fetch_cf_cache_status_total', {
+        description: 'Count of Strapi fetches by Cloudflare cache status.',
+      })
+      .add(1, { endpoint, cf_cache_status: cfCacheStatus });
+
+    if (ageSeconds !== null) {
+      meter
+        .createHistogram('strapi_fetch_cf_cache_age_seconds', {
+          description:
+            'Age in seconds of CF-cached Strapi API responses at fetch time.',
+          unit: 's',
+        })
+        .record(ageSeconds, { endpoint, cf_cache_status: cfCacheStatus });
+    }
+  } catch (error) {
+    console.error(error, 'Error recording fetch cache metric.');
+  }
+};


### PR DESCRIPTION
## Summary

- Adds a `fetchStrapi` wrapper that logs Cloudflare cache headers (`cf-cache-status`, `age`, `cache-control`) via Pino and records OTel metrics (`strapi_fetch_cf_cache_status_total` counter, `strapi_fetch_cf_cache_age_seconds` histogram) per endpoint — surfaces the invisible CF TTL that caused 1h+ staleness on staging
- Adds matching cache tags to `getQuestsBy` (`fetch()`) and `fetchQuestBySlugForPage` (`unstable_cache()`) so `revalidateTag('quest:slug:<slug>')` busts both layers together
- Adds `'partner-themes'` tag to `getPartnerThemes` fetch
- Aligns `generateMetadata` in the missions page to use `fetchQuestBySlugForPage` (same `unstable_cache` path as `MissionPageContent`) so metadata and page body are always served from the same cache entry
- Lowers `expireTime` from 86400 s (1 day) to 900 s (15 min) to cap full route cache staleness

## Test plan

- [ ] `pnpm typecheck` — no errors
- [ ] Hit `/en/missions/private-swaps` locally after `pnpm build && pnpm start`, confirm Pino log line in stdout with `endpoint: 'quests'`, `cfCacheStatus`, and `age` fields
- [ ] Confirm `generateMetadata` and page body return the same quest data (no version mismatch between title and content)
- [ ] Call `revalidateTag('quest:slug:private-swaps')` and verify both the `unstable_cache` and fetch-cache entries are invalidated on the next request

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated cached content expiration from 1 day to 15 minutes for fresher mission data.
  * Improved cache invalidation for mission and CMS requests using more precise cache tagging.
  * Standardized CMS fetching across the application for more consistent results.
  * Added monitoring for cache performance and introduced configurable logging to help diagnose issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->