### PR TITLE
feat: orders and market price sections for advanced widget side panel

### DIFF
--- a/gen-limit-order-api.sh
+++ b/gen-limit-order-api.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+LIMIT_ORDER_SWAGGER_URL="${NEXT_PUBLIC_LIMIT_ORDER_BACKEND_URL:-http://localhost:8080}/openapi/json"
+
+# curl to /tmp/limit-order-swagger.json
+curl -s "$LIMIT_ORDER_SWAGGER_URL" > /tmp/limit-order-swagger.json
+
+# generate api
+npx swagger-typescript-api generate \
+  --path '/tmp/limit-order-swagger.json' \
+  --api-class-name='JumperLimitOrder' \
+  --name="jumper-limit-order.ts" \
+  --output="src/types/"
+
+# patch generated file with the request parameters
+# -0777 slurps the whole file so `or die` fires when the pattern is absent anywhere
+perl -i -0777 -pe "s|// \@ts-nocheck|// \@ts-nocheck\nimport config from '\@/config/env-config';| or die \"Patch failed: '// \@ts-nocheck' not found in generated file\\n\"" src/types/jumper-limit-order.ts
+perl -i -0777 -pe "s|headers: \{\},|headers: { Referer: config.NEXT_PUBLIC_SITE_URL },|g or die \"Patch failed: 'headers: {}' not found in generated file\\n\"" src/types/jumper-limit-order.ts
+perl -i -0777 -pe 's|referrerPolicy: "no-referrer"|referrerPolicy: "strict-origin-when-cross-origin"|g or die "Patch failed: '\''referrerPolicy: \"no-referrer\"'\'' not found in generated file\n"' src/types/jumper-limit-order.ts
+
+# format
+npx prettier --write src/types/jumper-limit-order.ts

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "dev:production": "dotenv -e .env.production next dev",
     "build": "NODE_OPTIONS=--max-old-space-size=6144 next build --turbopack",
     "api": "./gen-api.sh",
+    "limit-order-api": "./gen-limit-order-api.sh",
     "gen:ondo-denylist": "node ./gen-ondo-denylist.mjs",
     "start": "next start",
     "lint": "eslint .",

--- a/src/app/lib/limitOrderClient.ts
+++ b/src/app/lib/limitOrderClient.ts
@@ -1,0 +1,8 @@
+import config from '@/config/env-config';
+import { JumperLimitOrder } from '@/types/jumper-limit-order';
+
+export const makeLimitOrderClient = (): JumperLimitOrder<unknown> => {
+  return new JumperLimitOrder({
+    baseUrl: config.NEXT_PUBLIC_LIMIT_ORDER_BACKEND_URL,
+  });
+};

--- a/src/app/ui/widget/AdvancedPageContent.tsx
+++ b/src/app/ui/widget/AdvancedPageContent.tsx
@@ -1,7 +1,78 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+import { WidgetEvent, useWidgetEvents } from '@lifi/widget';
+import { OrdersSection } from '@/components/LimitOrders/OrdersSection/OrdersSection';
+import { MarketPriceSection } from '@/components/LimitOrders/MarketPriceSection/MarketPriceSection';
+import { useWidgetSidePanelStore } from '@/stores/widgetSidePanel/WidgetSidePanelStore';
 import { MainWidgetPageContent } from './MainWidgetPageContent';
+import { WidgetSidePanel } from './WidgetSidePanel';
+import CloseFullscreenIcon from '@mui/icons-material/CloseFullscreen';
+import OpenInFullIcon from '@mui/icons-material/OpenInFull';
+import { IconButton } from '@/components/core/buttons/IconButton/IconButton';
+import { Size, Variant } from '@/components/core/buttons/types';
+import { useTranslation } from 'react-i18next';
 
 export const AdvancedPageContent = () => {
-  return <MainWidgetPageContent variant="advanced" />;
+  const { t } = useTranslation();
+  const widgetEvents = useWidgetEvents();
+  const [isLimitTabActive, setIsLimitTabActive] = useState(false);
+  const isSidePanelExpanded = useWidgetSidePanelStore(
+    (state) => state.isSidePanelExpanded,
+  );
+  const toggleSidePanelExpanded = useWidgetSidePanelStore(
+    (state) => state.toggleSidePanelExpanded,
+  );
+
+  useEffect(() => {
+    const handler = ({ tab }: { tab: string }) => {
+      setIsLimitTabActive(tab === 'limit');
+    };
+    widgetEvents.on(WidgetEvent.NavigationTabChanged, handler);
+    return () => {
+      widgetEvents.off(WidgetEvent.NavigationTabChanged, handler);
+    };
+  }, [widgetEvents]);
+
+  useEffect(() => {
+    return () => {
+      useWidgetSidePanelStore.setState({ isSidePanelExpanded: false });
+    };
+  }, []);
+
+  const expandButton = (
+    <IconButton
+      size={Size.SM}
+      variant={Variant.AlphaDark}
+      onClick={toggleSidePanelExpanded}
+      aria-expanded={isSidePanelExpanded}
+      aria-label={
+        isSidePanelExpanded
+          ? t('limitOrders.table.actions.collapsePanels')
+          : t('limitOrders.table.actions.expandPanels')
+      }
+      data-testid="orders-section-expand"
+      sx={{ height: 32, width: 32 }}
+    >
+      {isSidePanelExpanded ? <CloseFullscreenIcon /> : <OpenInFullIcon />}
+    </IconButton>
+  );
+
+  return (
+    <MainWidgetPageContent
+      variant="advanced"
+      isSidePanelExpanded={isSidePanelExpanded}
+      sidePanelContent={
+        isLimitTabActive ? (
+          <WidgetSidePanel>
+            <MarketPriceSection action={expandButton} />
+            <OrdersSection
+              isSidePanelExpanded={isSidePanelExpanded}
+              action={expandButton}
+            />
+          </WidgetSidePanel>
+        ) : undefined
+      }
+    />
+  );
 };

--- a/src/components/LimitOrders/MarketPriceSection/MarketPriceSection.styles.ts
+++ b/src/components/LimitOrders/MarketPriceSection/MarketPriceSection.styles.ts
@@ -1,0 +1,8 @@
+import Skeleton from '@mui/material/Skeleton';
+import { styled } from '@mui/material/styles';
+
+export const BaseSkeleton = styled(Skeleton)(({ theme }) => ({
+  transform: 'none',
+  backgroundColor: (theme.vars || theme).palette.grey[100],
+  borderRadius: theme.shape.buttonBorderRadius,
+}));

--- a/src/components/LimitOrders/MarketPriceSection/MarketPriceSection.tsx
+++ b/src/components/LimitOrders/MarketPriceSection/MarketPriceSection.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { AnimatePresence, motion } from 'motion/react';
+import { useTranslation } from 'react-i18next';
+import { ActionableSection } from '@/components/composite/ActionableSection/ActionableSection';
+import type { ReactNode } from 'react';
+import { useLimitOrders } from '@/hooks/useLimitOrders';
+import { MarketPriceSectionSkeleton } from './MarketPriceSectionSkeleton';
+
+interface MarketPriceSectionProps {
+  action: ReactNode;
+}
+
+export const MarketPriceSection = ({ action }: MarketPriceSectionProps) => {
+  const { t } = useTranslation();
+  const { isLoading } = useLimitOrders();
+
+  return (
+    <ActionableSection
+      title={t('limitOrders.marketPrice')}
+      action={action}
+      sx={{ flexShrink: 0 }}
+    >
+      <AnimatePresence mode="popLayout">
+        {isLoading && (
+          <motion.div
+            key="market-price-skeleton"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3, ease: 'easeInOut' }}
+          >
+            <MarketPriceSectionSkeleton />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </ActionableSection>
+  );
+};

--- a/src/components/LimitOrders/MarketPriceSection/MarketPriceSectionSkeleton.tsx
+++ b/src/components/LimitOrders/MarketPriceSection/MarketPriceSectionSkeleton.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import Stack from '@mui/material/Stack';
+import { BaseSkeleton } from './MarketPriceSection.styles';
+
+export const MarketPriceSectionSkeleton = () => {
+  return (
+    <Stack sx={{ gap: 2 }}>
+      <BaseSkeleton variant="rounded" sx={{ height: 120, width: '100%' }} />
+      <Stack direction="row" sx={{ gap: 2 }}>
+        <BaseSkeleton variant="rounded" sx={{ height: 16, flex: 1 }} />
+        <BaseSkeleton variant="rounded" sx={{ height: 16, flex: 1 }} />
+      </Stack>
+    </Stack>
+  );
+};

--- a/src/components/LimitOrders/OrdersSection/OrderCell.tsx
+++ b/src/components/LimitOrders/OrdersSection/OrderCell.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { NUMERIC_SX } from './constants';
+import { BaseSurface1Skeleton } from '@/components/core/skeletons/BaseSurfaceSkeleton/BaseSurfaceSkeleton.style';
+
+export const OrderCell = ({
+  children,
+  align = 'left',
+  strong,
+  muted,
+}: {
+  children: ReactNode;
+  align?: 'left' | 'right';
+  strong?: boolean;
+  muted?: boolean;
+}) => (
+  <Box
+    sx={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: align === 'right' ? 'flex-end' : 'flex-start',
+      width: '100%',
+      minWidth: 0,
+    }}
+  >
+    <Typography
+      variant={strong ? 'bodySmallStrong' : 'bodySmall'}
+      sx={{
+        ...NUMERIC_SX,
+        ...(muted && { color: 'text.disabled' }),
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        minWidth: 0,
+      }}
+    >
+      {children}
+    </Typography>
+  </Box>
+);
+
+export const OrderCellSkeleton = ({
+  width = '60%',
+  align = 'left',
+}: {
+  width?: number | string;
+  align?: 'left' | 'right';
+}) => (
+  <Box
+    sx={{
+      display: 'flex',
+      justifyContent: align === 'right' ? 'flex-end' : 'flex-start',
+    }}
+  >
+    <BaseSurface1Skeleton variant="rounded" sx={{ height: 16, width }} />
+  </Box>
+);

--- a/src/components/LimitOrders/OrdersSection/OrderRowMenu.tsx
+++ b/src/components/LimitOrders/OrdersSection/OrderRowMenu.tsx
@@ -1,0 +1,93 @@
+'use client';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+import Menu from '@mui/material/Menu';
+import Typography from '@mui/material/Typography';
+import { useState } from 'react';
+import { getSurfaceBorder } from '@/theme/utils/getSurfaceBorder';
+import { OrderMenuItemContainer } from './OrdersSection.styles';
+import { IconButton } from '@/components/core/buttons/IconButton/IconButton';
+import { Variant, Size } from '@/components/core/buttons/types';
+import { type Order } from '@/types/jumper-limit-order';
+
+interface OrderRowMenuProps {
+  order: Order;
+}
+
+export const OrderRowMenu = ({ order }: OrderRowMenuProps) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const open = Boolean(anchorEl);
+
+  const handleOpen = (e: React.MouseEvent<HTMLElement>) => {
+    e.stopPropagation();
+    setAnchorEl(e.currentTarget);
+  };
+
+  const handleClose = () => setAnchorEl(null);
+
+  const isCancellable = order.status === 'active' || order.status === 'pending';
+
+  return (
+    <>
+      <IconButton
+        variant={Variant.AlphaDark}
+        size={Size.SM}
+        onClick={handleOpen}
+      >
+        <MoreHorizIcon />
+      </IconButton>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        disableScrollLock
+        disableAutoFocusItem
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{
+          paper: {
+            sx: (theme) => ({
+              mt: 0.5,
+              minWidth: 180,
+              p: 1,
+              border: getSurfaceBorder(theme, 'surface1'),
+              boxShadow: theme.shadows[1],
+              borderRadius: `${theme.shape.radius16}px`,
+            }),
+          },
+          list: {
+            sx: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 0.5,
+            },
+          },
+        }}
+      >
+        <OrderMenuItemContainer onClick={handleClose}>
+          <Typography
+            variant="bodySmallStrong"
+            component="a"
+            href={`https://explorer.cow.fi/orders/${order.orderId}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{ textDecoration: 'none', color: 'inherit' }}
+          >
+            View on explorer
+          </Typography>
+        </OrderMenuItemContainer>
+        <OrderMenuItemContainer onClick={handleClose}>
+          <Typography variant="bodySmallStrong">Modify limit</Typography>
+        </OrderMenuItemContainer>
+        {isCancellable && (
+          <OrderMenuItemContainer onClick={handleClose}>
+            <Typography variant="bodySmallStrong" color="error">
+              Cancel order
+            </Typography>
+          </OrderMenuItemContainer>
+        )}
+      </Menu>
+    </>
+  );
+};

--- a/src/components/LimitOrders/OrdersSection/OrdersSection.styles.ts
+++ b/src/components/LimitOrders/OrdersSection/OrdersSection.styles.ts
@@ -1,0 +1,11 @@
+import { MenuItem } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+export const OrderMenuItemContainer = styled(MenuItem)(({ theme }) => ({
+  height: 40,
+  borderRadius: theme.shape.radius12,
+  padding: theme.spacing(1, 1.5),
+  '&:hover, &:focus, &:active, &.Mui-selected': {
+    backgroundColor: (theme.vars || theme).palette.alpha100.main,
+  },
+}));

--- a/src/components/LimitOrders/OrdersSection/OrdersSection.tsx
+++ b/src/components/LimitOrders/OrdersSection/OrdersSection.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useAccount } from '@lifi/wallet-management';
+import { AnimatePresence, motion } from 'motion/react';
+import { useTranslation } from 'react-i18next';
+import { ActionableSection } from '@/components/composite/ActionableSection/ActionableSection';
+import { OrdersTable } from './OrdersTable';
+import type { ReactNode } from 'react';
+import { useLimitOrders } from '@/hooks/useLimitOrders';
+
+interface OrdersSectionProps {
+  isSidePanelExpanded: boolean;
+  action: ReactNode;
+}
+
+export const OrdersSection = ({
+  isSidePanelExpanded,
+  action,
+}: OrdersSectionProps) => {
+  const { t } = useTranslation();
+  const { account } = useAccount();
+  const { data, isLoading } = useLimitOrders();
+
+  const shouldShow = !!account?.address && !isLoading && !!data?.length;
+
+  return (
+    <AnimatePresence mode="popLayout">
+      {shouldShow && (
+        <motion.div
+          key="orders-section"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.3, ease: 'easeInOut' }}
+        >
+          <ActionableSection
+            title={t('limitOrders.orders')}
+            action={action}
+            sx={{ flexShrink: 0 }}
+          >
+            <OrdersTable
+              orders={data ?? []}
+              isExpanded={isSidePanelExpanded}
+              stickyHeader
+            />
+          </ActionableSection>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/components/LimitOrders/OrdersSection/OrdersTable.stories.tsx
+++ b/src/components/LimitOrders/OrdersSection/OrdersTable.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { OrdersTable } from './OrdersTable';
+import { sampleOrders } from './fixtures';
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+const meta = {
+  title: 'LimitOrders/OrdersTable',
+  component: OrdersTable,
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
+} satisfies Meta<typeof OrdersTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    orders: sampleOrders,
+  },
+};
+
+export const ActiveOnly: Story = {
+  args: {
+    orders: sampleOrders.filter((o) => o.status === 'active'),
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    orders: [],
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    orders: [],
+    isLoading: true,
+  },
+};

--- a/src/components/LimitOrders/OrdersSection/OrdersTable.tsx
+++ b/src/components/LimitOrders/OrdersSection/OrdersTable.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { DataTable } from '@/components/composite/DataTable/DataTable';
+import { useOrderColumns } from './hooks';
+import { type Order } from '@/types/jumper-limit-order';
+
+interface OrdersTableProps {
+  orders: Order[];
+  isLoading?: boolean;
+  isExpanded?: boolean;
+  stickyHeader?: boolean;
+}
+
+export const OrdersTable = ({
+  orders,
+  isLoading = false,
+  isExpanded = false,
+  stickyHeader = false,
+}: OrdersTableProps) => {
+  const columns = useOrderColumns(isExpanded);
+  return (
+    <DataTable
+      rows={orders}
+      loading={isLoading}
+      columns={columns}
+      getRowKey={(order) => order.orderId}
+      hasMobileView={false}
+      showHeader
+      stickyHeader={stickyHeader}
+    />
+  );
+};

--- a/src/components/LimitOrders/OrdersSection/constants.ts
+++ b/src/components/LimitOrders/OrdersSection/constants.ts
@@ -1,0 +1,10 @@
+export const CHAIN_COL_WIDTH = 60;
+export const ACTIONS_COL_WIDTH = 48;
+
+export const NUMERIC_SX = {
+  fontVariantNumeric: 'tabular-nums',
+} as const;
+
+export const CHAIN_AVATAR_SIZE = 32;
+
+export const AMOUNT_COL_MAX_WIDTH = 120;

--- a/src/components/LimitOrders/OrdersSection/fixtures.ts
+++ b/src/components/LimitOrders/OrdersSection/fixtures.ts
@@ -1,0 +1,317 @@
+import type { Order, TokenDto } from '@/types/jumper-limit-order';
+
+const MAKER_ADDRESS = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb';
+
+const toUnixSeconds = (date: Date): number => Math.floor(date.getTime() / 1000);
+
+const daysFromNow = (days: number): number =>
+  toUnixSeconds(new Date(Date.now() + days * 24 * 60 * 60 * 1000));
+
+const daysAgo = (days: number): number =>
+  toUnixSeconds(new Date(Date.now() - days * 24 * 60 * 60 * 1000));
+
+const createToken = (
+  chainId: number,
+  token: Omit<TokenDto, 'chainId'>,
+): TokenDto => ({
+  chainId,
+  ...token,
+});
+
+const createOrder = (
+  order: Omit<Order, 'fromAddress'> & { fromAddress?: string },
+): Order => ({
+  ...order,
+  fromAddress: order.fromAddress ?? MAKER_ADDRESS,
+});
+
+const filledFromAmount = (fromAmount: string, percent: number): string => {
+  const total = BigInt(fromAmount);
+  return ((total * BigInt(Math.round(percent * 100))) / 10000n).toString();
+};
+
+const filledToAmount = (toAmount: string, percent: number): string => {
+  const total = BigInt(toAmount);
+  return ((total * BigInt(Math.round(percent * 100))) / 10000n).toString();
+};
+
+const USDC = (chainId: number): TokenDto =>
+  createToken(chainId, {
+    address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    symbol: 'USDC',
+    name: 'USD Coin',
+    decimals: 6,
+    coinKey: 'USDC',
+    priceUSD: '1.00',
+    logoURI:
+      'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png',
+  });
+
+const UNI = (chainId: number): TokenDto =>
+  createToken(chainId, {
+    address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+    symbol: 'UNI',
+    name: 'Uniswap',
+    decimals: 18,
+    priceUSD: '3.31',
+    logoURI:
+      'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984/logo.png',
+  });
+
+const WBTC = (chainId: number): TokenDto =>
+  createToken(chainId, {
+    address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+    symbol: 'WBTC',
+    name: 'Wrapped Bitcoin',
+    decimals: 8,
+    coinKey: 'WBTC',
+    priceUSD: '63820',
+  });
+
+const wstETH = (chainId: number): TokenDto =>
+  createToken(chainId, {
+    address: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
+    symbol: 'wstETH',
+    name: 'Wrapped stETH',
+    decimals: 18,
+    coinKey: 'WETH',
+    priceUSD: '2165',
+  });
+
+const ARB = (chainId: number): TokenDto =>
+  createToken(chainId, {
+    address: '0x912ce59144191c1204e64559fe8253a0e49e6548',
+    symbol: 'ARB',
+    name: 'Arbitrum',
+    decimals: 18,
+    priceUSD: '0.0851',
+  });
+
+const OP = (chainId: number): TokenDto =>
+  createToken(chainId, {
+    address: '0x4200000000000000000000000000000000000042',
+    symbol: 'OP',
+    name: 'Optimism',
+    decimals: 18,
+    priceUSD: '1.07',
+  });
+
+const DAI = (chainId: number): TokenDto =>
+  createToken(chainId, {
+    address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+    symbol: 'DAI',
+    name: 'Dai Stablecoin',
+    decimals: 18,
+    coinKey: 'DAI',
+    priceUSD: '1.00',
+  });
+
+const LINK = (chainId: number): TokenDto =>
+  createToken(chainId, {
+    address: '0x514910771af9ca656af840dff83e8264ecf986ca',
+    symbol: 'LINK',
+    name: 'Chainlink',
+    decimals: 18,
+    priceUSD: '8.04',
+  });
+
+const ETH = (chainId: number): TokenDto =>
+  createToken(chainId, {
+    address: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+    symbol: 'ETH',
+    name: 'Ether',
+    decimals: 18,
+    coinKey: 'ETH',
+    priceUSD: '1442',
+  });
+
+export const sampleOrders: Order[] = [
+  createOrder({
+    orderId: 'order-1',
+    tool: '1inch',
+    chainId: 42161,
+    fromToken: UNI(42161),
+    toToken: USDC(42161),
+    fromAmount: '450000000000000000000',
+    toAmount: '1479260000',
+    filledFromAmount: filledFromAmount('450000000000000000000', 37),
+    filledToAmount: filledToAmount('1479260000', 37),
+    status: 'active',
+    orderType: 'partial_fill',
+    validUntil: daysFromNow(4),
+    createdAt: daysAgo(2),
+  }),
+  createOrder({
+    orderId: 'order-2',
+    tool: '1inch',
+    chainId: 42161,
+    fromToken: USDC(42161),
+    toToken: WBTC(42161),
+    fromAmount: '6000000000',
+    toAmount: '9347000',
+    filledFromAmount: filledFromAmount('6000000000', 62),
+    filledToAmount: filledToAmount('9347000', 62),
+    status: 'active',
+    orderType: 'partial_fill',
+    validUntil: daysFromNow(3),
+    createdAt: daysAgo(1),
+  }),
+  createOrder({
+    orderId: 'order-3',
+    tool: '1inch',
+    chainId: 42161,
+    fromToken: USDC(42161),
+    toToken: wstETH(42161),
+    fromAmount: '3000000000',
+    toAmount: '1394500000000000000',
+    filledFromAmount: '3000000000',
+    filledToAmount: '1394500000000000000',
+    status: 'filled',
+    validUntil: daysFromNow(1),
+    createdAt: daysAgo(5),
+    filledAt: daysAgo(4),
+    orderType: 'fill_or_kill',
+  }),
+  createOrder({
+    orderId: 'order-4',
+    tool: 'cowswap',
+    chainId: 100,
+    fromToken: USDC(100),
+    toToken: UNI(100),
+    fromAmount: '2000000000',
+    toAmount: '742960000000000000000',
+    filledFromAmount: '0',
+    filledToAmount: '0',
+    status: 'cancelled',
+    orderType: 'partial_fill',
+    validUntil: daysFromNow(2),
+    createdAt: daysAgo(3),
+  }),
+  createOrder({
+    orderId: 'order-5',
+    tool: 'cowswap',
+    chainId: 1,
+    fromToken: USDC(1),
+    toToken: LINK(1),
+    fromAmount: '1500000000',
+    toAmount: '186980000000000000000',
+    filledFromAmount: '1500000000',
+    filledToAmount: '186980000000000000000',
+    status: 'filled',
+    validUntil: daysFromNow(1),
+    createdAt: daysAgo(7),
+    filledAt: daysAgo(6),
+    orderType: 'fill_or_kill',
+  }),
+  createOrder({
+    orderId: 'order-6',
+    tool: '1inch',
+    chainId: 42161,
+    fromToken: USDC(42161),
+    toToken: ETH(42161),
+    fromAmount: '1600000000',
+    toAmount: '1111300000000000000',
+    filledFromAmount: '0',
+    filledToAmount: '0',
+    status: 'expired',
+    orderType: 'partial_fill',
+    validUntil: daysAgo(1),
+    createdAt: daysAgo(10),
+  }),
+  createOrder({
+    orderId: 'order-7',
+    tool: '1inch',
+    chainId: 42161,
+    fromToken: ARB(42161),
+    toToken: USDC(42161),
+    fromAmount: '2400000000000000000000',
+    toAmount: '204370000',
+    filledFromAmount: '2400000000000000000000',
+    filledToAmount: '204370000',
+    status: 'filled',
+    validUntil: daysFromNow(1),
+    createdAt: daysAgo(4),
+    filledAt: daysAgo(3),
+    orderType: 'fill_or_kill',
+  }),
+  createOrder({
+    orderId: 'order-8',
+    tool: 'cowswap',
+    chainId: 10,
+    fromToken: USDC(10),
+    toToken: OP(10),
+    fromAmount: '1000000000',
+    toAmount: '9350740000000000000000',
+    filledFromAmount: '1000000000',
+    filledToAmount: '9350740000000000000000',
+    status: 'filled',
+    validUntil: daysFromNow(1),
+    createdAt: daysAgo(6),
+    filledAt: daysAgo(5),
+    orderType: 'fill_or_kill',
+  }),
+  createOrder({
+    orderId: 'order-9',
+    tool: '1inch',
+    chainId: 1,
+    fromToken: USDC(1),
+    toToken: DAI(1),
+    fromAmount: '5000000000',
+    toAmount: '4999660000000000000000',
+    filledFromAmount: '5000000000',
+    filledToAmount: '4999660000000000000000',
+    status: 'filled',
+    validUntil: daysFromNow(1),
+    createdAt: daysAgo(8),
+    filledAt: daysAgo(7),
+    orderType: 'fill_or_kill',
+  }),
+  createOrder({
+    orderId: 'order-10',
+    tool: '1inch',
+    chainId: 42161,
+    fromToken: ARB(42161),
+    toToken: USDC(42161),
+    fromAmount: '2400000000000000000000',
+    toAmount: '204370000',
+    filledFromAmount: '2400000000000000000000',
+    filledToAmount: '204370000',
+    status: 'filled',
+    validUntil: daysFromNow(1),
+    createdAt: daysAgo(4),
+    filledAt: daysAgo(3),
+    orderType: 'fill_or_kill',
+  }),
+  createOrder({
+    orderId: 'order-11',
+    tool: 'cowswap',
+    chainId: 10,
+    fromToken: USDC(10),
+    toToken: OP(10),
+    fromAmount: '1000000000',
+    toAmount: '9350740000000000000000',
+    filledFromAmount: '1000000000',
+    filledToAmount: '9350740000000000000000',
+    status: 'filled',
+    validUntil: daysFromNow(1),
+    createdAt: daysAgo(6),
+    filledAt: daysAgo(5),
+    orderType: 'fill_or_kill',
+  }),
+  createOrder({
+    orderId: 'order-12',
+    tool: '1inch',
+    chainId: 1,
+    fromToken: USDC(1),
+    toToken: DAI(1),
+    fromAmount: '5000000000',
+    toAmount: '4999660000000000000000',
+    filledFromAmount: '5000000000',
+    filledToAmount: '4999660000000000000000',
+    status: 'filled',
+    validUntil: daysFromNow(1),
+    createdAt: daysAgo(8),
+    filledAt: daysAgo(7),
+    orderType: 'fill_or_kill',
+  }),
+];

--- a/src/components/LimitOrders/OrdersSection/fixtures.ts
+++ b/src/components/LimitOrders/OrdersSection/fixtures.ts
@@ -1,14 +1,12 @@
 import type { Order, TokenDto } from '@/types/jumper-limit-order';
 
+import { addDays, subDays, getUnixTime } from 'date-fns';
 const MAKER_ADDRESS = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb';
 
-const toUnixSeconds = (date: Date): number => Math.floor(date.getTime() / 1000);
-
 const daysFromNow = (days: number): number =>
-  toUnixSeconds(new Date(Date.now() + days * 24 * 60 * 60 * 1000));
-
+  getUnixTime(addDays(new Date(), days));
 const daysAgo = (days: number): number =>
-  toUnixSeconds(new Date(Date.now() - days * 24 * 60 * 60 * 1000));
+  getUnixTime(subDays(new Date(), days));
 
 const createToken = (
   chainId: number,

--- a/src/components/LimitOrders/OrdersSection/hooks.tsx
+++ b/src/components/LimitOrders/OrdersSection/hooks.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { differenceInCalendarDays, isPast } from 'date-fns';
+import type { ColumnDef } from '@/components/composite/DataTable/DataTable.types';
+import { Badge } from '@/components/Badge/Badge';
+import { BadgeVariant } from '@/components/Badge/Badge.styles';
+import { Tooltip } from '@/components/core/Tooltip/Tooltip';
+import { useTokenFormatters } from '@/hooks/tokens/useTokenFormatters';
+import { createExtendedToken, createTokenBalance } from '@/types/tokens';
+import { EntityAvatar } from '@/components/composite/EntityAvatar/EntityAvatar';
+import { AvatarSize } from '@/components/core/AvatarStack/AvatarStack.types';
+import { OrderRowMenu } from './OrderRowMenu';
+import {
+  ACTIONS_COL_WIDTH,
+  AMOUNT_COL_MAX_WIDTH,
+  CHAIN_AVATAR_SIZE,
+  CHAIN_COL_WIDTH,
+} from './constants';
+import { OrderCell, OrderCellSkeleton } from './OrderCell';
+import {
+  getOrderFilledPercent,
+  getOrderLimitPrice,
+  getOrderMarketPrice,
+} from './utils';
+import type { Order, TokenDto } from '@/types/jumper-limit-order';
+import type { CoinKey } from '@lifi/sdk';
+import { BaseSurface1Skeleton } from '@/components/core/skeletons/BaseSurfaceSkeleton/BaseSurfaceSkeleton.style';
+
+export function useOrderColumns(isExpanded: boolean): ColumnDef<Order>[] {
+  const { t } = useTranslation();
+  const { toDisplayAmount, toDisplayAmountUSD } = useTokenFormatters();
+
+  const formatExpiry = (
+    status: Order['status'],
+    expiresAt?: number,
+  ): { label: string; variant: BadgeVariant } | null => {
+    if (status === 'cancelled') {
+      return {
+        label: t('limitOrders.table.status.cancelled'),
+        variant: BadgeVariant.Error,
+      };
+    }
+    if (status === 'filled') {
+      return null;
+    }
+    const EXPIRED = {
+      label: t('limitOrders.table.status.expired'),
+      variant: BadgeVariant.Disabled,
+    };
+    if (status === 'expired') {
+      return EXPIRED;
+    }
+    if (!expiresAt) {
+      return null;
+    }
+    const expiryDate = new Date(expiresAt * 1000);
+    if (isPast(expiryDate)) {
+      return EXPIRED;
+    }
+    const days = differenceInCalendarDays(expiryDate, new Date());
+    return {
+      label: t('limitOrders.table.status.days', { count: days }),
+      variant: BadgeVariant.Secondary,
+    };
+  };
+
+  function renderTokenCell(
+    token: TokenDto,
+    amount: string,
+    chainId: number,
+  ): ReactNode {
+    const balance = createTokenBalance(
+      createExtendedToken(
+        {
+          ...token,
+          name: token.symbol,
+          coinKey: (token.coinKey as CoinKey) ?? undefined,
+          logoURI: token.logoURI ?? '',
+          chainId,
+        },
+        token.priceUSD ?? '0',
+      ),
+      amount,
+    );
+    const tokenAmount = toDisplayAmount(balance, '', { compact: !isExpanded });
+    const tokenAmountSymbol = toDisplayAmount(balance, balance.token.symbol);
+    const tokenAmountUsd = token.priceUSD
+      ? toDisplayAmountUSD(balance)
+      : undefined;
+    return (
+      <OrderCell align="right">
+        {tokenAmountUsd ? (
+          <Tooltip title={`${tokenAmountSymbol} = ${tokenAmountUsd}`}>
+            <span>{tokenAmount}</span>
+          </Tooltip>
+        ) : (
+          tokenAmount
+        )}
+      </OrderCell>
+    );
+  }
+
+  return [
+    {
+      id: 'chain',
+      header: t('limitOrders.table.columns.chain'),
+      width: CHAIN_COL_WIDTH,
+      headerCellSx: {
+        zIndex: 3,
+      },
+      cellSx: { borderBottom: 'none' },
+      renderCell: (order) => (
+        <EntityAvatar
+          entity={{ chainId: order.chainId, chainKey: String(order.chainId) }}
+          size={AvatarSize.LG}
+        />
+      ),
+      renderSkeleton: () => (
+        <BaseSurface1Skeleton
+          variant="circular"
+          sx={{ width: CHAIN_AVATAR_SIZE, height: CHAIN_AVATAR_SIZE }}
+        />
+      ),
+    },
+    {
+      id: 'pair',
+      header: t('limitOrders.table.columns.pair'),
+      cellSx: { borderBottom: 'none' },
+      renderCell: (order) => (
+        <Stack
+          direction="row"
+          sx={{ alignItems: 'center', gap: 0.5, whiteSpace: 'nowrap' }}
+        >
+          <Typography variant="bodySmallStrong">
+            {order.fromToken.symbol}
+          </Typography>
+          <ArrowForwardIcon
+            sx={{
+              width: 12,
+              height: 12,
+              color: 'text.disabled',
+              flexShrink: 0,
+            }}
+            aria-hidden
+          />
+          <Typography variant="bodySmallStrong">
+            {order.toToken.symbol}
+          </Typography>
+        </Stack>
+      ),
+      renderSkeleton: () => <OrderCellSkeleton width="72px" />,
+    },
+    {
+      id: 'sell',
+      header: t('limitOrders.table.columns.sell'),
+      align: 'right',
+      cellSx: {
+        borderBottom: 'none',
+        maxWidth: AMOUNT_COL_MAX_WIDTH,
+        overflow: 'hidden',
+      },
+      renderCell: (order) =>
+        renderTokenCell(order.fromToken, order.fromAmount, order.chainId),
+      renderSkeleton: () => <OrderCellSkeleton width="72%" align="right" />,
+    },
+    {
+      id: 'buy',
+      header: t('limitOrders.table.columns.buy'),
+      align: 'right',
+      cellSx: {
+        borderBottom: 'none',
+        maxWidth: AMOUNT_COL_MAX_WIDTH,
+        overflow: 'hidden',
+      },
+      renderCell: (order) =>
+        renderTokenCell(order.toToken, order.toAmount, order.chainId),
+      renderSkeleton: () => <OrderCellSkeleton width="72%" align="right" />,
+    },
+    {
+      id: 'limit',
+      header: t('limitOrders.table.columns.limit'),
+      align: 'right',
+      cellSx: {
+        borderBottom: 'none',
+        maxWidth: AMOUNT_COL_MAX_WIDTH,
+        overflow: 'hidden',
+      },
+      renderCell: (order) => {
+        const limitPrice = getOrderLimitPrice(order);
+        if (limitPrice == null) {
+          return null;
+        }
+        return (
+          <OrderCell align="right" strong>
+            {t(`format.${isExpanded ? 'decimal' : 'decimalCompact'}`, {
+              value: limitPrice,
+              maximumFractionDigits: 2,
+            })}
+          </OrderCell>
+        );
+      },
+      renderSkeleton: () => <OrderCellSkeleton width="56%" align="right" />,
+    },
+    {
+      id: 'market',
+      header: t('limitOrders.table.columns.market'),
+      align: 'right',
+      hidden: !isExpanded,
+      cellSx: {
+        borderBottom: 'none',
+        maxWidth: AMOUNT_COL_MAX_WIDTH,
+        overflow: 'hidden',
+      },
+      renderCell: (order) => {
+        const marketPrice = getOrderMarketPrice(order);
+        if (marketPrice == null) {
+          return null;
+        }
+        return (
+          <OrderCell align="right" muted>
+            {t(`format.${isExpanded ? 'decimal' : 'decimalCompact'}`, {
+              value: marketPrice,
+              maximumFractionDigits: 2,
+            })}
+          </OrderCell>
+        );
+      },
+      renderSkeleton: () => <OrderCellSkeleton width="56%" align="right" />,
+    },
+    {
+      id: 'filled',
+      header: t('limitOrders.table.columns.filled'),
+      cellSx: { borderBottom: 'none' },
+      renderCell: (order) => (
+        <OrderCell>{getOrderFilledPercent(order)}%</OrderCell>
+      ),
+      renderSkeleton: () => <OrderCellSkeleton width={40} />,
+    },
+    {
+      id: 'expires',
+      header: t('limitOrders.table.columns.expires'),
+      cellSx: { borderBottom: 'none' },
+      renderCell: (order) => {
+        const expiry = formatExpiry(order.status, order.validUntil);
+        return expiry ? (
+          <Badge label={expiry.label} variant={expiry.variant} />
+        ) : null;
+      },
+      renderSkeleton: () => <OrderCellSkeleton width={72} />,
+    },
+    {
+      id: 'actions',
+      headerAriaLabel: t('limitOrders.table.actions.rowActions'),
+      width: ACTIONS_COL_WIDTH,
+      headerCellSx: { px: 1, pr: 1 },
+      cellSx: { px: 1, pr: 1, borderBottom: 'none' },
+      renderCell: (order) => (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: '100%',
+          }}
+        >
+          <OrderRowMenu order={order} />
+        </Box>
+      ),
+      renderSkeleton: () => (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: '100%',
+          }}
+        >
+          <BaseSurface1Skeleton
+            variant="circular"
+            sx={{ width: 24, height: 24 }}
+          />
+        </Box>
+      ),
+    },
+  ];
+}

--- a/src/components/LimitOrders/OrdersSection/types.ts
+++ b/src/components/LimitOrders/OrdersSection/types.ts
@@ -1,0 +1,31 @@
+export type OrderStatus =
+  | 'pending'
+  | 'active'
+  | 'partially_filled'
+  | 'filled'
+  | 'cancelled'
+  | 'expired';
+
+export interface LimitOrderToken {
+  address: string;
+  symbol: string;
+  decimals: number;
+  logoURI?: string;
+  priceUSD?: string;
+}
+
+export interface LimitOrder {
+  id: string;
+  protocol: '1inch' | 'cowswap';
+  chainId: number;
+  fromToken: LimitOrderToken;
+  toToken: LimitOrderToken;
+  sellAmount: string;
+  buyAmount: string;
+  limitPrice: string;
+  marketPrice?: string;
+  filledPercent: number;
+  status: OrderStatus;
+  expiresAt?: string;
+  createdAt: string;
+}

--- a/src/components/LimitOrders/OrdersSection/utils.spec.ts
+++ b/src/components/LimitOrders/OrdersSection/utils.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type { Order } from '@/types/jumper-limit-order';
+import {
+  getOrderFilledPercent,
+  getOrderLimitPrice,
+  getOrderMarketPrice,
+} from './utils';
+
+const baseOrder: Order = {
+  orderId: 'order-1',
+  tool: 'cowswap',
+  chainId: 1,
+  fromAddress: '0xabc',
+  fromToken: {
+    address: '0x1',
+    chainId: 1,
+    symbol: 'UNI',
+    name: 'Uniswap',
+    decimals: 18,
+    priceUSD: '3.31',
+  },
+  fromAmount: '450000000000000000000',
+  filledFromAmount: '166500000000000000000',
+  toToken: {
+    address: '0x2',
+    chainId: 1,
+    symbol: 'USDC',
+    name: 'USD Coin',
+    decimals: 6,
+    priceUSD: '1.00',
+  },
+  toAmount: '1479260000',
+  filledToAmount: '547326000',
+  createdAt: 1700000000,
+  validUntil: 1700086400,
+  status: 'partially_filled',
+  orderType: 'partial_fill',
+};
+
+describe('utils', () => {
+  it('computes limit price for alt -> stable', () => {
+    expect(getOrderLimitPrice(baseOrder)).toBeCloseTo(3.287, 2);
+  });
+
+  it('computes limit price for stable -> alt', () => {
+    const order: Order = {
+      ...baseOrder,
+      fromToken: baseOrder.toToken,
+      toToken: baseOrder.fromToken,
+      fromAmount: '2000000000',
+      toAmount: '742960000000000000000',
+    };
+    expect(getOrderLimitPrice(order)).toBeCloseTo(2.69, 2);
+  });
+
+  it('returns market price for the non-stable token', () => {
+    expect(getOrderMarketPrice(baseOrder)).toBe(3.31);
+  });
+
+  it('computes filled percent from sell-side amounts', () => {
+    expect(getOrderFilledPercent(baseOrder)).toBe(37);
+  });
+});

--- a/src/components/LimitOrders/OrdersSection/utils.ts
+++ b/src/components/LimitOrders/OrdersSection/utils.ts
@@ -1,0 +1,63 @@
+import type { Order, TokenDto } from '@/types/jumper-limit-order';
+import { formatTokenAmount } from '@lifi/widget';
+
+const STABLE_SYMBOL_REGEX =
+  /^(DAI|GHO|MNEE|AMPL|FEI|DJED|VAI|FLX|STDN|ESD|BAC|BUCK|DOLA|BRZ|QGOLD|MIM|FXD|ZARP|EDLC|ONC|MTR|MIMATIC|BLC|JPYC|SBC|KBC|TRYB|PAR|ISR|GYD|UXD|USDC|USDT|BUSD|FRAX|USDCe|USDe|FDUSD|USDT0|USDF|USDm|GUSDT|axlUSDC|HONEY|BYUSD|APEUSD|FEUSD|USD)$/i;
+
+const STABLE_SYMBOL_FLEXIBLE_REGEX = /(USD|EUR|XAU|YEN|IDR|CHF|CAD|CNH|MXN)/i;
+
+const isStableToken = (token: TokenDto): boolean => {
+  if (token.coinKey && STABLE_SYMBOL_REGEX.test(token.coinKey)) {
+    return true;
+  }
+  return (
+    STABLE_SYMBOL_REGEX.test(token.symbol) ||
+    STABLE_SYMBOL_FLEXIBLE_REGEX.test(token.symbol)
+  );
+};
+
+/** Price of the non-stable token in the order's quote terms. */
+export const getOrderLimitPrice = (order: Order): number | null => {
+  const fromAmount = Number(
+    formatTokenAmount(BigInt(order.fromAmount), order.fromToken.decimals),
+  );
+  const toAmount = Number(
+    formatTokenAmount(BigInt(order.toAmount), order.toToken.decimals),
+  );
+
+  if (fromAmount <= 0 || toAmount <= 0) {
+    return null;
+  }
+
+  if (isStableToken(order.fromToken)) {
+    return fromAmount / toAmount;
+  }
+
+  return toAmount / fromAmount;
+};
+
+/** Current USD price of the token the limit price is expressed against. */
+export const getOrderMarketPrice = (order: Order): number | null => {
+  const priceUSD = isStableToken(order.fromToken)
+    ? order.toToken.priceUSD
+    : isStableToken(order.toToken)
+      ? order.fromToken.priceUSD
+      : order.toToken.priceUSD;
+
+  if (!priceUSD) {
+    return null;
+  }
+
+  const value = Number(priceUSD);
+  return Number.isFinite(value) && value > 0 ? value : null;
+};
+
+export const getOrderFilledPercent = (order: Order): number => {
+  const total = BigInt(order.fromAmount);
+  if (total === 0n) {
+    return 0;
+  }
+
+  const filled = BigInt(order.filledFromAmount);
+  return Math.min(100, Math.round(Number((filled * 10000n) / total) / 100));
+};

--- a/src/components/composite/DataTable/DataTable.styles.ts
+++ b/src/components/composite/DataTable/DataTable.styles.ts
@@ -1,0 +1,98 @@
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import { styled } from '@mui/material/styles';
+
+export const TABLE_HEADER_CELL_SX = {
+  color: 'text.secondary',
+  borderBottom: '1px solid',
+  borderColor: 'divider',
+  height: 40,
+  py: 0,
+  px: 1.5,
+  pr: 2,
+  typography: 'bodySmall',
+  fontWeight: 400,
+  textTransform: 'none',
+} as const;
+
+export const TABLE_CELL_SX = {
+  borderBottom: '1px solid',
+  borderColor: 'divider',
+  py: 0,
+  px: 1.5,
+  pr: 2,
+  verticalAlign: 'middle',
+} as const;
+
+export const DataTableContainer = styled(Stack)(({ theme }) => ({
+  gap: theme.spacing(2),
+  [theme.breakpoints.up('sm')]: {
+    gap: theme.spacing(1),
+    padding: theme.spacing(1.5),
+    background: (theme.vars || theme).palette.surface1.main,
+    boxShadow: theme.shadows[3],
+    borderRadius: `${theme.shape.borderRadius}px`,
+  },
+}));
+
+export const DataTableHeader = styled(Box)(({ theme }) => ({
+  display: 'none',
+  padding: theme.spacing(1, 1.5),
+  [theme.breakpoints.up('sm')]: {
+    display: 'flex',
+  },
+}));
+
+export const DataTableValueCell = styled(Box)({
+  flex: '1 1 0',
+  minWidth: 0,
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const DataTableDesktopRow = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  padding: theme.spacing(1.5),
+  borderRadius: `${theme.shape.borderRadius}px`,
+}));
+
+export const DataTableMobileRowContainer = styled(Stack)(({ theme }) => ({
+  padding: theme.spacing(1.5),
+  gap: theme.spacing(3),
+  borderRadius: `${theme.shape.borderRadius}px`,
+}));
+
+export const DataTableMobileRowSection = styled(Stack)(({ theme }) => ({
+  gap: theme.spacing(1),
+}));
+
+export const DataTableMobilePairRow = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  gap: theme.spacing(1),
+}));
+
+export const DataTableRowCard = styled(Stack, {
+  shouldForwardProp: (prop) => prop !== 'isInteractive',
+})<{ isInteractive?: boolean }>(({ theme, isInteractive }) => ({
+  borderRadius: `${theme.shape.borderRadius}px`,
+  boxShadow: theme.shadows[3],
+  background: (theme.vars || theme).palette.surface1.main,
+  padding: theme.spacing(1.5),
+  cursor: isInteractive ? 'pointer' : 'default',
+  '& > :first-child': {
+    transition: 'background-color 300ms ease-in-out',
+  },
+  '&:not(:has([data-hint-hover-active]))': {
+    '&:hover, &:focus-visible, &:focus': {
+      '& > :first-child': {
+        backgroundColor: (theme.vars || theme).palette.alpha100.main,
+      },
+    },
+  },
+  [theme.breakpoints.up('sm')]: {
+    boxShadow: 'none',
+    borderRadius: 0,
+    padding: 0,
+  },
+}));

--- a/src/components/composite/DataTable/DataTable.tsx
+++ b/src/components/composite/DataTable/DataTable.tsx
@@ -1,0 +1,317 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import Box from '@mui/material/Box';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import { BaseSurfaceSkeleton } from '@/components/core/skeletons/BaseSurfaceSkeleton/BaseSurfaceSkeleton.style';
+import type {
+  ColumnDef,
+  DataTableProps,
+  MobileSection,
+} from './DataTable.types';
+import {
+  DataTableContainer,
+  DataTableDesktopRow,
+  DataTableHeader,
+  DataTableMobilePairRow,
+  DataTableMobileRowContainer,
+  DataTableMobileRowSection,
+  DataTableRowCard,
+  DataTableValueCell,
+  TABLE_CELL_SX,
+  TABLE_HEADER_CELL_SX,
+} from './DataTable.styles';
+
+const DEFAULT_ROW_HEIGHT = 56;
+const DEFAULT_SKELETON_COUNT = 4;
+
+function FlexRowDesktop<T>({
+  row,
+  columns,
+}: {
+  row: T;
+  columns: ColumnDef<T>[];
+}) {
+  const visible = columns.filter((c) => !c.hidden);
+  return (
+    <DataTableDesktopRow>
+      {visible.map((col) => (
+        <DataTableValueCell key={col.id} sx={col.cellSx}>
+          {col.renderCell?.(row)}
+        </DataTableValueCell>
+      ))}
+    </DataTableDesktopRow>
+  );
+}
+
+function FlexRowMobile<T>({
+  row,
+  columns,
+  sections,
+}: {
+  row: T;
+  columns: ColumnDef<T>[];
+  sections: MobileSection[];
+}) {
+  const colMap = Object.fromEntries(columns.map((c) => [c.id, c]));
+  return (
+    <DataTableMobileRowContainer>
+      {sections.map((section, i) => (
+        <DataTableMobileRowSection key={i} sx={section.sx}>
+          <DataTableMobilePairRow>
+            {section.columnIds.map((id) => {
+              const col = colMap[id] as ColumnDef<T> | undefined;
+              if (!col || col.hidden) {
+                return null;
+              }
+              return (
+                <DataTableValueCell key={id} sx={col.cellSx}>
+                  {col.renderCell?.(row)}
+                </DataTableValueCell>
+              );
+            })}
+          </DataTableMobilePairRow>
+        </DataTableMobileRowSection>
+      ))}
+    </DataTableMobileRowContainer>
+  );
+}
+
+function FlexRow<T>({
+  row,
+  columns,
+  sections,
+  onClick,
+}: {
+  row: T;
+  columns: ColumnDef<T>[];
+  sections: MobileSection[];
+  onClick?: (row: T) => void;
+}) {
+  const isMobile = useMediaQuery((theme) => theme.breakpoints.down('sm'));
+  const isInteractive = Boolean(onClick);
+  return (
+    <DataTableRowCard
+      isInteractive={isInteractive}
+      tabIndex={isInteractive ? 0 : undefined}
+      role={isInteractive ? 'button' : undefined}
+      onClick={isInteractive ? () => onClick?.(row) : undefined}
+      onKeyDown={
+        isInteractive
+          ? (e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onClick?.(row);
+              }
+            }
+          : undefined
+      }
+    >
+      {isMobile ? (
+        <FlexRowMobile row={row} columns={columns} sections={sections} />
+      ) : (
+        <FlexRowDesktop row={row} columns={columns} />
+      )}
+    </DataTableRowCard>
+  );
+}
+
+export function DataTable<T>({
+  rows,
+  columns,
+  getRowKey,
+  hasMobileView = true,
+  sections = [],
+  showHeader = false,
+  stickyHeader = false,
+  rowHeight = DEFAULT_ROW_HEIGHT,
+  onRowClick,
+  loading = false,
+  skeletonCount = DEFAULT_SKELETON_COUNT,
+  renderRow,
+  renderSkeletonRow,
+  testId,
+}: DataTableProps<T>): ReactNode {
+  const visibleColumns = columns.filter((c) => !c.hidden);
+
+  if (!hasMobileView) {
+    const stickyHeaderCellSx = stickyHeader
+      ? ({
+          position: 'sticky' as const,
+          top: 0,
+          zIndex: 2,
+          backgroundColor: 'surface2.main',
+        } as const)
+      : {};
+
+    return (
+      <Box sx={{ overflowX: 'auto', overflowY: 'visible' }}>
+        <Table
+          sx={{
+            width: 'max-content',
+            minWidth: '100%',
+            borderCollapse: 'separate',
+            borderSpacing: 0,
+          }}
+        >
+          {showHeader && (
+            <TableHead>
+              <TableRow>
+                {visibleColumns.map((col) => (
+                  <TableCell
+                    key={col.id}
+                    aria-label={col.headerAriaLabel}
+                    sx={{
+                      ...TABLE_HEADER_CELL_SX,
+                      ...stickyHeaderCellSx,
+                      ...(col.width && {
+                        width: col.width,
+                        minWidth: col.width,
+                      }),
+                      ...(col.align && { textAlign: col.align }),
+                      ...col.headerCellSx,
+                    }}
+                  >
+                    {col.header}
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+          )}
+          <TableBody>
+            {loading
+              ? Array.from({ length: skeletonCount }, (_, i) => {
+                  if (renderSkeletonRow) {
+                    return renderSkeletonRow(i);
+                  }
+                  return (
+                    <TableRow key={i}>
+                      {visibleColumns.map((col) => (
+                        <TableCell
+                          key={col.id}
+                          sx={{
+                            ...TABLE_CELL_SX,
+                            height: rowHeight,
+                            ...(col.width && {
+                              width: col.width,
+                              minWidth: col.width,
+                            }),
+                            ...col.cellSx,
+                          }}
+                        >
+                          {col.renderSkeleton ? (
+                            col.renderSkeleton()
+                          ) : (
+                            <BaseSurfaceSkeleton
+                              variant="rounded"
+                              sx={{ height: 16, width: '60%' }}
+                            />
+                          )}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  );
+                })
+              : rows.map((row, i) => {
+                  const key = getRowKey(row);
+                  if (renderRow) {
+                    return renderRow(row, i);
+                  }
+                  return (
+                    <TableRow
+                      key={key}
+                      sx={[
+                        {
+                          '&:last-child td, &:last-child th': {
+                            borderBottom: 0,
+                          },
+                        },
+                        Boolean(onRowClick) && { cursor: 'pointer' },
+                      ]}
+                      onClick={onRowClick ? () => onRowClick(row) : undefined}
+                      data-testid={testId ? `${testId}-row-${key}` : undefined}
+                    >
+                      {visibleColumns.map((col) => (
+                        <TableCell
+                          key={col.id}
+                          sx={{
+                            ...TABLE_CELL_SX,
+                            height: rowHeight,
+                            ...(col.width && {
+                              width: col.width,
+                              minWidth: col.width,
+                            }),
+                            ...(col.align && { textAlign: col.align }),
+                            ...col.cellSx,
+                          }}
+                        >
+                          {col.renderCell?.(row)}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  );
+                })}
+          </TableBody>
+        </Table>
+      </Box>
+    );
+  }
+
+  return (
+    <DataTableContainer>
+      {showHeader && (
+        <DataTableHeader>
+          {visibleColumns.map((col) => (
+            <DataTableValueCell key={col.id} sx={col.cellSx}>
+              {col.header}
+            </DataTableValueCell>
+          ))}
+        </DataTableHeader>
+      )}
+      {loading
+        ? Array.from({ length: skeletonCount }, (_, i) => {
+            if (renderSkeletonRow) {
+              return renderSkeletonRow(i);
+            }
+            return (
+              <DataTableRowCard key={i} isInteractive={false}>
+                <DataTableDesktopRow>
+                  {visibleColumns.map((col) => (
+                    <DataTableValueCell key={col.id} sx={col.cellSx}>
+                      {col.renderSkeleton ? (
+                        col.renderSkeleton()
+                      ) : (
+                        <BaseSurfaceSkeleton
+                          variant="rounded"
+                          sx={{ height: 16, width: '60%' }}
+                        />
+                      )}
+                    </DataTableValueCell>
+                  ))}
+                </DataTableDesktopRow>
+              </DataTableRowCard>
+            );
+          })
+        : rows.map((row, i) => {
+            const key = getRowKey(row);
+            if (renderRow) {
+              return renderRow(row, i);
+            }
+            return (
+              <FlexRow
+                key={key}
+                row={row}
+                columns={columns}
+                sections={sections}
+                onClick={onRowClick}
+              />
+            );
+          })}
+    </DataTableContainer>
+  );
+}

--- a/src/components/composite/DataTable/DataTable.types.ts
+++ b/src/components/composite/DataTable/DataTable.types.ts
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react';
+import type { SxProps, Theme } from '@mui/material/styles';
+
+export interface ColumnDef<T> {
+  id: string;
+  header?: ReactNode;
+  headerAriaLabel?: string;
+  renderCell?: (row: T) => ReactNode;
+  renderSkeleton?: () => ReactNode;
+  cellSx?: SxProps<Theme>;
+  headerCellSx?: SxProps<Theme>;
+  width?: number;
+  align?: 'left' | 'right' | 'center';
+  hidden?: boolean;
+}
+
+export interface MobileSection {
+  columnIds: string[];
+  sx?: SxProps<Theme>;
+}
+
+export interface DataTableProps<T> {
+  rows: T[];
+  columns: ColumnDef<T>[];
+  getRowKey: (row: T) => string;
+  hasMobileView?: boolean;
+  sections?: MobileSection[];
+  showHeader?: boolean;
+  stickyHeader?: boolean;
+  rowHeight?: number;
+  onRowClick?: (row: T) => void;
+  loading?: boolean;
+  skeletonCount?: number;
+  renderRow?: (row: T, index: number) => ReactNode;
+  renderSkeletonRow?: (index: number) => ReactNode;
+  testId?: string;
+}

--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -70,6 +70,8 @@ const clientBuildTimeEnv: RuntimeConfig = {
   NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN ?? '',
   NEXT_PUBLIC_LIFI_COMPOSER_BACKEND_URL:
     process.env.NEXT_PUBLIC_LIFI_COMPOSER_BACKEND_URL ?? '',
+  NEXT_PUBLIC_LIMIT_ORDER_BACKEND_URL:
+    process.env.NEXT_PUBLIC_LIMIT_ORDER_BACKEND_URL ?? '',
 };
 
 // Initialize config based on environment

--- a/src/hooks/tokens/useTokenFormatters.ts
+++ b/src/hooks/tokens/useTokenFormatters.ts
@@ -18,6 +18,7 @@ export interface FormatAmountUSDOptions {
 
 export interface FormatAmountOptions {
   decimals?: number;
+  compact?: boolean;
   maximumFractionDigits?: number;
   minimumFractionDigits?: number;
 }
@@ -73,11 +74,14 @@ export const useTokenFormatters = () => {
       if (numeric > 0 && numeric < DUST_AMOUNT_THRESHOLD) {
         return formatTokenAmountWithDust(amount, symbol ?? '', t);
       }
-      const formatted = t('format.decimal', {
-        value: Number(amount),
-        minimumFractionDigits: options?.minimumFractionDigits,
-        maximumFractionDigits: options?.maximumFractionDigits ?? 3,
-      });
+      const formatted = t(
+        `format.${options?.compact ? 'decimalCompact' : 'decimal'}`,
+        {
+          value: Number(amount),
+          minimumFractionDigits: options?.minimumFractionDigits,
+          maximumFractionDigits: options?.maximumFractionDigits ?? 3,
+        },
+      );
       if (!symbol) {
         return formatted;
       }

--- a/src/hooks/useLimitOrders.ts
+++ b/src/hooks/useLimitOrders.ts
@@ -1,0 +1,25 @@
+'use client';
+import { useAccount } from '@lifi/wallet-management';
+import { useQuery } from '@tanstack/react-query';
+import { makeLimitOrderClient } from '@/app/lib/limitOrderClient';
+import { getQueryKey } from '@/utils/queries/getQueryKey';
+
+export const useLimitOrders = () => {
+  const { account } = useAccount();
+  const address = account?.address;
+
+  return useQuery({
+    queryKey: [getQueryKey('limit-orders'), address],
+    queryFn: async () => {
+      if (!address) {
+        return [];
+      }
+
+      const client = makeLimitOrderClient();
+      const res =
+        await client.limitOrder.ordersControllerGetOrdersByUser(address);
+      return res.data ?? [];
+    },
+    enabled: !!address,
+  });
+};

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -457,6 +457,33 @@ export default interface Resources {
       title: 'Leaderboard';
       updatedLabel: 'Updated: {{date}}';
     };
+    limitOrders: {
+      marketPrice: 'Market Price';
+      orders: 'Orders';
+      table: {
+        actions: {
+          collapsePanels: 'Collapse panels';
+          expandPanels: 'Expand panels';
+          rowActions: 'Row actions';
+        };
+        columns: {
+          buy: 'Buy';
+          chain: 'Chain';
+          expires: 'Expires';
+          filled: 'Filled';
+          limit: 'Limit';
+          market: 'Market';
+          pair: 'Pair';
+          sell: 'Sell';
+        };
+        status: {
+          cancelled: 'Cancelled';
+          days_one: '{{count}} day';
+          days_other: '{{count}} days';
+          expired: 'Expired';
+        };
+      };
+    };
     links: {
       discover: 'Discover {{name}}';
     };

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -1296,5 +1296,32 @@
   },
   "alerts": {
     "extension": "Some browser extensions like {{extensionName}} can overwrite transactions initiated through Jumper and add an extra fee. We recommend disabling these extensions before swapping."
+  },
+  "limitOrders": {
+    "orders": "Orders",
+    "marketPrice": "Market Price",
+    "table": {
+      "columns": {
+        "chain": "Chain",
+        "pair": "Pair",
+        "sell": "Sell",
+        "buy": "Buy",
+        "limit": "Limit",
+        "market": "Market",
+        "filled": "Filled",
+        "expires": "Expires"
+      },
+      "status": {
+        "cancelled": "Cancelled",
+        "expired": "Expired",
+        "days_one": "{{count}} day",
+        "days_other": "{{count}} days"
+      },
+      "actions": {
+        "rowActions": "Row actions",
+        "expandPanels": "Expand panels",
+        "collapsePanels": "Collapse panels"
+      }
+    }
   }
 }

--- a/src/types/jumper-limit-order.ts
+++ b/src/types/jumper-limit-order.ts
@@ -1,0 +1,1316 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+import config from '@/config/env-config';
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export interface AllowDenyPreferDto {
+  /**
+   * Allowed protocols (default: all)
+   * @example ["cowswap","1inch"]
+   */
+  allow?: string[];
+  /**
+   * Denied protocols (default: none)
+   * @example ["cowswap"]
+   */
+  deny?: string[];
+  /**
+   * Preferred protocols - use if available, fall back to others
+   * @example ["1inch"]
+   */
+  prefer?: string[];
+}
+
+export interface OrderRouteOptionsDto {
+  /** Exchange/protocol filtering options */
+  exchanges?: AllowDenyPreferDto;
+}
+
+export interface OrderRoutesDto {
+  /**
+   * Source chain ID
+   * @example 1
+   */
+  fromChainId: number;
+  /**
+   * User wallet address
+   * @example "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb"
+   */
+  fromAddress?: string;
+  /** From token address */
+  fromTokenAddress: string;
+  /**
+   * From token amount (in wei)
+   * @example "1000000000"
+   */
+  fromAmount: string;
+  /**
+   * Destination chain ID
+   * @example 1
+   */
+  toChainId: number;
+  /** Receiver address (if different from user) */
+  toAddress?: string;
+  /** To token address */
+  toTokenAddress: string;
+  /**
+   * To token amount (desired output amount)
+   * @example "1500000000"
+   */
+  toAmount: string;
+  /**
+   * Unix timestamp (in seconds) until which the order should be valid
+   * @example 1780000000
+   */
+  validUntil: number;
+  /**
+   * Allow partial fills
+   * @default true
+   */
+  partiallyFillable?: boolean;
+  /** Route options for exchange selection */
+  options?: OrderRouteOptionsDto;
+  /**
+   * Integrator identifier
+   * @example "jumper.exchange"
+   */
+  integrator?: string;
+  /**
+   * Referrer identifier
+   * @example "jmp"
+   */
+  referrer?: string;
+}
+
+export interface TokenDto {
+  /**
+   * Token contract address
+   * @example "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+   */
+  address: string;
+  /**
+   * Chain ID
+   * @example 1
+   */
+  chainId: number;
+  /**
+   * Token ticker symbol
+   * @example "USDC"
+   */
+  symbol: string;
+  /**
+   * Number of decimals
+   * @example 6
+   */
+  decimals: number;
+  /**
+   * Full token name
+   * @example "USD Coin"
+   */
+  name: string;
+  /**
+   * LI.FI CoinKey identifier
+   * @example "USDC"
+   */
+  coinKey?:
+    | 'ETH'
+    | 'MATIC'
+    | 'POL'
+    | 'BNB'
+    | 'DAI'
+    | 'FTM'
+    | 'AVAX'
+    | 'ONE'
+    | 'FSN'
+    | 'MOVR'
+    | 'CELO'
+    | 'FUSE'
+    | 'TLOS'
+    | 'CRO'
+    | 'RBTC'
+    | 'VLX'
+    | 'GLMR'
+    | 'METIS'
+    | 'EVM'
+    | 'MNT'
+    | 'SEI'
+    | 'G'
+    | 'IMX'
+    | 'KAIA'
+    | 'OKB'
+    | 'WLD'
+    | 'LSK'
+    | 'BERA'
+    | 'S'
+    | 'APE'
+    | 'GHO'
+    | 'WGHO'
+    | 'XTZ'
+    | 'HYPE'
+    | 'XDC'
+    | 'VIC'
+    | 'FLR'
+    | 'VAN'
+    | 'RON'
+    | 'PLUME'
+    | 'NIBI'
+    | 'SOPH'
+    | 'XPL'
+    | 'FLOW'
+    | 'MON'
+    | 'GUSDT'
+    | 'SOL'
+    | 'wSOL'
+    | 'SUI'
+    | 'BTC'
+    | 'BCH'
+    | 'LTC'
+    | 'DOGE'
+    | 'TRX'
+    | 'WTRX'
+    | 'XAUt'
+    | 'HEMI'
+    | 'USDT'
+    | 'USDC'
+    | 'BUSD'
+    | 'USDCe'
+    | 'USDCn'
+    | 'USDe'
+    | 'USDB'
+    | 'FRAX'
+    | 'axlUSDC'
+    | 'FDUSD'
+    | 'HONEY'
+    | 'BYUSD'
+    | 'APEUSD'
+    | 'FEUSD'
+    | 'USDT0'
+    | 'USDF'
+    | 'USDm'
+    | 'WBTC'
+    | 'WETH'
+    | 'SUSHI'
+    | 'DODO'
+    | 'MCB'
+    | 'CELR'
+    | 'IF'
+    | 'RUNE'
+    | 'WMNT'
+    | 'frxETH'
+    | 'wfrxETH'
+    | 'WSEI'
+    | 'WG'
+    | 'WIMX'
+    | 'WPOL'
+    | 'WKAIA'
+    | 'WOKB'
+    | 'WBNB'
+    | 'WCRO'
+    | 'WBERA'
+    | 'wS'
+    | 'WAPE'
+    | 'WXTZ'
+    | 'WHYPE'
+    | 'WXDC'
+    | 'WVIC'
+    | 'WFLR'
+    | 'WVAN'
+    | 'WRON'
+    | 'WPLUME'
+    | 'WNIBI'
+    | 'WSOPH'
+    | 'WFRAX'
+    | 'WXPL'
+    | 'WFLOW'
+    | 'WMON'
+    | 'pBTC'
+    | null;
+  /**
+   * Token logo URL
+   * @example "https://assets.coingecko.com/coins/images/6319/thumb/usdc.png"
+   */
+  logoURI?: string | null;
+  /**
+   * Token price in USD as a string
+   * @example "1.00"
+   */
+  priceUSD: string;
+}
+
+export interface ActionDto {
+  /**
+   * Chain ID
+   * @example 1
+   */
+  fromChainId: number;
+  /** Source token */
+  fromToken: TokenDto;
+  /**
+   * Amount to sell (in wei)
+   * @example "1000000000000000000"
+   */
+  fromAmount: string;
+  /** Sender address */
+  fromAddress?: string;
+  /**
+   * Chain ID
+   * @example 1
+   */
+  toChainId: number;
+  /** Destination token */
+  toToken: TokenDto;
+  /**
+   * Desired limit order amount (in wei)
+   * @example "1500000000"
+   */
+  toAmount: string;
+  /** Recipient address */
+  toAddress: string;
+  /**
+   * Unix timestamp (in seconds) until which the order is valid
+   * @example 1780000000
+   */
+  validUntil: number;
+  /** Whether partial fills are allowed */
+  partiallyFillable: boolean;
+}
+
+export interface FeeCostDto {
+  /**
+   * Fee name
+   * @example "Protocol Fee"
+   */
+  name: string;
+  /** Fee description */
+  description?: string;
+  /**
+   * Fee amount
+   * @example "1000000"
+   */
+  amount: string;
+  /**
+   * Fee amount in USD
+   * @example "1.00"
+   */
+  amountUSD?: string;
+  /**
+   * Fee percentage
+   * @example "0.1"
+   */
+  percentage: string;
+  /** Token used for fee */
+  token: TokenDto;
+  /** Whether the fee is included in the amount */
+  included?: boolean;
+}
+
+export interface GasCostDto {
+  /**
+   * Type of gas cost
+   * @example "SEND"
+   */
+  type: string;
+  /**
+   * Estimated gas amount
+   * @example "21000"
+   */
+  estimate: string;
+  /**
+   * Gas limit
+   * @example "30000"
+   */
+  limit: string;
+  /**
+   * Gas amount in native token
+   * @example "0.001"
+   */
+  amount: string;
+  /**
+   * Gas amount in USD
+   * @example "2.50"
+   */
+  amountUSD?: string;
+  /**
+   * Gas price in wei
+   * @example "50000000000"
+   */
+  price: string;
+  /** Token used for gas */
+  token: TokenDto;
+}
+
+export interface OrderEstimateDto {
+  /** Tool providing the estimate */
+  tool: '1inch' | 'cowswap';
+  /**
+   * Amount to sell (in wei)
+   * @example "1000000000000000000"
+   */
+  fromAmount: string;
+  /**
+   * Amount to sell in USD
+   * @example "1000.00"
+   */
+  fromAmountUSD?: string;
+  /**
+   * Expected output amount (in wei)
+   * @example "1500000000"
+   */
+  toAmount: string;
+  /**
+   * Expected output amount in USD
+   * @example "1500.00"
+   */
+  toAmountUSD?: string;
+  /**
+   * Address to approve tokens to
+   * @example "0x1111111254EEB25477B68fb85Ed929f73A960582"
+   */
+  approvalAddress?: string;
+  /** Whether the approval needs to be reset to 0 first (legacy ERC-20) */
+  approvalReset?: boolean;
+  /** Skip token approval (e.g. for Hyperliquid) */
+  skipApproval?: boolean;
+  /** Skip permit usage for some HyperEVM transactions */
+  skipPermit?: boolean;
+  /** Fee costs breakdown */
+  feeCosts?: FeeCostDto[];
+  /** Gas costs breakdown */
+  gasCosts?: GasCostDto[];
+  /**
+   * Likelihood of order execution
+   * @example "high"
+   */
+  executionLikelihood?: 'high' | 'medium' | 'low';
+  /**
+   * Reason for execution likelihood assessment
+   * @example "Order price is close to market price"
+   */
+  executionLikelihoodReason?: string;
+}
+
+export interface TransactionRequestDto {
+  /**
+   * Chain ID
+   * @example 1
+   */
+  chainId: number;
+  /** Transaction data (hex encoded) */
+  data: string;
+  /** Sender address */
+  from: string;
+  /** Target contract address */
+  to: string;
+  /** Value in wei (hex encoded) */
+  value?: string;
+  /** Gas limit */
+  gasLimit?: string;
+  /** Gas price */
+  gasPrice?: string;
+}
+
+export interface StepToolDetailsDto {
+  /** Tool identifier key */
+  key: string;
+  /** Human-readable tool name */
+  name: string;
+  /** Tool logo URI */
+  logoURI: string;
+}
+
+export interface OrderStepDto {
+  /** Internal quote cache identifier */
+  id?: string;
+  /** Order action details */
+  action: ActionDto;
+  /** Execution estimate (LiFi Estimate type) */
+  estimate?: OrderEstimateDto;
+  /** Tool/protocol identifier */
+  tool: '1inch' | 'cowswap';
+  /** Transaction request to execute (for on-chain orders) */
+  transactionRequest?: TransactionRequestDto;
+  /** EIP-712 typed data to sign (for signature-based orders) */
+  typedData?: object[];
+  /** Tool details (bridge/DEX metadata) */
+  toolDetails: StepToolDetailsDto;
+  /** Integrator identifier */
+  integrator?: string;
+  /** Referrer identifier */
+  referrer?: string;
+}
+
+export interface OrderRouteDto {
+  /** Unique route identifier */
+  id: string;
+  /** Source chain ID */
+  fromChainId: number;
+  /** From amount in USD */
+  fromAmountUSD: string;
+  /** From amount in wei */
+  fromAmount: string;
+  /** Source token */
+  fromToken: TokenDto;
+  /** Sender address */
+  fromAddress?: string;
+  /** Destination chain ID */
+  toChainId: number;
+  /** To amount in USD */
+  toAmountUSD: string;
+  /** To amount in wei */
+  toAmount: string;
+  /** Minimum to amount in wei */
+  toAmountMin: string;
+  /** Destination token */
+  toToken: TokenDto;
+  /** Recipient address */
+  toAddress?: string;
+  /** Aggregated gas cost in USD */
+  gasCostUSD?: string;
+  /** Whether the route requires a chain switch */
+  containsSwitchChain?: boolean;
+  /** Route tags */
+  tags?: ('RECOMMENDED' | 'FASTEST' | 'CHEAPEST' | 'SAFEST')[];
+  /** Ordered list of steps to execute */
+  steps: OrderStepDto[];
+}
+
+export interface FilteredProtocolDto {
+  /** Protocol that was filtered out */
+  tool: '1inch' | 'cowswap';
+  /** Reason for filtering */
+  reason: string;
+}
+
+export interface FailedRouteDto {
+  /** Protocol that failed */
+  tool: '1inch' | 'cowswap';
+  /** Error message */
+  message: string;
+  /** Error code */
+  code: string;
+}
+
+export interface UnavailableRoutesDto {
+  /** Tools filtered out based on user preferences */
+  filteredOut: FilteredProtocolDto[];
+  /** Tools that failed to provide quotes */
+  failed: FailedRouteDto[];
+}
+
+export interface OrderRoutesResponseDto {
+  /** Available routes for this order */
+  routes: OrderRouteDto[];
+  /** Unavailable routes with reasons */
+  unavailableRoutes: UnavailableRoutesDto;
+}
+
+export interface StepTransactionRequestDto {
+  /** Internal quote cache identifier */
+  id?: string;
+  /** Order action details */
+  action: ActionDto;
+  /** Execution estimate (LiFi Estimate type) */
+  estimate?: OrderEstimateDto;
+  /** Tool/protocol identifier */
+  tool: '1inch' | 'cowswap';
+  /** Transaction request to execute (for on-chain orders) */
+  transactionRequest?: TransactionRequestDto;
+  /** EIP-712 typed data to sign (for signature-based orders) */
+  typedData?: object[];
+  /** Tool details (bridge/DEX metadata) */
+  toolDetails: StepToolDetailsDto;
+  /** Integrator identifier */
+  integrator?: string;
+  /** Referrer identifier */
+  referrer?: string;
+}
+
+export interface StepTransactionResponseDto {
+  /** Internal quote cache identifier */
+  id?: string;
+  /** Order action details */
+  action: ActionDto;
+  /** Execution estimate (LiFi Estimate type) */
+  estimate?: OrderEstimateDto;
+  /** Tool/protocol identifier */
+  tool: '1inch' | 'cowswap';
+  /** Transaction request to execute (for on-chain orders) */
+  transactionRequest?: TransactionRequestDto;
+  /** EIP-712 typed data to sign (for signature-based orders) */
+  typedData?: object[];
+  /** Tool details (bridge/DEX metadata) */
+  toolDetails: StepToolDetailsDto;
+  /** Integrator identifier */
+  integrator?: string;
+  /** Referrer identifier */
+  referrer?: string;
+}
+
+export interface RelayRequestDto {
+  /** Internal quote cache identifier */
+  id?: string;
+  /** Order action details */
+  action: ActionDto;
+  /** Execution estimate (LiFi Estimate type) */
+  estimate?: OrderEstimateDto;
+  /** Tool/protocol identifier */
+  tool: '1inch' | 'cowswap';
+  /** Transaction request to execute (for on-chain orders) */
+  transactionRequest?: TransactionRequestDto;
+  /** Signed EIP-712 typed data (required for relay) */
+  typedData?: object[];
+  /** Tool details (bridge/DEX metadata) */
+  toolDetails: StepToolDetailsDto;
+  /** Integrator identifier */
+  integrator?: string;
+  /** Referrer identifier */
+  referrer?: string;
+}
+
+export interface RelayResponseDataDto {
+  /** Unique identifier for tracking the relayed task */
+  taskId: string;
+  /** Explorer link to the transaction */
+  txLink?: string;
+}
+
+export interface RelayResponseDto {
+  /** Response status */
+  status: 'ok' | 'error';
+  /** Response data */
+  data: RelayResponseDataDto;
+}
+
+export interface RelayerStatusResponseDto {
+  /** Response status discriminant */
+  status: 'ok' | 'error';
+  /** Relay status data, or error details when status is "error" */
+  data: any;
+}
+
+export interface StatusResponseDto {
+  /** Order execution status */
+  status: 'NOT_FOUND' | 'INVALID' | 'PENDING' | 'DONE' | 'FAILED';
+  /** Unique identifier for the order */
+  orderId?: object;
+}
+
+export interface CancelStepTransactionRequestDto {
+  /**
+   * Chain ID
+   * @example 1
+   */
+  chainId: number;
+  /** Tool/protocol identifier */
+  tool: '1inch' | 'cowswap';
+  /** Unique identifier for the order */
+  orderId: string;
+}
+
+export interface CancelEstimateDto {
+  /** Fee costs breakdown */
+  feeCosts?: FeeCostDto[];
+  /** Gas costs breakdown */
+  gasCosts?: GasCostDto[];
+}
+
+export interface CancelStepTransactionResponseDto {
+  /** Cost estimate for the cancellation */
+  estimate?: CancelEstimateDto;
+  /** Transaction request to execute (for on-chain cancellation) */
+  transactionRequest?: TransactionRequestDto;
+  /** EIP-712 typed data to sign (for off-chain cancellation) */
+  typedData?: object[];
+}
+
+export interface CancelRelayRequestDto {
+  /** Cost estimate for the cancellation */
+  estimate?: CancelEstimateDto;
+  /** Transaction request to execute (for on-chain cancellation) */
+  transactionRequest?: TransactionRequestDto;
+  /** Signed EIP-712 typed data (required for relay) */
+  typedData?: object[];
+  /**
+   * Chain ID
+   * @example 1
+   */
+  chainId: number;
+  /** Tool/protocol identifier */
+  tool: '1inch' | 'cowswap';
+}
+
+export interface TokensResponseDto {
+  /** Mapping of chain IDs to their supported tokens */
+  tokens: object;
+}
+
+export interface Order {
+  /**
+   * Protocol-specific order ID
+   * @example "0x1234..."
+   */
+  orderId: string;
+  /**
+   * Protocol name
+   * @example "cowswap"
+   */
+  tool: string;
+  /**
+   * Chain ID
+   * @example 1
+   */
+  chainId: number;
+  /**
+   * Maker wallet address
+   * @example "0xabc..."
+   */
+  fromAddress: string;
+  fromToken: TokenDto;
+  /**
+   * Sell amount
+   * @example "1000000"
+   */
+  fromAmount: string;
+  /**
+   * Amount filled so far (sell token)
+   * @example "0"
+   */
+  filledFromAmount: string;
+  /**
+   * Recipient address
+   * @example "0xabc..."
+   */
+  toAddress?: string | null;
+  toToken: TokenDto;
+  /**
+   * Desired buy amount
+   * @example "1000000"
+   */
+  toAmount: string;
+  /**
+   * Amount filled so far (buy token)
+   * @example "0"
+   */
+  filledToAmount: string;
+  /**
+   * Order creation Unix timestamp
+   * @example 1700000000
+   */
+  createdAt: number;
+  /**
+   * Order expiry Unix timestamp
+   * @example 1700086400
+   */
+  validUntil: number;
+  /**
+   * Fill Unix timestamp
+   * @example 1700043200
+   */
+  filledAt?: number | null;
+  /** Current order status */
+  status:
+    | 'pending'
+    | 'active'
+    | 'temporarily_invalid'
+    | 'partially_filled'
+    | 'filled'
+    | 'cancelled'
+    | 'expired'
+    | 'failed';
+  /** Fill type */
+  orderType: 'fill_or_kill' | 'partial_fill';
+}
+
+export type QueryParamsType = Record<string | number, any>;
+export type ResponseFormat = keyof Omit<Body, 'body' | 'bodyUsed'>;
+
+export interface FullRequestParams extends Omit<RequestInit, 'body'> {
+  /** set parameter to `true` for call `securityWorker` for this request */
+  secure?: boolean;
+  /** request path */
+  path: string;
+  /** content type of request body */
+  type?: ContentType;
+  /** query params */
+  query?: QueryParamsType;
+  /** format of response (i.e. response.json() -> format: "json") */
+  format?: ResponseFormat;
+  /** request body */
+  body?: unknown;
+  /** base url */
+  baseUrl?: string;
+  /** request cancellation token */
+  cancelToken?: CancelToken;
+}
+
+export type RequestParams = Omit<
+  FullRequestParams,
+  'body' | 'method' | 'query' | 'path'
+>;
+
+export interface ApiConfig<SecurityDataType = unknown> {
+  baseUrl?: string;
+  baseApiParams?: Omit<RequestParams, 'baseUrl' | 'cancelToken' | 'signal'>;
+  securityWorker?: (
+    securityData: SecurityDataType | null,
+  ) => Promise<RequestParams | void> | RequestParams | void;
+  customFetch?: typeof fetch;
+}
+
+export interface HttpResponse<
+  D extends unknown,
+  E extends unknown = unknown,
+> extends Response {
+  data: D;
+  error: E;
+}
+
+type CancelToken = Symbol | string | number;
+
+export enum ContentType {
+  Json = 'application/json',
+  JsonApi = 'application/vnd.api+json',
+  FormData = 'multipart/form-data',
+  UrlEncoded = 'application/x-www-form-urlencoded',
+  Text = 'text/plain',
+}
+
+export class HttpClient<SecurityDataType = unknown> {
+  public baseUrl: string = '';
+  private securityData: SecurityDataType | null = null;
+  private securityWorker?: ApiConfig<SecurityDataType>['securityWorker'];
+  private abortControllers = new Map<CancelToken, AbortController>();
+  private customFetch = (...fetchParams: Parameters<typeof fetch>) =>
+    fetch(...fetchParams);
+
+  private baseApiParams: RequestParams = {
+    credentials: 'same-origin',
+    headers: { Referer: config.NEXT_PUBLIC_SITE_URL },
+    redirect: 'follow',
+    referrerPolicy: 'strict-origin-when-cross-origin',
+  };
+
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
+  }
+
+  public setSecurityData = (data: SecurityDataType | null) => {
+    this.securityData = data;
+  };
+
+  protected encodeQueryParam(key: string, value: any) {
+    const encodedKey = encodeURIComponent(key);
+    return `${encodedKey}=${encodeURIComponent(typeof value === 'number' ? value : `${value}`)}`;
+  }
+
+  protected addQueryParam(query: QueryParamsType, key: string) {
+    return this.encodeQueryParam(key, query[key]);
+  }
+
+  protected addArrayQueryParam(query: QueryParamsType, key: string) {
+    const value = query[key];
+    return value.map((v: any) => this.encodeQueryParam(key, v)).join('&');
+  }
+
+  protected toQueryString(rawQuery?: QueryParamsType): string {
+    const query = rawQuery || {};
+    const keys = Object.keys(query).filter(
+      (key) => 'undefined' !== typeof query[key],
+    );
+    return keys
+      .map((key) =>
+        Array.isArray(query[key])
+          ? this.addArrayQueryParam(query, key)
+          : this.addQueryParam(query, key),
+      )
+      .join('&');
+  }
+
+  protected addQueryParams(rawQuery?: QueryParamsType): string {
+    const queryString = this.toQueryString(rawQuery);
+    return queryString ? `?${queryString}` : '';
+  }
+
+  private contentFormatters: Record<ContentType, (input: any) => any> = {
+    [ContentType.Json]: (input: any) =>
+      input !== null && (typeof input === 'object' || typeof input === 'string')
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.JsonApi]: (input: any) =>
+      input !== null && (typeof input === 'object' || typeof input === 'string')
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.Text]: (input: any) =>
+      input !== null && typeof input !== 'string'
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.FormData]: (input: any) => {
+      if (input instanceof FormData) {
+        return input;
+      }
+
+      return Object.keys(input || {}).reduce((formData, key) => {
+        const property = input[key];
+        formData.append(
+          key,
+          property instanceof Blob
+            ? property
+            : typeof property === 'object' && property !== null
+              ? JSON.stringify(property)
+              : `${property}`,
+        );
+        return formData;
+      }, new FormData());
+    },
+    [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),
+  };
+
+  protected mergeRequestParams(
+    params1: RequestParams,
+    params2?: RequestParams,
+  ): RequestParams {
+    return {
+      ...this.baseApiParams,
+      ...params1,
+      ...(params2 || {}),
+      headers: {
+        ...(this.baseApiParams.headers || {}),
+        ...(params1.headers || {}),
+        ...((params2 && params2.headers) || {}),
+      },
+    };
+  }
+
+  protected createAbortSignal = (
+    cancelToken: CancelToken,
+  ): AbortSignal | undefined => {
+    if (this.abortControllers.has(cancelToken)) {
+      const abortController = this.abortControllers.get(cancelToken);
+      if (abortController) {
+        return abortController.signal;
+      }
+      return void 0;
+    }
+
+    const abortController = new AbortController();
+    this.abortControllers.set(cancelToken, abortController);
+    return abortController.signal;
+  };
+
+  public abortRequest = (cancelToken: CancelToken) => {
+    const abortController = this.abortControllers.get(cancelToken);
+
+    if (abortController) {
+      abortController.abort();
+      this.abortControllers.delete(cancelToken);
+    }
+  };
+
+  public request = async <T = any, E = any>({
+    body,
+    secure,
+    path,
+    type,
+    query,
+    format,
+    baseUrl,
+    cancelToken,
+    ...params
+  }: FullRequestParams): Promise<HttpResponse<T, E>> => {
+    const secureParams =
+      ((typeof secure === 'boolean' ? secure : this.baseApiParams.secure) &&
+        this.securityWorker &&
+        (await this.securityWorker(this.securityData))) ||
+      {};
+    const requestParams = this.mergeRequestParams(params, secureParams);
+    const queryString = query && this.toQueryString(query);
+    const payloadFormatter = this.contentFormatters[type || ContentType.Json];
+    const responseFormat = format || requestParams.format;
+
+    return this.customFetch(
+      `${baseUrl || this.baseUrl || ''}${path}${queryString ? `?${queryString}` : ''}`,
+      {
+        ...requestParams,
+        headers: {
+          ...(requestParams.headers || {}),
+          ...(type && type !== ContentType.FormData
+            ? { 'Content-Type': type }
+            : {}),
+        },
+        signal:
+          (cancelToken
+            ? this.createAbortSignal(cancelToken)
+            : requestParams.signal) || null,
+        body:
+          typeof body === 'undefined' || body === null
+            ? null
+            : payloadFormatter(body),
+      },
+    ).then(async (response) => {
+      const r = response as HttpResponse<T, E>;
+      r.data = null as unknown as T;
+      r.error = null as unknown as E;
+
+      const responseToParse = responseFormat ? response.clone() : response;
+      const data = !responseFormat
+        ? r
+        : await responseToParse[responseFormat]()
+            .then((data) => {
+              if (r.ok) {
+                r.data = data;
+              } else {
+                r.error = data;
+              }
+              return r;
+            })
+            .catch((e) => {
+              r.error = e;
+              return r;
+            });
+
+      if (cancelToken) {
+        this.abortControllers.delete(cancelToken);
+      }
+
+      if (!response.ok) throw data;
+      return data;
+    });
+  };
+}
+
+/**
+ * @title Limit Orders API
+ * @version 1.0
+ * @contact
+ *
+ * Unified API for limit order aggregation across multiple protocols (1inch & CoW Swap)
+ */
+export class JumperLimitOrder<
+  SecurityDataType extends unknown,
+> extends HttpClient<SecurityDataType> {
+  healthcheck = {
+    /**
+     * No description
+     *
+     * @tags Healthcheck
+     * @name AppControllerGetHello
+     * @summary Healthcheck endpoint for kubernetes
+     * @request GET:/healthcheck
+     */
+    appControllerGetHello: (params: RequestParams = {}) =>
+      this.request<void, any>({
+        path: `/healthcheck`,
+        method: 'GET',
+        ...params,
+      }),
+  };
+  limitOrder = {
+    /**
+     * @description Returns all available routes with quotes from different protocols to help users make informed decisions
+     *
+     * @tags orders
+     * @name OrdersControllerGetRoutes
+     * @summary Get available routes for order execution
+     * @request POST:/limit-order/advanced/routes
+     */
+    ordersControllerGetRoutes: (
+      data: OrderRoutesDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<OrderRoutesResponseDto, void>({
+        path: `/limit-order/advanced/routes`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Returns the transactionRequest/typedData needed to sign and execute a step
+     *
+     * @tags orders
+     * @name OrdersControllerStepTransaction
+     * @summary Get execution details for a step
+     * @request POST:/limit-order/advanced/stepTransaction
+     */
+    ordersControllerStepTransaction: (
+      data: StepTransactionRequestDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<StepTransactionResponseDto, void>({
+        path: `/limit-order/advanced/stepTransaction`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Submits a signed order to the protocol orderbook
+     *
+     * @tags orders
+     * @name OrdersControllerRelay
+     * @summary Relay a signed order
+     * @request POST:/limit-order/advanced/relay
+     */
+    ordersControllerRelay: (
+      data: RelayRequestDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<RelayResponseDto, void>({
+        path: `/limit-order/advanced/relay`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Retrieves the current status of a task submitted via /advanced/relay
+     *
+     * @tags orders
+     * @name OrdersControllerRelayerStatus
+     * @summary Get the status of a relayed order
+     * @request GET:/limit-order/relayer/status
+     */
+    ordersControllerRelayerStatus: (
+      query: {
+        /** Unique identifier for the task to check */
+        taskId: string;
+        /** Tool/bridge identifier */
+        bridge?: string;
+        /** Source chain ID */
+        fromChain?: number;
+        /** Destination chain ID */
+        toChain?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<RelayerStatusResponseDto, void>({
+        path: `/limit-order/relayer/status`,
+        method: 'GET',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Retrieves the status of an order by task ID or transaction hash
+     *
+     * @tags orders
+     * @name OrdersControllerOrderStatus
+     * @summary Get order status
+     * @request GET:/limit-order/status
+     */
+    ordersControllerOrderStatus: (
+      query: {
+        /** Tool/bridge identifier (e.g. "1inch", "cowswap") */
+        bridge: string;
+        /** Source chain ID */
+        fromChain?: number;
+        /** Destination chain ID */
+        toChain?: number;
+        /** Task ID from relay step (provide taskId or txHash) */
+        taskId?: string;
+        /** On-chain transaction hash (provide taskId or txHash) */
+        txHash?: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<StatusResponseDto, void>({
+        path: `/limit-order/status`,
+        method: 'GET',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Returns the transaction data needed to cancel a limit order
+     *
+     * @tags orders
+     * @name OrdersControllerCancelCalldata
+     * @summary Get cancellation calldata for an order
+     * @request POST:/limit-order/cancel/calldata
+     */
+    ordersControllerCancelCalldata: (
+      data: CancelStepTransactionRequestDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<CancelStepTransactionResponseDto, void>({
+        path: `/limit-order/cancel/calldata`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Relays a signed cancellation to the protocol orderbook
+     *
+     * @tags orders
+     * @name OrdersControllerCancelOrderRelay
+     * @summary Relay a signed order cancellation
+     * @request POST:/limit-order/cancel/relay
+     */
+    ordersControllerCancelOrderRelay: (
+      data: CancelRelayRequestDto,
+      params: RequestParams = {},
+    ) =>
+      this.request<RelayResponseDto, void>({
+        path: `/limit-order/cancel/relay`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Retrieves all supported chains, optionally filtered by chain type
+     *
+     * @tags orders
+     * @name OrdersControllerGetChains
+     * @summary Get supported chains for limit orders
+     * @request GET:/limit-order/chains
+     */
+    ordersControllerGetChains: (
+      query?: {
+        /** Type of chains to filter */
+        chainTypes?: string[];
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<void, any>({
+        path: `/limit-order/chains`,
+        method: 'GET',
+        query: query,
+        ...params,
+      }),
+
+    /**
+     * @description Retrieves all supported tokens, optionally filtered by chain
+     *
+     * @tags orders
+     * @name OrdersControllerGetTokens
+     * @summary Get supported tokens for limit orders
+     * @request GET:/limit-order/tokens
+     */
+    ordersControllerGetTokens: (
+      query?: {
+        /** Filter by chain type */
+        chainTypes?: ('EVM' | 'SVM')[];
+        /**
+         * Filter by chain ID
+         * @example [1,10,137]
+         */
+        chains?: number[];
+        /** Order by criteria */
+        orderBy?: 'name' | 'amount' | 'price';
+        /**
+         * Maximum number of tokens to retrieve
+         * @default 100
+         */
+        limit?: number;
+        /**
+         * Include extended token information
+         * @default false
+         */
+        extended?: boolean;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TokensResponseDto[], any>({
+        path: `/limit-order/tokens`,
+        method: 'GET',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Retrieves all orders for a specific user address
+     *
+     * @tags orders
+     * @name OrdersControllerGetOrdersByUser
+     * @summary Get orders by user address
+     * @request GET:/limit-order/{address}
+     */
+    ordersControllerGetOrdersByUser: (
+      address: string,
+      query?: {
+        /** Filter by tool/protocol */
+        tools?: ('1inch' | 'cowswap')[];
+        /**
+         * Filter by chain IDs
+         * @example [1,10,137]
+         */
+        chainIds?: number[];
+        /** Filter by order status */
+        status?: (
+          | 'pending'
+          | 'active'
+          | 'partially_filled'
+          | 'filled'
+          | 'cancelled'
+          | 'expired'
+        )[];
+        /** Filter by from token address */
+        fromTokenAddress?: string;
+        /** Filter by to token address */
+        toTokenAddress?: string;
+        /**
+         * Maximum number of orders
+         * @default 10
+         */
+        limit?: number;
+        /**
+         * Offset for pagination
+         * @default 0
+         */
+        offset?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<Order[], any>({
+        path: `/limit-order/${address}`,
+        method: 'GET',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Retrieves an order by its ID for a specific tool and chain
+     *
+     * @tags orders
+     * @name OrdersControllerGetOrder
+     * @summary Get order by ID
+     * @request GET:/limit-order/{tool}/{chainId}/{orderId}
+     */
+    ordersControllerGetOrder: (
+      tool: '1inch' | 'cowswap',
+      chainId: string,
+      orderId: string,
+      params: RequestParams = {},
+    ) =>
+      this.request<Order, void>({
+        path: `/limit-order/${tool}/${chainId}/${orderId}`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `LimitOrders/OrdersSection` and `LimitOrders/MarketPriceSection` components with full orders table, row actions, skeletons, and hooks
- Adds `DataTable` reusable primitive used by the orders table
- Adds limit order API client (`limitOrderClient`), `useLimitOrders` hook, generated types (`jumper-limit-order`), and `gen-limit-order-api.sh` script
- Updates `AdvancedPageContent` to show the side panel (orders + market price) only when the `limit` tab is active via `NavigationTabChanged` widget event

## Test plan

- [ ] On `/advanced`, switching to the limit tab shows the orders + market price side panel
- [ ] On `/advanced`, switching to swap-advanced or bridge-advanced hides the side panel
- [ ] Expand/collapse button resizes the side panel correctly
- [ ] Orders table loads and displays with correct skeletons while loading

Closes JUM-1179