### PR TITLE
fix: align perk counters

### DIFF
--- a/src/app/[lng]/(infos)/perks/page.tsx
+++ b/src/app/[lng]/(infos)/perks/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
-import { getPerks } from 'src/app/lib/getPerks';
-import { PerksPage } from 'src/components/PerksPage/PerksPage';
-import { PerksPageSkeleton } from 'src/components/PerksPage/PerksPageSkeleton';
+import { getAllPerks } from '@/app/lib/getPerks';
+import { PerksPage } from '@/components/PerksPage/PerksPage';
+import { PerksPageSkeleton } from '@/components/PerksPage/PerksPageSkeleton';
 import { AppPaths, getSiteUrl } from '@/const/urls';
 
 export const metadata: Metadata = {
@@ -15,23 +15,11 @@ export const metadata: Metadata = {
 };
 
 export default async function Page() {
-  // Fetch the total count first, then request every perk in a single follow-up
-  // call so the hub never silently caps as more perks are added.
-  const { data: countResponse } = await getPerks({
-    page: 1,
-    pageSize: 1,
-    withCount: true,
-  });
-  const total = countResponse.meta.pagination.total;
-
-  const { data: perksResponse } = await getPerks({
-    page: 1,
-    pageSize: Math.max(total, 1),
-  });
+  const perks = await getAllPerks();
 
   return (
     <Suspense fallback={<PerksPageSkeleton />}>
-      <PerksPage perks={perksResponse.data} />
+      <PerksPage perks={perks} />
     </Suspense>
   );
 }

--- a/src/app/[lng]/(infos)/profile/[walletAddress]/page.tsx
+++ b/src/app/[lng]/(infos)/profile/[walletAddress]/page.tsx
@@ -3,10 +3,9 @@ import { walletAddressSchema } from '@/utils/validation-schemas';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
-import { getPerks } from 'src/app/lib/getPerks';
-import { ProfilePage } from 'src/components/ProfilePage/ProfilePage';
-import { ProfilePageSkeleton } from 'src/components/ProfilePage/ProfilePageSkeleton';
-import { PAGE_SIZE } from 'src/const/perks';
+import { getAllPerks } from '@/app/lib/getPerks';
+import { ProfilePage } from '@/components/ProfilePage/ProfilePage';
+import { ProfilePageSkeleton } from '@/components/ProfilePage/ProfilePageSkeleton';
 
 type Params = Promise<{ walletAddress: string }>;
 
@@ -63,13 +62,7 @@ export default async function Page({ params }: { params: Params }) {
   }
 
   const sanitizedAddress = result.data;
-  const { data: perksResponse } = await getPerks({
-    page: 1,
-    pageSize: PAGE_SIZE,
-    withCount: true,
-  });
-
-  const perks = perksResponse.data;
+  const perks = await getAllPerks();
 
   return (
     <Suspense fallback={<ProfilePageSkeleton />}>

--- a/src/app/[lng]/(infos)/profile/page.tsx
+++ b/src/app/[lng]/(infos)/profile/page.tsx
@@ -6,10 +6,9 @@ import {
 import { AppPaths, getSiteUrl } from '@/const/urls';
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
-import { getPerks } from 'src/app/lib/getPerks';
-import { ProfilePage } from 'src/components/ProfilePage/ProfilePage';
-import { ProfilePageSkeleton } from 'src/components/ProfilePage/ProfilePageSkeleton';
-import { PAGE_SIZE } from 'src/const/perks';
+import { getAllPerks } from '@/app/lib/getPerks';
+import { ProfilePage } from '@/components/ProfilePage/ProfilePage';
+import { ProfilePageSkeleton } from '@/components/ProfilePage/ProfilePageSkeleton';
 
 export const metadata: Metadata = {
   title: pageMetadataFields.profile.title,
@@ -27,13 +26,7 @@ export const metadata: Metadata = {
 };
 
 export default async function Page() {
-  const { data: perksResponse } = await getPerks({
-    page: 1,
-    pageSize: PAGE_SIZE,
-    withCount: true,
-  });
-
-  const perks = perksResponse.data;
+  const perks = await getAllPerks();
 
   return (
     <Suspense fallback={<ProfilePageSkeleton />}>

--- a/src/app/lib/getPerks.ts
+++ b/src/app/lib/getPerks.ts
@@ -37,3 +37,24 @@ export async function getPerks(
 
   return { data };
 }
+
+/**
+ * Fetch every perk: read the total count, then request them all in one follow-up
+ * call. Used wherever a complete perk list is required (profile page, perks hub,
+ * navbar) so unlocked-perk counts never silently cap as more perks are added.
+ */
+export async function getAllPerks(): Promise<PerksDataAttributes[]> {
+  const { data: countResponse } = await getPerks({
+    page: 1,
+    pageSize: 1,
+    withCount: true,
+  });
+  const total = countResponse.meta.pagination.total;
+
+  const { data: perksResponse } = await getPerks({
+    page: 1,
+    pageSize: Math.max(total, 1),
+  });
+
+  return perksResponse.data;
+}

--- a/src/components/ProfilePage/sections/UnlockedPerksSection/UnlockedPerksSection.tsx
+++ b/src/components/ProfilePage/sections/UnlockedPerksSection/UnlockedPerksSection.tsx
@@ -25,6 +25,7 @@ import {
   openHubButtonSx,
   unlockedPerksCardSx,
 } from './UnlockedPerksSection.styles';
+import { sortBy } from 'lodash';
 
 interface UnlockedPerksSectionProps {
   perks: PerksDataAttributes[];
@@ -50,12 +51,9 @@ export const UnlockedPerksSection = ({ perks }: UnlockedPerksSectionProps) => {
 
   // Show every unlocked perk so the count here matches the Jumper Pass stat.
   // Still-claimable perks come first; already-claimed ones follow, rendered
-  // dimmed with a "Claimed" badge (same card as the Perks Hub). Array.sort is
-  // stable, so the incoming order is preserved within each group.
-  const orderedPerks = [...unlockedPerks].sort(
-    (a, b) =>
-      Number(isClaimedPerk(a, claimedIds)) -
-      Number(isClaimedPerk(b, claimedIds)),
+  // dimmed with a "Claimed" badge (same card as the Perks Hub).
+  const orderedPerks = sortBy(unlockedPerks, (perk) =>
+    Number(isClaimedPerk(perk, claimedIds)),
   );
 
   const isEmpty = unlockedPerks.length === 0;

--- a/src/components/ProfilePage/sections/UnlockedPerksSection/UnlockedPerksSection.tsx
+++ b/src/components/ProfilePage/sections/UnlockedPerksSection/UnlockedPerksSection.tsx
@@ -46,14 +46,19 @@ export const UnlockedPerksSection = ({ perks }: UnlockedPerksSectionProps) => {
     return null;
   }
 
-  // This section is for perks that can still be claimed, so drop any the wallet
-  // has already claimed (those live in the Perks Hub's Claimed tab).
   const claimedIds = new Set((claimedPerks ?? []).map((claim) => claim.perkId));
-  const claimablePerks = unlockedPerks.filter(
-    (perk) => !isClaimedPerk(perk, claimedIds),
+
+  // Show every unlocked perk so the count here matches the Jumper Pass stat.
+  // Still-claimable perks come first; already-claimed ones follow, rendered
+  // dimmed with a "Claimed" badge (same card as the Perks Hub). Array.sort is
+  // stable, so the incoming order is preserved within each group.
+  const orderedPerks = [...unlockedPerks].sort(
+    (a, b) =>
+      Number(isClaimedPerk(a, claimedIds)) -
+      Number(isClaimedPerk(b, claimedIds)),
   );
 
-  const isEmpty = claimablePerks.length === 0;
+  const isEmpty = unlockedPerks.length === 0;
 
   return (
     <PerkClaimModalProvider>
@@ -75,7 +80,7 @@ export const UnlockedPerksSection = ({ perks }: UnlockedPerksSectionProps) => {
               <InfoDivider />
               <Typography variant="bodySmallParagraph" color="textSecondary">
                 {t('profile_page.unlockedPerks.count', {
-                  count: claimablePerks.length,
+                  count: unlockedPerks.length,
                 })}
               </Typography>
             </InfoBottom>
@@ -86,8 +91,14 @@ export const UnlockedPerksSection = ({ perks }: UnlockedPerksSectionProps) => {
           <UnlockedPerksEmpty />
         ) : (
           <SectionCarousel>
-            {claimablePerks.map((perk) => (
-              <PerkCard key={perk.id} perk={perk} status="unlocked" />
+            {orderedPerks.map((perk) => (
+              <PerkCard
+                key={perk.id}
+                perk={perk}
+                status={
+                  isClaimedPerk(perk, claimedIds) ? 'claimed' : 'unlocked'
+                }
+              />
             ))}
           </SectionCarousel>
         )}

--- a/src/const/perks.ts
+++ b/src/const/perks.ts
@@ -1,1 +1,0 @@
-export const PAGE_SIZE = 10;

--- a/src/hooks/perks/usePerks.ts
+++ b/src/hooks/perks/usePerks.ts
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getPerks } from 'src/app/lib/getPerks';
-import { PAGE_SIZE } from 'src/const/perks';
+import { getAllPerks } from '@/app/lib/getPerks';
 
 /**
  * Client-side fetch of the perks list — the same query the profile page runs
@@ -10,14 +9,7 @@ import { PAGE_SIZE } from 'src/const/perks';
 export const usePerks = () => {
   const { data, isLoading } = useQuery({
     queryKey: ['perks'],
-    queryFn: async () => {
-      const { data } = await getPerks({
-        page: 1,
-        pageSize: PAGE_SIZE,
-        withCount: true,
-      });
-      return data.data;
-    },
+    queryFn: () => getAllPerks(),
     // Matches the server-side revalidate window of getPerks.
     staleTime: 1000 * 60 * 5,
   });


### PR DESCRIPTION
## JUM-1207: Fix inconsistent "unlocked perks" count on the Jumper Pass page

### Problem
The Jumper Pass page reported different "unlocked perks" numbers in two places, and the number itself could be too low.

Two independent causes:
1. The top stats chip counted all unlocked perks, while the Unlocked Perks section counted only *still-claimable* ones (unlocked minus already-claimed), so the two disagreed (e.g. header 10, section 8).
2. The profile page and navbar fetched perks with `pageSize: 10`, sorted `Featured desc, UnlockLevel asc`. The unlocked count was computed over only those 10 perks, so it silently capped and undercounted (e.g. a wallet with >10 unlocked perks showing 6). This is unrelated to the loyalty level, which is correct.

### Fix
Reconcile every counter to "all unlocked perks", and stop capping the fetch.

- Unlocked Perks section now counts all unlocked perks (`unlockedPerks.length`), matching the stats chip and the navbar which already counted all unlocked.
- The section carousel now shows every unlocked perk: still-claimable ones first, then already-claimed ones rendered dimmed with a "Claimed" badge (the same card the Perks Hub already uses). Ordering uses a stable sort so incoming order is preserved within each group.
- Added `getAllPerks` (fetch the total count, then request them all) and routed the profile pages, the navbar's `usePerks`, and the Perks Hub through it, replacing the `pageSize: 10` fetch. Removed the now-unused `PAGE_SIZE` constant.

### Result
- Header 10 vs section 8: both now report all unlocked perks and agree.
- Header 6 vs actual >10: the fetch no longer caps at 10, so the count reflects the full catalog. The wallet's level was already correct.

### Testing
- `pnpm typecheck` and eslint pass.
- Exact catalog counts could not be verified from the dev sandbox (no network access to Strapi); worth a quick manual check on `develop` after deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Perks now load the full available list on the perks and profile pages (and the perks hook), improving consistency across the app.
* **Bug Fixes**
  * Unlocked perks now render all unlocked items with a stable order that shows unclaimed perks before already claimed ones.
  * Empty states and displayed counts now reflect the total number of unlocked perks.
* **Refactor**
  * Standardized perks retrieval around a shared “all perks” fetch flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->