### PR TITLE
refactor(settings): single source of truth for the persist key/version

### DIFF
--- a/src/stores/settings/createSettingsStore.tsx
+++ b/src/stores/settings/createSettingsStore.tsx
@@ -4,6 +4,10 @@ import { persist } from 'zustand/middleware';
 import { shallow } from 'zustand/shallow';
 import { createWithEqualityFn } from 'zustand/traditional';
 import { defaultSettings } from '@/config/config';
+import {
+  SETTINGS_PERSIST_KEY,
+  SETTINGS_PERSIST_VERSION,
+} from '@/stores/settings/persistConfig';
 import type { SettingsProps, SettingsState } from '@/types/settings';
 import type { EarnCardVariant } from '@/components/Cards/EarnCard/EarnCard.types';
 
@@ -71,8 +75,8 @@ export const createSettingsStore = (props: Partial<SettingsProps>) =>
         },
       }),
       {
-        name: 'jumper-store',
-        version: 4,
+        name: SETTINGS_PERSIST_KEY,
+        version: SETTINGS_PERSIST_VERSION,
         migrate: (persistedState: any, version: number) => {
           if (version === 0) {
             const newStore = { ...persistedState };

--- a/src/stores/settings/persistConfig.ts
+++ b/src/stores/settings/persistConfig.ts
@@ -1,0 +1,5 @@
+// Shared with the E2E welcome-screen pre-seed (tests/e2e/utils/welcomeScreen.ts) —
+// a deliberate, narrow exception to the tests↛src boundary for dependency-free
+// constants (JUM-1239). Keep this module import-free.
+export const SETTINGS_PERSIST_KEY = 'jumper-store';
+export const SETTINGS_PERSIST_VERSION = 4;

--- a/tests/e2e/utils/welcomeScreen.ts
+++ b/tests/e2e/utils/welcomeScreen.ts
@@ -1,8 +1,9 @@
-import type { Page } from '@playwright/test';
+import {
+  SETTINGS_PERSIST_KEY,
+  SETTINGS_PERSIST_VERSION,
+} from '../../../src/stores/settings/persistConfig';
 
-// Mirrors the zustand persist config in src/stores/settings/createSettingsStore.tsx.
-const SETTINGS_STORE_KEY = 'jumper-store';
-const SETTINGS_STORE_VERSION = 4;
+import type { Page } from '@playwright/test';
 
 /**
  * Seeds the persisted settings store so the welcome overlay never mounts.
@@ -25,6 +26,6 @@ export async function seedWelcomeScreenClosed(page: Page): Promise<void> {
         }),
       );
     },
-    { key: SETTINGS_STORE_KEY, version: SETTINGS_STORE_VERSION },
+    { key: SETTINGS_PERSIST_KEY, version: SETTINGS_PERSIST_VERSION },
   );
 }


### PR DESCRIPTION
Closes JUM-1239

## Why

Ioana's review suggestion on #3008: the E2E welcome-screen pre-seed (`tests/e2e/utils/welcomeScreen.ts`) mirrored the settings store's persist key/version as hand-copied literals.

The honest value here is **discoverability at the point of change**, not leak prevention: drift was always loud (a key rename makes the overlay reappear and tests fail visibly) — but whoever renames `'jumper-store'` today gets *no signal* that tests seed it, and finds out via a confusing suite-wide red plus a debugging session. Since #3009 the seed is load-bearing for effectively the whole suite (9 call sites + the `connectedTest` fixture), so that scenario got materially more expensive. The shared file puts the dependency note at the definition site instead.

## What

- `src/stores/settings/persistConfig.ts` (new) — **dependency-free leaf module** exporting `SETTINGS_PERSIST_KEY` / `SETTINGS_PERSIST_VERSION`. Import-free on purpose: the tests' TS project pulls in two constants, not zustand/React transitively.
- `createSettingsStore.tsx` — uses the constants. Pure literal extraction, behavior-identical, no bundle impact.
- `tests/e2e/utils/welcomeScreen.ts` — imports them; mirrored constants deleted.

The tests→src import is a deliberate, **narrow** exception to the `tests/CLAUDE.md` boundary convention, for import-free constants only (precedent: `mobileView.spec.ts` already imports a translation JSON from src). The rule itself stays as-is.

## Considered and excluded — why the file has exactly two constants

- **`.welcome-screen-container` selector** (`LandingPage`) — a class name shouldn't be an app↔test contract at all; the right fix is a `data-testid` (JUM-924), not cementing the class as shared.
- **Theme RGBs** (`tests/e2e/data/themes.ts` ← `src/theme`) — fails the leaf-module constraint: theme modules pull MUI, so tests would transitively import the app's dependency graph. Sharing these needs the tokens extracted to their own leaf first — separate decision if ever wanted.
- **`welcomeScreenClosed` property name** in the seeded state — could be type-checked via a type-only import of `SettingsProps`, but that widens the exception from "constants" to "types"; left out deliberately.
- **`ROUTE_LABELS` / `CHAIN_NAMES_BY_ID`** — mirror the widget/LiFi side (external package); nothing shareable app-side.

## Validation

- `pnpm typecheck` (app) + `pnpm tsc:tests` (tests project compiles the src import) both clean.
- Runtime transpile proven: migrated specs run green against prod through the new import path (the seed works — `mainMenu` qase 12 opens the menu straight after goto, only possible with the overlay seeded away).
- Slack-silent `workflow_dispatch` on the branch: [28954751559](https://github.com/jumperexchange/jumper-exchange/actions/runs/28954751559) — all 5 shards green, every seed-dependent spec first-attempt `expected` (only flaky: mainMenu qase 22 Learn nav, known pre-existing). Also the first run of the new report pipeline on this branch: [published report](https://jumperexchange.github.io/jumper-exchange/run-20260708-28954751559-1/) + encrypted artifact both worked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Aligned app settings persistence and test pre-seeding to use the same stored key and version, reducing the chance of mismatch issues.
  * Kept persisted settings behavior unchanged while making the configured values consistent across the app and end-to-end setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->