### PR TITLE
feat(cache): Redis incremental cacheHandler for ISR route output (stacked on #2953) - JUM-1162

### DIFF
--- a/cache-handler-incremental.cjs
+++ b/cache-handler-incremental.cjs
@@ -5,7 +5,12 @@
 // so it is shared across replicas and bounded by a TTL, instead of growing on
 // each pod's local filesystem cache. This is distinct from `cacheHandlers`
 // (plural) in cache-handler.cjs, which only backs the `"use cache"` directive.
-const { client, withPrefix } = require('./cache-handler-redis.cjs');
+const {
+  client,
+  withPrefix,
+  compress,
+  decompress,
+} = require('./cache-handler-redis.cjs');
 
 const DEFAULT_EXPIRE_SECONDS = 60 * 60 * 24; // fallback TTL to bound Redis memory
 
@@ -42,11 +47,11 @@ module.exports = class IncrementalCacheHandler {
 
   async get(cacheKey) {
     try {
-      const stored = await client.get(key(cacheKey));
+      const stored = await client.getBuffer(key(cacheKey));
       if (!stored) {
         return null;
       }
-      const entry = JSON.parse(stored, reviver);
+      const entry = JSON.parse(await decompress(stored), reviver);
       return { lastModified: entry.lastModified, value: entry.value };
     } catch {
       return null;
@@ -68,7 +73,7 @@ module.exports = class IncrementalCacheHandler {
         { value: data, lastModified: Date.now(), tags },
         replacer,
       );
-      await client.set(key(cacheKey), payload, 'EX', expire);
+      await client.set(key(cacheKey), await compress(payload), 'EX', expire);
       if (tags.length) {
         const pipe = client.pipeline();
         for (const tag of tags) {

--- a/cache-handler-incremental.cjs
+++ b/cache-handler-incremental.cjs
@@ -5,26 +5,12 @@
 // so it is shared across replicas and bounded by a TTL, instead of growing on
 // each pod's local filesystem cache. This is distinct from `cacheHandlers`
 // (plural) in cache-handler.cjs, which only backs the `"use cache"` directive.
-const Redis = require('ioredis');
+const { client, withPrefix } = require('./cache-handler-redis.cjs');
 
-const prefix = process.env.REDIS_PREFIX ?? 'jumper:cache:';
 const DEFAULT_EXPIRE_SECONDS = 60 * 60 * 24; // fallback TTL to bound Redis memory
 
-const client = new Redis({
-  host: process.env.REDIS_HOST,
-  port: Number(process.env.REDIS_PORT ?? 6379),
-  password: process.env.REDIS_PASSWORD || undefined,
-  lazyConnect: false,
-  maxRetriesPerRequest: 1,
-  connectTimeout: 500,
-  enableOfflineQueue: false,
-});
-client.on('error', (err) =>
-  console.error('[incremental-cache] Redis error:', err),
-);
-
-const key = (k) => `${prefix}route:${k}`;
-const tagKey = (t) => `${prefix}route-tag:${t}`;
+const key = (k) => withPrefix(`route:${k}`);
+const tagKey = (t) => withPrefix(`route-tag:${t}`);
 
 // Buffer (rscData/body/image buffer) and Map (segmentData) are not JSON-safe.
 function replacer(_k, value) {

--- a/cache-handler-incremental.cjs
+++ b/cache-handler-incremental.cjs
@@ -1,0 +1,113 @@
+'use strict';
+/* eslint-disable @typescript-eslint/no-require-imports */
+// Classic incremental cache handler (Next `cacheHandler`, singular).
+// Stores ISR/prerender route output (APP_PAGE, APP_ROUTE, PAGES, ...) in Redis
+// so it is shared across replicas and bounded by a TTL, instead of growing on
+// each pod's local filesystem cache. This is distinct from `cacheHandlers`
+// (plural) in cache-handler.cjs, which only backs the `"use cache"` directive.
+const Redis = require('ioredis');
+
+const prefix = process.env.REDIS_PREFIX ?? 'jumper:cache:';
+const DEFAULT_EXPIRE_SECONDS = 60 * 60 * 24; // fallback TTL to bound Redis memory
+
+const client = new Redis({
+  host: process.env.REDIS_HOST,
+  port: Number(process.env.REDIS_PORT ?? 6379),
+  password: process.env.REDIS_PASSWORD || undefined,
+  lazyConnect: false,
+  maxRetriesPerRequest: 1,
+  connectTimeout: 500,
+  enableOfflineQueue: false,
+});
+client.on('error', (err) =>
+  console.error('[incremental-cache] Redis error:', err),
+);
+
+const key = (k) => `${prefix}route:${k}`;
+const tagKey = (t) => `${prefix}route-tag:${t}`;
+
+// Buffer (rscData/body/image buffer) and Map (segmentData) are not JSON-safe.
+function replacer(_k, value) {
+  if (Buffer.isBuffer(value)) {
+    return { __t: 'Buffer', d: value.toString('base64') };
+  }
+  if (value instanceof Map) {
+    return { __t: 'Map', d: Array.from(value.entries()) };
+  }
+  return value;
+}
+
+function reviver(_k, value) {
+  if (value && typeof value === 'object') {
+    if (value.__t === 'Buffer') {
+      return Buffer.from(value.d, 'base64');
+    }
+    if (value.__t === 'Map') {
+      return new Map(value.d);
+    }
+  }
+  return value;
+}
+
+module.exports = class IncrementalCacheHandler {
+  constructor(ctx) {
+    this.ctx = ctx;
+  }
+
+  async get(cacheKey) {
+    try {
+      const stored = await client.get(key(cacheKey));
+      if (!stored) {
+        return null;
+      }
+      const entry = JSON.parse(stored, reviver);
+      return { lastModified: entry.lastModified, value: entry.value };
+    } catch {
+      return null;
+    }
+  }
+
+  async set(cacheKey, data, ctx) {
+    try {
+      if (data == null) {
+        await client.del(key(cacheKey));
+        return;
+      }
+      const tags = Array.isArray(data.tags) ? data.tags : (ctx?.tags ?? []);
+      const expire =
+        ctx?.cacheControl?.expire && ctx.cacheControl.expire > 0
+          ? Math.ceil(ctx.cacheControl.expire)
+          : DEFAULT_EXPIRE_SECONDS;
+      const payload = JSON.stringify(
+        { value: data, lastModified: Date.now(), tags },
+        replacer,
+      );
+      await client.set(key(cacheKey), payload, 'EX', expire);
+      if (tags.length) {
+        const pipe = client.pipeline();
+        for (const tag of tags) {
+          pipe.sadd(tagKey(tag), cacheKey);
+          pipe.expire(tagKey(tag), expire);
+        }
+        await pipe.exec();
+      }
+    } catch {}
+  }
+
+  async revalidateTag(tags) {
+    try {
+      const list = Array.isArray(tags) ? tags : [tags];
+      for (const tag of list) {
+        const members = await client.smembers(tagKey(tag));
+        const pipe = client.pipeline();
+        if (members.length) {
+          pipe.del(members.map(key));
+        }
+        pipe.del(tagKey(tag));
+        await pipe.exec();
+      }
+    } catch {}
+  }
+
+  resetRequestCache() {}
+};

--- a/cache-handler-redis.cjs
+++ b/cache-handler-redis.cjs
@@ -1,0 +1,24 @@
+'use strict';
+/* eslint-disable @typescript-eslint/no-require-imports */
+// Shared ioredis client + key helpers for the two Next cache handlers:
+//  - cache-handler.cjs            (`cacheHandlers` plural, the "use cache" directive)
+//  - cache-handler-incremental.cjs (`cacheHandler` singular, ISR route output)
+// Both run in the same server process, so they share a single connection.
+const Redis = require('ioredis');
+
+const prefix = process.env.REDIS_PREFIX ?? 'jumper:cache:';
+
+const client = new Redis({
+  host: process.env.REDIS_HOST,
+  port: Number(process.env.REDIS_PORT ?? 6379),
+  password: process.env.REDIS_PASSWORD || undefined,
+  lazyConnect: false,
+  maxRetriesPerRequest: 1,
+  connectTimeout: 500,
+  enableOfflineQueue: false,
+});
+client.on('error', (err) => console.error('[redis-cache] Redis error:', err));
+
+const withPrefix = (k) => `${prefix}${k}`;
+
+module.exports = { client, prefix, withPrefix };

--- a/cache-handler-redis.cjs
+++ b/cache-handler-redis.cjs
@@ -5,6 +5,8 @@
 //  - cache-handler-incremental.cjs (`cacheHandler` singular, ISR route output)
 // Both run in the same server process, so they share a single connection.
 const Redis = require('ioredis');
+const zlib = require('zlib');
+const { promisify } = require('util');
 
 const prefix = process.env.REDIS_PREFIX ?? 'jumper:cache:';
 
@@ -21,4 +23,22 @@ client.on('error', (err) => console.error('[redis-cache] Redis error:', err));
 
 const withPrefix = (k) => `${prefix}${k}`;
 
-module.exports = { client, prefix, withPrefix };
+// Cache entries are large text (RSC payloads / HTML); brotli shrinks Redis
+// memory and network. Quality 4 is a deliberate balance — compress runs on the
+// server during cache writes (decompress on reads is cheap). Bump quality for a
+// better ratio, or lower it, if profiling shows CPU pressure on hot paths.
+const brotliCompressAsync = promisify(zlib.brotliCompress);
+const brotliDecompressAsync = promisify(zlib.brotliDecompress);
+const BROTLI_OPTIONS = {
+  params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 4 },
+};
+
+/** Compress a UTF-8 string to a brotli Buffer (stored raw in Redis). */
+const compress = (text) =>
+  brotliCompressAsync(Buffer.from(text, 'utf8'), BROTLI_OPTIONS);
+
+/** Decompress a brotli Buffer (from Redis getBuffer) back to a UTF-8 string. */
+const decompress = async (buffer) =>
+  (await brotliDecompressAsync(buffer)).toString('utf8');
+
+module.exports = { client, prefix, withPrefix, compress, decompress };

--- a/cache-handler.cjs
+++ b/cache-handler.cjs
@@ -1,21 +1,6 @@
 'use strict';
 /* eslint-disable @typescript-eslint/no-require-imports */
-const Redis = require('ioredis');
-
-const prefix = process.env.REDIS_PREFIX ?? 'jumper:cache:';
-
-const client = new Redis({
-  host: process.env.REDIS_HOST,
-  port: Number(process.env.REDIS_PORT ?? 6379),
-  password: process.env.REDIS_PASSWORD || undefined,
-  lazyConnect: false,
-  maxRetriesPerRequest: 1,
-  connectTimeout: 500,
-  enableOfflineQueue: false,
-});
-client.on('error', (err) => console.error('[cache-handler] Redis error:', err));
-
-const key = (k) => `${prefix}${k}`;
+const { client, withPrefix: key } = require('./cache-handler-redis.cjs');
 
 const localTagTimestamps = new Map();
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -23,6 +23,13 @@ const nextConfig = {
   cacheHandlers: process.env.NODE_ENV === 'production'
     ? { default: require.resolve('./cache-handler.cjs') }
     : undefined,
+  // Classic incremental cache (ISR/prerender route output) shared via Redis.
+  // Distinct from `cacheHandlers` above, which only backs the `"use cache"`
+  // directive and does NOT store ISR route output.
+  cacheHandler:
+    process.env.NODE_ENV === 'production'
+      ? require.resolve('./cache-handler-incremental.cjs')
+      : undefined,
   expireTime: 86400, // one day in seconds
   experimental: {
     serverSourceMaps: false,


### PR DESCRIPTION
Stacked on top of #2953 (`fix/JUM-884-next-custom-cache`) — **review/merge #2953 first**, this targets that branch.

## Why

#2953 wires `cacheHandlers` (**plural**) = the Next 16 `"use cache"` handler. That does **not** store ISR/prerender route output. With ~30 replicas on the default filesystem incremental cache, ISR pages (home, swap, bridge, ...) accumulate on each pod's local disk (`ephemeral-storage` 3Gi limit) and regenerate independently.

## What

- `cache-handler-incremental.cjs` — classic `cacheHandler` (**singular**) implementing the Next 16.2.7 incremental-cache interface (`get`/`set`/`revalidateTag`/`resetRequestCache` over `IncrementalCacheValue`). Serializes the `Buffer`/`Map` fields (`rscData`, `body`, `segmentData`); TTL from `cacheControl.expire` to bound Redis memory; fail-safe (Redis error → cache miss, never breaks ISR).
- `next.config.mjs` — registers `cacheHandler` (singular) alongside #2953's `cacheHandlers` (plural). They're complementary.
- `cache-handler-redis.cjs` — **refactor**: shared ioredis client + key helpers, so the `"use cache"` handler and the incremental handler reuse a single connection/config instead of duplicating it.

## Validate before prod

Intercepts **all** ISR caching, not just bridge — verify a round-trip in staging (page renders, revalidation timing, Redis memory/TTL) before production.

## Notes

- Time-based ISR revalidation is fully covered (the bridge use case). On-demand `revalidatePath`/`revalidateTag` for route cache is best-effort (Next's route `set` context doesn't always surface tags).
- Pairs with: bridge on-demand ISR (#2964), token/chains fetch caching (#2952), CDN cache rule (JUM-1160).

Ticket: JUM-1162

Made with [Cursor](https://cursor.com)