### PR TITLE
fix: partner theme selection and color mode on scan and fresh loads

### DIFF
--- a/src/app/[lng]/layout.tsx
+++ b/src/app/[lng]/layout.tsx
@@ -30,10 +30,7 @@ import {
   pageOpenGraph,
   pageTwitter,
 } from '../lib/metadata';
-import {
-  THEME_COLOR_SCHEME_STORAGE_KEY,
-  THEME_MODE_STORAGE_KEY,
-} from '@/providers/ThemeProvider/constants';
+import { getThemeBootstrapInlineScript } from '@/providers/ThemeProvider/getThemeBootstrapInlineScript';
 import { ExtensionDetectionProvider } from '@/providers/ExtensionDetectionProvider/ExtensionDetectionProvider';
 import { getPocketUniverseHtmlDataCsnSnapshotInlineScript } from '@/providers/ExtensionDetectionProvider/detectors/pocketUniverse/htmlDataCsnDetector';
 import { getPostMessageNativeSnapshotInlineScript } from '@/providers/ExtensionDetectionProvider/detectors/pocketUniverse/postMessageProxyDetector';
@@ -145,28 +142,7 @@ export default async function RootLayout({
           id="theme-bootstrap"
           data-cfasync="false"
           dangerouslySetInnerHTML={{
-            __html: `
-            (function() {
-              try {
-                var mode = localStorage.getItem('${THEME_MODE_STORAGE_KEY}') || 'system';
-                var dark = localStorage.getItem('${THEME_COLOR_SCHEME_STORAGE_KEY}-dark') || 'dark';
-                var light = localStorage.getItem('${THEME_COLOR_SCHEME_STORAGE_KEY}-light') || 'light';
-                var colorScheme = '';
-                if (mode === 'system') {
-                  colorScheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? dark : light;
-                } else {
-                  colorScheme = (mode === 'dark') ? dark : light;
-                }
-                if (colorScheme) {
-                  var d = document.documentElement;
-                  d.classList.remove('light', 'dark', light, dark); 
-                  d.classList.add(colorScheme);
-                  d.setAttribute('data-mui-color-scheme', colorScheme);
-                  d.style.colorScheme = (colorScheme === dark) ? 'dark' : 'light';
-                }
-              } catch (e) {}
-            })();
-          `,
+            __html: getThemeBootstrapInlineScript(),
           }}
         />
         <meta name="base:app_id" content={appId} />

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -14,6 +14,7 @@ import { ReactQueryProvider } from 'src/providers/ReactQueryProvider';
 import { SettingsStoreProvider } from 'src/stores/settings/SettingsStore';
 import { ServerNavbar } from 'src/components/Navbar/ServerNavbar';
 import { getPartnerThemes } from './lib/getPartnerThemes';
+import { getThemeBootstrapInlineScript } from '@/providers/ThemeProvider/getThemeBootstrapInlineScript';
 
 export default async function NotFound() {
   const { resources } = await initTranslations(fallbackLng, namespaces);
@@ -26,6 +27,13 @@ export default async function NotFound() {
       className={fonts.map((f) => f.variable).join(' ')}
     >
       <head>
+        <script
+          id="theme-bootstrap"
+          data-cfasync="false"
+          dangerouslySetInnerHTML={{
+            __html: getThemeBootstrapInlineScript(),
+          }}
+        />
         <link rel="icon" href="/favicon.ico" sizes="any" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <Script

--- a/src/components/Menus/ThemeModesSubMenu/useThemeModesMenuContent.tsx
+++ b/src/components/Menus/ThemeModesSubMenu/useThemeModesMenuContent.tsx
@@ -4,7 +4,7 @@ import WbSunnyOutlinedIcon from '@mui/icons-material/WbSunnyOutlined';
 import NightlightIcon from '@mui/icons-material/Nightlight';
 import BrightnessAutoIcon from '@mui/icons-material/BrightnessAuto';
 import FlareRoundedIcon from '@mui/icons-material/FlareRounded';
-import { useMemo, useCallback, useEffect } from 'react';
+import { useMemo, useCallback } from 'react';
 import type { Appearance } from '@lifi/widget';
 import type { PartnerThemesData } from '@/types/strapi';
 import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
@@ -16,10 +16,12 @@ import {
   TrackingEventParameter,
 } from '@/const/trackingKeys';
 import { isDarkOrLightThemeMode } from '@/utils/formatTheme';
-import { selectAvailablePartnerThemes } from '@/stores/theme/createThemeStore';
+import { useActiveMenuPartnerTheme } from '@/hooks/theme/useActiveMenuPartnerTheme';
+import {
+  applySelectedPartnerColorMode,
+  clearPartnerColorModeOverride,
+} from '@/providers/ThemeProvider/partnerThemeMode';
 import { PartnerThemeIcon } from './PartnerThemeIcon';
-import { AB_TEST_NAME } from '@/const/abtests';
-import { useABTest } from '@/hooks/useABTest';
 
 interface SubmenuItem {
   label: string;
@@ -45,75 +47,28 @@ const MODE_OPTIONS = {
 } as const;
 
 const STANDARD_MODES: Appearance[] = ['light', 'dark', 'system'];
+
 export const useThemeModesMenuContent = () => {
   const { mode, setMode } = useColorScheme();
   const { t } = useTranslation();
   const { trackEvent } = useUserTracking();
   const { isMainPaths } = useMainPaths();
 
-  const [setConfigThemeState, configThemeStates] = useThemeStore((state) => [
-    state.setConfigThemeState,
-    state.configThemeStates,
-  ]);
-  const availablePartnerThemes = useThemeStore(selectAvailablePartnerThemes);
-  const { isEnabled: isThemePartnerDefaultEnabled } = useABTest({
-    feature: AB_TEST_NAME.THEME_PARTNER_DEFAULT,
-  });
+  const setConfigThemeState = useThemeStore(
+    (state) => state.setConfigThemeState,
+  );
+  const partnerThemes = useThemeStore((state) => state.partnerThemes);
+  const { activeConfigThemeUid, displayablePartnerThemes } =
+    useActiveMenuPartnerTheme();
 
   const defaultMode = isMainPaths ? 'system' : 'light';
   const selectedThemeMode = mode ?? defaultMode;
-
-  const { activeConfigThemeUid, activeConfigTheme } = useMemo(() => {
-    if (!isThemePartnerDefaultEnabled) {
-      return { activeConfigThemeUid: undefined, activeConfigTheme: undefined };
-    }
-
-    for (const [uid, state] of Object.entries(configThemeStates)) {
-      if (state.isSelected) {
-        const theme = availablePartnerThemes.find((t) => t.uid === uid);
-        return { activeConfigThemeUid: uid, activeConfigTheme: theme };
-      }
-    }
-    return { activeConfigThemeUid: undefined, activeConfigTheme: undefined };
-  }, [configThemeStates, availablePartnerThemes, isThemePartnerDefaultEnabled]);
-
-  useEffect(() => {
-    if (!isThemePartnerDefaultEnabled) {
-      for (const [uid, state] of Object.entries(configThemeStates)) {
-        if (state.isSelected) {
-          setConfigThemeState(uid, { isSelected: false });
-        }
-      }
-    }
-  }, [isThemePartnerDefaultEnabled, configThemeStates, setConfigThemeState]);
-
-  useEffect(() => {
-    if (!activeConfigTheme) {
-      if (activeConfigThemeUid) {
-        setMode('system');
-        console.debug('Changed theme mode to: system');
-        setConfigThemeState(activeConfigThemeUid, { isSelected: false });
-      }
-      return;
-    }
-
-    const themeMode = isDarkOrLightThemeMode(activeConfigTheme);
-    if (themeMode !== mode) {
-      setMode(themeMode);
-      console.debug(`Changed theme mode to: ${themeMode}`);
-    }
-  }, [
-    activeConfigThemeUid,
-    activeConfigTheme,
-    mode,
-    setMode,
-    setConfigThemeState,
-  ]);
 
   const clearPartnerTheme = useCallback(() => {
     if (activeConfigThemeUid) {
       setConfigThemeState(activeConfigThemeUid, { isSelected: false });
     }
+    clearPartnerColorModeOverride();
   }, [activeConfigThemeUid, setConfigThemeState]);
 
   const handleSwitchMode = useCallback(
@@ -125,9 +80,8 @@ export const useThemeModesMenuContent = () => {
         data: { [TrackingEventParameter.SwitchedTheme]: newMode },
       });
       clearPartnerTheme();
-      const newModeWithFallback = newMode ?? 'system';
-      setMode(newModeWithFallback);
-      console.debug(`Changing theme mode to: ${newModeWithFallback}`);
+      clearPartnerColorModeOverride();
+      setMode(newMode ?? 'system');
     },
     [trackEvent, setMode, clearPartnerTheme],
   );
@@ -142,21 +96,19 @@ export const useThemeModesMenuContent = () => {
       });
       clearPartnerTheme();
       setConfigThemeState(theme.uid, { isSelected: true });
-      const newMode = isDarkOrLightThemeMode(theme);
-      setMode(newMode);
-      console.debug(`Changing theme mode to: ${newMode}`);
+      const nextStates = {
+        [theme.uid]: { isSelected: true as const },
+      };
+      applySelectedPartnerColorMode(nextStates, partnerThemes);
+      setMode(isDarkOrLightThemeMode(theme));
     },
-    [trackEvent, setConfigThemeState, setMode, clearPartnerTheme],
-  );
-
-  const displayablePartnerThemes = useMemo(
-    () =>
-      isThemePartnerDefaultEnabled
-        ? availablePartnerThemes.filter(
-            (t) => t.SelectableInMenu && t.PartnerName,
-          )
-        : [],
-    [availablePartnerThemes, isThemePartnerDefaultEnabled],
+    [
+      trackEvent,
+      setConfigThemeState,
+      setMode,
+      clearPartnerTheme,
+      partnerThemes,
+    ],
   );
 
   const standardModeItems = useMemo<SubmenuItem[]>(
@@ -192,7 +144,7 @@ export const useThemeModesMenuContent = () => {
   );
 
   const selectedPartnerThemeItem = useMemo(
-    () => partnerThemeItems.find((t) => t.checkIcon),
+    () => partnerThemeItems.find((item) => item.checkIcon),
     [partnerThemeItems],
   );
 

--- a/src/hooks/theme/useActiveMenuPartnerTheme.ts
+++ b/src/hooks/theme/useActiveMenuPartnerTheme.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { useMemo } from 'react';
+import { AB_TEST_NAME } from '@/const/abtests';
+import { useABTest } from '@/hooks/useABTest';
+import { resolveSelectedMenuPartnerTheme } from '@/providers/ThemeProvider/partnerThemeMode';
+import { useThemeStore } from '@/stores/theme';
+import { selectAvailablePartnerThemes } from '@/stores/theme/createThemeStore';
+
+export const useActiveMenuPartnerTheme = () => {
+  const configThemeStates = useThemeStore((state) => state.configThemeStates);
+  const availablePartnerThemes = useThemeStore(selectAvailablePartnerThemes);
+  const partnerThemes = useThemeStore((state) => state.partnerThemes);
+  const {
+    isEnabled: isThemePartnerDefaultEnabled,
+    isLoading: isThemePartnerDefaultLoading,
+  } = useABTest({
+    feature: AB_TEST_NAME.THEME_PARTNER_DEFAULT,
+  });
+
+  const showPartnerThemes =
+    isThemePartnerDefaultEnabled || isThemePartnerDefaultLoading;
+
+  const activeConfigTheme = useMemo(() => {
+    if (!showPartnerThemes) {
+      return undefined;
+    }
+
+    return resolveSelectedMenuPartnerTheme(configThemeStates, partnerThemes);
+  }, [configThemeStates, partnerThemes, showPartnerThemes]);
+
+  const activeConfigThemeUid = activeConfigTheme?.uid;
+
+  const displayablePartnerThemes = useMemo(
+    () =>
+      showPartnerThemes
+        ? availablePartnerThemes.filter(
+            (t) => t.SelectableInMenu && t.PartnerName,
+          )
+        : [],
+    [availablePartnerThemes, showPartnerThemes],
+  );
+
+  return {
+    activeConfigThemeUid,
+    activeConfigTheme,
+    displayablePartnerThemes,
+    isThemePartnerDefaultEnabled,
+    isThemePartnerDefaultLoading,
+    showPartnerThemes,
+  };
+};

--- a/src/providers/ThemeProvider/DefaultThemeProvider.tsx
+++ b/src/providers/ThemeProvider/DefaultThemeProvider.tsx
@@ -1,10 +1,12 @@
 'use client';
 import { useMetaTag } from '@/hooks/useMetaTag';
 import { ThemeStoreProvider } from '@/stores/theme';
+import { buildInitialConfigThemeStates } from '@/stores/theme/createThemeStore';
 import { formatConfig, formatTheme } from '@/utils/formatTheme';
 import { useMemo } from 'react';
 import type { ThemeProviderProps } from './types';
 import { getPartnerTheme } from './utils';
+import { applySelectedPartnerColorMode } from './partnerThemeMode';
 import type { ThemeProps } from 'src/types/theme';
 import { getDefaultWidgetThemeV2 } from 'src/config/widgetConfig';
 import { deepmerge } from '@mui/utils';
@@ -12,8 +14,19 @@ import { deepmerge } from '@mui/utils';
 export function DefaultThemeProvider({ children, themes }: ThemeProviderProps) {
   const metaTheme = useMetaTag('partner-theme');
 
-  const partnerTheme = metaTheme || 'default';
-  const partnerThemeConfig = getPartnerTheme(themes, partnerTheme);
+  const partnerThemeConfig = useMemo(() => {
+    if (!metaTheme) {
+      return getPartnerTheme(themes, 'default');
+    }
+
+    const matched = getPartnerTheme(themes, metaTheme);
+    if (matched) {
+      return matched;
+    }
+
+    // Meta uid not in Strapi — treat as no route partner theme; fall back to default.
+    return getPartnerTheme(themes, 'default');
+  }, [metaTheme, themes]);
 
   const themeStore = useMemo((): ThemeProps => {
     // Get formatted partner theme data
@@ -36,9 +49,16 @@ export function DefaultThemeProvider({ children, themes }: ThemeProviderProps) {
 
     // Compute jumper themes
     const partnerJumperTheme = formatted?.jumperTheme ?? {};
+    const routeConfig = formatConfig(partnerThemeConfig);
+    const configThemeStates = buildInitialConfigThemeStates(
+      routeConfig,
+      themes ?? [],
+    );
+
+    applySelectedPartnerColorMode(configThemeStates, themes ?? []);
 
     return {
-      configTheme: formatConfig(partnerThemeConfig),
+      configTheme: routeConfig,
       partnerThemes: themes!,
       widgetTheme: {
         light: defaultWidgetLight,
@@ -50,7 +70,7 @@ export function DefaultThemeProvider({ children, themes }: ThemeProviderProps) {
         default: {},
         partner: partnerJumperTheme,
       },
-      configThemeStates: {},
+      configThemeStates,
     };
   }, [themes, partnerThemeConfig]);
 

--- a/src/providers/ThemeProvider/DefaultThemeProvider.tsx
+++ b/src/providers/ThemeProvider/DefaultThemeProvider.tsx
@@ -3,7 +3,7 @@ import { useMetaTag } from '@/hooks/useMetaTag';
 import { ThemeStoreProvider } from '@/stores/theme';
 import { buildInitialConfigThemeStates } from '@/stores/theme/createThemeStore';
 import { formatConfig, formatTheme } from '@/utils/formatTheme';
-import { useMemo } from 'react';
+import { useMemo, useLayoutEffect } from 'react';
 import type { ThemeProviderProps } from './types';
 import { getPartnerTheme } from './utils';
 import { applySelectedPartnerColorMode } from './partnerThemeMode';
@@ -55,8 +55,6 @@ export function DefaultThemeProvider({ children, themes }: ThemeProviderProps) {
       themes ?? [],
     );
 
-    applySelectedPartnerColorMode(configThemeStates, themes ?? []);
-
     return {
       configTheme: routeConfig,
       partnerThemes: themes!,
@@ -73,6 +71,10 @@ export function DefaultThemeProvider({ children, themes }: ThemeProviderProps) {
       configThemeStates,
     };
   }, [themes, partnerThemeConfig]);
+
+  useLayoutEffect(() => {
+    applySelectedPartnerColorMode(themeStore.configThemeStates, themes ?? []);
+  }, [themeStore.configThemeStates, themes]);
 
   return <ThemeStoreProvider value={themeStore}>{children}</ThemeStoreProvider>;
 }

--- a/src/providers/ThemeProvider/MUIThemePartnerSync.tsx
+++ b/src/providers/ThemeProvider/MUIThemePartnerSync.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useActiveMenuPartnerTheme } from '@/hooks/theme/useActiveMenuPartnerTheme';
+import { clearPartnerColorModeOverride } from '@/providers/ThemeProvider/partnerThemeMode';
+import { useThemeStore } from '@/stores/theme';
+
+/**
+ * Clears menu partner selection when the partner-theme AB test is off.
+ * Color mode is applied synchronously via applySelectedPartnerColorMode (no setMode here).
+ */
+export const MUIThemePartnerSync = () => {
+  const setConfigThemeState = useThemeStore(
+    (state) => state.setConfigThemeState,
+  );
+  const configThemeStates = useThemeStore((state) => state.configThemeStates);
+  const { isThemePartnerDefaultEnabled, isThemePartnerDefaultLoading } =
+    useActiveMenuPartnerTheme();
+
+  useEffect(() => {
+    if (isThemePartnerDefaultLoading || isThemePartnerDefaultEnabled) {
+      return;
+    }
+
+    for (const [uid, state] of Object.entries(configThemeStates)) {
+      if (state.isSelected) {
+        setConfigThemeState(uid, { isSelected: false });
+      }
+    }
+
+    clearPartnerColorModeOverride();
+  }, [
+    isThemePartnerDefaultLoading,
+    isThemePartnerDefaultEnabled,
+    configThemeStates,
+    setConfigThemeState,
+  ]);
+
+  return null;
+};

--- a/src/providers/ThemeProvider/MUIThemeProvider.tsx
+++ b/src/providers/ThemeProvider/MUIThemeProvider.tsx
@@ -11,6 +11,7 @@ import {
   THEME_MODE_STORAGE_KEY,
 } from './constants';
 import CssBaseline from '@mui/material/CssBaseline';
+import { MUIThemePartnerSync } from './MUIThemePartnerSync';
 
 /**
  * App's theme provider component.
@@ -41,6 +42,7 @@ export function MUIThemeProvider({ children }: PropsWithChildren) {
       disableTransitionOnChange
     >
       <CssBaseline enableColorScheme />
+      <MUIThemePartnerSync />
       {children}
     </ThemeProvider>
   );

--- a/src/providers/ThemeProvider/constants.ts
+++ b/src/providers/ThemeProvider/constants.ts
@@ -5,3 +5,4 @@
  */
 export const THEME_MODE_STORAGE_KEY = 'jumper-mode';
 export const THEME_COLOR_SCHEME_STORAGE_KEY = 'jumper-color-scheme';
+export const PARTNER_COLOR_MODE_STORAGE_KEY = 'jumper-partner-color-mode';

--- a/src/providers/ThemeProvider/getThemeBootstrapInlineScript.ts
+++ b/src/providers/ThemeProvider/getThemeBootstrapInlineScript.ts
@@ -1,0 +1,32 @@
+import {
+  PARTNER_COLOR_MODE_STORAGE_KEY,
+  THEME_COLOR_SCHEME_STORAGE_KEY,
+  THEME_MODE_STORAGE_KEY,
+} from './constants';
+
+export const getThemeBootstrapInlineScript = () =>
+  `
+(function() {
+  try {
+    var partnerMode = localStorage.getItem('${PARTNER_COLOR_MODE_STORAGE_KEY}');
+    var mode = (partnerMode === 'light' || partnerMode === 'dark')
+      ? partnerMode
+      : (localStorage.getItem('${THEME_MODE_STORAGE_KEY}') || 'system');
+    var dark = localStorage.getItem('${THEME_COLOR_SCHEME_STORAGE_KEY}-dark') || 'dark';
+    var light = localStorage.getItem('${THEME_COLOR_SCHEME_STORAGE_KEY}-light') || 'light';
+    var colorScheme = '';
+    if (mode === 'system') {
+      colorScheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? dark : light;
+    } else {
+      colorScheme = (mode === 'dark') ? dark : light;
+    }
+    if (colorScheme) {
+      var d = document.documentElement;
+      d.classList.remove('light', 'dark', light, dark);
+      d.classList.add(colorScheme);
+      d.setAttribute('data-mui-color-scheme', colorScheme);
+      d.style.colorScheme = (colorScheme === dark) ? 'dark' : 'light';
+    }
+  } catch (e) {}
+})();
+`.trim();

--- a/src/providers/ThemeProvider/partnerThemeMode.ts
+++ b/src/providers/ThemeProvider/partnerThemeMode.ts
@@ -1,0 +1,72 @@
+import type { PartnerThemesData } from '@/types/strapi';
+import type { ConfigThemeStates } from '@/types/theme';
+import { isDarkOrLightThemeMode } from '@/utils/formatTheme';
+import {
+  PARTNER_COLOR_MODE_STORAGE_KEY,
+  THEME_COLOR_SCHEME_STORAGE_KEY,
+  THEME_MODE_STORAGE_KEY,
+} from './constants';
+
+export const resolveSelectedMenuPartnerTheme = (
+  configThemeStates: ConfigThemeStates,
+  partnerThemes: PartnerThemesData[],
+): PartnerThemesData | undefined => {
+  for (const [uid, state] of Object.entries(configThemeStates)) {
+    if (!state.isSelected) {
+      continue;
+    }
+
+    const theme = partnerThemes.find((t) => t.uid === uid);
+    if (theme?.SelectableInMenu && theme.PartnerName) {
+      return theme;
+    }
+  }
+
+  return undefined;
+};
+
+const applyColorSchemeToDocument = (colorScheme: 'light' | 'dark') => {
+  const root = document.documentElement;
+  const dark =
+    localStorage.getItem(`${THEME_COLOR_SCHEME_STORAGE_KEY}-dark`) || 'dark';
+  const light =
+    localStorage.getItem(`${THEME_COLOR_SCHEME_STORAGE_KEY}-light`) || 'light';
+
+  root.classList.remove('light', 'dark', light, dark);
+  root.classList.add(colorScheme);
+  root.setAttribute('data-mui-color-scheme', colorScheme);
+  root.style.colorScheme = colorScheme === dark ? 'dark' : 'light';
+};
+
+export const clearPartnerColorModeOverride = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  localStorage.removeItem(PARTNER_COLOR_MODE_STORAGE_KEY);
+};
+
+/** Apply partner light/dark before MUI mounts — avoids post-hydration mode flicker. */
+export const applySelectedPartnerColorMode = (
+  configThemeStates: ConfigThemeStates,
+  partnerThemes: PartnerThemesData[],
+) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const selectedPartner = resolveSelectedMenuPartnerTheme(
+    configThemeStates,
+    partnerThemes,
+  );
+
+  if (!selectedPartner) {
+    clearPartnerColorModeOverride();
+    return;
+  }
+
+  const colorMode = isDarkOrLightThemeMode(selectedPartner);
+  localStorage.setItem(PARTNER_COLOR_MODE_STORAGE_KEY, colorMode);
+  localStorage.setItem(THEME_MODE_STORAGE_KEY, colorMode);
+  applyColorSchemeToDocument(colorMode);
+};

--- a/src/stores/theme/createThemeStore.spec.ts
+++ b/src/stores/theme/createThemeStore.spec.ts
@@ -125,7 +125,11 @@ describe('createThemeStore', () => {
 
       const store = createThemeStore(
         makeProps({
-          configTheme: { uid: 'cd', partnerName: 'CD' },
+          configTheme: {
+            uid: 'cd',
+            partnerName: 'CD',
+            selectableInMenu: true,
+          },
           partnerThemes: [makePartnerTheme('cd')],
         }),
       );

--- a/src/stores/theme/createThemeStore.tsx
+++ b/src/stores/theme/createThemeStore.tsx
@@ -1,3 +1,5 @@
+import { formatConfig } from '@/utils/formatTheme';
+import { applySelectedPartnerColorMode } from '@/providers/ThemeProvider/partnerThemeMode';
 import type { PartnerThemeConfig } from '@/types/PartnerThemeConfig';
 import type { PartnerThemesData } from '@/types/strapi';
 import type {
@@ -37,6 +39,9 @@ const getOrCreateConfigThemeState = (
   return states[uid] ?? { ...defaultConfigThemeState };
 };
 
+const isMenuSelectablePartnerTheme = (config?: Partial<PartnerThemeConfig>) =>
+  !!(config?.selectableInMenu && config?.partnerName);
+
 const initializeConfigThemeStates = (
   configTheme: Partial<PartnerThemeConfig>,
   persistedStates: ConfigThemeStates = {},
@@ -54,12 +59,43 @@ const initializeConfigThemeStates = (
   return {
     ...persistedStates,
     [currentThemeUid]: {
-      // We select it by default only if there is a partner name
-      // This will make sure the default fallback config will not trigger any changes in the UI
-      isSelected: !!configTheme.partnerName,
+      isSelected: isMenuSelectablePartnerTheme(configTheme),
     },
   };
 };
+
+const buildInitialConfigThemeStates = (
+  configTheme: Partial<PartnerThemeConfig>,
+  partnerThemes: PartnerThemesData[] = [],
+  persistedStates: ConfigThemeStates = {},
+): ConfigThemeStates => {
+  const defaultMenuPartnerConfig = formatConfig(
+    partnerThemes.find((theme) => theme.uid === 'default'),
+  );
+
+  const useDefaultMenuPartner =
+    !!configTheme?.uid && configTheme.selectableInMenu === false;
+
+  const selectionConfig = useDefaultMenuPartner
+    ? defaultMenuPartnerConfig
+    : configTheme;
+
+  let configThemeStates = initializeConfigThemeStates(
+    selectionConfig,
+    persistedStates,
+  );
+
+  if (useDefaultMenuPartner && configTheme.uid) {
+    configThemeStates = {
+      ...configThemeStates,
+      [configTheme.uid]: { isSelected: false },
+    };
+  }
+
+  return configThemeStates;
+};
+
+export { buildInitialConfigThemeStates };
 
 // Default empty widget theme config
 const emptyWidgetThemeConfig = { config: {} };
@@ -241,11 +277,22 @@ export const createThemeStore = (props: ThemeProps) =>
           return {
             ...persisted,
             ...currentState,
-            configThemeStates: initializeConfigThemeStates(
+            configThemeStates: buildInitialConfigThemeStates(
               currentState.configTheme,
+              currentState.partnerThemes,
               cleanedConfigThemeStates,
             ),
           };
+        },
+        onRehydrateStorage: () => (state) => {
+          if (!state) {
+            return;
+          }
+
+          applySelectedPartnerColorMode(
+            state.configThemeStates,
+            state.partnerThemes,
+          );
         },
       },
     ),


### PR DESCRIPTION
## Summary

- Fix partner theme menu on `/scan` and other routes where `partner-theme` meta does not match a Strapi uid exactly (e.g. `scan` with no Strapi entry): fall back to the `default` partner theme instead of a broken synthetic config that left System/Auto selected.
- When a route theme is not menu-selectable, auto-select the default menu partner in the theme store (`buildInitialConfigThemeStates`) rather than the route theme itself.
- Fix AB-test loading race in the theme menu: keep partner themes visible and avoid clearing selection while feature flags are still loading.
- Fix partner vs system color mode mismatch (dark partner background + light UI): apply partner light/dark synchronously before MUI mounts via `applySelectedPartnerColorMode`, shared HTML bootstrap script, and store hydration — no post-paint `setMode` effect (avoids flicker).
- Extract shared theme bootstrap script and apply it to both `[lng]/layout` and `not-found`.

## Test plan

- [ ] Fresh session (cleared site data): open `/scan` → theme menu shows default partner (e.g. Private) selected, not System
- [ ] Fresh session on home → default partner selected in theme menu
- [ ] Partner theme with dark-only config + OS light preference → no light→dark flicker on load; UI and background match without opening the menu
- [ ] Switch to Light/Dark/System in menu → partner deselected, standard mode works
- [ ] Select a partner theme in menu → color mode matches partner; reload → correct mode on first paint
- [ ] Hit a 404 → page respects saved partner color mode (no flash to wrong scheme)
- [ ] Navigate home → scan → previously selected menu partner persists
- [ ] User not in partner-theme AB test → partner menu entries hidden and selection cleared

# Which Jira task belongs to this PR?

Closes JUM-1183

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added partner-theme synchronization tied to the active menu partner theme default setting.
* **Refactor**
  * Centralized theme bootstrap script generation and applied it consistently across the app, including not-found pages.
  * Improved partner theme selection, mode switching, and theme state initialization/persistence so the UI reflects the selected partner mode.
* **Bug Fixes**
  * Ensured the correct light/dark color-scheme classes and attributes are applied earlier and more reliably on page load.
* **Tests**
  * Updated partner theme configuration test coverage for partner-switch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->