### PR TITLE
fix(e2e): migrate welcome-screen dismissals to the persisted-store pre-seed

### DIFF
--- a/tests/e2e/connectWallet.spec.ts
+++ b/tests/e2e/connectWallet.spec.ts
@@ -5,6 +5,7 @@ import { realWalletTest as test } from './fixtures/realWallet';
 import { ConnectWalletPage } from './pages/ConnectWalletPage';
 import { LandingPage } from './pages/LandingPage';
 import { ProfilePage } from './pages/ProfilePage';
+import { seedWelcomeScreenClosed } from './utils/welcomeScreen';
 
 test.describe('Connect/disconnect MetaMask with Jumper and open /profile', () => {
   // JUM-1116: flaky in CI (6/15) — the real-MetaMask connect + post-connect Perks tab
@@ -14,6 +15,7 @@ test.describe('Connect/disconnect MetaMask with Jumper and open /profile', () =>
     qase(36, 'Connect MetaMask wallet to Jumper'),
     async ({ wallet }) => {
       const page = await wallet.getContext().newPage();
+      await seedWelcomeScreenClosed(page);
       await page.goto('/');
       await page.waitForLoadState('domcontentloaded');
 
@@ -22,7 +24,6 @@ test.describe('Connect/disconnect MetaMask with Jumper and open /profile', () =>
       const profilePage = new ProfilePage(page);
 
       await test.step('Connect MetaMask wallet to Jumper', async () => {
-        await landingPage.closeWelcomeScreen();
         await connectWalletPage.clickConnect();
         await connectWalletPage.expectSelectWalletDialogVisible();
         await connectWalletPage.selectWalletOption(WALLET_OPTIONS.METAMASK);

--- a/tests/e2e/fixtures/connectedWallet.ts
+++ b/tests/e2e/fixtures/connectedWallet.ts
@@ -1,6 +1,7 @@
 import { CHAINS, WALLET_OPTIONS } from '../data/urls';
 import { ConnectWalletPage } from '../pages/ConnectWalletPage';
 import { LandingPage } from '../pages/LandingPage';
+import { seedWelcomeScreenClosed } from '../utils/welcomeScreen';
 import { realWalletTest } from './realWallet';
 
 import type { Page } from '@playwright/test';
@@ -19,6 +20,7 @@ export const connectedTest = realWalletTest.extend<ConnectedWalletFixtures>({
 
   jumperPage: async ({ walletContext }, use) => {
     const page = await walletContext.newPage();
+    await seedWelcomeScreenClosed(page);
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
     await use(page);
@@ -31,8 +33,7 @@ export const connectedTest = realWalletTest.extend<ConnectedWalletFixtures>({
 
   // Auto-runs the connect flow before each test. For specs that test connect itself, use realWalletTest.
   walletConnected: [
-    async ({ connectWalletPage, landingPage, wallet, walletContext }, use) => {
-      await landingPage.closeWelcomeScreen();
+    async ({ connectWalletPage, wallet, walletContext }, use) => {
       await connectWalletPage.clickConnect();
       await connectWalletPage.expectSelectWalletDialogVisible();
       await connectWalletPage.selectWalletOption(WALLET_OPTIONS.METAMASK);

--- a/tests/e2e/landingPage.spec.ts
+++ b/tests/e2e/landingPage.spec.ts
@@ -4,13 +4,14 @@ import { EXCHANGE_TAB_LABEL_PATTERN, WALLET_OPTIONS } from './data/urls';
 import { noWalletTest as test } from './fixtures/noWallet';
 import { ConnectWalletPage } from './pages/ConnectWalletPage';
 import { LandingPage } from './pages/LandingPage';
+import { seedWelcomeScreenClosed } from './utils/welcomeScreen';
 
 test.describe('Landing page and navigation', () => {
   test.beforeEach(async ({ page }) => {
     const landingPage = new LandingPage(page);
+    await seedWelcomeScreenClosed(page);
     await landingPage.goto();
     await page.waitForLoadState('load');
-    await landingPage.closeWelcomeScreen();
   });
 
   test(

--- a/tests/e2e/mainMenu.spec.ts
+++ b/tests/e2e/mainMenu.spec.ts
@@ -6,13 +6,14 @@ import { noWalletTest as test } from './fixtures/noWallet';
 import { LandingPage } from './pages/LandingPage';
 import { MainMenuPage } from './pages/MainMenuPage';
 import { ScanPage } from './pages/ScanPage';
+import { seedWelcomeScreenClosed } from './utils/welcomeScreen';
 const NAV_TIMEOUT_MS = 30_000;
 
 test.describe('Main Menu flows', () => {
   test.beforeEach(async ({ page }) => {
     const landingPage = new LandingPage(page);
+    await seedWelcomeScreenClosed(page);
     await landingPage.goto();
-    await landingPage.closeWelcomeScreen();
     await new MainMenuPage(page).open();
   });
 

--- a/tests/e2e/mobileView.spec.ts
+++ b/tests/e2e/mobileView.spec.ts
@@ -7,6 +7,7 @@ import { LandingPage } from './pages/LandingPage';
 import { MainMenuPage, Theme } from './pages/MainMenuPage';
 import { isFullyInViewport } from './utils/elementUtils';
 import { removeFormattingTags } from './utils/translationUtils';
+import { seedWelcomeScreenClosed } from './utils/welcomeScreen';
 
 test.describe('Verify essential mobile flows', () => {
   test.use({ viewport: { height: 812, width: 375 } });
@@ -77,11 +78,12 @@ test.describe('Verify essential mobile flows', () => {
   );
 
   test(qase(6, 'Verify items in the menu'), async ({ page }) => {
-    const landingPage = new LandingPage(page);
     const mainMenu = new MainMenuPage(page);
 
-    await test.step('close the welcome screen', async () => {
-      await landingPage.closeWelcomeScreen();
+    await test.step('bypass the welcome screen', async () => {
+      // The seed only applies on the next navigation, so re-goto after it.
+      await seedWelcomeScreenClosed(page);
+      await page.goto('/');
     });
 
     await test.step('open the menu', async () => {

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -4,6 +4,7 @@ import { SETTINGS_MENU } from './data/settingsMenu';
 import { noWalletTest as test } from './fixtures/noWallet';
 import { LandingPage } from './pages/LandingPage';
 import { SettingsPage } from './pages/SettingsPage';
+import { seedWelcomeScreenClosed } from './utils/welcomeScreen';
 for (const { name, size } of [
   { name: 'Mobile', size: { height: 812, width: 375 } },
   { name: 'Desktop', size: { height: 1080, width: 1920 } },
@@ -16,8 +17,8 @@ for (const { name, size } of [
 
     test.beforeEach(async ({ page }) => {
       const landingPage = new LandingPage(page);
+      await seedWelcomeScreenClosed(page);
       await landingPage.goto();
-      await landingPage.closeWelcomeScreen();
     });
     // jscpd:ignore-end
 

--- a/tests/e2e/themeManipulation.spec.ts
+++ b/tests/e2e/themeManipulation.spec.ts
@@ -5,20 +5,20 @@ import { THEME_DARK_BG_RGB, THEME_LIGHT_BG_RGB } from './data/themes';
 import { noWalletTest as test } from './fixtures/noWallet';
 import { LandingPage } from './pages/LandingPage';
 import { MainMenuPage, Theme } from './pages/MainMenuPage';
+import { seedWelcomeScreenClosed } from './utils/welcomeScreen';
 
 test.describe('Switch theme — dark mode', () => {
   test.use({ colorScheme: 'dark' });
 
   test.beforeEach(async ({ page }) => {
+    await seedWelcomeScreenClosed(page);
     await page.goto('/');
   });
 
   test(
     qase(30, 'Should able to change the theme color to Dark'),
     async ({ page }) => {
-      const landingPage = new LandingPage(page);
       const mainMenu = new MainMenuPage(page);
-      await landingPage.closeWelcomeScreen();
       await mainMenu.open();
       await mainMenu.switchTheme(Theme.Dark);
       await mainMenu.expectBackgroundColor(THEME_DARK_BG_RGB);
@@ -30,6 +30,7 @@ test.describe('Switch theme — light mode', () => {
   test.use({ colorScheme: 'light' });
 
   test.beforeEach(async ({ page }) => {
+    await seedWelcomeScreenClosed(page);
     await page.goto('/');
   });
 
@@ -38,7 +39,6 @@ test.describe('Switch theme — light mode', () => {
     async ({ page }) => {
       const landingPage = new LandingPage(page);
       const mainMenu = new MainMenuPage(page);
-      await landingPage.closeWelcomeScreen();
       await mainMenu.toggle();
       await landingPage.clickMenuItem('Theme');
       await landingPage.clickMenuItem(Theme.Light);
@@ -50,6 +50,7 @@ test.describe('Switch theme — light mode', () => {
 
 test.describe('Switch theme — partner themes', () => {
   test.beforeEach(async ({ page }) => {
+    await seedWelcomeScreenClosed(page);
     await page.goto('/');
   });
 
@@ -61,7 +62,6 @@ test.describe('Switch theme — partner themes', () => {
     async ({ page }) => {
       const landingPage = new LandingPage(page);
       const mainMenu = new MainMenuPage(page);
-      await landingPage.closeWelcomeScreen();
 
       const backgroundElement = page.locator('#background-root');
       const initialBgColor = await backgroundElement.evaluate(


### PR DESCRIPTION
Closes JUM-1238

## Why

JUM-1237 (#3008) introduced `seedWelcomeScreenClosed()` — pre-seeding `welcomeScreenClosed` into the persisted settings store so the overlay never mounts — but only migrated `swapActions.spec.ts`. Everywhere else still dismisses the overlay with a single un-retried "Get Started" click, which races React hydration under CI load (the source of the historical `.welcome-screen-container still visible` failures).

## What

Migrated the remaining pure-setup dismissals — 6 specs, 8 call sites — to the seed (always placed before the navigation it applies to).

**Deliberately kept the real overlay + click where the welcome screen itself is under test:**
- `landingPage` qase 1 (overlay re-shows on logo click — `ClientNavbar` flips the store at runtime, so behavior against a seeded store is identical, verified)
- `mobileView` qase 5 (mobile welcome elements + "welcome can be closed")
- `mobileView` qase 4 untouched entirely — it measures the welcome view's viewport fit, so no seed at all

`closeWelcomeScreen()` therefore stays in the POM with those two users — it retires from *setup*, not from existence. Two now-dead `landingPage` locals removed.

## Validation

- Slack-silent `workflow_dispatch` [28948638532](https://github.com/jumperexchange/jumper-exchange/actions/runs/28948638532): all 5 shards green, every migrated spec **first-attempt** green (incl. settings qase 7 Mobile and both welcome-screen-under-test cases). Only flaky: earnPage qase 39 (pre-existing, unrelated). (An earlier dispatch was cancelled — shard 1 died at `webServer was not able to start`, the day's recurring upstream build blip, zero tests ran.)
- Local prod runs: migrated specs pass sequentially; the two failures that appear under a 5-file single-worker batch (`mobileView` qase 5 stats counters, `settings` qase 7 Mobile) **reproduce identically on develop without this diff** — pre-existing batch-profile artifact, A/B-exonerated.

## Follow-ups (tracked, out of scope)

- JUM-1239 — shared persist key/version constants between store and tests (Ioana's #3008 suggestion)
- JUM-1240 — wallet-framework hygiene (dead unlock path + clipboard cleanup hardening)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test setup to start with the welcome screen already closed.
  * Improved consistency across landing page, menu, settings, theme, mobile, and wallet connection flows.
  * Simplified test steps by removing repeated welcome-screen dismissal actions and standardizing the setup using a shared seeding helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->