### PR TITLE
fix: add allowFeatureCardBackground to partner theme for feature card bg configuration

### DIFF
--- a/src/components/FeatureCards/hooks.ts
+++ b/src/components/FeatureCards/hooks.ts
@@ -199,17 +199,18 @@ export const useFeatureCardDisable = (data: FeatureCardData) => {
 };
 
 export const useFeatureCardStyles = (): SxProps<Theme> => {
-  const { shouldShowForTheme } = useThemeConditionsMet();
+  const { shouldShowForTheme, shouldShowFeatureCardBackground } =
+    useThemeConditionsMet();
 
   return useMemo(
     () =>
-      shouldShowForTheme
+      shouldShowForTheme && !shouldShowFeatureCardBackground
         ? {
             background: (theme: Theme) =>
               (theme.vars || theme).palette.surface1.main,
             border: (theme: Theme) => getSurfaceBorder(theme, 'surface1'),
           }
         : {},
-    [shouldShowForTheme],
+    [shouldShowForTheme, shouldShowFeatureCardBackground],
   );
 };

--- a/src/hooks/theme/useThemeConditionsMet.ts
+++ b/src/hooks/theme/useThemeConditionsMet.ts
@@ -31,5 +31,6 @@ export const useThemeConditionsMet = () => {
 
   return {
     shouldShowForTheme,
+    shouldShowFeatureCardBackground: configTheme.allowFeatureCardBackground,
   };
 };

--- a/src/hooks/theme/useThemeConditionsMet.ts
+++ b/src/hooks/theme/useThemeConditionsMet.ts
@@ -31,6 +31,6 @@ export const useThemeConditionsMet = () => {
 
   return {
     shouldShowForTheme,
-    shouldShowFeatureCardBackground: configTheme.allowFeatureCardBackground,
+    shouldShowFeatureCardBackground: configTheme?.allowFeatureCardBackground ?? true,
   };
 };

--- a/src/hooks/theme/useThemeConditionsMet.ts
+++ b/src/hooks/theme/useThemeConditionsMet.ts
@@ -31,6 +31,7 @@ export const useThemeConditionsMet = () => {
 
   return {
     shouldShowForTheme,
-    shouldShowFeatureCardBackground: configTheme?.allowFeatureCardBackground ?? true,
+    shouldShowFeatureCardBackground:
+      configTheme?.allowFeatureCardBackground ?? true,
   };
 };

--- a/src/types/PartnerThemeConfig.ts
+++ b/src/types/PartnerThemeConfig.ts
@@ -41,4 +41,5 @@ export interface PartnerThemeConfig {
   canvasBackground: { id: string; options: Record<string, unknown> } | null;
   allowedBridges: string[];
   allowedExchanges: string[];
+  allowFeatureCardBackground: boolean;
 }

--- a/src/types/strapi.ts
+++ b/src/types/strapi.ts
@@ -292,6 +292,7 @@ export interface Customization {
     id: string;
     options?: Record<string, unknown>;
   };
+  allowFeatureCardBackground?: boolean;
 }
 
 type WidgetConfigProps = Omit<WidgetConfig, 'integrator'> &

--- a/src/utils/formatTheme.ts
+++ b/src/utils/formatTheme.ts
@@ -109,6 +109,8 @@ export function formatConfig(
     hasThemeModeSwitch: customization?.hasThemeModeSwitch ?? true,
     hasBlurredNavigation: customization?.hasBlurredNavigation ?? false,
     hasBackgroundGradient: customization?.hasBackgroundGradient ?? false,
+    allowFeatureCardBackground:
+      customization?.allowFeatureCardBackground ?? true,
     canvasBackground: resolveCanvasBackgroundConfig(
       customization?.canvasBackground,
       backgroundColor,


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-1187/feature-card-is-broken-under-custom-theme

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a theme customization option to allow or suppress feature card background and border styling.
* **Behavior Changes**
  * Feature card background/border styling now shows only when theme visibility conditions are met and the new “allow feature card background” option is disabled/enabled appropriately.
* **Types / Configuration**
  * Extended partner theme and customization configuration with `allowFeatureCardBackground` (defaulting to enabled when unset).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->