### PR TITLE
fix: enable cacheComponents and complete app-wide caching migration

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,9 +18,9 @@ const nextConfig = {
   ],
   // expireTime: 86400, // one day in seconds
   expireTime: 900, // 15 minutes in seconds
+  cacheComponents: true,
   experimental: {
     serverSourceMaps: false,
-    useCache: true,
     optimizePackageImports: [],
   },
   webpack: (config) => {

--- a/src/app/.well-known/farcaster.json/route.ts
+++ b/src/app/.well-known/farcaster.json/route.ts
@@ -5,11 +5,7 @@ import envConfig from '@/config/env-config';
 export async function GET() {
   const PUBLIC_URL = envConfig.NEXT_PUBLIC_SITE_URL as string;
 
-  const { accountAssociation } = await getMiniAppSettings().catch((e) => {
-    console.error(
-      'Failed to fetch mini app settings, using default values.',
-      e,
-    );
+  const { accountAssociation } = await getMiniAppSettings().catch(() => {
     return { accountAssociation: {} };
   });
 

--- a/src/app/[lng]/(infos)/leaderboard/loading.tsx
+++ b/src/app/[lng]/(infos)/leaderboard/loading.tsx
@@ -1,0 +1,5 @@
+import { LeaderboardPageSkeleton } from '@/app/ui/leaderboard/LeaderboardPageSkeleton';
+
+export default function Loading() {
+  return <LeaderboardPageSkeleton />;
+}

--- a/src/app/[lng]/(infos)/leaderboard/page.tsx
+++ b/src/app/[lng]/(infos)/leaderboard/page.tsx
@@ -1,7 +1,9 @@
 import { getSiteUrl } from '@/const/urls';
 import { paginationSchema } from '@/utils/validation-schemas';
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
 import LeaderboardPage from 'src/app/ui/leaderboard/LeaderboardPage';
+import { LeaderboardPageSkeleton } from '@/app/ui/leaderboard/LeaderboardPageSkeleton';
 
 export const metadata: Metadata = {
   title: 'Jumper Leaderboard',
@@ -11,18 +13,24 @@ export const metadata: Metadata = {
   },
 };
 
-type SearchParams = { page: string | undefined };
+type SearchParams = Promise<{ page: string | undefined }>;
 
-export default async function Page({
+async function LeaderboardLoader({
   searchParams,
 }: {
   searchParams: SearchParams;
 }) {
   const { page } = await searchParams;
-
-  // Validate and transform page number
   const result = paginationSchema.safeParse(page);
   const validatedPage = result.success ? result.data.toString() : '1';
 
   return <LeaderboardPage page={validatedPage} />;
+}
+
+export default function Page({ searchParams }: { searchParams: SearchParams }) {
+  return (
+    <Suspense fallback={<LeaderboardPageSkeleton />}>
+      <LeaderboardLoader searchParams={searchParams} />
+    </Suspense>
+  );
 }

--- a/src/app/[lng]/(infos)/newsletter/confirm/page.tsx
+++ b/src/app/[lng]/(infos)/newsletter/confirm/page.tsx
@@ -5,8 +5,6 @@ import { NewsletterPageOverlayLayout } from '@/app/ui/newsletter/NewsletterPageO
 import { NewsletterWelcomeScreen } from '@/app/ui/newsletter/NewsletterWelcomeScreen';
 import { notFound } from 'next/navigation';
 
-export const dynamic = 'force-dynamic';
-
 interface PageProps {
   searchParams: Promise<{ jwt_token?: string }>;
 }

--- a/src/app/[lng]/(infos)/privacy-policy/page.tsx
+++ b/src/app/[lng]/(infos)/privacy-policy/page.tsx
@@ -26,8 +26,6 @@ export const metadata: Metadata = {
   },
 };
 
-export const revalidate = 300;
-
 export default function Page() {
   return <PrivacyPolicyPage />;
 }

--- a/src/app/[lng]/(infos)/profile/[walletAddress]/loading.tsx
+++ b/src/app/[lng]/(infos)/profile/[walletAddress]/loading.tsx
@@ -1,0 +1,5 @@
+import { ProfilePageSkeleton } from '@/components/ProfilePage/ProfilePageSkeleton';
+
+export default function Loading() {
+  return <ProfilePageSkeleton />;
+}

--- a/src/app/[lng]/(infos)/profile/[walletAddress]/page.tsx
+++ b/src/app/[lng]/(infos)/profile/[walletAddress]/page.tsx
@@ -3,13 +3,17 @@ import { walletAddressSchema } from '@/utils/validation-schemas';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
-import { getAllPerks } from '@/app/lib/getPerks';
+import { getPerksForPage } from '@/app/lib/getPerksForPage';
 import { ProfilePage } from '@/components/ProfilePage/ProfilePage';
 import { ProfilePageSkeleton } from '@/components/ProfilePage/ProfilePageSkeleton';
 
 type Params = Promise<{ walletAddress: string }>;
 
 const baseUrl = getSiteUrl();
+
+export function generateStaticParams() {
+  return [{ walletAddress: '0x0000000000000000000000000000000000000000' }];
+}
 
 export async function generateMetadata({
   params,
@@ -50,23 +54,24 @@ export async function generateMetadata({
   }
 }
 
-export const dynamic = 'force-static';
-
-export default async function Page({ params }: { params: Params }) {
+async function ProfileLoader({ params }: { params: Params }) {
   const { walletAddress } = await params;
 
-  // Validate wallet address
   const result = walletAddressSchema.safeParse(walletAddress);
   if (!result.success) {
     return notFound();
   }
 
   const sanitizedAddress = result.data;
-  const perks = await getAllPerks();
+  const perks = await getPerksForPage();
 
+  return <ProfilePage walletAddress={sanitizedAddress} perks={perks} />;
+}
+
+export default function Page({ params }: { params: Params }) {
   return (
     <Suspense fallback={<ProfilePageSkeleton />}>
-      <ProfilePage walletAddress={sanitizedAddress} perks={perks} />
+      <ProfileLoader params={params} />
     </Suspense>
   );
 }

--- a/src/app/[lng]/(infos)/profile/loading.tsx
+++ b/src/app/[lng]/(infos)/profile/loading.tsx
@@ -1,0 +1,5 @@
+import { ProfilePageSkeleton } from '@/components/ProfilePage/ProfilePageSkeleton';
+
+export default function Loading() {
+  return <ProfilePageSkeleton />;
+}

--- a/src/app/[lng]/(infos)/profile/page.tsx
+++ b/src/app/[lng]/(infos)/profile/page.tsx
@@ -3,12 +3,12 @@ import {
   pageOpenGraph,
   pageTwitter,
 } from '@/app/lib/metadata';
+import { cacheLife } from 'next/cache';
 import { AppPaths, getSiteUrl } from '@/const/urls';
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
-import { getAllPerks } from '@/app/lib/getPerks';
+import { getPerksForPage } from 'src/app/lib/getPerksForPage';
 import { ProfilePage } from '@/components/ProfilePage/ProfilePage';
-import { ProfilePageSkeleton } from '@/components/ProfilePage/ProfilePageSkeleton';
 
 export const metadata: Metadata = {
   title: pageMetadataFields.profile.title,
@@ -26,11 +26,9 @@ export const metadata: Metadata = {
 };
 
 export default async function Page() {
-  const perks = await getAllPerks();
+  'use cache';
+  cacheLife({ revalidate: 300 });
+  const perks = await getPerksForPage();
 
-  return (
-    <Suspense fallback={<ProfilePageSkeleton />}>
-      <ProfilePage isPublic={true} perks={perks} />
-    </Suspense>
-  );
+  return <ProfilePage isPublic={true} perks={perks} />;
 }

--- a/src/app/[lng]/(infos)/terms-of-business/page.tsx
+++ b/src/app/[lng]/(infos)/terms-of-business/page.tsx
@@ -27,8 +27,6 @@ export const metadata: Metadata = {
   },
 };
 
-export const revalidate = 300;
-
 export default function Page() {
   return <TermsOfBusinessPage />;
 }

--- a/src/app/[lng]/(main)/layout.tsx
+++ b/src/app/[lng]/(main)/layout.tsx
@@ -4,9 +4,6 @@ import type { PropsWithChildren } from 'react';
 import { Layout } from 'src/Layout';
 import App from '../../ui/app/App';
 
-export const fetchCache = 'default-cache';
-export const revalidate = 300; // 5 minutes
-
 export const metadata: Metadata = {
   other: {
     'partner-theme': 'default',

--- a/src/app/[lng]/bridge/[segments]/loading.tsx
+++ b/src/app/[lng]/bridge/[segments]/loading.tsx
@@ -1,0 +1,5 @@
+import { WidgetPageSkeleton } from '@/app/ui/shared/WidgetPageSkeleton';
+
+export default function Loading() {
+  return <WidgetPageSkeleton />;
+}

--- a/src/app/[lng]/bridge/[segments]/page.tsx
+++ b/src/app/[lng]/bridge/[segments]/page.tsx
@@ -5,6 +5,8 @@ import { resolveBridgeRoute } from '@/utils/bridge/resolveBridgeRoute';
 import { slugToDisplayLabel } from '@/utils/validation-schemas';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import { WidgetPageSkeleton } from '@/app/ui/shared/WidgetPageSkeleton';
+import { Suspense } from 'react';
 
 type Params = Promise<{ segments: string }>;
 
@@ -47,27 +49,12 @@ export async function generateMetadata({
   };
 }
 
-// Bridge pages are SEO landing pages with effectively static content, so they
-// only need to refresh once a month. Trigger an earlier refresh manually with
-// on-demand revalidation (revalidatePath/revalidateTag) when content changes.
-export const revalidate = 2592000; // 30 days
-export const dynamicParams = true;
-export const dynamic = 'force-static';
-
-// Prerender nothing at build time (the full pair matrix added ~15 min to the
-// build); generate each URL on first request and cache it (ISR).
-export function generateStaticParams() {
-  return [];
-}
-
-export default async function Page({ params }: { params: Params }) {
+async function BridgePageLoader({ params }: { params: Params }) {
   const { segments } = await params;
   const route = await resolveBridgeRoute(segments);
-
   if (!route) {
     return notFound();
   }
-
   return (
     <BridgePage
       sourceChain={route.sourceChain}
@@ -76,5 +63,13 @@ export default async function Page({ params }: { params: Params }) {
       destinationToken={route.destinationToken}
       chains={route.chains}
     />
+  );
+}
+
+export default function Page({ params }: { params: Params }) {
+  return (
+    <Suspense fallback={<WidgetPageSkeleton />}>
+      <BridgePageLoader params={params} />
+    </Suspense>
   );
 }

--- a/src/app/[lng]/bridge/layout.tsx
+++ b/src/app/[lng]/bridge/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import type { PropsWithChildren } from 'react';
 import { Layout } from 'src/Layout';
 
-export const fetchCache = 'default-cache';
 export const metadata: Metadata = {
   other: {
     'partner-theme': 'default',

--- a/src/app/[lng]/campaign/[slug]/loading.tsx
+++ b/src/app/[lng]/campaign/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { CampaignPageSkeleton } from '@/components/Campaign/CampaignPageSkeleton';
+
+export default function Loading() {
+  return <CampaignPageSkeleton />;
+}

--- a/src/app/[lng]/campaign/[slug]/page.tsx
+++ b/src/app/[lng]/campaign/[slug]/page.tsx
@@ -1,7 +1,7 @@
-import { getCampaigns } from '@/app/lib/getCampaigns';
+import { getCampaignsForPage } from '@/app/lib/campaign/cachedCampaignFetch';
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
-import { getCampaignBySlug } from 'src/app/lib/getCampaignsBySlug';
+import { getCampaignBySlugForPage } from '@/app/lib/campaign/cachedCampaignFetch';
 import { siteName } from 'src/app/lib/metadata';
 import { CampaignPage } from '@/components/Campaign/CampaignPage';
 import { CampaignPageSkeleton } from 'src/components/Campaign/CampaignPageSkeleton';
@@ -10,7 +10,7 @@ import { sliceStrToXChar } from 'src/utils/splitStringToXChar';
 
 // Add generateStaticParams function
 export async function generateStaticParams() {
-  const { data } = await getCampaigns();
+  const { data } = await getCampaignsForPage();
 
   if (!data) {
     return [];
@@ -21,10 +21,6 @@ export async function generateStaticParams() {
   }));
 }
 
-export const dynamicParams = true;
-export const dynamic = 'force-static';
-export const revalidate = 300;
-
 export async function generateMetadata({
   params,
 }: {
@@ -33,7 +29,7 @@ export async function generateMetadata({
   const { slug } = await params;
 
   try {
-    const campaign = await getCampaignBySlug(slug);
+    const campaign = await getCampaignBySlugForPage(slug);
 
     if (!campaign || !campaign.data || campaign.data.length === 0) {
       throw new Error(`Campaign for ${slug} not found`);
@@ -68,12 +64,15 @@ export async function generateMetadata({
 
 type Params = Promise<{ slug: string }>;
 
-export default async function Page({ params }: { params: Params }) {
+async function CampaignPageLoader({ params }: { params: Params }) {
   const { slug } = await params;
+  return <CampaignPage slug={slug} />;
+}
 
+export default function Page({ params }: { params: Params }) {
   return (
     <Suspense fallback={<CampaignPageSkeleton />}>
-      <CampaignPage slug={slug} />
+      <CampaignPageLoader params={params} />
     </Suspense>
   );
 }

--- a/src/app/[lng]/earn/[slug]/page.tsx
+++ b/src/app/[lng]/earn/[slug]/page.tsx
@@ -11,9 +11,6 @@ import { Suspense } from 'react';
 
 type Params = Promise<{ slug: string }>;
 
-export const dynamicParams = true;
-export const revalidate = 300;
-
 export async function generateMetadata({
   params,
 }: {
@@ -40,12 +37,15 @@ export async function generateMetadata({
   };
 }
 
-export default async function Page({ params }: { params: Params }) {
+async function EarnPageLoader({ params }: { params: Params }) {
   const { slug } = await params;
+  return <EarnPageContent slug={slug} />;
+}
 
+export default function Page({ params }: { params: Params }) {
   return (
     <Suspense fallback={<EarnPageSkeleton />}>
-      <EarnPageContent slug={slug} />
+      <EarnPageLoader params={params} />
     </Suspense>
   );
 }

--- a/src/app/[lng]/earn/layout.tsx
+++ b/src/app/[lng]/earn/layout.tsx
@@ -9,8 +9,6 @@ import { PageContainer } from 'src/components/Containers/PageContainer';
 import { Layout } from 'src/Layout';
 import { FetchInterceptorProvider } from 'src/providers/FetchInterceptorProvider';
 
-export const fetchCache = 'default-cache';
-
 export default function EarnLayout({ children }: PropsWithChildren) {
   if (!isEarnFeatureEnabled()) {
     return notFound();

--- a/src/app/[lng]/earn/loading.tsx
+++ b/src/app/[lng]/earn/loading.tsx
@@ -1,0 +1,5 @@
+import { EarnsPageSkeleton } from '@/app/ui/earn/EarnsPageSkeleton';
+
+export default function Loading() {
+  return <EarnsPageSkeleton />;
+}

--- a/src/app/[lng]/earn/page.tsx
+++ b/src/app/[lng]/earn/page.tsx
@@ -9,8 +9,6 @@ import { AppPaths, getSiteUrl } from '@/const/urls';
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
 
-export const revalidate = 300;
-
 export const metadata: Metadata = {
   title: pageMetadataFields.earn.title,
   description: pageMetadataFields.earn.description,

--- a/src/app/[lng]/error-preview/[statusCode]/page.tsx
+++ b/src/app/[lng]/error-preview/[statusCode]/page.tsx
@@ -1,6 +1,7 @@
 import { HttpError } from '@/types/http-error';
 import { notFound, redirect } from 'next/navigation';
 import { isProduction } from '@/utils/isProduction';
+import { connection } from 'next/server';
 
 type Params = Promise<{ statusCode: string }>;
 
@@ -11,6 +12,7 @@ interface ErrorPreviewPageProps {
 export default async function ErrorPreviewPage({
   params,
 }: ErrorPreviewPageProps) {
+  await connection();
   if (isProduction) {
     return redirect('/');
   }

--- a/src/app/[lng]/layout.tsx
+++ b/src/app/[lng]/layout.tsx
@@ -11,8 +11,8 @@ import NavbarWrapper from 'src/components/Navbar/NavbarWrapper';
 import { defaultNS, fallbackLng, namespaces } from 'src/i18n';
 import { IntercomProvider } from 'src/providers/IntercomProvider';
 import { SettingsStoreProvider } from 'src/stores/settings';
-import initTranslations from '@/app/i18n';
 import { getPartnerThemes } from '@/app/lib/getPartnerThemes';
+import { getTranslationResources } from '@/app/lib/getTranslationResources';
 import config, { getPublicEnvVars } from '@/config/env-config';
 import envConfig from '@/config/env-config';
 import { getSiteUrl } from '@/const/urls';
@@ -104,16 +104,12 @@ export default async function RootLayout({
 }) {
   const { lng } = await params;
 
-  const [partnerThemes, { appId }, { resources }] = await Promise.all([
+  const locale = lng || fallbackLng;
+
+  const [partnerThemes, { appId }, resources] = await Promise.all([
     getPartnerThemes().catch(() => ({ data: [] })),
-    getMiniAppSettings().catch((e) => {
-      console.error(
-        'Failed to fetch mini app settings, using default values.',
-        e,
-      );
-      return { appId: '' };
-    }),
-    initTranslations(lng || fallbackLng, namespaces),
+    getMiniAppSettings().catch(() => ({ appId: '' })),
+    getTranslationResources(locale, namespaces),
   ]);
 
   return (
@@ -225,17 +221,21 @@ export default async function RootLayout({
                   <MUIThemeProvider>
                     <SettingsStoreProvider>
                       <NuqsAdapter>
-                        <PortfolioProvider>
-                          <ExtensionDetectionProvider>
-                            <Suspense>
-                              <ReferrerCapture />
-                              <FeatureFlagsBootstrap />
-                            </Suspense>
-                            <NavbarWrapper />
-                            <IntercomProvider />
-                            <main>{children}</main>
-                          </ExtensionDetectionProvider>
-                        </PortfolioProvider>
+                        <Suspense fallback={null}>
+                          <PortfolioProvider>
+                            <ExtensionDetectionProvider>
+                              <Suspense>
+                                <ReferrerCapture />
+                                <FeatureFlagsBootstrap />
+                              </Suspense>
+                              <NavbarWrapper />
+                              <IntercomProvider />
+                              <main>
+                                <Suspense fallback={null}>{children}</Suspense>
+                              </main>
+                            </ExtensionDetectionProvider>
+                          </PortfolioProvider>
+                        </Suspense>
                       </NuqsAdapter>
                     </SettingsStoreProvider>
                   </MUIThemeProvider>

--- a/src/app/[lng]/missions/[slug]/page.tsx
+++ b/src/app/[lng]/missions/[slug]/page.tsx
@@ -25,7 +25,7 @@ const formatSlugToTitle = (slug: string) => slug.replaceAll('-', ' ');
 
 export async function generateStaticParams() {
   if (envConfig.NEXT_PUBLIC_ENVIRONMENT !== 'production') {
-    return [];
+    return [{ slug: '_placeholder' }];
   }
 
   const pageSize = 25;
@@ -120,19 +120,20 @@ export async function generateMetadata({
   }
 }
 
-export const dynamicParams = true;
-export const revalidate = 300;
-
-export default async function Page({ params }: { params: Params }) {
+async function MissionPageLoader({ params }: { params: Params }) {
   const { slug } = await params;
 
   if (!slug) {
     return notFound();
   }
 
+  return <MissionPageContent slug={slug} />;
+}
+
+export default function Page({ params }: { params: Params }) {
   return (
     <Suspense fallback={<MissionPageSkeleton />}>
-      <MissionPageContent slug={slug} />
+      <MissionPageLoader params={params} />
     </Suspense>
   );
 }

--- a/src/app/[lng]/missions/layout.tsx
+++ b/src/app/[lng]/missions/layout.tsx
@@ -3,8 +3,6 @@ import type { PropsWithChildren } from 'react';
 import { PageContainer } from 'src/components/Containers/PageContainer';
 import { Layout } from 'src/Layout';
 
-export const fetchCache = 'default-cache';
-
 export const metadata: Metadata = {
   other: {
     'partner-theme': 'default',

--- a/src/app/[lng]/missions/loading.tsx
+++ b/src/app/[lng]/missions/loading.tsx
@@ -1,0 +1,5 @@
+import { MissionsPageSkeleton } from '@/app/ui/missions/MissionsPageSkeleton';
+
+export default function Loading() {
+  return <MissionsPageSkeleton />;
+}

--- a/src/app/[lng]/missions/page.tsx
+++ b/src/app/[lng]/missions/page.tsx
@@ -4,8 +4,6 @@ import { MissionsPage } from 'src/app/ui/missions/MissionsPage';
 import { MissionsPageSkeleton } from 'src/app/ui/missions/MissionsPageSkeleton';
 import { getSiteUrl, AppPaths } from 'src/const/urls';
 
-export const revalidate = 300;
-
 export const metadata: Metadata = {
   title: 'Jumper Missions',
   description: `Discover, interact, and grow in DeFi with Jumper's missions and ecosystem campaigns.`,

--- a/src/app/[lng]/portfolio/layout.tsx
+++ b/src/app/[lng]/portfolio/layout.tsx
@@ -9,8 +9,6 @@ import { PageContainer } from 'src/components/Containers/PageContainer';
 import { Layout } from 'src/Layout';
 import { FetchInterceptorProvider } from 'src/providers/FetchInterceptorProvider';
 
-export const fetchCache = 'default-cache';
-
 export const metadata: Metadata = {
   other: {
     'partner-theme': 'default',

--- a/src/app/[lng]/quests/[slug]/page.tsx
+++ b/src/app/[lng]/quests/[slug]/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 import { redirect, RedirectType } from 'next/navigation';
 import { AppPaths, getSiteUrl } from 'src/const/urls';
 import { sliceStrToXChar } from 'src/utils/splitStringToXChar';
+import { Suspense } from 'react';
 
 type Params = Promise<{ slug: string }>;
 
@@ -34,8 +35,16 @@ export async function generateMetadata({
   };
 }
 
-export default async function Page({ params }: { params: Params }) {
+async function QuestRedirect({ params }: { params: Params }) {
   const { slug } = await params;
-
   redirect(`${AppPaths.Missions}/${slug}`, RedirectType.replace);
+  return null;
+}
+
+export default function Page({ params }: { params: Params }) {
+  return (
+    <Suspense>
+      <QuestRedirect params={params} />
+    </Suspense>
+  );
 }

--- a/src/app/[lng]/quests/layout.tsx
+++ b/src/app/[lng]/quests/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import type { PropsWithChildren } from 'react';
 import { Layout } from 'src/Layout';
 
-export const fetchCache = 'default-cache';
 export const metadata: Metadata = {
   other: {
     'partner-theme': 'default',

--- a/src/app/[lng]/scan/[[...segments]]/loading.tsx
+++ b/src/app/[lng]/scan/[[...segments]]/loading.tsx
@@ -1,0 +1,5 @@
+import { ScanPageSkeleton } from '@/app/ui/scan/ScanPageSkeleton';
+
+export default function Loading() {
+  return <ScanPageSkeleton />;
+}

--- a/src/app/[lng]/scan/[[...segments]]/page.tsx
+++ b/src/app/[lng]/scan/[[...segments]]/page.tsx
@@ -1,8 +1,10 @@
 import { siteName } from '@/app/lib/metadata';
-import ScanPage from '@/app/ui/scan/ScanPage';
+import ScanPageContent from '@/app/ui/scan/ScanPageContent';
+import { ScanPageSkeleton } from '@/app/ui/scan/ScanPageSkeleton';
 import { getSiteUrl } from '@/const/urls';
 import { scanParamsSchema } from '@/utils/validation-schemas';
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 
 type MetadataParams = Promise<{ segments: string[] }>;
@@ -15,7 +17,6 @@ export async function generateMetadata({
   try {
     const { segments = [] } = await params;
 
-    // Validate segments
     const result = scanParamsSchema.safeParse({ segments });
     if (!result.success) {
       throw new Error('Invalid scan segments');
@@ -35,51 +36,43 @@ export async function generateMetadata({
     const canonical = `${getSiteUrl()}/scan${segments.length === 0 ? '' : `/${segments.join('/')}`}`;
 
     return {
-      robots: {
-        index: false,
-      },
+      robots: { index: false },
       title,
       description,
-      alternates: {
-        canonical,
-      },
-      openGraph: {
-        title,
-        description,
-        siteName,
-        url: canonical,
-      },
-      twitter: {
-        title,
-        description,
-      },
+      alternates: { canonical },
+      openGraph: { title, description, siteName, url: canonical },
+      twitter: { title, description },
     };
   } catch (err) {
     return {
       title: 'Jumper Scan | Blockchain Explorer',
       description:
         'Jumper Scan is a blockchain explorer that allows you to search and explore transactions, blocks, and wallets on multiple blockchains.',
-      alternates: {
-        canonical: `${getSiteUrl()}/scan`,
-      },
+      alternates: { canonical: `${getSiteUrl()}/scan` },
     };
   }
 }
 
-export const dynamic = 'force-static';
-
 type Params = Promise<{ lng: string; segments: string[] }>;
-export default async function Page({
+
+async function ScanPageLoader({ params }: { params: Params }) {
+  const { lng, segments } = await params;
+  const result = scanParamsSchema.safeParse({ segments });
+  if (!result.success) {
+    notFound();
+  }
+  return <ScanPageContent lng={lng} />;
+}
+
+export default function Page({
   params,
 }: {
   children: React.ReactNode;
   params: Params;
 }) {
-  const { lng, segments } = await params;
-
   return (
-    <Suspense>
-      <ScanPage lng={lng} segments={segments} />
+    <Suspense fallback={<ScanPageSkeleton />}>
+      <ScanPageLoader params={params} />
     </Suspense>
   );
 }

--- a/src/app/[lng]/swap/[segments]/loading.tsx
+++ b/src/app/[lng]/swap/[segments]/loading.tsx
@@ -1,0 +1,5 @@
+import { WidgetPageSkeleton } from '@/app/ui/shared/WidgetPageSkeleton';
+
+export default function Loading() {
+  return <WidgetPageSkeleton />;
+}

--- a/src/app/[lng]/swap/[segments]/page.tsx
+++ b/src/app/[lng]/swap/[segments]/page.tsx
@@ -5,10 +5,19 @@ import { getChainByName } from '@/utils/tokenAndChain';
 import { slugify } from '@/utils/urls/slugify';
 import { chainNameSchema } from '@/utils/validation-schemas';
 import type { Metadata } from 'next';
+import { cacheLife } from 'next/cache';
 import { notFound } from 'next/navigation';
 import SwapPage from 'src/app/ui/swap/SwapPage';
+import { WidgetPageSkeleton } from '@/app/ui/shared/WidgetPageSkeleton';
+import { Suspense } from 'react';
 
 type Params = Promise<{ segments: string }>;
+
+async function getChainsForPage() {
+  'use cache';
+  cacheLife({ revalidate: 86400 });
+  return getChainsQuery();
+}
 
 export async function generateMetadata({
   params,
@@ -23,7 +32,7 @@ export async function generateMetadata({
     notFound();
   }
 
-  const { chains } = await getChainsQuery();
+  const { chains } = await getChainsForPage();
   const sourceChain = getChainByName(chains, result.data);
   const title = `Jumper | How To Swap on ${sourceChain?.name} | A Complete Guide`;
 
@@ -46,19 +55,15 @@ export async function generateMetadata({
   };
 }
 
-export const revalidate = 86400;
-export const dynamicParams = true; // or false, to 404 on unknown paths
-export const dynamic = 'force-static';
-
 export async function generateStaticParams() {
-  const { chains } = await getChainsQuery();
+  const { chains } = await getChainsForPage();
 
   return chains.map((chain) => ({
     segments: slugify(chain.name),
   }));
 }
 
-export default async function Page({ params }: { params: Params }) {
+async function SwapPageLoader({ params }: { params: Params }) {
   const { segments } = await params;
 
   try {
@@ -70,8 +75,7 @@ export default async function Page({ params }: { params: Params }) {
       return notFound();
     }
 
-    const { chains } = await getChainsQuery();
-
+    const { chains } = await getChainsForPage();
     const sourceChain = getChainByName(chains, result.data);
 
     if (!sourceChain) {
@@ -86,6 +90,14 @@ export default async function Page({ params }: { params: Params }) {
       />
     );
   } catch (e) {
-    notFound();
+    return notFound();
   }
+}
+
+export default function Page({ params }: { params: Params }) {
+  return (
+    <Suspense fallback={<WidgetPageSkeleton />}>
+      <SwapPageLoader params={params} />
+    </Suspense>
+  );
 }

--- a/src/app/[lng]/swap/layout.tsx
+++ b/src/app/[lng]/swap/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import type { PropsWithChildren } from 'react';
 import { Layout } from 'src/Layout';
 
-export const fetchCache = 'default-cache';
 export const metadata: Metadata = {
   other: {
     'partner-theme': 'default',

--- a/src/app/[lng]/zap/[slug]/loading.tsx
+++ b/src/app/[lng]/zap/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { ZapPageSkeleton } from '@/app/ui/zap/ZapPageSkeleton';
+
+export default function Loading() {
+  return <ZapPageSkeleton />;
+}

--- a/src/app/[lng]/zap/[slug]/page.tsx
+++ b/src/app/[lng]/zap/[slug]/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from 'next/navigation';
 import { getQuestBySlug } from 'src/app/lib/getQuestBySlug';
 import { siteName } from 'src/app/lib/metadata';
 import ZapPage from 'src/app/ui/zap/ZapPage';
+import { ZapPageSkeleton } from '@/app/ui/zap/ZapPageSkeleton';
+import { Suspense } from 'react';
 import { getSiteUrl } from 'src/const/urls';
 import { sliceStrToXChar } from 'src/utils/splitStringToXChar';
 import { resolveStrapiMediaUrl } from 'src/utils/strapi/strapiHelper';
@@ -59,14 +61,19 @@ export async function generateMetadata({
   }
 }
 
-export default async function Page({ params }: { params: Params }) {
+async function ZapPageLoader({ params }: { params: Params }) {
   const { slug } = await params;
-
   const { data } = await getQuestBySlug(slug);
-
   if (!data) {
     return notFound();
   }
-
   return <ZapPage market={data} />;
+}
+
+export default function Page({ params }: { params: Params }) {
+  return (
+    <Suspense fallback={<ZapPageSkeleton />}>
+      <ZapPageLoader params={params} />
+    </Suspense>
+  );
 }

--- a/src/app/api/env-config.js/route.ts
+++ b/src/app/api/env-config.js/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getPublicEnvVars } from 'src/config/env-config';
 
-export const dynamic = 'force-dynamic';
-
 export async function GET(request: Request) {
   return new NextResponse(
     `window._env_ = ` + JSON.stringify(getPublicEnvVars()),

--- a/src/app/api/metrics/error-increment/route.ts
+++ b/src/app/api/metrics/error-increment/route.ts
@@ -2,8 +2,6 @@ import type { NextRequest } from 'next/server';
 import { parseErrorOperation } from '@/utils/telemetry/errorOperations';
 import { recordServerError } from '@/utils/telemetry/recordError';
 
-export const dynamic = 'force-dynamic';
-
 export const POST = async (request: NextRequest) => {
   const body: unknown = await request.json().catch(() => null);
   const rawOperation =

--- a/src/app/api/widget-amounts/route.tsx
+++ b/src/app/api/widget-amounts/route.tsx
@@ -25,6 +25,7 @@ import WidgetAmountsImage from 'src/components/ImageGeneration/WidgetAmountImage
 import { getSiteUrl } from 'src/const/urls';
 import { getChainsQuery } from 'src/hooks/useChains';
 import { fetchChainTokensForPage } from '@/app/lib/tokens/cachedTokensFetch';
+import { isNextInternalError } from 'src/utils/image-generation/helpers';
 import { parseSearchParams } from 'src/utils/image-generation/parseSearchParams';
 import { sortChainsBySpecificName } from 'src/utils/image-generation/sortChains';
 import {
@@ -84,6 +85,9 @@ export async function GET(request: Request) {
       options,
     );
   } catch (error) {
+    if (isNextInternalError(error)) {
+      throw error;
+    }
     console.error('Error generating widget amounts image:', error);
     return new Response('Internal server error', { status: 500 });
   }

--- a/src/app/api/widget-execution/route.tsx
+++ b/src/app/api/widget-execution/route.tsx
@@ -31,6 +31,7 @@ import WidgetExecutionImage from 'src/components/ImageGeneration/WidgetExecution
 import { getSiteUrl } from 'src/const/urls';
 import { fetchChainData } from 'src/utils/image-generation/fetchChainData';
 import { fetchTokenData } from 'src/utils/image-generation/fetchTokenData';
+import { isNextInternalError } from 'src/utils/image-generation/helpers';
 import { parseSearchParams } from 'src/utils/image-generation/parseSearchParams';
 import {
   widgetExecutionSchema,
@@ -77,32 +78,33 @@ export async function GET(request: Request) {
     }) as CSSProperties;
 
     return new ImageResponse(
-      (
-        <div style={imageStyle}>
-          <img
-            alt="Widget Example"
-            width={'100%'}
-            height={'100%'}
-            style={imageStyle}
-            src={`${getSiteUrl()}/widget/widget-execution-${params.theme}.png`}
-          />
-          <WidgetExecutionImage
-            height={WIDGET_IMAGE_WIDTH}
-            isSwap={params.isSwap}
-            width={WIDGET_IMAGE_HEIGHT}
-            fromToken={fromTokenData}
-            toToken={toTokenData}
-            fromChain={fromChain}
-            theme={params.theme}
-            toChain={toChain}
-            amount={params.amount}
-            highlighted={params.highlighted as HighlightedAreas}
-          />
-        </div>
-      ),
+      <div style={imageStyle}>
+        <img
+          alt="Widget Example"
+          width={'100%'}
+          height={'100%'}
+          style={imageStyle}
+          src={`${getSiteUrl()}/widget/widget-execution-${params.theme}.png`}
+        />
+        <WidgetExecutionImage
+          height={WIDGET_IMAGE_WIDTH}
+          isSwap={params.isSwap}
+          width={WIDGET_IMAGE_HEIGHT}
+          fromToken={fromTokenData}
+          toToken={toTokenData}
+          fromChain={fromChain}
+          theme={params.theme}
+          toChain={toChain}
+          amount={params.amount}
+          highlighted={params.highlighted as HighlightedAreas}
+        />
+      </div>,
       options,
     );
   } catch (error) {
+    if (isNextInternalError(error)) {
+      throw error;
+    }
     console.error('Error generating widget execution image:', error);
     return new Response('Internal server error', { status: 500 });
   }

--- a/src/app/api/widget-quotes/route.tsx
+++ b/src/app/api/widget-quotes/route.tsx
@@ -31,6 +31,7 @@ import WidgetQuotesImage from 'src/components/ImageGeneration/WidgetQuotesImage'
 import { getSiteUrl } from 'src/const/urls';
 import { fetchChainData } from 'src/utils/image-generation/fetchChainData';
 import { fetchTokenData } from 'src/utils/image-generation/fetchTokenData';
+import { isNextInternalError } from 'src/utils/image-generation/helpers';
 import { parseSearchParams } from 'src/utils/image-generation/parseSearchParams';
 import {
   widgetQuotesSchema,
@@ -69,31 +70,32 @@ export async function GET(request: Request) {
     }) as CSSProperties;
 
     return new ImageResponse(
-      (
-        <div style={imageStyle}>
-          <img
-            alt="Widget Quotes Example"
-            width={'100%'}
-            height={'100%'}
-            style={imageStyle}
-            src={`${getSiteUrl()}/widget/widget-quotes-${params.theme}.png`}
-          />
-          <WidgetQuotesImage
-            height={WIDGET_IMAGE_WIDTH}
-            width={WIDGET_IMAGE_HEIGHT}
-            fromToken={fromTokenData}
-            toToken={toTokenData}
-            fromChain={fromChain}
-            toChain={toChain}
-            amount={params.amount}
-            theme={params.theme}
-            highlighted={params.highlighted as HighlightedAreas}
-          />
-        </div>
-      ),
+      <div style={imageStyle}>
+        <img
+          alt="Widget Quotes Example"
+          width={'100%'}
+          height={'100%'}
+          style={imageStyle}
+          src={`${getSiteUrl()}/widget/widget-quotes-${params.theme}.png`}
+        />
+        <WidgetQuotesImage
+          height={WIDGET_IMAGE_WIDTH}
+          width={WIDGET_IMAGE_HEIGHT}
+          fromToken={fromTokenData}
+          toToken={toTokenData}
+          fromChain={fromChain}
+          toChain={toChain}
+          amount={params.amount}
+          theme={params.theme}
+          highlighted={params.highlighted as HighlightedAreas}
+        />
+      </div>,
       options,
     );
   } catch (error) {
+    if (isNextInternalError(error)) {
+      throw error;
+    }
     console.error('Error generating widget quotes image:', error);
     return new Response('Internal server error', { status: 500 });
   }

--- a/src/app/api/widget-review/route.tsx
+++ b/src/app/api/widget-review/route.tsx
@@ -29,6 +29,7 @@ import WidgetReviewImage from 'src/components/ImageGeneration/WidgetReviewImage'
 import { getSiteUrl } from 'src/const/urls';
 import { fetchChainData } from 'src/utils/image-generation/fetchChainData';
 import { fetchTokenData } from 'src/utils/image-generation/fetchTokenData';
+import { isNextInternalError } from 'src/utils/image-generation/helpers';
 import { parseSearchParams } from 'src/utils/image-generation/parseSearchParams';
 import {
   widgetReviewSchema,
@@ -67,31 +68,32 @@ export async function GET(request: Request) {
     }) as CSSProperties;
 
     return new ImageResponse(
-      (
-        <div style={imageStyle}>
-          <img
-            alt="Widget Review Example"
-            width={'100%'}
-            height={'100%'}
-            style={imageStyle}
-            src={`${getSiteUrl()}/widget/widget-review-bridge-${params.theme}.png`}
-          />
-          <WidgetReviewImage
-            height={WIDGET_IMAGE_WIDTH}
-            width={WIDGET_IMAGE_HEIGHT}
-            fromToken={fromTokenData}
-            toToken={toTokenData}
-            fromChain={fromChain}
-            toChain={toChain}
-            amount={params.amount}
-            isSwap={params.isSwap}
-            theme={params.theme}
-          />
-        </div>
-      ),
+      <div style={imageStyle}>
+        <img
+          alt="Widget Review Example"
+          width={'100%'}
+          height={'100%'}
+          style={imageStyle}
+          src={`${getSiteUrl()}/widget/widget-review-bridge-${params.theme}.png`}
+        />
+        <WidgetReviewImage
+          height={WIDGET_IMAGE_WIDTH}
+          width={WIDGET_IMAGE_HEIGHT}
+          fromToken={fromTokenData}
+          toToken={toTokenData}
+          fromChain={fromChain}
+          toChain={toChain}
+          amount={params.amount}
+          isSwap={params.isSwap}
+          theme={params.theme}
+        />
+      </div>,
       options,
     );
   } catch (error) {
+    if (isNextInternalError(error)) {
+      throw error;
+    }
     console.error('Error generating widget review image:', error);
     return new Response('Internal server error', { status: 500 });
   }

--- a/src/app/api/widget-selection/route.tsx
+++ b/src/app/api/widget-selection/route.tsx
@@ -30,6 +30,7 @@ import WidgetSelectionImage from 'src/components/ImageGeneration/WidgetSelection
 import { getSiteUrl } from 'src/const/urls';
 import { fetchChainData } from 'src/utils/image-generation/fetchChainData';
 import { fetchTokenData } from 'src/utils/image-generation/fetchTokenData';
+import { isNextInternalError } from 'src/utils/image-generation/helpers';
 import { parseSearchParams } from 'src/utils/image-generation/parseSearchParams';
 import {
   widgetSelectionSchema,
@@ -68,31 +69,32 @@ export async function GET(request: Request) {
     }) as CSSProperties;
 
     return new ImageResponse(
-      (
-        <div style={imageStyle}>
-          <img
-            alt="Widget Selection Example"
-            width={'100%'}
-            height={'100%'}
-            style={imageStyle}
-            src={`${getSiteUrl()}/widget/widget-selection-${params.theme}.png`}
-          />
-          <WidgetSelectionImage
-            height={WIDGET_IMAGE_WIDTH}
-            width={WIDGET_IMAGE_HEIGHT}
-            fromToken={fromTokenData}
-            toToken={toTokenData}
-            fromChain={fromChain}
-            toChain={toChain}
-            amount={params.amount}
-            theme={params.theme}
-            highlighted={params.highlighted as HighlightedAreas}
-          />
-        </div>
-      ),
+      <div style={imageStyle}>
+        <img
+          alt="Widget Selection Example"
+          width={'100%'}
+          height={'100%'}
+          style={imageStyle}
+          src={`${getSiteUrl()}/widget/widget-selection-${params.theme}.png`}
+        />
+        <WidgetSelectionImage
+          height={WIDGET_IMAGE_WIDTH}
+          width={WIDGET_IMAGE_HEIGHT}
+          fromToken={fromTokenData}
+          toToken={toTokenData}
+          fromChain={fromChain}
+          toChain={toChain}
+          amount={params.amount}
+          theme={params.theme}
+          highlighted={params.highlighted as HighlightedAreas}
+        />
+      </div>,
       options,
     );
   } catch (error) {
+    if (isNextInternalError(error)) {
+      throw error;
+    }
     console.error('Error generating widget selection image:', error);
     return new Response('Internal server error', { status: 500 });
   }

--- a/src/app/api/widget-success/route.tsx
+++ b/src/app/api/widget-success/route.tsx
@@ -27,6 +27,7 @@ import WidgetSuccessImage from 'src/components/ImageGeneration/WidgetSuccessImag
 import { getSiteUrl } from 'src/const/urls';
 import { fetchChainData } from 'src/utils/image-generation/fetchChainData';
 import { fetchTokenData } from 'src/utils/image-generation/fetchTokenData';
+import { isNextInternalError } from 'src/utils/image-generation/helpers';
 import { parseSearchParams } from 'src/utils/image-generation/parseSearchParams';
 import {
   widgetSuccessSchema,
@@ -63,28 +64,29 @@ export async function GET(request: Request) {
     }) as CSSProperties;
 
     return new ImageResponse(
-      (
-        <div style={imageStyle}>
-          <img
-            alt="Widget Success Example"
-            width={'100%'}
-            height={'100%'}
-            style={imageStyle}
-            src={`${getSiteUrl()}/widget/widget-success-${params.theme}.png`}
-          />
-          <WidgetSuccessImage
-            height={WIDGET_IMAGE_WIDTH}
-            width={WIDGET_IMAGE_HEIGHT}
-            toToken={toTokenData}
-            toChain={toChain}
-            amount={params.amount}
-            theme={params.theme}
-          />
-        </div>
-      ),
+      <div style={imageStyle}>
+        <img
+          alt="Widget Success Example"
+          width={'100%'}
+          height={'100%'}
+          style={imageStyle}
+          src={`${getSiteUrl()}/widget/widget-success-${params.theme}.png`}
+        />
+        <WidgetSuccessImage
+          height={WIDGET_IMAGE_WIDTH}
+          width={WIDGET_IMAGE_HEIGHT}
+          toToken={toTokenData}
+          toChain={toChain}
+          amount={params.amount}
+          theme={params.theme}
+        />
+      </div>,
       options,
     );
   } catch (error) {
+    if (isNextInternalError(error)) {
+      throw error;
+    }
     console.error('Error generating widget success image:', error);
     return new Response('Internal server error', { status: 500 });
   }

--- a/src/app/bridge/sitemap.xml/route.ts
+++ b/src/app/bridge/sitemap.xml/route.ts
@@ -5,16 +5,20 @@ import {
   createSitemapIndexXmlResponse,
   createSitemapServiceUnavailableResponse,
 } from '@/utils/sitemaps/xml';
+import { cacheLife } from 'next/cache';
 
-export const dynamic = 'force-static';
-export const revalidate = 86400;
+async function getBridgeSitemapIndexData() {
+  'use cache';
+  cacheLife({ revalidate: 86400 });
+  const ids = await getBridgeSitemapChunkIds();
+  const lastModified = toSitemapDate(Date.now());
+  const locs = ids.map((id) => buildUrl('bridge', 'sitemap', `${id}.xml`));
+  return { locs, lastModified };
+}
 
 export async function GET() {
   try {
-    const ids = await getBridgeSitemapChunkIds();
-    const lastModified = toSitemapDate(Date.now());
-    const locs = ids.map((id) => buildUrl('bridge', 'sitemap', `${id}.xml`));
-
+    const { locs, lastModified } = await getBridgeSitemapIndexData();
     return createSitemapIndexXmlResponse(locs, lastModified);
   } catch (error) {
     captureException(error);

--- a/src/app/bridge/sitemap/[id]/route.ts
+++ b/src/app/bridge/sitemap/[id]/route.ts
@@ -9,11 +9,8 @@ import {
   createSitemapServiceUnavailableResponse,
   createSitemapXmlResponse,
 } from '@/utils/sitemaps/xml';
-
-export const dynamic = 'force-static';
-export const revalidate = 86400;
-
-const lastModified = toSitemapDate(Date.now());
+import type { SitemapXmlEntry } from '@/utils/sitemaps/xml';
+import { cacheLife } from 'next/cache';
 
 const parseChunkIndex = (id: string): number | null => {
   if (!id.endsWith('.xml')) {
@@ -27,6 +24,21 @@ const parseChunkIndex = (id: string): number | null => {
 
   return Number(chunkId);
 };
+
+async function getBridgeSitemapChunkEntries(
+  chunkIndex: number,
+): Promise<SitemapXmlEntry[] | null> {
+  'use cache';
+  cacheLife({ revalidate: 86400 });
+  const inRange = await isBridgeSitemapChunkInRange(chunkIndex);
+
+  if (!inRange) {
+    return null;
+  }
+
+  const lastModified = toSitemapDate(Date.now());
+  return getBridgeSitemapEntriesForChunk(chunkIndex, lastModified);
+}
 
 export async function generateStaticParams() {
   try {
@@ -50,16 +62,12 @@ export async function GET(
   }
 
   try {
-    const inRange = await isBridgeSitemapChunkInRange(chunkIndex);
+    const entries = await getBridgeSitemapChunkEntries(chunkIndex);
 
-    if (!inRange) {
+    if (!entries) {
       return new Response('Not Found', { status: 404 });
     }
 
-    const entries = await getBridgeSitemapEntriesForChunk(
-      chunkIndex,
-      lastModified,
-    );
     return createSitemapXmlResponse(entries);
   } catch (error) {
     captureException(error);

--- a/src/app/learn/sitemap/[id]/route.ts
+++ b/src/app/learn/sitemap/[id]/route.ts
@@ -3,9 +3,8 @@ import {
   getLearnSitemapEntriesForChunk,
 } from '@/utils/sitemaps/learn';
 import { createSitemapXmlResponse } from '@/utils/sitemaps/xml';
-
-export const dynamic = 'force-static';
-export const revalidate = 86400;
+import type { SitemapXmlEntry } from '@/utils/sitemaps/xml';
+import { cacheLife } from 'next/cache';
 
 const parseChunkIndex = (id: string): number | null => {
   if (!id.endsWith('.xml')) {
@@ -19,6 +18,14 @@ const parseChunkIndex = (id: string): number | null => {
 
   return Number(chunkId);
 };
+
+async function getLearnSitemapChunkEntries(
+  chunkIndex: number,
+): Promise<SitemapXmlEntry[]> {
+  'use cache';
+  cacheLife({ revalidate: 86400 });
+  return getLearnSitemapEntriesForChunk(chunkIndex);
+}
 
 export async function generateStaticParams() {
   const ids = await getLearnSitemapChunkIds();
@@ -36,6 +43,6 @@ export async function GET(
     return new Response('Not Found', { status: 404 });
   }
 
-  const entries = await getLearnSitemapEntriesForChunk(chunkIndex);
+  const entries = await getLearnSitemapChunkEntries(chunkIndex);
   return createSitemapXmlResponse(entries);
 }

--- a/src/app/lib/campaign/cachedCampaignFetch.ts
+++ b/src/app/lib/campaign/cachedCampaignFetch.ts
@@ -1,0 +1,17 @@
+import { getCampaignBySlug } from '@/app/lib/getCampaignsBySlug';
+import { getCampaigns } from '@/app/lib/getCampaigns';
+import { cacheLife } from 'next/cache';
+
+const CAMPAIGN_PAGE_REVALIDATE_SECONDS = 300;
+
+export async function getCampaignsForPage() {
+  'use cache';
+  cacheLife({ revalidate: CAMPAIGN_PAGE_REVALIDATE_SECONDS });
+  return getCampaigns();
+}
+
+export async function getCampaignBySlugForPage(slug: string) {
+  'use cache';
+  cacheLife({ revalidate: CAMPAIGN_PAGE_REVALIDATE_SECONDS });
+  return getCampaignBySlug(slug);
+}

--- a/src/app/lib/getMiniAppSettings.ts
+++ b/src/app/lib/getMiniAppSettings.ts
@@ -1,6 +1,7 @@
 import { getStrapiBaseUrl } from 'src/utils/strapi/strapiHelper';
 import envConfig from '@/config/env-config';
 import type { StrapiResponse } from '@/types/strapi';
+import { cacheLife } from 'next/cache';
 
 const BASE_MINI_APP_SETTING_API_ENDPOINT = 'base-mini-app-settings';
 
@@ -17,6 +18,8 @@ export interface MiniAppSettingAttributes {
 }
 
 export async function getMiniAppSettings(): Promise<MiniAppSettingAttributes> {
+  'use cache';
+  cacheLife({ revalidate: 300 });
   const publicUrl = new URL(envConfig.NEXT_PUBLIC_SITE_URL);
 
   const baseUrl = getStrapiBaseUrl();
@@ -38,7 +41,15 @@ export async function getMiniAppSettings(): Promise<MiniAppSettingAttributes> {
 
   const data: StrapiResponse<MiniAppSettingAttributes> = await res.json();
   if (!data.data[0]) {
-    throw new Error(`No mini app settings found for ${publicUrl.origin}`);
+    return {
+      id: 0,
+      documentId: '',
+      appId: '',
+      url: publicUrl.origin,
+      accountAssociation: {},
+      createdAt: '',
+      updatedAt: '',
+    };
   }
   return data.data[0];
 }

--- a/src/app/lib/getPartnerThemes.ts
+++ b/src/app/lib/getPartnerThemes.ts
@@ -1,16 +1,20 @@
 import type { PartnerThemesData, StrapiResponse } from '@/types/strapi';
 import { PartnerThemeStrapiApi } from '@/utils/strapi/StrapiApi';
 import { fetchStrapi } from '@/app/lib/fetchStrapi';
+import { cacheLife, cacheTag } from 'next/cache';
 
 export async function getPartnerThemes(): Promise<
   StrapiResponse<PartnerThemesData>
 > {
+  'use cache';
+  cacheTag('partner-themes');
+  cacheLife({ revalidate: 300 });
   const urlParams = new PartnerThemeStrapiApi();
   const apiUrl = urlParams.getApiUrl();
 
   const res = await fetchStrapi(
     decodeURIComponent(apiUrl),
-    { next: { revalidate: 60 * 5, tags: ['partner-themes'] } },
+    {},
     'partner-themes',
   );
 

--- a/src/app/lib/getPerks.ts
+++ b/src/app/lib/getPerks.ts
@@ -24,9 +24,7 @@ export async function getPerks(
   const apiUrl = urlParams.getApiUrl();
 
   const res = await fetch(decodeURIComponent(apiUrl), {
-    next: {
-      revalidate: 60 * 5, // revalidate every 5 minutes
-    },
+    next: { revalidate: 300 },
   });
 
   if (!res.ok) {

--- a/src/app/lib/getPerksForPage.ts
+++ b/src/app/lib/getPerksForPage.ts
@@ -1,0 +1,27 @@
+import type { PaginationProps } from '@/utils/strapi/StrapiApi';
+import { cacheLife } from 'next/cache';
+import { getPerks } from '@/app/lib/getPerks';
+
+export async function getPerksForPage(
+  pagination: PaginationProps = {
+    page: 1,
+    pageSize: 10,
+    withCount: false,
+  },
+) {
+  'use cache';
+  cacheLife({ revalidate: 300 });
+  const { data: countResponse } = await getPerks({
+    page: 1,
+    pageSize: 1,
+    withCount: true,
+  });
+  const total = countResponse.meta.pagination.total;
+
+  const { data: perksResponse } = await getPerks({
+    page: 1,
+    pageSize: Math.max(total, 1),
+  });
+
+  return perksResponse.data;
+}

--- a/src/app/lib/getTranslationResources.ts
+++ b/src/app/lib/getTranslationResources.ts
@@ -1,0 +1,15 @@
+import initTranslations from '@/app/i18n';
+import type { Resource } from 'i18next';
+import { cacheLife } from 'next/cache';
+
+const TRANSLATION_RESOURCES_REVALIDATE_SECONDS = 300;
+
+export async function getTranslationResources(
+  locale: string,
+  namespaces: string[],
+): Promise<Resource> {
+  'use cache';
+  cacheLife({ revalidate: TRANSLATION_RESOURCES_REVALIDATE_SECONDS });
+  const { resources } = await initTranslations(locale, namespaces);
+  return resources;
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,4 +1,4 @@
-import initTranslations from '@/app/i18n';
+import { getTranslationResources } from '@/app/lib/getTranslationResources';
 import Background from '@/components/Background';
 import { NotFoundComponent } from '@/components/NotFound/NotFound';
 import config, { getPublicEnvVars } from '@/config/env-config';
@@ -17,7 +17,7 @@ import { getPartnerThemes } from './lib/getPartnerThemes';
 import { getThemeBootstrapInlineScript } from '@/providers/ThemeProvider/getThemeBootstrapInlineScript';
 
 export default async function NotFound() {
-  const { resources } = await initTranslations(fallbackLng, namespaces);
+  const resources = await getTranslationResources(fallbackLng, namespaces);
   const partnerThemes = await getPartnerThemes().catch(() => ({ data: [] }));
 
   return (

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -3,11 +3,11 @@ import { buildUrl } from '@/utils/sitemap';
 import { isProduction } from '@/utils/isProduction';
 import { getLearnSitemapChunkIds } from '@/utils/sitemaps/learn';
 import type { MetadataRoute } from 'next';
-
-export const dynamic = 'force-static';
-export const revalidate = 86400;
+import { cacheLife } from 'next/cache';
 
 export default async function robots(): Promise<MetadataRoute.Robots> {
+  'use cache';
+  cacheLife({ revalidate: 86400 });
   // Bridge uses a sitemap index; learn/swap remain listed directly until indexed similarly.
   const learnSitemaps = (await getLearnSitemapChunkIds()).map((id) =>
     buildUrl('learn', 'sitemap', `${id}.xml`),

--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -2,9 +2,6 @@ import { toSitemapDate } from '@/utils/sitemap';
 import { getRootSitemapEntries } from '@/utils/sitemaps/root';
 import { createSitemapXmlResponse } from '@/utils/sitemaps/xml';
 
-export const dynamic = 'force-static';
-export const revalidate = 86400;
-
 const lastModified = toSitemapDate(Date.now());
 
 export async function GET() {

--- a/src/app/swap/sitemap.xml/route.ts
+++ b/src/app/swap/sitemap.xml/route.ts
@@ -1,13 +1,16 @@
 import { toSitemapDate } from '@/utils/sitemap';
 import { getSwapSitemapEntries } from '@/utils/sitemaps/swap';
 import { createSitemapXmlResponse } from '@/utils/sitemaps/xml';
+import { cacheLife } from 'next/cache';
 
-export const dynamic = 'force-static';
-export const revalidate = 86400;
-
-const lastModified = toSitemapDate(Date.now());
+async function getSwapSitemapEntriesCached() {
+  'use cache';
+  cacheLife({ revalidate: 86400 });
+  const lastModified = toSitemapDate(Date.now());
+  return getSwapSitemapEntries(lastModified);
+}
 
 export async function GET() {
-  const entries = await getSwapSitemapEntries(lastModified);
+  const entries = await getSwapSitemapEntriesCached();
   return createSitemapXmlResponse(entries);
 }

--- a/src/app/ui/earn/EarnPageContent.tsx
+++ b/src/app/ui/earn/EarnPageContent.tsx
@@ -6,6 +6,7 @@ import { EarnPage } from '@/app/ui/earn/EarnPage';
 import { earnOpportunityBySlugQueryKey } from '@/app/lib/earn/earnQueries';
 import { earnRelatedMarketsQueryKey } from '@/app/lib/earn/earnQueries';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import { cacheLife } from 'next/cache';
 import { notFound } from 'next/navigation';
 import { makeQueryClient } from '@/app/lib/makeQueryClient';
 
@@ -14,6 +15,8 @@ interface EarnPageContentProps {
 }
 
 export const EarnPageContent = async ({ slug }: EarnPageContentProps) => {
+  'use cache';
+  cacheLife({ revalidate: 300 });
   const queryClient = makeQueryClient();
 
   const [opportunity] = await Promise.all([

--- a/src/app/ui/earn/EarnsPageContent.tsx
+++ b/src/app/ui/earn/EarnsPageContent.tsx
@@ -6,9 +6,12 @@ import { EarnsPage } from '@/app/ui/earn/EarnsPage';
 import { earnFilterOpportunitiesQueryKey } from '@/app/lib/earn/earnQueries';
 import { earnTopOpportunitiesQueryKey } from '@/app/lib/earn/earnQueries';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import { cacheLife } from 'next/cache';
 import { makeQueryClient } from '@/app/lib/makeQueryClient';
 
 export const EarnsPageContent = async () => {
+  'use cache';
+  cacheLife({ revalidate: 300 });
   const queryClient = makeQueryClient();
 
   await Promise.all([

--- a/src/app/ui/leaderboard/LeaderboardPageSkeleton.tsx
+++ b/src/app/ui/leaderboard/LeaderboardPageSkeleton.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Skeleton from '@mui/material/Skeleton';
+import { PageContainer } from '@/components/ProfilePage/ProfilePage.style';
+import { LEADERBOARD_LENGTH } from '@/components/Leaderboard/Leaderboard';
+import { LeaderboardEntrySkeleton } from '@/components/Leaderboard/LeaderboardEntrySkeleton';
+import {
+  LeaderboardContainer,
+  LeaderboardEntryDivider,
+  LeaderboardEntryStack,
+  LeaderboardHeader,
+  LeaderboardTitleBox,
+} from '@/components/Leaderboard/Leaderboard.style';
+
+export const LeaderboardPageSkeleton = () => {
+  return (
+    <PageContainer>
+      <LeaderboardContainer>
+        <LeaderboardHeader>
+          <LeaderboardTitleBox>
+            <Skeleton
+              variant="rounded"
+              width={200}
+              height={32}
+              sx={(theme) => ({ borderRadius: theme.shape.radius8 })}
+            />
+          </LeaderboardTitleBox>
+        </LeaderboardHeader>
+        <LeaderboardEntrySkeleton isUserPosition />
+        <LeaderboardEntryStack direction="column">
+          {Array.from({ length: LEADERBOARD_LENGTH }).map((_, index) => (
+            <Box key={`leaderboard-skeleton-entry-${index}`}>
+              <LeaderboardEntrySkeleton />
+              {index !== LEADERBOARD_LENGTH - 1 && <LeaderboardEntryDivider />}
+            </Box>
+          ))}
+        </LeaderboardEntryStack>
+      </LeaderboardContainer>
+    </PageContainer>
+  );
+};

--- a/src/app/ui/mission/MissionPageContent.tsx
+++ b/src/app/ui/mission/MissionPageContent.tsx
@@ -2,6 +2,7 @@ import { fetchQuestBySlugForPage } from '@/app/lib/missions/cachedMissionsFetch'
 import { MissionPage } from '@/app/ui/mission/MissionPage';
 import { questBySlugQueryKey } from '@/app/lib/missions/missionQueries';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import { cacheLife } from 'next/cache';
 import { notFound } from 'next/navigation';
 import { makeQueryClient } from '@/app/lib/makeQueryClient';
 
@@ -10,6 +11,8 @@ interface MissionPageContentProps {
 }
 
 export const MissionPageContent = async ({ slug }: MissionPageContentProps) => {
+  'use cache';
+  cacheLife({ revalidate: 300 });
   const queryClient = makeQueryClient();
 
   const quest = await queryClient

--- a/src/app/ui/scan/ScanPageSkeleton.tsx
+++ b/src/app/ui/scan/ScanPageSkeleton.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Skeleton from '@mui/material/Skeleton';
+
+export const ScanPageSkeleton = () => {
+  return (
+    <Box
+      sx={{
+        p: 4,
+        paddingBottom: {
+          xs: 12,
+          md: 8,
+        },
+      }}
+    >
+      <Skeleton
+        variant="rounded"
+        sx={{
+          width: '100%',
+          minHeight: 600,
+          borderRadius: 3,
+        }}
+      />
+    </Box>
+  );
+};

--- a/src/app/ui/shared/WidgetPageSkeleton.tsx
+++ b/src/app/ui/shared/WidgetPageSkeleton.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import Container from '@mui/material/Container';
+import Skeleton from '@mui/material/Skeleton';
+import Stack from '@mui/material/Stack';
+import { WidgetSkeleton } from '@/components/Widgets/variants/base/WidgetSkeleton';
+
+interface WidgetPageSkeletonProps {
+  showTitle?: boolean;
+}
+
+export const WidgetPageSkeleton = ({
+  showTitle = true,
+}: WidgetPageSkeletonProps) => {
+  return (
+    <Container>
+      <Stack
+        direction="column"
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        {showTitle && (
+          <Skeleton
+            variant="rounded"
+            sx={{
+              width: { xs: '100%', sm: 600 },
+              maxWidth: '100%',
+              height: 48,
+              my: 2,
+              borderRadius: 2,
+            }}
+          />
+        )}
+        <WidgetSkeleton />
+      </Stack>
+    </Container>
+  );
+};

--- a/src/app/ui/zap/ZapPageSkeleton.tsx
+++ b/src/app/ui/zap/ZapPageSkeleton.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { TwoColumnLayout } from '@/components/TwoColumnLayout/TwoColumnLayout';
+import { MissionDetailsSkeleton } from '@/app/ui/mission/MissionDetailsSkeleton';
+import { WidgetSkeleton } from '@/components/Widgets/variants/base/WidgetSkeleton';
+
+export const ZapPageSkeleton = () => {
+  return (
+    <TwoColumnLayout
+      mainContent={<MissionDetailsSkeleton />}
+      sideContent={<WidgetSkeleton />}
+      shouldStretchSideContent
+    />
+  );
+};

--- a/src/components/Campaign/CampaignPage.tsx
+++ b/src/components/Campaign/CampaignPage.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { getCampaignBySlug } from 'src/app/lib/getCampaignsBySlug';
+import { getCampaignBySlugForPage } from '@/app/lib/campaign/cachedCampaignFetch';
 import { CampaignPageContent } from './CampaignPageContent';
 
 interface CampaignPageProps {
@@ -7,7 +7,7 @@ interface CampaignPageProps {
 }
 
 export async function CampaignPage({ slug }: CampaignPageProps) {
-  const campaign = await getCampaignBySlug(slug);
+  const campaign = await getCampaignBySlugForPage(slug);
 
   if (!campaign || !campaign.data || campaign.data.length === 0) {
     notFound();

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -8,9 +8,9 @@ export const useSession = (): string => {
       typeof window !== 'undefined' &&
       typeof sessionStorage !== 'undefined'
     ) {
-      return sessionStorage.getItem('session_id') || uuidv7();
+      return sessionStorage.getItem('session_id') ?? '';
     }
-    return uuidv7();
+    return '';
   });
 
   useEffect(() => {
@@ -18,8 +18,12 @@ export const useSession = (): string => {
       typeof window !== 'undefined' &&
       typeof sessionStorage !== 'undefined'
     ) {
-      sessionStorage.setItem('session_id', session);
-      setSession(session);
+      const sessionId =
+        session || sessionStorage.getItem('session_id') || uuidv7();
+      sessionStorage.setItem('session_id', sessionId);
+      if (sessionId !== session) {
+        setSession(sessionId);
+      }
     }
   }, [session]);
 

--- a/src/providers/ExtensionDetectionProvider/ExtensionDetectionProvider.tsx
+++ b/src/providers/ExtensionDetectionProvider/ExtensionDetectionProvider.tsx
@@ -16,8 +16,10 @@ extensionDetectionStore
   .getState()
   .initRegistry(extensionDetectionInitialDefinitions);
 
-for (const def of extensionDetectionInitialDefinitions) {
-  void extensionDetectionStore.getState().runCheck(def.name);
+if (typeof window !== 'undefined') {
+  for (const def of extensionDetectionInitialDefinitions) {
+    void extensionDetectionStore.getState().runCheck(def.name);
+  }
 }
 
 export interface ExtensionDetectionProviderProps {

--- a/src/utils/image-generation/helpers.ts
+++ b/src/utils/image-generation/helpers.ts
@@ -1,5 +1,14 @@
-import { Appearance } from '@lifi/widget';
-import { ImageTheme } from 'src/components/ImageGeneration/ImageGeneration.types';
+import type { Appearance } from '@lifi/widget';
+import type { ImageTheme } from 'src/components/ImageGeneration/ImageGeneration.types';
+
+export function isNextInternalError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'digest' in error &&
+    typeof (error as { digest?: string }).digest === 'string' &&
+    (error as { digest: string }).digest.startsWith('NEXT_')
+  );
+}
 
 export const getOffset = (type?: string, extendedHeight?: boolean) => {
   if (type === 'amount') {


### PR DESCRIPTION
## Summary

**Part 2 of 2** — builds on [#2967](https://github.com/jumperexchange/jumper-exchange/pull/2967).

#2967 migrates the cached fetch helpers to `'use cache'` and enables `experimental.useCache`. This PR enables the stable `cacheComponents` flag and updates the rest of the app so production builds pass with Partial Prerendering.

**Base:** `fix/use-cache-directive` → merge this before #2967 goes upstream.

## What changed

### Config
- `next.config.mjs`: `cacheComponents: true`; remove `experimental.useCache`

### Lib & data fetching
- `'use cache'` on `getPartnerThemes`, `getMerklRewards`, `getMiniAppSettings`, sitemap/robots helpers
- New cached wrappers: `getTranslationResources`, `getPerksForPage`, `cachedCampaignFetch`
- Sitemap route handlers: cache plain data inside `'use cache'` helpers; return `Response` outside the cache

### Pages & layouts
- Remove incompatible segment configs (`revalidate`, `dynamic`, `fetchCache`, …)
- Suspense loaders for dynamic params (`params`, `searchParams`)
- Root layout: cached i18n, `PortfolioProvider` + `children` wrapped in Suspense

### Prerender / SSR fixes
- `getMiniAppSettings`: return defaults instead of throwing when Strapi has no record
- `'use cache'` on React Query prefetch components (`EarnsPageContent`, `EarnPageContent`, `MissionPageContent`)
- `useSession`: defer UUID creation to `useEffect`
- `ExtensionDetectionProvider`: skip browser-only checks during SSR

### Loading UX
- Route `loading.tsx` files and Suspense fallbacks with proper skeletons (bridge, swap, zap, scan, leaderboard, profile, earn, missions, campaign)
- New skeletons: `LeaderboardPageSkeleton`, `WidgetPageSkeleton`, `ZapPageSkeleton`, `ScanPageSkeleton`

### Caching behaviour

| Data | Revalidate |
|------|------------|
| CMS / API pages (earn, missions, perks, campaigns, themes) | 300s |
| i18n resources (`getTranslationResources`) | 300s |
| Sitemaps, robots, chain lists | 86400s |
| CDN `expireTime` in `next.config.mjs` | 900s (15 min) |

## Test plan

- [x] `pnpm build` passes locally (1654 static pages)
- [ ] `/earn`, `/missions`, `/campaign/[slug]`, `/profile`, `/leaderboard` — skeleton → content transition
- [ ] `/bridge/[segments]`, `/swap/[segments]`, `/zap/[slug]`, `/scan` — loading skeletons while streaming
- [ ] `/robots.txt`, `/sitemap.xml`, `/bridge/sitemap.xml`, `/swap/sitemap.xml` — valid XML
- [ ] `revalidateTag('quest:slug:X')` still invalidates mission pages
- [ ] Translation copy updates within ~5 minutes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading states across several pages, so users now see skeleton screens while content loads.
  * Improved page responsiveness with smoother transitions on leaderboard, profile, campaign, missions, earn, swap, scan, bridge, and zap routes.

* **Bug Fixes**
  * Made error handling more reliable in several image and API responses.
  * Improved fallback behavior for settings and preview pages.

* **Refactor**
  * Updated caching and rendering behavior across the app for better performance and more consistent page updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->