### PR TITLE
fix(e2e): paste wallet seed/password into MetaMask instead of typing

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -100,8 +100,10 @@ jobs:
       - name: Install Playwright Browsers
         run: |
           pnpm exec playwright install --with-deps chromium
-      - name: Install xvfb
-        run: sudo apt-get update && sudo apt-get install -y xvfb
+      - name: Install xvfb and xclip
+        # xclip owns the CLIPBOARD selection under xvfb; the wallet seed is pasted
+        # (not typed) into MetaMask so it never lands in a Playwright trace.
+        run: sudo apt-get update && sudo apt-get install -y xvfb xclip
       - name: Run Playwright tests
         env:
           QASE_TESTOPS_RUN_ID: ${{ needs.create-qase-run.outputs.run_id || '' }}

--- a/tests/e2e/wallet/pages/MetaMaskPage.ts
+++ b/tests/e2e/wallet/pages/MetaMaskPage.ts
@@ -4,6 +4,7 @@ import { EXTENSION_NAME } from '../constants/extensionConstants';
 import { LONG_TIMEOUT } from '../constants/timeoutConstants';
 import { launchBrowserWithExtension } from '../core/browser/BrowserManager';
 import { metamaskLocators as selectors } from '../locators/metaMask';
+import { clearOsClipboard, writeOsClipboard } from '../utils/clipboard';
 import WalletPage from './core/WalletPage';
 
 import type { BrowserContext, Page } from '@playwright/test';
@@ -191,45 +192,26 @@ export default class MetaMaskPage extends WalletPage {
   }
 
   /**
-   * Processes and fills the seed phrase by:
-   * 1. Parsing the seed phrase and verifying the valid word count.
-   * 2. Selecting the appropriate dropdown option based on the seed phrase length.
-   * 3. Filling each recovery word input field with the corresponding word.
+   * Validates the word count, then enters the phrase with a single paste (see
+   * pasteSecret) — MetaMask distributes a pasted phrase across the SRP inputs.
    *
    * @param {string} seedPhrase - The provided seed phrase.
-   * @returns {Promise<void>}
-   * @throws {Error} Throws an error if the seed phrase does not contain a valid number of words.
+   * @throws {Error} If the phrase does not contain a valid number of words.
    */
   async fillSeedPhrase(seedPhrase: string): Promise<void> {
-    // Split the input string using a regex to handle spaces, commas, and other common delimiters,
-    // then filter out any empty entries.
     const words = seedPhrase.split(/[\s,]+/).filter((w) => w.trim());
 
-    // Define valid seed phrase lengths.
     const valid = [12, 15, 18, 21, 24];
-
-    // Validate the number of words in the seed phrase.
     if (!valid.includes(words.length)) {
       throw new Error(
         `Seed phrase must be one of [${valid.join(', ')}], got ${words.length}`,
       );
     }
 
-    // Fill each recovery word input field with the corresponding word from the seed phrase.
-    for (let i = 0; i < words.length; i++) {
-      if (i === 0) {
-        await this.play.fillSecret(
-          this.selectors.seedPhrase.inputField,
-          words[i],
-        );
-      } else {
-        await this.play.fillSecret(
-          this.selectors.seedPhrase.wordInputPrefix + i,
-          words[i],
-        );
-      }
-      await this.play.pressSpace();
-    }
+    await this.pasteSecret(
+      this.selectors.seedPhrase.inputField,
+      words.join(' '),
+    );
   }
 
   /**
@@ -291,8 +273,8 @@ export default class MetaMaskPage extends WalletPage {
    * @returns {Promise<void>}
    */
   async setupPassword(password: string): Promise<void> {
-    await this.play.fillSecret(this.selectors.password.newInput, password);
-    await this.play.fillSecret(this.selectors.password.confirmInput, password);
+    await this.pasteSecret(this.selectors.password.newInput, password);
+    await this.pasteSecret(this.selectors.password.confirmInput, password);
     await this.play.click(this.selectors.password.termsCheckbox);
     await this.play.click(this.selectors.password.importButton);
   }
@@ -375,6 +357,24 @@ export default class MetaMaskPage extends WalletPage {
         0,
         LONG_TIMEOUT,
       );
+    }
+  }
+
+  /**
+   * Enters a wallet secret by pasting it from the OS clipboard rather than
+   * typing it. A typed `fill()`/`type()` records the value verbatim in
+   * Playwright's trace, which is uploaded to Qase on a public URL; a pasted
+   * value travels OS clipboard -> browser and never passes through a traced
+   * call, so the trace only captures the Ctrl/Cmd+V keypress. The clipboard is
+   * cleared afterwards so the secret does not linger.
+   */
+  private async pasteSecret(selector: string, value: string): Promise<void> {
+    writeOsClipboard(value);
+    try {
+      await this.play.click(selector);
+      await this.page.keyboard.press('ControlOrMeta+V');
+    } finally {
+      clearOsClipboard();
     }
   }
 }

--- a/tests/e2e/wallet/utils/clipboard.ts
+++ b/tests/e2e/wallet/utils/clipboard.ts
@@ -1,0 +1,30 @@
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Clears the OS clipboard so the seed phrase does not linger after a paste —
+ * matters on a developer's own machine (CI runners are ephemeral).
+ */
+export function clearOsClipboard(): void {
+  writeOsClipboard('');
+}
+
+/**
+ * Writes text to the OS clipboard via a native tool, passing the value on stdin
+ * (never argv, so it can't surface in a process list).
+ *
+ * On Linux, `xclip` daemonizes to serve the selection and holds the parent's
+ * stdout/stderr open — capturing those pipes makes `execFileSync` block forever
+ * — so they're detached, with a timeout that fails fast rather than freezing the
+ * synchronous run.
+ */
+export function writeOsClipboard(text: string): void {
+  if (process.platform === 'darwin') {
+    execFileSync('pbcopy', { input: text });
+    return;
+  }
+  execFileSync('xclip', ['-selection', 'clipboard'], {
+    input: text,
+    stdio: ['pipe', 'ignore', 'ignore'],
+    timeout: 5_000,
+  });
+}


### PR DESCRIPTION
Closes JUM-1235

## Why

Playwright records `fill()`/`type()` values verbatim in its trace, and our e2e traces get uploaded to Qase. Typing the test wallet's seed phrase and MetaMask password therefore wrote those secrets into trace artifacts. Wallet secrets shouldn't live in test artifacts.

## What

Enter the seed and password by **pasting from the OS clipboard** (`pbcopy` on macOS, `xclip` on Linux) via Ctrl/Cmd+V, instead of typing. A pasted value travels OS clipboard → browser and never passes through a traced Playwright call, so the trace only records the keypress. MetaMask distributes a pasted multi-word phrase across the SRP inputs.

- `tests/e2e/wallet/utils/clipboard.ts` — new clipboard helpers. The value is passed on stdin (never argv, so it can't surface in a process list). On Linux, `xclip` daemonizes to serve the selection, so its stdout/stderr are detached and a hard timeout is set — otherwise the synchronous call blocks the run headless.
- `tests/e2e/wallet/pages/MetaMaskPage.ts` — a `pasteSecret()` helper; `fillSeedPhrase` and `setupPassword` paste instead of `fillSecret`.
- `.github/workflows/playwright.yml` — install `xclip` (needed to own the CLIPBOARD selection under xvfb).

## Validation

- A per-test trace contains **0** occurrences of the seed and **0** of the password; only non-secret form fields remain as `fill()` values.
- Verified in CI (headless, xvfb + xclip): `walletAddCustomNetwork` (qase 204) — the full seed-import-via-paste path — passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved wallet setup handling in end-to-end tests by using clipboard-based input for seed phrases and passwords, making test runs more reliable.
  * Reduced the chance of sensitive pasted values appearing in browser traces during automated testing.

* **Chores**
  * Updated the Playwright test environment to include required clipboard support for Linux-based runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->