### PR TITLE
feat: use ExtraWideImage for Profile page mission cards - JUM-1208

### DIFF
--- a/src/app/ui/missions/MissionCard.tsx
+++ b/src/app/ui/missions/MissionCard.tsx
@@ -21,7 +21,9 @@ interface MissionCardProps {
 }
 
 export const MissionCard: FC<MissionCardProps> = ({ mission }) => {
-  const missionDisplayData = useFormatDisplayQuestData(mission, false);
+  const missionDisplayData = useFormatDisplayQuestData(mission, {
+    useBannerImage: false,
+  });
   const { status, isDisabled } = useMissionTimeStatus(
     mission.StartDate,
     mission.EndDate,

--- a/src/components/Campaign/MissionsSection/MissionCard.tsx
+++ b/src/components/Campaign/MissionsSection/MissionCard.tsx
@@ -21,7 +21,9 @@ interface MissionCardProps {
 }
 
 export const MissionCard: FC<MissionCardProps> = ({ mission }) => {
-  const missionDisplayData = useFormatDisplayQuestData(mission, false);
+  const missionDisplayData = useFormatDisplayQuestData(mission, {
+    useBannerImage: false,
+  });
   const { status, isDisabled } = useMissionTimeStatus(
     mission.StartDate,
     mission.EndDate,

--- a/src/components/ProfilePage/sections/EarnXpSection/MissionXpCard.tsx
+++ b/src/components/ProfilePage/sections/EarnXpSection/MissionXpCard.tsx
@@ -25,7 +25,10 @@ interface MissionXpCardProps {
 
 export const MissionXpCard: FC<MissionXpCardProps> = ({ mission }) => {
   const { t } = useTranslation();
-  const missionDisplayData = useFormatDisplayQuestData(mission, false, true);
+  const missionDisplayData = useFormatDisplayQuestData(mission, {
+    useBannerImage: false,
+    preferExtraWideImage: true,
+  });
   const { isDisabled } = useMissionTimeStatus(
     mission.StartDate,
     mission.EndDate,

--- a/src/components/ProfilePage/sections/EarnXpSection/MissionXpCard.tsx
+++ b/src/components/ProfilePage/sections/EarnXpSection/MissionXpCard.tsx
@@ -25,7 +25,7 @@ interface MissionXpCardProps {
 
 export const MissionXpCard: FC<MissionXpCardProps> = ({ mission }) => {
   const { t } = useTranslation();
-  const missionDisplayData = useFormatDisplayQuestData(mission, false);
+  const missionDisplayData = useFormatDisplayQuestData(mission, false, true);
   const { isDisabled } = useMissionTimeStatus(
     mission.StartDate,
     mission.EndDate,

--- a/src/components/Zap/ZapDetails.tsx
+++ b/src/components/Zap/ZapDetails.tsx
@@ -44,7 +44,12 @@ export const ZapDetails: FC<ZapDetailsProps> = ({ market }) => {
     return market.tasks_verification;
   }, [market]);
 
-  const zapDisplayData = useFormatDisplayQuestData(market, true, AppPaths.Zap);
+  const zapDisplayData = useFormatDisplayQuestData(
+    market,
+    true,
+    false,
+    AppPaths.Zap,
+  );
   const participants = useMemo(
     () => zapDisplayData.participants,
     [zapDisplayData.participants],

--- a/src/components/Zap/ZapDetails.tsx
+++ b/src/components/Zap/ZapDetails.tsx
@@ -44,12 +44,9 @@ export const ZapDetails: FC<ZapDetailsProps> = ({ market }) => {
     return market.tasks_verification;
   }, [market]);
 
-  const zapDisplayData = useFormatDisplayQuestData(
-    market,
-    true,
-    false,
-    AppPaths.Zap,
-  );
+  const zapDisplayData = useFormatDisplayQuestData(market, {
+    baseNavPath: AppPaths.Zap,
+  });
   const participants = useMemo(
     () => zapDisplayData.participants,
     [zapDisplayData.participants],

--- a/src/hooks/quests/useFormatDisplayQuestData.ts
+++ b/src/hooks/quests/useFormatDisplayQuestData.ts
@@ -43,17 +43,20 @@ function isQuest(quest: Quest | QuestData): quest is Quest {
 export function useFormatDisplayQuestData(
   quest: Quest,
   useBannerImage?: boolean,
+  preferExtraWideImage?: boolean,
   baseNavPath?: string,
 ): DisplayQuestData;
 export function useFormatDisplayQuestData(
   quest: QuestData,
   useBannerImage?: boolean,
+  preferExtraWideImage?: boolean,
   baseNavPath?: string,
 ): DisplayQuestData;
 
 export function useFormatDisplayQuestData(
   quest: Quest | QuestData,
   useBannerImage: boolean = true,
+  preferExtraWideImage: boolean = false,
   baseNavPath: string = AppPaths.Missions,
 ) {
   const rewardGroups = useFormatDisplayRewardsData(
@@ -88,7 +91,11 @@ export function useFormatDisplayQuestData(
 
     let imageUrl: string | undefined;
 
-    if (useBannerImage) {
+    if (preferExtraWideImage) {
+      imageUrl = resolveStrapiMediaUrl(
+        quest.ExtraWideImage?.url || quest.Image?.url,
+      );
+    } else if (useBannerImage) {
       imageUrl = isQuest(quest)
         ? resolveStrapiMediaUrl(quest.BannerImage?.[0]?.url)
         : resolveStrapiMediaUrl(quest.BannerImage?.url);

--- a/src/hooks/quests/useFormatDisplayQuestData.ts
+++ b/src/hooks/quests/useFormatDisplayQuestData.ts
@@ -36,28 +36,32 @@ interface DisplayQuestData {
   };
 }
 
+interface UseFormatDisplayQuestDataOptions {
+  useBannerImage?: boolean;
+  preferExtraWideImage?: boolean;
+  baseNavPath?: string;
+}
+
 function isQuest(quest: Quest | QuestData): quest is Quest {
   return 'BannerImage' in quest;
 }
 
 export function useFormatDisplayQuestData(
   quest: Quest,
-  useBannerImage?: boolean,
-  preferExtraWideImage?: boolean,
-  baseNavPath?: string,
+  options?: UseFormatDisplayQuestDataOptions,
 ): DisplayQuestData;
 export function useFormatDisplayQuestData(
   quest: QuestData,
-  useBannerImage?: boolean,
-  preferExtraWideImage?: boolean,
-  baseNavPath?: string,
+  options?: UseFormatDisplayQuestDataOptions,
 ): DisplayQuestData;
 
 export function useFormatDisplayQuestData(
   quest: Quest | QuestData,
-  useBannerImage: boolean = true,
-  preferExtraWideImage: boolean = false,
-  baseNavPath: string = AppPaths.Missions,
+  {
+    useBannerImage = true,
+    preferExtraWideImage = false,
+    baseNavPath = AppPaths.Missions,
+  }: UseFormatDisplayQuestDataOptions = {},
 ) {
   const rewardGroups = useFormatDisplayRewardsData(
     quest.Slug,
@@ -91,6 +95,10 @@ export function useFormatDisplayQuestData(
 
     let imageUrl: string | undefined;
 
+    // preferExtraWideImage takes priority over useBannerImage. Use it for slots
+    // that need a ~3:1 ratio (e.g. Profile page tiles) where BannerImage (2:1)
+    // and Image (~1.54:1) would both be cropped incorrectly by object-fit:cover.
+    // Falls back to Image if ExtraWideImage is not set on the quest.
     if (preferExtraWideImage) {
       imageUrl = resolveStrapiMediaUrl(
         quest.ExtraWideImage?.url || quest.Image?.url,

--- a/src/types/loyaltyPass.ts
+++ b/src/types/loyaltyPass.ts
@@ -108,6 +108,7 @@ export type QuestAttributes = {
   CustomInformation?: QuestDetails; // JSON object that can change and where type is not enforced inside Strapi yet.
   Image: StrapiMediaData;
   BannerImage: BannerImageData[];
+  ExtraWideImage?: StrapiMediaData;
   quests_platform: QuestsPlatformData;
   tasks_verification: TaskVerification[];
 };

--- a/src/types/strapi.ts
+++ b/src/types/strapi.ts
@@ -367,6 +367,7 @@ export interface QuestData {
   Information: string | null;
   CustomInformation: any;
   BannerImage?: StrapiMediaData;
+  ExtraWideImage?: StrapiMediaData;
   ClaimingId: string | null;
   Subtitle: string | null;
   tasks_verification?: TaskVerification[];

--- a/src/utils/strapi/StrapiApi.ts
+++ b/src/utils/strapi/StrapiApi.ts
@@ -235,6 +235,7 @@ class QuestParams {
     'quests_platform',
     'quests_platform.Logo',
     'BannerImage',
+    'ExtraWideImage',
     'tasks_verification',
     'tasks_verification.TaskWidgetInformation',
     'tasks_verification.TaskWidgetInformation.sourceChain',


### PR DESCRIPTION
## Summary

- Adds `ExtraWideImage` field to frontend types and API populate list so it comes back from `/api/quests`
- Extends `useFormatDisplayQuestData` hook with a `preferExtraWideImage` param; when true, resolves `ExtraWideImage?.url || Image?.url` as the image URL
- Profile page mission cards (Earn XP carousel, Your Achievements tile) now use `preferExtraWideImage=true`, centralising image resolution in the hook

## Changes

- `src/types/strapi.ts` + `src/types/loyaltyPass.ts` — added `ExtraWideImage?: StrapiMediaData`
- `src/utils/strapi/StrapiApi.ts` — added `'ExtraWideImage'` to `QuestParams.defaultPopulates`
- `src/hooks/quests/useFormatDisplayQuestData.ts` — new optional `preferExtraWideImage` param (3rd positional, default `false`)
- `src/components/ProfilePage/sections/EarnXpSection/MissionXpCard.tsx` — passes `preferExtraWideImage=true`, uses `missionDisplayData.imageUrl`
- `src/components/ProfilePage/sections/YourAchievementsSection/CompletedMissionCard.tsx` — now uses the hook with `preferExtraWideImage=true`
- `src/components/Zap/ZapDetails.tsx` — explicitly passes `false` for the new param (no behaviour change)

## Linear

JUM-1208

## Sister PR

https://github.com/jumperexchange/strapi-cms/pull/125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Some mission and quest cards now support wider imagery, improving the visual presentation of featured content.

* **Bug Fixes**
  * Updated mission and zap details to use more consistent display data, helping links, titles, IDs, and XP badges render correctly.
  * Improved image selection so quest cards can show the best available artwork when extra-wide images are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->