### PR TITLE
feat: default to underlying token when opening Earn withdraw - JUM-1106

### DIFF
--- a/src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget.tsx
+++ b/src/components/Widgets/variants/base/ZapWidget/ZapWithdrawWidget.tsx
@@ -51,6 +51,17 @@ export const ZapWithdrawWidget: FC<ZapWithdrawWidgetProps> = ({
     };
   }, [zapData?.market?.address, zapData?.market?.lpToken.symbol]);
 
+  const toToken = useMemo(() => {
+    const depositToken = zapData?.market?.depositToken;
+    if (!depositToken?.address) {
+      return undefined;
+    }
+    return {
+      tokenAddress: depositToken.address,
+      tokenSymbol: depositToken.symbol ?? '',
+    };
+  }, [zapData?.market?.depositToken]);
+
   const fromChain = useMemo(() => {
     if (!projectData?.chainId) {
       return undefined;
@@ -84,9 +95,10 @@ export const ZapWithdrawWidget: FC<ZapWithdrawWidgetProps> = ({
         sourceToken: fromToken,
         sourceChain: fromChain,
         destinationChain: toChain,
+        destinationToken: toToken,
       },
     };
-  }, [ctx, fromToken, fromChain, toChain]);
+  }, [ctx, fromToken, fromChain, toChain, toToken]);
 
   const widgetEvents = useWidgetEvents();
   // Custom effect to refetch the balance


### PR DESCRIPTION
## Summary

When a user clicks Withdraw on an Earn position, the destination token picker was left blank, requiring the user to manually select the underlying asset. This change pre-selects the position's underlying token as the default output token when the Withdraw modal opens.

## Changes

- Added a `toToken` memo in `ZapWithdrawWidget` derived from `zapData.market.depositToken` (which maps from `earnOpportunity.asset`)
- Wired `destinationToken: toToken` into the widget's `formData`, flowing through `useSharedFormConfig` → `config.toToken`
- The destination picker remains fully editable — no `disabledUI`/`hiddenUI` added

## Linked Linear ticket

JUM-1106

## Sister PRs

N/A

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token selection in the withdrawal widget so the destination token updates correctly when the selected market changes.
  * Ensured the widget refreshes its displayed withdrawal context when the target token changes, reducing stale or inconsistent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->