### PR TITLE
chore: remove Porto wallet option (Ithaca sunset)

### DIFF
--- a/src/providers/WalletProvider/WalletProvider.tsx
+++ b/src/providers/WalletProvider/WalletProvider.tsx
@@ -39,7 +39,6 @@ export const widgetProviders = [
     walletConnect: defaultWalletConnectConfig,
     coinbase: defaultCoinbaseConfig,
     metaMask: defaultMetaMaskConfig,
-    porto: true,
     baseAccount: true,
   }),
   SolanaWidgetProvider(),


### PR DESCRIPTION
# Which Jira task belongs to this PR?

[EMB-458](https://linear.app/lifi-linear/issue/EMB-458/remove-porto-wallet-support-ithaca-sunset)

# Why did I implement it this way?

Ithaca is [sunsetting Porto](https://ithaca.xyz/updates/sunsetting-porto) — users must move funds out by **2026-07-24**, after which the connector stops being useful. This drops the `porto: true` flag from the `EthereumWidgetProvider` config in `WalletProvider.tsx` so the Porto connector is no longer offered in the wallet list.

The change is forward-compatible with the widget side: `@lifi/widget-provider-ethereum@4.1.0` ([lifinance/widget#800](https://github.com/lifinance/widget/pull/800)) removes the `porto` option from the public config type entirely, so this flag must go before adopting that version. It is also safe against the currently pinned widget (the option is optional). No lockfile change is needed — `porto` was only a transitive optional peer of `@wagmi/connectors`.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [x] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged

**QA:** open the connect-wallet modal → the EVM wallet list no longer shows Porto; all other wallets connect as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated wallet provider configuration to improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->