### PR TITLE
feat: add pagination to orders table

### DIFF
--- a/src/components/LimitOrders/OrdersSection/OrdersTable.tsx
+++ b/src/components/LimitOrders/OrdersSection/OrdersTable.tsx
@@ -1,8 +1,16 @@
 'use client';
 
+import { useState } from 'react';
+import { useMediaQuery } from '@mui/material';
 import { DataTable } from '@/components/composite/DataTable/DataTable';
-import { useOrderColumns } from './hooks';
+import {
+  Pagination,
+  PaginationVariant,
+} from '@/components/core/Pagination/Pagination';
 import { type Order } from '@/types/jumper-limit-order';
+import { useOrderColumns } from './hooks';
+
+const PAGE_SIZE = 10;
 
 interface OrdersTableProps {
   orders: Order[];
@@ -18,16 +26,50 @@ export const OrdersTable = ({
   stickyHeader = false,
 }: OrdersTableProps) => {
   const columns = useOrderColumns(isExpanded);
+  const isMobile = useMediaQuery((theme) => theme.breakpoints.down('sm'));
+  const isTablet = useMediaQuery((theme) => theme.breakpoints.down('md'));
+  const isSmallScreen = useMediaQuery((theme) => theme.breakpoints.down('lg'));
+  const [page, setPage] = useState(0);
+
+  const maxVisiblePages = isMobile
+    ? 1
+    : isTablet || (isSmallScreen && !isExpanded)
+      ? 2
+      : isSmallScreen
+        ? 3
+        : 5;
+
+  // TODO: replace with server-side pagination once the API exposes limit/offset total count
+  const pageCount = Math.ceil(orders.length / PAGE_SIZE);
+  const pagedOrders = orders.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+
   return (
-    <DataTable
-      rows={orders}
-      loading={isLoading}
-      columns={columns}
-      getRowKey={(order) => order.orderId}
-      hasMobileView={false}
-      showHeader
-      stickyHeader={stickyHeader}
-      sx={{ marginInline: (theme) => theme.spacing(-1.5) }}
-    />
+    <>
+      <DataTable
+        rows={pagedOrders}
+        loading={isLoading}
+        columns={columns}
+        getRowKey={(order) => order.orderId}
+        hasMobileView={false}
+        showHeader
+        stickyHeader={stickyHeader}
+        sx={{ marginInline: (theme) => theme.spacing(-1.5) }}
+      />
+      {pageCount > 1 && (
+        <Pagination
+          variant={PaginationVariant.WindowedPages}
+          page={page}
+          setPage={setPage}
+          pagination={{
+            page,
+            pageSize: PAGE_SIZE,
+            pageCount,
+            total: orders.length,
+          }}
+          maxVisiblePages={maxVisiblePages}
+          sx={{ mt: 1, gap: (theme) => theme.spacing(0.5) }}
+        />
+      )}
+    </>
   );
 };


### PR DESCRIPTION
## Summary
- Adds client-side pagination to the orders table with 10 items per page
- Wires up the existing `Pagination` component (`WindowedPages` variant)
- `maxVisiblePages` scales with screen size and panel expanded state (1 → 2 → 3 → 5)

Closes JUMADV-3

## Test plan
- [ ] Orders table with >10 orders shows pagination controls
- [ ] Page navigation works correctly
- [ ] Pagination controls stay on a single row at all breakpoints (mobile, tablet, desktop)
- [ ] Collapsed vs expanded panel shows correct number of visible page buttons
- [ ] Orders table with ≤10 orders shows no pagination