### PR TITLE
fix(e2e): stabilize swap-pair specs against deeplink token-resolution race

### DIFF
--- a/tests/e2e/data/urls.ts
+++ b/tests/e2e/data/urls.ts
@@ -38,6 +38,12 @@ export const CHAINS = {
 
 export type ChainName = (typeof CHAINS)[keyof typeof CHAINS];
 
+// Deeplink chain id → LiFi display name (the widget token card's subheader).
+export const CHAIN_NAMES_BY_ID: Record<string, string> = {
+  '1': 'Ethereum',
+  '42161': 'Arbitrum',
+};
+
 export const JUMPER_BUTTONS = {
   CONNECT: 'Connect',
   PASS: 'Pass',

--- a/tests/e2e/pages/LandingPage.ts
+++ b/tests/e2e/pages/LandingPage.ts
@@ -1,12 +1,14 @@
 import { expect } from '@playwright/test';
 
-import { ROUTE_LABELS } from '../data/urls';
+import { CHAIN_NAMES_BY_ID, ROUTE_LABELS } from '../data/urls';
 
+import type { WidgetUrlParams } from '../data/urlParams';
 import type { Locator, Page } from '@playwright/test';
 
 const WELCOME_OVERLAY_SELECTOR = '.welcome-screen-container';
 const WELCOME_VISIBLE_TIMEOUT_MS = 30_000;
 const WELCOME_CLOSE_TIMEOUT_MS = 17_000;
+const TOKEN_RESOLUTION_TIMEOUT_MS = 30_000;
 
 export class LandingPage {
   readonly bridgesCount: Locator;
@@ -102,6 +104,27 @@ export class LandingPage {
     await expect(relayLabel).toBeVisible();
   }
 
+  /**
+   * Deeplinked token addresses resolve into tokens only after the widget's
+   * token list loads — until then the route query is gated off entirely, so
+   * under CI load routes can lose the race against a fixed timeout. Waits for
+   * the chain-name subheader (renders only once chain AND token resolve);
+   * asserting the token symbol would break across environments (develop
+   * serves 'USDT' where prod serves 'USDT0' for the same Arbitrum token).
+   */
+  async expectSwapPairResolved(pair: WidgetUrlParams): Promise<void> {
+    await expect(
+      this.tokenCard('From').getByText(this.chainNameOf(pair.fromChain), {
+        exact: true,
+      }),
+    ).toBeVisible({ timeout: TOKEN_RESOLUTION_TIMEOUT_MS });
+    await expect(
+      this.tokenCard('To').getByText(this.chainNameOf(pair.toChain), {
+        exact: true,
+      }),
+    ).toBeVisible({ timeout: TOKEN_RESOLUTION_TIMEOUT_MS });
+  }
+
   async expectWelcomeHeadingVisible(): Promise<void> {
     await expect(
       this.page.getByRole('heading', { name: ROUTE_LABELS.WELCOME_HEADING }),
@@ -129,6 +152,16 @@ export class LandingPage {
     await expect(label).toBeVisible();
   }
 
+  private chainNameOf(chainId: string): string {
+    const name = CHAIN_NAMES_BY_ID[chainId];
+    if (!name) {
+      throw new Error(
+        `No display name mapped for chain ${chainId} — add it to CHAIN_NAMES_BY_ID in data/urls.ts`,
+      );
+    }
+    return name;
+  }
+
   // Counter animates via useCountUpAnimation; poll the semantic assertion so transient "0" snapshots don't fail us.
   private async expectStatGreaterThanZero(locator: Locator): Promise<void> {
     await expect
@@ -136,5 +169,12 @@ export class LandingPage {
         timeout: 10_000,
       })
       .toBeGreaterThan(0);
+  }
+
+  // TODO(app): JUM-924 — widget token select buttons lack testids; anchored on the card title text.
+  private tokenCard(title: 'From' | 'To'): Locator {
+    return this.page
+      .locator('button')
+      .filter({ has: this.page.getByText(title, { exact: true }) });
   }
 }

--- a/tests/e2e/swapActions.spec.ts
+++ b/tests/e2e/swapActions.spec.ts
@@ -6,6 +6,7 @@ import { buildUrlParams } from './data/urlParams';
 import { noWalletTest as test } from './fixtures/noWallet';
 import { LandingPage } from './pages/LandingPage';
 import { SettingsPage } from './pages/SettingsPage';
+import { seedWelcomeScreenClosed } from './utils/welcomeScreen';
 [
   { name: 'Mobile', size: { height: 812, width: 375 } },
   { name: 'Desktop', size: { height: 1080, width: 1920 } },
@@ -18,8 +19,8 @@ import { SettingsPage } from './pages/SettingsPage';
 
     test.beforeEach(async ({ page }) => {
       const landingPage = new LandingPage(page);
+      await seedWelcomeScreenClosed(page);
       await landingPage.goto();
-      await landingPage.closeWelcomeScreen();
     });
     // jscpd:ignore-end
 
@@ -34,8 +35,9 @@ import { SettingsPage } from './pages/SettingsPage';
           await settings.deselectAll();
           await settings.goBack();
 
-          const urlParams = buildUrlParams(chainData.ETHtoETHswap.ETHtoETH);
-          await page.goto(`/${urlParams}`);
+          const pair = chainData.ETHtoETHswap.ETHtoETH;
+          await page.goto(`/${buildUrlParams(pair)}`);
+          await landingPage.expectSwapPairResolved(pair);
           await landingPage.expectRoutesVisibility({
             bestReturnShouldBeVisible: true,
             checkRelayRoute: true,
@@ -50,14 +52,18 @@ import { SettingsPage } from './pages/SettingsPage';
         const landingPage = new LandingPage(page);
 
         await test.step(`Check ${chainData.ARBtoARB.ETHtoUSDT.tokenSymbol} to ${chainData.ARBtoARB.ETHtoUSDT.toTokenSymbol} swap pair`, async () => {
-          await page.goto(`/${buildUrlParams(chainData.ARBtoARB.ETHtoUSDT)}`);
+          const pair = chainData.ARBtoARB.ETHtoUSDT;
+          await page.goto(`/${buildUrlParams(pair)}`);
+          await landingPage.expectSwapPairResolved(pair);
           await landingPage.expectRoutesVisibility({
             bestReturnShouldBeVisible: true,
           });
         });
 
         await test.step(`Check ${chainData.ARBtoARB.USDCtoWBTC.tokenSymbol} to ${chainData.ARBtoARB.USDCtoWBTC.toTokenSymbol} swap pair`, async () => {
-          await page.goto(`/${buildUrlParams(chainData.ARBtoARB.USDCtoWBTC)}`);
+          const pair = chainData.ARBtoARB.USDCtoWBTC;
+          await page.goto(`/${buildUrlParams(pair)}`);
+          await landingPage.expectSwapPairResolved(pair);
           await landingPage.expectRoutesVisibility({
             bestReturnShouldBeVisible: true,
           });

--- a/tests/e2e/utils/welcomeScreen.ts
+++ b/tests/e2e/utils/welcomeScreen.ts
@@ -1,0 +1,30 @@
+import type { Page } from '@playwright/test';
+
+// Mirrors the zustand persist config in src/stores/settings/createSettingsStore.tsx.
+const SETTINGS_STORE_KEY = 'jumper-store';
+const SETTINGS_STORE_VERSION = 4;
+
+/**
+ * Seeds the persisted settings store so the welcome overlay never mounts.
+ * Dismissing it by clicking races React hydration under CI load (a single
+ * missed "Get Started" click leaves the overlay up); pre-seeding removes the
+ * interaction entirely. Call before the test's first goto().
+ */
+export async function seedWelcomeScreenClosed(page: Page): Promise<void> {
+  await page.addInitScript(
+    ({ key, version }) => {
+      const existing = JSON.parse(
+        globalThis.localStorage.getItem(key) ?? 'null',
+      );
+      globalThis.localStorage.setItem(
+        key,
+        JSON.stringify({
+          version,
+          ...existing,
+          state: { ...existing?.state, welcomeScreenClosed: true },
+        }),
+      );
+    },
+    { key: SETTINGS_STORE_KEY, version: SETTINGS_STORE_VERSION },
+  );
+}


### PR DESCRIPTION
Closes JUM-1237

## Why

`swapActions.spec.ts` qase 23/24/26/27 (ETH/ARB swap pairs, both viewports) fail intermittently in CI: `getByText('Best Return')` times out, failure screenshots show From/To stuck on "Select…" with **zero route requests fired**.

Root cause: the widget only enables the route query once both deeplinked token **addresses** resolve into token objects against the loaded token list. Under CI shard load the list loses that race against the fixed 30s route timeout — the deeplink is parsed fine, but no routes are ever requested. Secondary: the specs dismissed the welcome overlay with a single un-retried "Get Started" click, which races React hydration.

## What

- `LandingPage.expectSwapPairResolved(pair)` — waits for the resolved swap pair before asserting routes, called after each deeplink `goto` in the four specs. Anchors on the **chain-name subheader** (renders only once chain AND token resolve), not the token symbol — the symbol drifts between environments (develop pipeline serves `USDT` where prod serves `USDT0` for the same Arbitrum token).
- `tests/e2e/utils/welcomeScreen.ts` — `seedWelcomeScreenClosed(page)` pre-seeds `welcomeScreenClosed` into the persisted settings store via `addInitScript` (merge, not overwrite), so the overlay never mounts; replaces the click in the swapActions `beforeEach`. Also ~5s faster per test.

## Validation

Two consecutive silent `workflow_dispatch` runs on this branch — qase 23/24/26/27 all green **on first attempt** (8/8, retries unused):

| | qase 23 | qase 24 | qase 26 | qase 27 |
|---|---|---|---|---|
| Baseline (recent develop-based runs) | ❌ fail | ✅ | ⚠️ flaky | ❌ fail |
| [28936639952](https://github.com/jumperexchange/jumper-exchange/actions/runs/28936639952) | ✅ 1st | ✅ 1st | ✅ 1st | ✅ 1st |
| [28937563259](https://github.com/jumperexchange/jumper-exchange/actions/runs/28937563259) | ✅ 1st | ✅ 1st | ✅ 1st | ✅ 1st |

Remaining flaky in those runs are unrelated (mainMenu qase 22/9, portfolioPage qase 52 — pre-existing, tracked separately).

## Noted during investigation, out of scope

- If platform requests (chains/tokens) **error** rather than load slowly, the widget parks on "Select…" with no retry — a failed deeplink is a dead widget for users too. Potential product finding.
- `SettingsPage` `getByText('Bridges', { exact: true })` strict-mode violation (2 elements) under load — pre-existing fragility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for swap flows with stronger checks that token pair details resolve correctly before validating routes.
  * Added more reliable setup for the welcome screen state to reduce test flakiness in automated runs.
  * Introduced chain ID to display-name mapping to support clearer validation of linked token/network information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->