### PR TITLE
fix(perf): convert /bridge to on-demand ISR instead of force-dynamic - JUM-1162

### DIFF
--- a/src/app/[lng]/bridge/[segments]/page.tsx
+++ b/src/app/[lng]/bridge/[segments]/page.tsx
@@ -47,7 +47,10 @@ export async function generateMetadata({
   };
 }
 
-export const revalidate = 86400;
+// Bridge pages are SEO landing pages with effectively static content, so they
+// only need to refresh once a month. Trigger an earlier refresh manually with
+// on-demand revalidation (revalidatePath/revalidateTag) when content changes.
+export const revalidate = 2592000; // 30 days
 export const dynamicParams = true;
 export const dynamic = 'force-static';
 

--- a/src/app/[lng]/bridge/[segments]/page.tsx
+++ b/src/app/[lng]/bridge/[segments]/page.tsx
@@ -47,7 +47,15 @@ export async function generateMetadata({
   };
 }
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 86400;
+export const dynamicParams = true;
+export const dynamic = 'force-static';
+
+// Prerender nothing at build time (the full pair matrix added ~15 min to the
+// build); generate each URL on first request and cache it (ISR).
+export function generateStaticParams() {
+  return [];
+}
 
 export default async function Page({ params }: { params: Params }) {
   const { segments } = await params;


### PR DESCRIPTION
## Summary

`/[lng]/bridge/[segments]` was `force-dynamic` → fully SSR'd on every request (~9.5s prod TTFB, `private, no-store`, never CDN-cacheable). This is the primary driver of origin CPU saturation (combinatorial sitemap = ~1.8 MB of URLs, all hitting origin).

This converts it to **on-demand ISR without build-time enumeration**:

```ts
export const revalidate = 86400;
export const dynamicParams = true;
export const dynamic = 'force-static';
export function generateStaticParams() { return []; }
```

- **Build time unaffected** — `generateStaticParams` returns `[]`, so nothing is prebuilt (the previous full pair matrix added ~15 min to the build, which is why it was made dynamic).
- **Runtime:** each URL renders once on first request, then is cached (ISR) and CDN-served.

Verified the bridge UI subtree uses no server-side dynamic APIs (`cookies`/`headers`/`searchParams`), so `force-static` is safe (same model as `/swap/[segments]`).

## Important follow-up (not in this PR) — JUM-1162 Part 2

With ~30 replicas + the **default filesystem** incremental cache, each pod would accumulate its slice of the combinatorial URL space on local disk (`ephemeral-storage` 3Gi limit) and regenerate independently. ISR route output must be backed by a **shared Redis `cacheHandler` (singular)**.

⚠️ Note: PR #2953 wires `cacheHandlers` (**plural** = Next 16 `"use cache"` handler), which does **not** cover ISR route output. The classic `cacheHandler` (singular) is required and should be added to #2953 (it already brings `ioredis` + plumbing). Until that lands, deploy this together with the CDN cache rule (JUM-1160) so origin stays cold after first generation.

Ticket: JUM-1162 (sub-issue of JUM-884)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Bridge pages now use improved caching for faster load times, generating route content on first request and serving it from cache afterward.
  * Content is refreshed periodically (up to every 30 days) to keep results up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->