### PR TITLE
chore: interchange tx asset in and out

### DIFF
--- a/src/components/composite/TransactionTable/components/TransactionSummaryColumn.tsx
+++ b/src/components/composite/TransactionTable/components/TransactionSummaryColumn.tsx
@@ -290,11 +290,11 @@ export const COLUMN_DEFINITIONS: Record<
     label: 'portfolio.transactionSummary.columns.assetIn',
     render: (content, config) => (
       <TransactionAssetStack
-        tokens={content.fromTokens}
-        nfts={content.fromNfts}
+        tokens={content.toTokens}
+        nfts={content.toNfts}
         config={config}
-        amountTitle={content.fromAmountTitle}
-        amountHints={content.fromAmountHints}
+        amountTitle={content.toAmountTitle}
+        amountHints={content.toAmountHints}
       />
     ),
     renderSkeleton: (config) => (
@@ -305,11 +305,11 @@ export const COLUMN_DEFINITIONS: Record<
     label: 'portfolio.transactionSummary.columns.assetOut',
     render: (content, config) => (
       <TransactionAssetStack
-        tokens={content.toTokens}
-        nfts={content.toNfts}
+        tokens={content.fromTokens}
+        nfts={content.fromNfts}
         config={config}
-        amountTitle={content.toAmountTitle}
-        amountHints={content.toAmountHints}
+        amountTitle={content.fromAmountTitle}
+        amountHints={content.fromAmountHints}
       />
     ),
     renderSkeleton: (config) => (


### PR DESCRIPTION
# Which Jira task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/JUM-1245/transaction-tab-shows-asset-inout-values-swapped

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the asset details shown in transaction summaries so incoming assets now display the right “to” information and outgoing assets show the matching “from” information.
  * Improved the accuracy of token, NFT, and amount labels in the transaction table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->