### PR TITLE
fix: remove button caption once multiple wallets are connected

### DIFF
--- a/src/components/Navbar/components/Buttons/WalletMenuToggle.tsx
+++ b/src/components/Navbar/components/Buttons/WalletMenuToggle.tsx
@@ -65,6 +65,13 @@ export const WalletMenuToggle = () => {
     return t('navbar.wallet');
   }, [numberOfWallets, t]);
 
+  const caption = useMemo(() => {
+    if (numberOfWallets > 1) {
+      return undefined;
+    }
+    return walletLabel;
+  }, [numberOfWallets, walletLabel]);
+
   const handleWalletMenuClick = () => {
     setWalletMenuState(!_openWalletMenu);
     if (!_openWalletMenu) {
@@ -84,7 +91,7 @@ export const WalletMenuToggle = () => {
     <LabelButton
       icon={icon}
       label={label}
-      caption={walletLabel}
+      caption={caption}
       isLabelVisible={isDesktop}
       onClick={handleWalletMenuClick}
       id="wallet-digest-button"


### PR DESCRIPTION
# Which Jira task belongs to this PR?

https://linear.app/lifi-linear/issue/JUM-1224/hide-wallet-address-caption-when-multiple-wallets-are-connected

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet menu labeling so the displayed caption is only shown when a single wallet is connected.
  * Prevented confusing or incorrect captions when multiple wallets are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->