### PR TITLE
feat: add level to pass button

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -5,6 +5,8 @@ import { NO_PARTNER_THEME_UID } from './partnerThemeConstants.ts';
 import { withProviders } from './withProviders';
 
 sb.mock(import('@lifi/wallet-management'), { spy: true });
+sb.mock(import('../src/hooks/useLoyaltyPass.ts'), { spy: true });
+sb.mock(import('../src/hooks/perks/usePerks.ts'), { spy: true });
 
 sb.mock(import('../src/hooks/useFeatureFlags.ts'));
 

--- a/src/components/Navbar/components/Buttons/PassButton.stories.tsx
+++ b/src/components/Navbar/components/Buttons/PassButton.stories.tsx
@@ -1,14 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { mocked, sb } from 'storybook/test';
+import { mocked } from 'storybook/test';
 import { ChainType } from '@lifi/sdk';
 import type { Account } from '@lifi/widget-provider';
 import { useAccount } from '@lifi/wallet-management';
 import { useLoyaltyPass } from '@/hooks/useLoyaltyPass';
-import { usePerks } from 'src/hooks/perks/usePerks';
+import { usePerks } from '@/hooks/perks/usePerks';
 import { PassButton } from './PassButton';
-
-sb.mock(import('@/hooks/useLoyaltyPass'), { spy: true });
-sb.mock(import('src/hooks/perks/usePerks'), { spy: true });
 
 const mockAccount: Account = {
   address: '0x1234567890123456789012345678901234567890',

--- a/src/components/Navbar/components/Buttons/PassButton.stories.tsx
+++ b/src/components/Navbar/components/Buttons/PassButton.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { mocked, sb } from 'storybook/test';
+import { ChainType } from '@lifi/sdk';
+import type { Account } from '@lifi/widget-provider';
+import { useAccount } from '@lifi/wallet-management';
+import { useLoyaltyPass } from '@/hooks/useLoyaltyPass';
+import { usePerks } from 'src/hooks/perks/usePerks';
+import { PassButton } from './PassButton';
+
+sb.mock(import('@/hooks/useLoyaltyPass'), { spy: true });
+sb.mock(import('src/hooks/perks/usePerks'), { spy: true });
+
+const mockAccount: Account = {
+  address: '0x1234567890123456789012345678901234567890',
+  chainId: 1,
+  chainType: ChainType.EVM,
+  isConnected: true,
+  isConnecting: false,
+  isDisconnected: false,
+  isReconnecting: false,
+  status: 'connected' as const,
+};
+
+const meta = {
+  title: 'components/Navbar/components/Buttons/PassButton',
+  component: PassButton,
+  beforeEach: async () => {
+    mocked(useAccount).mockReturnValue({
+      account: mockAccount,
+      accounts: [mockAccount],
+    });
+    mocked(usePerks).mockReturnValue({ perks: [], isLoading: false });
+  },
+} satisfies Meta<typeof PassButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// No points yet — label falls back to plain "Pass".
+export const WithoutLevel: Story = {
+  beforeEach: async () => {
+    mocked(useLoyaltyPass).mockReturnValue({
+      isSuccess: true,
+      isLoading: false,
+      points: undefined,
+    });
+  },
+};
+
+// Enough points to reach level 12 — label shows "Pass - lvl 12".
+export const WithLevel: Story = {
+  beforeEach: async () => {
+    mocked(useLoyaltyPass).mockReturnValue({
+      isSuccess: true,
+      isLoading: false,
+      points: 900,
+    });
+  },
+};

--- a/src/components/Navbar/components/Buttons/PassButton.tsx
+++ b/src/components/Navbar/components/Buttons/PassButton.tsx
@@ -14,7 +14,7 @@ export const PassButton = () => {
   const { t } = useTranslation();
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'));
   const pathname = usePathnameWithoutLocale();
-  const { progress, unlockedPerksCount, points, isLoading } =
+  const { progress, unlockedPerksCount, points, level, isLoading } =
     usePassDisplayData();
 
   return (
@@ -31,7 +31,7 @@ export const PassButton = () => {
           </PassProgressChip>
         </Tooltip>
       }
-      label={t('navbar.pass')}
+      label={level ? t('navbar.passWithLevel', { level }) : t('navbar.pass')}
       caption={t('navbar.perksUnlocked', { count: unlockedPerksCount })}
       href={AppPaths.Profile}
       id="wallet-digest-button-xp"

--- a/src/components/Navbar/hooks.ts
+++ b/src/components/Navbar/hooks.ts
@@ -40,6 +40,7 @@ export const usePassDisplayData = () => {
     progress: getLevelProgress(points, levelData),
     unlockedPerksCount: unlockedPerks.length,
     points,
+    level: levelData.level,
     isLoading: isLoading || arePerksLoading,
   };
 };

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -651,6 +651,7 @@ export default interface Resources {
         theme: 'Theme';
       };
       pass: 'Pass';
+      passWithLevel: 'Pass - lvl {{level, number}}';
       passXp: '{{xp}} XP';
       perksUnlocked_one: '{{count}} Perk unlocked';
       perksUnlocked_other: '{{count}} Perks unlocked';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -32,6 +32,7 @@
       }
     },
     "pass": "Pass",
+    "passWithLevel": "Pass - lvl {{level, number}}",
     "passXp": "{{xp}} XP",
     "perksUnlocked_one": "{{count}} Perk unlocked",
     "perksUnlocked_other": "{{count}} Perks unlocked",


### PR DESCRIPTION
## Show user level next to "Pass" label

Adds the user's current Jumper Pass level inline with the "Pass" label in the navbar, e.g. "Pass - lvl 12", per [JUM-1209](https://linear.app/lifi-linear/issue/JUM-1209/show-user-level-next-to-pass-label-pass-lvl-x).

### Changes

- `usePassDisplayData` now also returns the computed `level` alongside `progress`, `unlockedPerksCount`, and `points`.
- `PassButton` renders `Pass - lvl {level}` when a level is available, falling back to plain `Pass` (e.g. no points yet).
- Added `navbar.passWithLevel` translation key and regenerated typed i18n resources.
- Added `PassButton.stories.tsx` mocking `useAccount`, `useLoyaltyPass`, and `usePerks` to cover both the with-level and without-level states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the navigation pass button to show a level-aware label (e.g., “Pass - lvl …”) when level data is available; otherwise it shows “Pass”.
* **Documentation**
  * Added Storybook coverage for both the default pass state and the level-based variant.
  * Added a new localized string for the “Pass - lvl …” label.
* **Tests / Chores**
  * Improved Storybook hook mocks to support the new pass button scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->