### PR TITLE
fix: remove Phantom from Bitcoin wallet priority

### DIFF
--- a/src/providers/WalletProvider/constants.ts
+++ b/src/providers/WalletProvider/constants.ts
@@ -5,7 +5,7 @@ import uniq from 'lodash/uniq';
 // Define priority order for each wallet - these options are fixed at the start of the list
 const walletPriorities: Record<string, ChainType[]> = {
   MetaMask: [ChainType.EVM, ChainType.UTXO, ChainType.SVM, ChainType.TVM],
-  Phantom: [ChainType.SVM, ChainType.EVM, ChainType.UTXO],
+  Phantom: [ChainType.SVM, ChainType.EVM],
 } as const;
 
 const allChainTypes = Object.values(ChainType);


### PR DESCRIPTION
Phantom deprecated its Bitcoin wallet, so it no longer connects for Bitcoin.

Drops `ChainType.UTXO` from Phantom's entry in `walletEcosystemsOrder` priorities, keeping Phantom prioritized for Solana/EVM. The actual Bitcoin connector removal lands upstream in the LI.FI Widget (lifinance/widget#804); Jumper picks it up on the next `@lifi/widget` bump.

Refs [EMB-454](https://linear.app/lifi-linear/issue/EMB-454).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated wallet ordering so Phantom no longer prioritizes UTXO ahead of other chain types.
  * Wallet ecosystem ordering now reflects the expected priority sequence more consistently while still including all supported chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->