### PR TITLE
feat: add order row actions (cancel, modify, repeat)

### DIFF
--- a/src/components/LimitOrders/OrdersSection/OrderRowMenu.tsx
+++ b/src/components/LimitOrders/OrdersSection/OrderRowMenu.tsx
@@ -3,19 +3,29 @@ import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import Menu from '@mui/material/Menu';
 import Typography from '@mui/material/Typography';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { getSurfaceBorder } from '@/theme/utils/getSurfaceBorder';
 import { OrderMenuItemContainer } from './OrdersSection.styles';
 import { IconButton } from '@/components/core/buttons/IconButton/IconButton';
 import { Variant, Size } from '@/components/core/buttons/types';
+import { useCancelOrderFlowStore } from '@/stores/limitOrderFlow/CancelOrderFlowStore';
+import { useModifyOrderFlowStore } from '@/stores/limitOrderFlow/ModifyOrderFlowStore';
+import { useRepeatOrderFlowStore } from '@/stores/limitOrderFlow/RepeatOrderFlowStore';
 import { type Order } from '@/types/jumper-limit-order';
+import { isOrderExpired } from './utils';
+import { ORDERS_COMPLETED_STATUS, ORDERS_ONGOING_STATUS } from './constants';
 
 interface OrderRowMenuProps {
   order: Order;
 }
 
 export const OrderRowMenu = ({ order }: OrderRowMenuProps) => {
+  const { t } = useTranslation();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const open = Boolean(anchorEl);
+  const openCancelModal = useCancelOrderFlowStore((state) => state.openModal);
+  const openModifyModal = useModifyOrderFlowStore((state) => state.openModal);
+  const openRepeatModal = useRepeatOrderFlowStore((state) => state.openModal);
 
   const handleOpen = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
@@ -24,7 +34,25 @@ export const OrderRowMenu = ({ order }: OrderRowMenuProps) => {
 
   const handleClose = () => setAnchorEl(null);
 
-  const isCancellable = order.status === 'active' || order.status === 'pending';
+  const expired = isOrderExpired(order);
+  const isEditable = ORDERS_ONGOING_STATUS.includes(order.status) && !expired;
+  const isRepeatable =
+    ORDERS_COMPLETED_STATUS.includes(order.status) || expired;
+
+  const handleModifyClick = () => {
+    handleClose();
+    openModifyModal(order);
+  };
+
+  const handleCancelClick = () => {
+    handleClose();
+    openCancelModal(order);
+  };
+
+  const handleRepeatClick = () => {
+    handleClose();
+    openRepeatModal(order);
+  };
 
   return (
     <>
@@ -74,16 +102,27 @@ export const OrderRowMenu = ({ order }: OrderRowMenuProps) => {
             rel="noopener noreferrer"
             sx={{ textDecoration: 'none', color: 'inherit' }}
           >
-            View on explorer
+            {t('limitOrders.table.actions.viewOnExplorer')}
           </Typography>
         </OrderMenuItemContainer>
-        <OrderMenuItemContainer onClick={handleClose}>
-          <Typography variant="bodySmallStrong">Modify limit</Typography>
-        </OrderMenuItemContainer>
-        {isCancellable && (
-          <OrderMenuItemContainer onClick={handleClose}>
+        {isEditable && (
+          <OrderMenuItemContainer onClick={handleModifyClick}>
+            <Typography variant="bodySmallStrong">
+              {t('limitOrders.table.actions.modifyLimit')}
+            </Typography>
+          </OrderMenuItemContainer>
+        )}
+        {isEditable && (
+          <OrderMenuItemContainer onClick={handleCancelClick}>
             <Typography variant="bodySmallStrong" color="error">
-              Cancel order
+              {t('limitOrders.table.actions.cancelOrder')}
+            </Typography>
+          </OrderMenuItemContainer>
+        )}
+        {isRepeatable && (
+          <OrderMenuItemContainer onClick={handleRepeatClick}>
+            <Typography variant="bodySmallStrong">
+              {t('limitOrders.table.actions.repeatOrder')}
             </Typography>
           </OrderMenuItemContainer>
         )}

--- a/src/components/LimitOrders/OrdersSection/OrdersSection.tsx
+++ b/src/components/LimitOrders/OrdersSection/OrdersSection.tsx
@@ -4,6 +4,9 @@ import { useAccount } from '@lifi/wallet-management';
 import { AnimatePresence, motion } from 'motion/react';
 import { useTranslation } from 'react-i18next';
 import { ActionableSection } from '@/components/composite/ActionableSection/ActionableSection';
+import { CancelOrderFlowModal } from '@/components/composite/CancelOrderFlow/CancelOrderFlow';
+import { ModifyOrderFlowModal } from '@/components/composite/ModifyOrderFlow/ModifyOrderFlow';
+import { RepeatOrderFlowModal } from '@/components/composite/RepeatOrderFlow/RepeatOrderFlow';
 import { OrdersTable } from './OrdersTable';
 import type { ReactNode } from 'react';
 import { useLimitOrders } from '@/hooks/useLimitOrders';
@@ -24,28 +27,33 @@ export const OrdersSection = ({
   const shouldShow = !!account?.address && !isLoading && !!data?.length;
 
   return (
-    <AnimatePresence mode="popLayout">
-      {shouldShow && (
-        <motion.div
-          key="orders-section"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.3, ease: 'easeInOut' }}
-        >
-          <ActionableSection
-            title={t('limitOrders.orders')}
-            action={action}
-            sx={{ flexShrink: 0 }}
+    <>
+      <AnimatePresence mode="popLayout">
+        {shouldShow && (
+          <motion.div
+            key="orders-section"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3, ease: 'easeInOut' }}
           >
-            <OrdersTable
-              orders={data ?? []}
-              isExpanded={isSidePanelExpanded}
-              stickyHeader
-            />
-          </ActionableSection>
-        </motion.div>
-      )}
-    </AnimatePresence>
+            <ActionableSection
+              title={t('limitOrders.orders')}
+              action={action}
+              sx={{ flexShrink: 0 }}
+            >
+              <OrdersTable
+                orders={data ?? []}
+                isExpanded={isSidePanelExpanded}
+                stickyHeader
+              />
+            </ActionableSection>
+          </motion.div>
+        )}
+      </AnimatePresence>
+      <CancelOrderFlowModal />
+      <ModifyOrderFlowModal />
+      <RepeatOrderFlowModal />
+    </>
   );
 };

--- a/src/components/LimitOrders/OrdersSection/constants.ts
+++ b/src/components/LimitOrders/OrdersSection/constants.ts
@@ -8,3 +8,6 @@ export const NUMERIC_SX = {
 export const CHAIN_AVATAR_SIZE = 32;
 
 export const AMOUNT_COL_MAX_WIDTH = 120;
+
+export const ORDERS_ONGOING_STATUS = ['active', 'pending'];
+export const ORDERS_COMPLETED_STATUS = ['filled', 'cancelled', 'expired'];

--- a/src/components/LimitOrders/OrdersSection/hooks.tsx
+++ b/src/components/LimitOrders/OrdersSection/hooks.tsx
@@ -6,7 +6,7 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { differenceInCalendarDays, isPast } from 'date-fns';
+import { differenceInCalendarDays } from 'date-fns';
 import type { ColumnDef } from '@/components/composite/DataTable/DataTable.types';
 import { Badge } from '@/components/Badge/Badge';
 import { BadgeVariant } from '@/components/Badge/Badge.styles';
@@ -27,6 +27,7 @@ import {
   getOrderFilledPercent,
   getOrderLimitPrice,
   getOrderMarketPrice,
+  isOrderExpired,
 } from './utils';
 import type { Order, TokenDto } from '@/types/jumper-limit-order';
 import type { CoinKey } from '@lifi/sdk';
@@ -37,33 +38,33 @@ export function useOrderColumns(isExpanded: boolean): ColumnDef<Order>[] {
   const { toDisplayAmount, toDisplayAmountUSD } = useTokenFormatters();
 
   const formatExpiry = (
-    status: Order['status'],
-    expiresAt?: number,
+    order: Order,
   ): { label: string; variant: BadgeVariant } | null => {
-    if (status === 'cancelled') {
+    if (order.status === 'cancelled') {
       return {
         label: t('limitOrders.table.status.cancelled'),
         variant: BadgeVariant.Error,
       };
     }
-    if (status === 'filled') {
+    if (order.status === 'filled') {
+      return {
+        label: t('limitOrders.table.status.filled'),
+        variant: BadgeVariant.Success,
+      };
+    }
+    if (isOrderExpired(order)) {
+      return {
+        label: t('limitOrders.table.status.expired'),
+        variant: BadgeVariant.Disabled,
+      };
+    }
+    if (!order.validUntil) {
       return null;
     }
-    const EXPIRED = {
-      label: t('limitOrders.table.status.expired'),
-      variant: BadgeVariant.Disabled,
-    };
-    if (status === 'expired') {
-      return EXPIRED;
-    }
-    if (!expiresAt) {
-      return null;
-    }
-    const expiryDate = new Date(expiresAt * 1000);
-    if (isPast(expiryDate)) {
-      return EXPIRED;
-    }
-    const days = differenceInCalendarDays(expiryDate, new Date());
+    const days = differenceInCalendarDays(
+      new Date(order.validUntil * 1000),
+      new Date(),
+    );
     return {
       label: t('limitOrders.table.status.days', { count: days }),
       variant: BadgeVariant.Secondary,
@@ -247,7 +248,7 @@ export function useOrderColumns(isExpanded: boolean): ColumnDef<Order>[] {
       header: t('limitOrders.table.columns.expires'),
       cellSx: { borderBottom: 'none' },
       renderCell: (order) => {
-        const expiry = formatExpiry(order.status, order.validUntil);
+        const expiry = formatExpiry(order);
         return expiry ? (
           <Badge label={expiry.label} variant={expiry.variant} />
         ) : null;

--- a/src/components/LimitOrders/OrdersSection/utils.ts
+++ b/src/components/LimitOrders/OrdersSection/utils.ts
@@ -1,3 +1,4 @@
+import { isPast } from 'date-fns';
 import type { Order, TokenDto } from '@/types/jumper-limit-order';
 import { formatTokenAmount } from '@lifi/widget';
 
@@ -51,6 +52,17 @@ export const getOrderMarketPrice = (order: Order): number | null => {
   const value = Number(priceUSD);
   return Number.isFinite(value) && value > 0 ? value : null;
 };
+
+/**
+ * Whether an order has effectively expired, even if the backend hasn't
+ * updated `status` to `'expired'` yet.
+ */
+export const isOrderExpired = (order: Order): boolean =>
+  order.status === 'expired' ||
+  (order.status !== 'cancelled' &&
+    order.status !== 'filled' &&
+    !!order.validUntil &&
+    isPast(new Date(order.validUntil * 1000)));
 
 export const getOrderFilledPercent = (order: Order): number => {
   const total = BigInt(order.fromAmount);

--- a/src/components/composite/CancelOrderFlow/CancelOrderFlow.tsx
+++ b/src/components/composite/CancelOrderFlow/CancelOrderFlow.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { HeightAnimatedContainer } from '@jumperexchange/shared-ui/components';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useQueryClient } from '@tanstack/react-query';
+import { motion } from 'motion/react';
+import { useTranslation } from 'react-i18next';
+import { SectionCard } from '@/components/Cards/SectionCard/SectionCard';
+import { StatusBottomSheet } from '@/components/composite/StatusBottomSheet/StatusBottomSheet';
+import { Button } from '@/components/core/buttons/Button/Button';
+import { Variant } from '@/components/core/buttons/types';
+import { ModalContainer } from '@/components/core/modals/ModalContainer/ModalContainer';
+import { useCancelOrderFlowStore } from '@/stores/limitOrderFlow/CancelOrderFlowStore';
+import { getQueryKey } from '@/utils/queries/getQueryKey';
+import { useCancelOrder } from './hooks/useCancelOrder';
+import { useCancelOrderStatusSheet } from './hooks/useCancelOrderStatusSheet';
+
+const CONTAINER_ID = 'cancel-order-modal';
+const BOTTOM_SHEET_TOP_OFFSET = 24;
+const ANIMATION_DURATION_SECONDS = 0.3;
+
+export const CancelOrderFlowModal = () => {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const { isModalOpen, selectedOrder, closeModal } = useCancelOrderFlowStore(
+    (state) => state,
+  );
+  const { cancelOrderAsync, result, isPending, isSuccess, isError, reset } =
+    useCancelOrder();
+
+  const handleClose = () => {
+    reset();
+    closeModal();
+  };
+
+  const handleDone = () => {
+    queryClient.invalidateQueries({ queryKey: [getQueryKey('limit-orders')] });
+    handleClose();
+  };
+
+  const handleConfirm = () => {
+    if (!selectedOrder) {
+      return;
+    }
+    cancelOrderAsync(selectedOrder).catch(() => {
+      // isError below surfaces the failure via the status sheet.
+    });
+  };
+
+  const statusSheet = useCancelOrderStatusSheet({
+    isSuccess,
+    isError,
+    result,
+    onRetry: handleConfirm,
+    onDone: handleDone,
+    onCloseError: handleClose,
+  });
+
+  if (!selectedOrder) {
+    return null;
+  }
+
+  return (
+    <ModalContainer isOpen={isModalOpen} onClose={handleClose}>
+      <Box id={CONTAINER_ID} sx={{ position: 'relative' }}>
+        <HeightAnimatedContainer
+          isOpen={statusSheet.isOpen}
+          offsetHeight={BOTTOM_SHEET_TOP_OFFSET}
+          animationDuration={ANIMATION_DURATION_SECONDS}
+          defaultHeight="auto"
+        >
+          {({ onHeightChange, motionProps }) => (
+            <motion.div {...motionProps} style={{ x: 0, y: 0 }}>
+              <SectionCard sx={{ width: 'min(90vw, 400px)' }}>
+                <Stack sx={{ gap: 2 }}>
+                  <Typography variant="titleSmall">
+                    {t('limitOrders.cancelModal.title')}
+                  </Typography>
+                  <Typography variant="bodySmall" color="textSecondary">
+                    {t('limitOrders.cancelModal.description')}
+                  </Typography>
+                  <Stack direction="row" sx={{ gap: 1.5 }}>
+                    <Button
+                      variant={Variant.AlphaDark}
+                      sx={{ flex: 1 }}
+                      onClick={handleClose}
+                      disabled={isPending}
+                    >
+                      {t('limitOrders.cancelModal.keepOrder')}
+                    </Button>
+                    <Button
+                      variant={Variant.Error}
+                      sx={{ flex: 1 }}
+                      onClick={handleConfirm}
+                      loading={isPending}
+                    >
+                      {t('limitOrders.cancelModal.cancelOrder')}
+                    </Button>
+                  </Stack>
+                </Stack>
+              </SectionCard>
+
+              <StatusBottomSheet
+                containerId={CONTAINER_ID}
+                isOpen={statusSheet.isOpen}
+                onClose={statusSheet.onClose}
+                onHeightChange={onHeightChange}
+                {...statusSheet.content}
+              />
+            </motion.div>
+          )}
+        </HeightAnimatedContainer>
+      </Box>
+    </ModalContainer>
+  );
+};

--- a/src/components/composite/CancelOrderFlow/hooks/useCancelOrder.ts
+++ b/src/components/composite/CancelOrderFlow/hooks/useCancelOrder.ts
@@ -94,6 +94,8 @@ export const useCancelOrder = () => {
             ],
           })
           .catch(() => {
+            setIsAwaitingOnchainTx(false);
+            setOnchainChainId(undefined);
             throw new CancelOrderError(
               'Failed to send the cancellation transaction',
               CancelOrderErrorType.TransactionFailed,

--- a/src/components/composite/CancelOrderFlow/hooks/useCancelOrder.ts
+++ b/src/components/composite/CancelOrderFlow/hooks/useCancelOrder.ts
@@ -1,0 +1,184 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useSignTypedData } from 'wagmi';
+import type { Hex } from 'viem';
+import { makeLimitOrderClient } from '@/app/lib/limitOrderClient';
+import { useTransactionFlow } from '@/hooks/transactions/useTransactionFlow';
+import type { Order } from '@/types/jumper-limit-order';
+
+export enum CancelOrderErrorType {
+  CalldataFailed = 'calldataFailed',
+  SignatureFailed = 'signatureFailed',
+  TransactionFailed = 'transactionFailed',
+  RelayFailed = 'relayFailed',
+  Unsupported = 'unsupported',
+  Unknown = 'unknown',
+}
+
+export class CancelOrderError extends Error {
+  constructor(
+    message: string,
+    public type: CancelOrderErrorType,
+  ) {
+    super(message);
+    this.name = 'CancelOrderError';
+  }
+}
+
+/** The generated client types `typedData` as an untyped `object[]`; this is
+ * the EIP-712 shape the limit-order backend actually sends. */
+interface LimitOrderTypedData {
+  domain: Record<string, unknown>;
+  types: Record<string, unknown>;
+  primaryType: string;
+  message: Record<string, unknown>;
+}
+
+export interface CancelOrderResult {
+  /** Set when the order was cancelled via an on-chain transaction. */
+  txHash?: Hex;
+  /** Set when the order was cancelled via a signed+relayed cancellation. */
+  txLink?: string;
+  chainId: number;
+}
+
+/**
+ * On-chain cancellations go through `useTransactionFlow`, which handles
+ * chain-switching and the execute → confirm state machine, instead of
+ * hitting a raw executor directly. Off-chain (sign + relay) cancellations
+ * don't fit that tx-action-list model, so they run as a plain async mutation.
+ */
+export const useCancelOrder = () => {
+  const { signTypedDataAsync } = useSignTypedData();
+  const txFlow = useTransactionFlow();
+
+  const [isAwaitingOnchainTx, setIsAwaitingOnchainTx] = useState(false);
+  const [onchainChainId, setOnchainChainId] = useState<number>();
+
+  const prepareAndSubmitFn = useCallback(
+    async (order: Order): Promise<CancelOrderResult | undefined> => {
+      const client = makeLimitOrderClient();
+      const tool = order.tool as '1inch' | 'cowswap';
+
+      const calldataResponse = await client.limitOrder
+        .ordersControllerCancelCalldata({
+          chainId: order.chainId,
+          tool,
+          orderId: order.orderId,
+        })
+        .catch(() => {
+          throw new CancelOrderError(
+            'Failed to fetch cancellation calldata',
+            CancelOrderErrorType.CalldataFailed,
+          );
+        });
+      const { transactionRequest, typedData, estimate } = calldataResponse.data;
+
+      if (transactionRequest) {
+        setOnchainChainId(transactionRequest.chainId);
+        setIsAwaitingOnchainTx(true);
+        await txFlow
+          .executeFlow({
+            actions: [
+              {
+                name: 'cancelOrder',
+                tx: {
+                  to: transactionRequest.to,
+                  data: transactionRequest.data,
+                  value: transactionRequest.value,
+                  chainId: transactionRequest.chainId,
+                },
+              },
+            ],
+          })
+          .catch(() => {
+            throw new CancelOrderError(
+              'Failed to send the cancellation transaction',
+              CancelOrderErrorType.TransactionFailed,
+            );
+          });
+        // Final success/error is driven by txFlow's reactive state below.
+        return undefined;
+      }
+
+      if (typedData?.length) {
+        const payload = typedData[0] as LimitOrderTypedData;
+        const signature = await signTypedDataAsync(
+          payload as Parameters<typeof signTypedDataAsync>[0],
+        ).catch(() => {
+          throw new CancelOrderError(
+            'Failed to sign the cancellation',
+            CancelOrderErrorType.SignatureFailed,
+          );
+        });
+
+        const relayResponse = await client.limitOrder
+          .ordersControllerCancelOrderRelay({
+            chainId: order.chainId,
+            tool,
+            estimate,
+            typedData: [{ ...payload, signature }],
+          })
+          .catch(() => {
+            throw new CancelOrderError(
+              'Failed to relay the cancellation',
+              CancelOrderErrorType.RelayFailed,
+            );
+          });
+        return {
+          txLink: relayResponse.data.data.txLink,
+          chainId: order.chainId,
+        };
+      }
+
+      throw new CancelOrderError(
+        'No cancellation method available for this order',
+        CancelOrderErrorType.Unsupported,
+      );
+    },
+    [signTypedDataAsync, txFlow],
+  );
+
+  const mutation = useMutation({ mutationFn: prepareAndSubmitFn });
+
+  const reset = useCallback(() => {
+    mutation.reset();
+    txFlow.resetFlow();
+    setIsAwaitingOnchainTx(false);
+    setOnchainChainId(undefined);
+  }, [mutation, txFlow]);
+
+  const isPending =
+    mutation.isPending ||
+    (isAwaitingOnchainTx &&
+      (txFlow.isExecuting || txFlow.isPending || txFlow.isConfirming));
+  const isSuccess = isAwaitingOnchainTx
+    ? txFlow.currentStep === 'success'
+    : mutation.isSuccess;
+  const isError = isAwaitingOnchainTx ? !!txFlow.error : mutation.isError;
+
+  const errorType = isAwaitingOnchainTx
+    ? CancelOrderErrorType.TransactionFailed
+    : mutation.error instanceof CancelOrderError
+      ? mutation.error.type
+      : CancelOrderErrorType.Unknown;
+
+  const result: CancelOrderResult | undefined = isAwaitingOnchainTx
+    ? txFlow.currentStep === 'success' && onchainChainId
+      ? { txHash: txFlow.txHash, chainId: onchainChainId }
+      : undefined
+    : mutation.data;
+
+  return {
+    cancelOrderAsync: mutation.mutateAsync,
+    result,
+    isPending,
+    isSuccess,
+    isError,
+    errorType,
+    reset,
+    error: mutation.error,
+  };
+};

--- a/src/components/composite/CancelOrderFlow/hooks/useCancelOrderStatusSheet.ts
+++ b/src/components/composite/CancelOrderFlow/hooks/useCancelOrderStatusSheet.ts
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { StatusBottomSheetProps } from '@/components/composite/StatusBottomSheet/StatusBottomSheet';
+import { useGetAddressExplorerUrl } from '@/hooks/useBlockchainExplorerURL';
+import { openInNewTab } from '@/utils/openInNewTab';
+import type { CancelOrderResult } from './useCancelOrder';
+
+type StatusSheetContent = Pick<
+  StatusBottomSheetProps,
+  | 'title'
+  | 'description'
+  | 'callToAction'
+  | 'callToActionType'
+  | 'secondaryCallToAction'
+  | 'status'
+  | 'onClick'
+  | 'onSecondaryClick'
+>;
+
+interface UseCancelOrderStatusSheetOptions {
+  isSuccess: boolean;
+  isError: boolean;
+  result?: CancelOrderResult;
+  onRetry: () => void;
+  onDone: () => void;
+  onCloseError: () => void;
+}
+
+const EMPTY_CONTENT: StatusSheetContent = {
+  title: '',
+  callToAction: '',
+  callToActionType: 'button',
+};
+
+/** Mirrors useDustConversionStatusSheet: keep the last content around while
+ * the sheet plays its closing transition, instead of clearing it mid-animation. */
+export const useCancelOrderStatusSheet = ({
+  isSuccess,
+  isError,
+  result,
+  onRetry,
+  onDone,
+  onCloseError,
+}: UseCancelOrderStatusSheetOptions) => {
+  const { t } = useTranslation();
+  const getTxExplorerUrl = useGetAddressExplorerUrl('tx');
+  const lastContentRef = useRef<StatusSheetContent | null>(null);
+
+  // `StatusBottomSheet.onClose` fires both for a manual swipe-dismiss and for
+  // the sheet auto-hiding whenever `isOpen` flips false (e.g. `isError`
+  // clearing the instant a retry starts). Track dismissal locally instead of
+  // treating either as "close the whole modal" — only a fresh success/error
+  // (the rising edge below) is allowed to clear it and show the sheet again.
+  const [isDismissed, setIsDismissed] = useState(false);
+  const isTerminal = isSuccess || isError;
+  const wasTerminalRef = useRef(false);
+
+  useEffect(() => {
+    if (isTerminal && !wasTerminalRef.current) {
+      setIsDismissed(false);
+    }
+    wasTerminalRef.current = isTerminal;
+  }, [isTerminal]);
+
+  const explorerLink =
+    result?.txLink ??
+    (result?.txHash
+      ? getTxExplorerUrl(result.chainId, result.txHash)
+      : undefined);
+
+  const content = useMemo((): StatusSheetContent | null => {
+    if (isSuccess) {
+      return {
+        status: 'success',
+        title: t('limitOrders.cancelModal.successTitle'),
+        description: t('limitOrders.cancelModal.successDescription'),
+        callToAction: t('limitOrders.cancelModal.done'),
+        callToActionType: 'button',
+        secondaryCallToAction: explorerLink
+          ? t('limitOrders.cancelModal.viewOnExplorer')
+          : undefined,
+        onClick: onDone,
+        onSecondaryClick: explorerLink
+          ? () => openInNewTab(explorerLink)
+          : undefined,
+      };
+    }
+    if (isError) {
+      return {
+        status: 'error',
+        title: t('limitOrders.cancelModal.errorTitle'),
+        description: t('limitOrders.cancelModal.error'),
+        callToAction: t('limitOrders.cancelModal.tryAgain'),
+        callToActionType: 'button',
+        secondaryCallToAction: t('limitOrders.cancelModal.close'),
+        onClick: onRetry,
+        onSecondaryClick: onCloseError,
+      };
+    }
+    return null;
+  }, [isSuccess, isError, explorerLink, onDone, onRetry, onCloseError, t]);
+
+  useEffect(() => {
+    if (content) {
+      lastContentRef.current = content;
+    }
+  }, [content]);
+
+  return {
+    isOpen: isTerminal && !isDismissed,
+    content: content ?? lastContentRef.current ?? EMPTY_CONTENT,
+    onClose: () => setIsDismissed(true),
+  };
+};

--- a/src/components/composite/ModifyOrderFlow/ModifyOrderFlow.tsx
+++ b/src/components/composite/ModifyOrderFlow/ModifyOrderFlow.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useTranslation } from 'react-i18next';
+import { Badge } from '@/components/Badge/Badge';
+import { BadgeVariant } from '@/components/Badge/Badge.styles';
+import { SectionCard } from '@/components/Cards/SectionCard/SectionCard';
+import { ModalContainer } from '@/components/core/modals/ModalContainer/ModalContainer';
+import { useModifyOrderFlowStore } from '@/stores/limitOrderFlow/ModifyOrderFlowStore';
+
+/**
+ * Stand-in for the real modify-order widget, which doesn't exist yet.
+ * Swap this out once the limit-order widget supports editing an order.
+ */
+export const ModifyOrderFlowModal = () => {
+  const { t } = useTranslation();
+  const { isModalOpen, selectedOrder, closeModal } = useModifyOrderFlowStore(
+    (state) => state,
+  );
+
+  if (!selectedOrder) {
+    return null;
+  }
+
+  return (
+    <ModalContainer isOpen={isModalOpen} onClose={closeModal}>
+      <SectionCard sx={{ width: 'min(90vw, 400px)' }}>
+        <Stack sx={{ gap: 3 }}>
+          <Badge
+            startIcon={<AccessTimeIcon />}
+            label={t('limitOrders.modifyModal.placeholderTitle')}
+            variant={BadgeVariant.Secondary}
+          />
+          <Stack sx={{ gap: 0.5 }}>
+            <Typography variant="bodyLargeStrong">
+              {t('limitOrders.modifyModal.title')}
+            </Typography>
+            <Typography variant="bodySmall" color="textSecondary">
+              {t('limitOrders.modifyModal.placeholderDescription')}
+            </Typography>
+          </Stack>
+        </Stack>
+      </SectionCard>
+    </ModalContainer>
+  );
+};

--- a/src/components/composite/RepeatOrderFlow/RepeatOrderFlow.tsx
+++ b/src/components/composite/RepeatOrderFlow/RepeatOrderFlow.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useTranslation } from 'react-i18next';
+import { Badge } from '@/components/Badge/Badge';
+import { BadgeVariant } from '@/components/Badge/Badge.styles';
+import { SectionCard } from '@/components/Cards/SectionCard/SectionCard';
+import { ModalContainer } from '@/components/core/modals/ModalContainer/ModalContainer';
+import { useRepeatOrderFlowStore } from '@/stores/limitOrderFlow/RepeatOrderFlowStore';
+
+/**
+ * Stand-in for the real repeat-order widget, which doesn't exist yet.
+ * Swap this out once the limit-order widget supports pre-filling from a
+ * cancelled/expired order.
+ */
+export const RepeatOrderFlowModal = () => {
+  const { t } = useTranslation();
+  const { isModalOpen, selectedOrder, closeModal } = useRepeatOrderFlowStore(
+    (state) => state,
+  );
+
+  if (!selectedOrder) {
+    return null;
+  }
+
+  return (
+    <ModalContainer isOpen={isModalOpen} onClose={closeModal}>
+      <SectionCard sx={{ width: 'min(90vw, 400px)' }}>
+        <Stack sx={{ gap: 3 }}>
+          <Badge
+            startIcon={<AccessTimeIcon />}
+            label={t('limitOrders.repeatModal.placeholderTitle')}
+            variant={BadgeVariant.Secondary}
+          />
+          <Stack sx={{ gap: 0.5 }}>
+            <Typography variant="bodyLargeStrong">
+              {t('limitOrders.repeatModal.title')}
+            </Typography>
+            <Typography variant="bodySmall" color="textSecondary">
+              {t('limitOrders.repeatModal.placeholderDescription')}
+            </Typography>
+          </Stack>
+        </Stack>
+      </SectionCard>
+    </ModalContainer>
+  );
+};

--- a/src/components/core/buttons/Button/Button.style.ts
+++ b/src/components/core/buttons/Button/Button.style.ts
@@ -164,6 +164,19 @@ export const StyledButton = styled(MuiButton, {
       },
     },
     {
+      props: { buttonVariant: ButtonVariant.Error },
+      style: {
+        color: (theme.vars || theme).palette.statusErrorFg,
+        backgroundColor: (theme.vars || theme).palette.statusErrorBg,
+        '&:hover, &:focus-visible': {
+          backgroundColor: `color-mix(in srgb, ${(theme.vars || theme).palette.statusErrorBg} ${(1 - theme.palette.action.hoverOpacity) * 100}%, black 10%)`,
+        },
+        '&:active, &:focus-visible:active': {
+          backgroundColor: `color-mix(in srgb, ${(theme.vars || theme).palette.statusErrorBg} ${(1 - theme.palette.action.activatedOpacity) * 100}%, black 10%)`,
+        },
+      },
+    },
+    {
       props: { buttonSize: ButtonSize.XS },
       style: {
         padding: theme.spacing(0.5),

--- a/src/components/core/buttons/types.ts
+++ b/src/components/core/buttons/types.ts
@@ -8,6 +8,7 @@ export enum Variant {
   Disabled = 'disabled',
   Borderless = 'borderless',
   Success = 'success',
+  Error = 'error',
 }
 
 export enum Size {

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -458,14 +458,42 @@ export default interface Resources {
       updatedLabel: 'Updated: {{date}}';
     };
     limitOrders: {
+      cancelModal: {
+        cancelOrder: 'Cancel order';
+        close: 'Close';
+        description: "This stops the order from filling and marks it cancelled. Any portion already filled stays settled. This can't be undone.";
+        done: 'Done';
+        error: 'Something went wrong cancelling this order. Please try again.';
+        errorTitle: 'Cancellation failed';
+        keepOrder: 'Keep order';
+        successDescription: 'This order will no longer fill.';
+        successTitle: 'Order cancelled';
+        title: 'Cancel limit order';
+        tryAgain: 'Try again';
+        viewOnExplorer: 'View on explorer';
+      };
       marketPrice: 'Market Price';
       marketPriceEmptyState: 'Select a token to see its market price';
+      modifyModal: {
+        placeholderDescription: "Editing an active order isn't available yet. Cancel it and place a new one instead.";
+        placeholderTitle: 'Coming soon';
+        title: 'Modify limit order';
+      };
       orders: 'Orders';
+      repeatModal: {
+        placeholderDescription: "Repeating an order isn't available yet. Placing a new order manually works the same way.";
+        placeholderTitle: 'Coming soon';
+        title: 'Repeat order';
+      };
       table: {
         actions: {
+          cancelOrder: 'Cancel order';
           collapsePanels: 'Collapse panels';
           expandPanels: 'Expand panels';
+          modifyLimit: 'Modify limit';
+          repeatOrder: 'Repeat order';
           rowActions: 'Row actions';
+          viewOnExplorer: 'View on explorer';
         };
         columns: {
           buy: 'Buy';
@@ -482,6 +510,7 @@ export default interface Resources {
           days_one: '{{count}} day';
           days_other: '{{count}} days';
           expired: 'Expired';
+          filled: 'Filled';
         };
       };
     };

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -1315,14 +1315,43 @@
       "status": {
         "cancelled": "Cancelled",
         "expired": "Expired",
+        "filled": "Filled",
         "days_one": "{{count}} day",
         "days_other": "{{count}} days"
       },
       "actions": {
         "rowActions": "Row actions",
         "expandPanels": "Expand panels",
-        "collapsePanels": "Collapse panels"
+        "collapsePanels": "Collapse panels",
+        "viewOnExplorer": "View on explorer",
+        "modifyLimit": "Modify limit",
+        "cancelOrder": "Cancel order",
+        "repeatOrder": "Repeat order"
       }
+    },
+    "cancelModal": {
+      "title": "Cancel limit order",
+      "description": "This stops the order from filling and marks it cancelled. Any portion already filled stays settled. This can't be undone.",
+      "keepOrder": "Keep order",
+      "cancelOrder": "Cancel order",
+      "error": "Something went wrong cancelling this order. Please try again.",
+      "successTitle": "Order cancelled",
+      "successDescription": "This order will no longer fill.",
+      "done": "Done",
+      "viewOnExplorer": "View on explorer",
+      "errorTitle": "Cancellation failed",
+      "tryAgain": "Try again",
+      "close": "Close"
+    },
+    "modifyModal": {
+      "title": "Modify limit order",
+      "placeholderTitle": "Coming soon",
+      "placeholderDescription": "Editing an active order isn't available yet. Cancel it and place a new one instead."
+    },
+    "repeatModal": {
+      "title": "Repeat order",
+      "placeholderTitle": "Coming soon",
+      "placeholderDescription": "Repeating an order isn't available yet. Placing a new order manually works the same way."
     }
   }
 }

--- a/src/stores/limitOrderFlow/CancelOrderFlowStore.ts
+++ b/src/stores/limitOrderFlow/CancelOrderFlowStore.ts
@@ -1,0 +1,28 @@
+import { createWithEqualityFn } from 'zustand/traditional';
+import { shallow } from 'zustand/shallow';
+import type { Order } from '@/types/jumper-limit-order';
+
+interface CancelOrderFlowState {
+  isModalOpen: boolean;
+  selectedOrder: Order | null;
+
+  openModal: (order: Order) => void;
+  closeModal: () => void;
+}
+
+export const useCancelOrderFlowStore =
+  createWithEqualityFn<CancelOrderFlowState>(
+    (set) => ({
+      isModalOpen: false,
+      selectedOrder: null,
+
+      openModal: (order: Order) => {
+        set({ isModalOpen: true, selectedOrder: order });
+      },
+
+      closeModal: () => {
+        set({ isModalOpen: false });
+      },
+    }),
+    shallow,
+  );

--- a/src/stores/limitOrderFlow/ModifyOrderFlowStore.ts
+++ b/src/stores/limitOrderFlow/ModifyOrderFlowStore.ts
@@ -1,0 +1,28 @@
+import { createWithEqualityFn } from 'zustand/traditional';
+import { shallow } from 'zustand/shallow';
+import type { Order } from '@/types/jumper-limit-order';
+
+interface ModifyOrderFlowState {
+  isModalOpen: boolean;
+  selectedOrder: Order | null;
+
+  openModal: (order: Order) => void;
+  closeModal: () => void;
+}
+
+export const useModifyOrderFlowStore =
+  createWithEqualityFn<ModifyOrderFlowState>(
+    (set) => ({
+      isModalOpen: false,
+      selectedOrder: null,
+
+      openModal: (order: Order) => {
+        set({ isModalOpen: true, selectedOrder: order });
+      },
+
+      closeModal: () => {
+        set({ isModalOpen: false });
+      },
+    }),
+    shallow,
+  );

--- a/src/stores/limitOrderFlow/RepeatOrderFlowStore.ts
+++ b/src/stores/limitOrderFlow/RepeatOrderFlowStore.ts
@@ -1,0 +1,28 @@
+import { createWithEqualityFn } from 'zustand/traditional';
+import { shallow } from 'zustand/shallow';
+import type { Order } from '@/types/jumper-limit-order';
+
+interface RepeatOrderFlowState {
+  isModalOpen: boolean;
+  selectedOrder: Order | null;
+
+  openModal: (order: Order) => void;
+  closeModal: () => void;
+}
+
+export const useRepeatOrderFlowStore =
+  createWithEqualityFn<RepeatOrderFlowState>(
+    (set) => ({
+      isModalOpen: false,
+      selectedOrder: null,
+
+      openModal: (order: Order) => {
+        set({ isModalOpen: true, selectedOrder: order });
+      },
+
+      closeModal: () => {
+        set({ isModalOpen: false });
+      },
+    }),
+    shallow,
+  );


### PR DESCRIPTION
## Summary
- Adds Cancel / Modify / Repeat actions to the limit order row menu (`OrderRowMenu`), gated by order status (ongoing vs. completed/expired).
- Cancellation is fully wired: fetches cancel calldata, then either sends an on-chain tx (via `useTransactionFlow`, same chain-switch/execute/confirm state machine used elsewhere) or signs + relays an off-chain cancellation, with a confirmation modal and a `StatusBottomSheet` for pending/success/error feedback (height-animated, matching existing widget conventions).
- Modify and Repeat currently render placeholder "coming soon" modals until the real order-editing widget exists; they're wired through their own stores/components so swapping in the real widget later is a self-contained change.
- Adds a `Filled` badge to the expiry column, a shared `isOrderExpired` check reused by both the table and the row menu, and a `maxWidth` + ellipsis guard on the amount columns.
- Adds an `Error` variant to the shared `Button` component (`src/components/core/buttons`) for the destructive cancel action.

Contributes to JUM-1179
Closes https://linear.app/lifi-linear/issue/JUM-1174/cancel-order-modal-flow

## Test plan
- [ ] `pnpm typecheck` / `pnpm lint` / unit tests pass (verified locally via `tsc --noEmit`, `eslint`, `prettier --check`, `vitest run`)
- [ ] Manually open the orders table, exercise the row menu for an active order (Modify, Cancel with confirm/keep, retry-on-error) and a cancelled/expired order (Repeat)
- [ ] Confirm the cancel status sheet animates height correctly and doesn't close the modal when retrying after an error