### PR TITLE
feat: migrate cached fetch helpers to 'use cache' directive

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,6 +20,7 @@ const nextConfig = {
   expireTime: 900, // 15 minutes in seconds
   experimental: {
     serverSourceMaps: false,
+    useCache: true,
     optimizePackageImports: [],
   },
   webpack: (config) => {

--- a/src/app/lib/earn/cachedEarnFetch.ts
+++ b/src/app/lib/earn/cachedEarnFetch.ts
@@ -1,4 +1,4 @@
-import { unstable_cache } from 'next/cache';
+import { cacheLife } from 'next/cache';
 
 import type { EarnOpportunityFilter } from '@/app/lib/getOpportunitiesFiltered';
 import {
@@ -11,32 +11,28 @@ import type { Hex } from 'viem';
 
 const EARN_PAGE_REVALIDATE_SECONDS = 300;
 
-export const fetchEarnFilterOpportunitiesForPage = (
+export async function fetchEarnFilterOpportunitiesForPage(
   filter: EarnOpportunityFilter,
-) =>
-  unstable_cache(
-    () => fetchEarnFilterOpportunities(filter),
-    ['earn-page-filter-opportunities', JSON.stringify(filter)],
-    { revalidate: EARN_PAGE_REVALIDATE_SECONDS },
-  )();
+) {
+  'use cache';
+  cacheLife({ revalidate: EARN_PAGE_REVALIDATE_SECONDS });
+  return fetchEarnFilterOpportunities(filter);
+}
 
-export const fetchEarnOpportunityBySlugForPage = (slug: string) =>
-  unstable_cache(
-    () => fetchEarnOpportunityBySlug(slug),
-    ['earn-page-opportunity-by-slug', slug],
-    { revalidate: EARN_PAGE_REVALIDATE_SECONDS },
-  )();
+export async function fetchEarnOpportunityBySlugForPage(slug: string) {
+  'use cache';
+  cacheLife({ revalidate: EARN_PAGE_REVALIDATE_SECONDS });
+  return fetchEarnOpportunityBySlug(slug);
+}
 
-export const fetchEarnRelatedMarketsForPage = (slug: string) =>
-  unstable_cache(
-    () => fetchEarnRelatedMarkets(slug),
-    ['earn-page-related-markets', slug],
-    { revalidate: EARN_PAGE_REVALIDATE_SECONDS },
-  )();
+export async function fetchEarnRelatedMarketsForPage(slug: string) {
+  'use cache';
+  cacheLife({ revalidate: EARN_PAGE_REVALIDATE_SECONDS });
+  return fetchEarnRelatedMarkets(slug);
+}
 
-export const fetchEarnTopOpportunitiesForPage = (address?: Hex) =>
-  unstable_cache(
-    () => fetchEarnTopOpportunities(address),
-    ['earn-page-top-opportunities', address ?? 'anonymous'],
-    { revalidate: EARN_PAGE_REVALIDATE_SECONDS },
-  )();
+export async function fetchEarnTopOpportunitiesForPage(address?: Hex) {
+  'use cache';
+  cacheLife({ revalidate: EARN_PAGE_REVALIDATE_SECONDS });
+  return fetchEarnTopOpportunities(address);
+}

--- a/src/app/lib/missions/cachedMissionsFetch.ts
+++ b/src/app/lib/missions/cachedMissionsFetch.ts
@@ -1,4 +1,4 @@
-import { unstable_cache } from 'next/cache';
+import { cacheLife, cacheTag } from 'next/cache';
 
 import { fetchQuestBySlug } from '@/app/lib/missions/missionQueries';
 import type { PaginationProps } from '@/utils/strapi/StrapiApi';
@@ -7,29 +7,24 @@ import { getQuestsWithNoCampaignAttached } from '@/app/lib/getQuestsWithNoCampai
 
 const MISSIONS_PAGE_REVALIDATE_SECONDS = 300;
 
-export const fetchMissionsListForPage = (
+export async function fetchMissionsListForPage(
   pagination: PaginationProps,
   daysAhead: number,
-) =>
-  unstable_cache(
-    () => getQuestsWithNoCampaignAttached(pagination, daysAhead),
-    ['missions-page-list', JSON.stringify(pagination), String(daysAhead)],
-    { revalidate: MISSIONS_PAGE_REVALIDATE_SECONDS },
-  )();
+) {
+  'use cache';
+  cacheLife({ revalidate: MISSIONS_PAGE_REVALIDATE_SECONDS });
+  return getQuestsWithNoCampaignAttached(pagination, daysAhead);
+}
 
-export const fetchQuestBySlugForPage = (slug: string) =>
-  unstable_cache(
-    () => fetchQuestBySlug(slug),
-    ['missions-page-quest-by-slug', slug],
-    {
-      revalidate: MISSIONS_PAGE_REVALIDATE_SECONDS,
-      tags: [`quest:slug:${slug}`],
-    },
-  )();
+export async function fetchQuestBySlugForPage(slug: string) {
+  'use cache';
+  cacheTag(`quest:slug:${slug}`);
+  cacheLife({ revalidate: MISSIONS_PAGE_REVALIDATE_SECONDS });
+  return fetchQuestBySlug(slug);
+}
 
-export const fetchProfileBannerCampaignsForPage = () =>
-  unstable_cache(
-    () => getProfileBannerCampaigns(),
-    ['missions-page-banner-campaigns'],
-    { revalidate: MISSIONS_PAGE_REVALIDATE_SECONDS },
-  )();
+export async function fetchProfileBannerCampaignsForPage() {
+  'use cache';
+  cacheLife({ revalidate: MISSIONS_PAGE_REVALIDATE_SECONDS });
+  return getProfileBannerCampaigns();
+}

--- a/src/app/lib/tokens/cachedTokensFetch.ts
+++ b/src/app/lib/tokens/cachedTokensFetch.ts
@@ -1,4 +1,4 @@
-import { unstable_cache } from 'next/cache';
+import { cacheLife } from 'next/cache';
 import type { ChainId } from '@lifi/sdk';
 import {
   getTokensQuery,
@@ -7,14 +7,14 @@ import {
 
 const TOKENS_REVALIDATE_SECONDS = 300;
 
-export const fetchTokensForPage = () =>
-  unstable_cache(() => getTokensQuery(), ['tokens'], {
-    revalidate: TOKENS_REVALIDATE_SECONDS,
-  })();
+export async function fetchTokensForPage() {
+  'use cache';
+  cacheLife({ revalidate: TOKENS_REVALIDATE_SECONDS });
+  return getTokensQuery();
+}
 
-export const fetchChainTokensForPage = (chainId: ChainId) =>
-  unstable_cache(
-    () => getChainTokensQuery(chainId),
-    ['chain-tokens', String(chainId)],
-    { revalidate: TOKENS_REVALIDATE_SECONDS },
-  )();
+export async function fetchChainTokensForPage(chainId: ChainId) {
+  'use cache';
+  cacheLife({ revalidate: TOKENS_REVALIDATE_SECONDS });
+  return getChainTokensQuery(chainId);
+}


### PR DESCRIPTION
## Summary

**Part 1 of 2** in the Next.js 16 caching migration.

This PR is intentionally narrow: it replaces `unstable_cache` with the `'use cache'` directive in the three existing cached fetch modules and enables the experimental cache flag in Next config.

It does **not** enable `cacheComponents`, remove route-segment caching configs, or migrate pages/layouts. That work is in **Part 2 → [#2974](https://github.com/jumperexchange/jumper-exchange/pull/2974)**.

Merge order: **#2974 into this branch**, then this stack into `fix/JUM-884-cookie-and-tokens-cache`.

### Why split?

- `unstable_cache` is deprecated in favour of `'use cache'`
- The fetch-helper migration is a self-contained, reviewable step
- Turning on `cacheComponents` and updating the rest of the app surfaced build/prerender issues that belong in a separate PR

## What changed (this PR only)

| File | Change |
|------|--------|
| `next.config.mjs` | `experimental.useCache: true` |
| `cachedEarnFetch.ts` | 4 functions: `unstable_cache` → `'use cache'` + `cacheLife({ revalidate: 300 })` |
| `cachedMissionsFetch.ts` | 3 functions; `cacheTag('quest:slug:…')` preserved for on-demand invalidation |
| `cachedTokensFetch.ts` | 2 functions: same migration pattern |

Revalidate windows are unchanged (300s).

## Out of scope → #2974

- `cacheComponents: true` (replaces `experimental.useCache`)
- Removing incompatible segment configs (`revalidate`, `dynamic`, `fetchCache`, …)
- Page, layout, sitemap, and lib migrations (`getPartnerThemes`, `getMiniAppSettings`, …)
- Root layout Suspense, loading skeletons, prerender/SSR fixes

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] Earn, missions, and token flows still load (cached helpers behave as before)
- [ ] Merge [#2974](https://github.com/jumperexchange/jumper-exchange/pull/2974), then verify `pnpm build` passes end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved page data loading for earn, missions, and token pages.
  * Pages should now refresh more consistently while still benefiting from caching, helping balance speed with up-to-date content.
* **Bug Fixes**
  * Reduced the chance of stale information appearing on frequently viewed pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->