### PR TITLE
feat: modify order modal flow

### DIFF
--- a/src/components/composite/ModifyOrderFlow/ModifyOrderFlow.tsx
+++ b/src/components/composite/ModifyOrderFlow/ModifyOrderFlow.tsx
@@ -1,48 +1,192 @@
 'use client';
 
-import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import { HeightAnimatedContainer } from '@jumperexchange/shared-ui/components';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+import { motion } from 'motion/react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Badge } from '@/components/Badge/Badge';
-import { BadgeVariant } from '@/components/Badge/Badge.styles';
+import { Widget as BaseWidget } from '@/components/Widgets/variants/base/Widget';
 import { SectionCard } from '@/components/Cards/SectionCard/SectionCard';
+import { StatusBottomSheet } from '@/components/composite/StatusBottomSheet/StatusBottomSheet';
+import { useCancelOrder } from '@/components/composite/CancelOrderFlow/hooks/useCancelOrder';
+import { useCancelOrderStatusSheet } from '@/components/composite/CancelOrderFlow/hooks/useCancelOrderStatusSheet';
+import { Button } from '@/components/core/buttons/Button/Button';
+import { Variant } from '@/components/core/buttons/types';
 import { ModalContainer } from '@/components/core/modals/ModalContainer/ModalContainer';
 import { useModifyOrderFlowStore } from '@/stores/limitOrderFlow/ModifyOrderFlowStore';
+import type { LimitOrdersWidgetContext } from '@/components/Widgets/variants/widgetConfig/types';
+import { useTokenAmountInput } from '@/hooks/tokens/useTokenAmountInput';
+import { useTheme } from '@mui/material';
 
-/**
- * Stand-in for the real modify-order widget, which doesn't exist yet.
- * Swap this out once the limit-order widget supports editing an order.
- */
+const CONTAINER_ID = 'modify-order-modal';
+const BOTTOM_SHEET_TOP_OFFSET = 24;
+const ANIMATION_DURATION_SECONDS = 0.3;
+
+type Step = 'cancel' | 'place';
+
 export const ModifyOrderFlowModal = () => {
   const { t } = useTranslation();
+  const { toAmount } = useTokenAmountInput();
+  const theme = useTheme();
   const { isModalOpen, selectedOrder, closeModal } = useModifyOrderFlowStore(
     (state) => state,
   );
+
+  const [step, setStep] = useState<Step>('cancel');
+
+  const { cancelOrderAsync, result, isPending, isSuccess, isError, reset } =
+    useCancelOrder();
+
+  useEffect(() => {
+    if (isSuccess) {
+      setStep('place');
+    }
+  }, [isSuccess]);
+
+  const handleClose = () => {
+    reset();
+    setStep('cancel');
+    closeModal();
+  };
+
+  const handleConfirm = () => {
+    if (!selectedOrder) {
+      return;
+    }
+    cancelOrderAsync(selectedOrder).catch(() => {});
+  };
+
+  const statusSheet = useCancelOrderStatusSheet({
+    isSuccess,
+    isError,
+    result,
+    onRetry: handleConfirm,
+    onDone: () => setStep('place'),
+    onCloseError: handleClose,
+  });
+
+  const context = useMemo((): LimitOrdersWidgetContext | null => {
+    if (!selectedOrder) {
+      return null;
+    }
+    return {
+      overrideHeader: t('limitOrders.modifyModal.title'),
+      disabledUI: { fromToken: true, toToken: true },
+      theme: {
+        container: {
+          maxHeight: 'calc(100vh - 6rem)',
+          minWidth: 'min(100vw, 360px)',
+          maxWidth: 400,
+          borderRadius: `${theme.shape.cardBorderRadiusLarge}px`,
+          [theme.breakpoints.up('sm')]: {
+            maxHeight: 'calc(100vh - 6rem)',
+            minWidth: 400,
+          },
+        },
+      },
+      formData: {
+        sourceChain: {
+          chainId: selectedOrder.fromToken.chainId.toString(),
+          chainKey: '',
+        },
+        sourceToken: {
+          tokenAddress: selectedOrder.fromToken.address,
+          tokenSymbol: selectedOrder.fromToken.symbol,
+        },
+        destinationChain: {
+          chainId: selectedOrder.toToken.chainId.toString(),
+          chainKey: '',
+        },
+        destinationToken: {
+          tokenAddress: selectedOrder.toToken.address,
+          tokenSymbol: selectedOrder.toToken.symbol,
+        },
+        fromAmount: toAmount(
+          BigInt(selectedOrder.fromAmount),
+          selectedOrder.fromToken.decimals,
+        ),
+      },
+    };
+  }, [selectedOrder, toAmount, t, theme]);
+
+  useEffect(() => {
+    return () => {
+      closeModal();
+    };
+  }, [closeModal]);
 
   if (!selectedOrder) {
     return null;
   }
 
+  if (step === 'place' && context) {
+    return (
+      <ModalContainer isOpen={isModalOpen} onClose={handleClose}>
+        <BaseWidget type="limit" ctx={context} />
+      </ModalContainer>
+    );
+  }
+
   return (
-    <ModalContainer isOpen={isModalOpen} onClose={closeModal}>
-      <SectionCard sx={{ width: 'min(90vw, 400px)' }}>
-        <Stack sx={{ gap: 3 }}>
-          <Badge
-            startIcon={<AccessTimeIcon />}
-            label={t('limitOrders.modifyModal.placeholderTitle')}
-            variant={BadgeVariant.Secondary}
-          />
-          <Stack sx={{ gap: 0.5 }}>
-            <Typography variant="bodyLargeStrong">
-              {t('limitOrders.modifyModal.title')}
-            </Typography>
-            <Typography variant="bodySmall" color="textSecondary">
-              {t('limitOrders.modifyModal.placeholderDescription')}
-            </Typography>
-          </Stack>
-        </Stack>
-      </SectionCard>
+    <ModalContainer isOpen={isModalOpen} onClose={handleClose}>
+      <div id={CONTAINER_ID} style={{ position: 'relative' }}>
+        <HeightAnimatedContainer
+          isOpen={statusSheet.isOpen}
+          offsetHeight={BOTTOM_SHEET_TOP_OFFSET}
+          animationDuration={ANIMATION_DURATION_SECONDS}
+          defaultHeight="auto"
+        >
+          {({ onHeightChange, motionProps }) => (
+            <motion.div {...motionProps} style={{ x: 0, y: 0 }}>
+              <SectionCard sx={{ width: 'min(90vw, 400px)' }}>
+                <Stack sx={{ gap: 2 }}>
+                  <Typography variant="titleSmall">
+                    {t('limitOrders.modifyModal.cancelStep.title')}
+                  </Typography>
+                  <Typography variant="bodySmall" color="textSecondary">
+                    {t('limitOrders.modifyModal.cancelStep.description')}
+                  </Typography>
+                  <Stack direction="row" sx={{ gap: 1.5 }}>
+                    <Button
+                      variant={Variant.AlphaDark}
+                      sx={{ flex: 1 }}
+                      onClick={handleClose}
+                      disabled={isPending}
+                    >
+                      {t('limitOrders.cancelModal.keepOrder')}
+                    </Button>
+                    <Button
+                      variant={Variant.Primary}
+                      sx={{
+                        flex: 1,
+                        '& .MuiButton-buttonLabel': {
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                        },
+                      }}
+                      onClick={handleConfirm}
+                      loading={isPending}
+                      loadingPosition="start"
+                    >
+                      {t('limitOrders.modifyModal.cancelStep.confirm')}
+                    </Button>
+                  </Stack>
+                </Stack>
+              </SectionCard>
+
+              <StatusBottomSheet
+                containerId={CONTAINER_ID}
+                isOpen={statusSheet.isOpen}
+                onClose={statusSheet.onClose}
+                onHeightChange={onHeightChange}
+                {...statusSheet.content}
+              />
+            </motion.div>
+          )}
+        </HeightAnimatedContainer>
+      </div>
     </ModalContainer>
   );
 };


### PR DESCRIPTION
## Summary

Implements `ModifyOrderFlowModal` as a two-step cancel → place flow:

- Step 1: cancel confirmation card (reuses `useCancelOrder`, `useCancelOrderStatusSheet`) with "Keep order" / "Cancel & continue" buttons
- Step 2: limit widget pre-filled with the order's token pair and sell amount

Given that modifying a limit order requires 2 intermediary screens before execution starts (cancel confirmation + place order review), it would make sense to extend the widget to support navigating to custom screens before the execution begins. This PR contains the current placeholder implementation; a follow-up will wire the full 3-step flow once the widget supports custom route injection.

Closes [JUM-1175](https://linear.app/lifi-linear/issue/JUM-1175/modify-order-modal-flow)

Depends on #3015

## Test plan

- [ ] Open `/advanced`, switch to Limit tab, find an active order and click "Modify"
- [ ] Cancel step shows order pair + warning; "Keep order" closes without cancelling; "Cancel & continue" executes cancellation
- [ ] On success, widget opens pre-filled with the order's tokens and amount
- [ ] Error state shows retry option via `StatusBottomSheet`
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)