### PR TITLE
fix(perf): remove dead pathname Set-Cookie so CDN can cache static HTML - JUM-1160

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -26,10 +26,6 @@ export function proxy(request: NextRequest) {
     });
   }
 
-  // Set a cookie with the pathname that was used on the first page load
-  const pathname = request.nextUrl.pathname;
-  response.cookies.set('pathname', pathname, { path: '/', sameSite: 'strict' });
-
   return response;
 }
 


### PR DESCRIPTION
## Summary

`src/proxy.ts` set a `pathname` cookie on **every** response. Cloudflare bypasses its cache whenever a response carries `Set-Cookie`, so 100% of static HTML returned `cf-cache-status: BYPASS` and every request hit the origin Next.js pods. The pods are CPU-saturated as a result — even prerendered cache HITs took 5–25s TTFB, `/meta/_health` timed out, and pods restarted in a loop (~3.3k probe-failure events on a single pod over ~4 days).

The `pathname` cookie is **written but never read** anywhere in the codebase, so this is a dead-code removal with no functional change.

## Evidence

- `GET https://jumper.xyz/` ×5: all `x-nextjs-cache: HIT` + `cf-cache-status: BYPASS`, TTFB **1.6s / 13s / 5.5s / 4.7s / 0.1s** (variance = which origin pod).
- Temporary Cloudflare Cache Rule on `/de` → all `HIT`, flat **~65ms** TTFB. Confirms the page is static; the latency is pure origin saturation caused by the cache bypass.

## Change

Remove the unconditional `pathname` `Set-Cookie` in `src/proxy.ts`.

## Follow-up (not in this PR)

Add a Cache Rule making HTML `Eligible for cache` with `respect origin cache-control` (origin already emits `s-maxage=300, stale-while-revalidate` for static pages, `private, no-store` for dynamic). Cache Key must include the `RSC` request header (avoid HTML/RSC poisoning) and `NEXT_LOCALE` cookie (locale correctness for the unprefixed `/`).

## ⚠️ Conflicts with #2952

[#2952](https://github.com/jumperexchange/jumper-exchange/pull/2952) ("guard pathname cookie and cache token list fetches server-side") touches the same lines of `src/proxy.ts`, but only sets the cookie `if-empty` instead of removing it. Since the cookie is never read, **full removal is preferable** — first-load responses under #2952 still carry `Set-Cookie` and still BYPASS on the first hit per visitor.

Recommended reconciliation (team decision):
- **Option A:** fold this removal into #2952 (replace its `proxy.ts` hunk with the deletion), keep #2952's token-cache work, and close this PR.
- **Option B:** merge this PR, and drop the `proxy.ts` hunk from #2952 (keep only its token-cache changes).

Ticket: JUM-1160 (sub-issue of JUM-884)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed pathname cookie being set by the middleware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->