### PR TITLE
fix: remove type assertion from language imports

### DIFF
--- a/src/i18n/translations/index.ts
+++ b/src/i18n/translations/index.ts
@@ -78,19 +78,19 @@
 //   language: zhLanguage,
 // };
 
-import bn from './bn/language.json' with { type: 'json' };
-import en from './en/language.json' with { type: 'json' };
-import es from './es/language.json' with { type: 'json' };
-import fr from './fr/language.json' with { type: 'json' };
-import id from './id/language.json' with { type: 'json' };
-import it from './it/language.json' with { type: 'json' };
-import ja from './ja/language.json' with { type: 'json' };
-import ko from './ko/language.json' with { type: 'json' };
-import pt from './pt/language.json' with { type: 'json' };
-import th from './th/language.json' with { type: 'json' };
-import tr from './tr/language.json' with { type: 'json' };
-import uk from './uk/language.json' with { type: 'json' };
-import vi from './vi/language.json' with { type: 'json' };
-import zh from './zh/language.json' with { type: 'json' };
+import bn from './bn/language.json';
+import en from './en/language.json';
+import es from './es/language.json';
+import fr from './fr/language.json';
+import id from './id/language.json';
+import it from './it/language.json';
+import ja from './ja/language.json';
+import ko from './ko/language.json';
+import pt from './pt/language.json';
+import th from './th/language.json';
+import tr from './tr/language.json';
+import uk from './uk/language.json';
+import vi from './vi/language.json';
+import zh from './zh/language.json';
 
 export { bn, en, es, fr, id, it, ja, ko, pt, th, tr, uk, vi, zh };


### PR DESCRIPTION
## Summary

Storybook failed to load with `SyntaxError: Unexpected identifier 'assert'`, thrown at `src/i18n/translations/index.ts`.

The language JSON imports used `import ... with { type: 'json' }` import attributes. Vite's dev server rewrites `with` to the legacy `assert` syntax when serving the module to the browser, but current Chrome only supports `with` — so the browser's own parser failed on the served file.

The import attribute isn't needed here: Vite, webpack, and Next.js's JSON loader all resolve plain `.json` imports natively. Removed the attribute clause from all fourteen language imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s translation loading to work with JSON language files more broadly.
  * No user-facing language options or translations were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->