### PR TITLE
fix: widget stage layout and sticky behaviour for advanced side panel

### DIFF
--- a/src/app/ui/widget/AdvancedPageContent.tsx
+++ b/src/app/ui/widget/AdvancedPageContent.tsx
@@ -13,7 +13,6 @@ import { MainWidgetPageContent } from './MainWidgetPageContent';
 import { WidgetSidePanel } from './WidgetSidePanel';
 import { useTranslation } from 'react-i18next';
 
-
 export const AdvancedPageContent = () => {
   const { t } = useTranslation();
   const widgetEvents = useWidgetEvents();
@@ -64,15 +63,17 @@ export const AdvancedPageContent = () => {
       variant="advanced"
       isSidePanelExpanded={isSidePanelExpanded}
       sidePanelContent={
-        isLimitTabActive ? (<WidgetSidePanel>
-          <MarketPriceSection action={expandButton} />
-          <OrdersSection
-            isSidePanelExpanded={isSidePanelExpanded}
-            action={expandButton}
-          />
-        </WidgetSidePanel>
+        isLimitTabActive ? (
+          <WidgetSidePanel>
+            <MarketPriceSection action={expandButton} />
+            <OrdersSection
+              isSidePanelExpanded={isSidePanelExpanded}
+              action={expandButton}
+            />
+          </WidgetSidePanel>
         ) : undefined
-    }
+      }
+      sx={isLimitTabActive ? { mb: 6 } : undefined}
     />
   );
 };

--- a/src/app/ui/widget/MainWidgetPageContent.tsx
+++ b/src/app/ui/widget/MainWidgetPageContent.tsx
@@ -7,6 +7,7 @@ import { Widgets } from '@/components/Widgets/Widgets';
 import { useWelcomeScreen } from '@/hooks/useWelcomeScreen';
 import type { StarterVariantType } from '@/types/internal';
 import { WidgetStage } from './WidgetStage';
+import type { SxProps, Theme } from '@mui/material/styles';
 
 interface MainWidgetPageContentProps {
   variant: StarterVariantType;
@@ -14,6 +15,7 @@ interface MainWidgetPageContentProps {
   isLoading?: boolean;
   sidePanelContent?: ReactNode;
   isSidePanelExpanded?: boolean;
+  sx?: SxProps<Theme>;
 }
 
 export const MainWidgetPageContent = ({
@@ -22,6 +24,7 @@ export const MainWidgetPageContent = ({
   isLoading,
   sidePanelContent,
   isSidePanelExpanded = false,
+  sx,
 }: MainWidgetPageContentProps) => {
   const { welcomeScreenClosed, enabled } = useWelcomeScreen();
   const isWelcomeScreenClosed = welcomeScreenClosed || !enabled;
@@ -46,6 +49,7 @@ export const MainWidgetPageContent = ({
         </>
       }
       sidePanelContent={sidePanelContent}
+      sx={sx}
     />
   );
 };

--- a/src/app/ui/widget/WidgetStage.tsx
+++ b/src/app/ui/widget/WidgetStage.tsx
@@ -3,6 +3,7 @@
 import Box from '@mui/material/Box';
 import type { SxProps, Theme } from '@mui/material/styles';
 import { useTheme } from '@mui/material/styles';
+import useScrollTrigger from '@mui/material/useScrollTrigger';
 import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { WIDGET_WIDTH } from 'src/config/widgetConfig';
@@ -21,7 +22,7 @@ const getGridTemplateColumns = (
   isSidePanelExpanded: boolean,
   isWelcomeScreenOpen: boolean,
 ) => {
-  const widgetOnly = `auto ${WIDGET_COL_WIDTH}px`;
+  const widgetOnly = 'auto auto';
   // minmax(0, ...) lets these columns shrink below their ideal width instead
   // of overflowing when the collapsed side panel doesn't have its full width
   // available (e.g. narrower "lg" viewports).
@@ -123,9 +124,9 @@ const getStickyColumnSx = (stickyTop: string): SxProps<Theme> => ({
   alignSelf: 'start',
 });
 
-const getWidgetWidthSx = (): SxProps<Theme> => ({
+const getWidgetWidthSx = (constrained = true): SxProps<Theme> => ({
   width: '100%',
-  maxWidth: { sm: WIDGET_WIDTH },
+  ...(constrained && { maxWidth: { sm: WIDGET_WIDTH } }),
   justifySelf: { sm: 'center' },
 });
 
@@ -139,10 +140,14 @@ export const WidgetStage = ({
 }: WidgetStageProps) => {
   const theme = useTheme();
   const headerHeightPx = useHeaderHeight();
-  const bannerStickyTop = getWidgetStickyTop(headerHeightPx, theme);
-  const bannerRef = useRef<HTMLDivElement>(null);
+  const isHeaderHidden = useScrollTrigger();
   const hasAnnouncement = Boolean(announcementContent);
   const hasSidePanel = Boolean(sidePanelContent);
+  const bannerStickyTop = getWidgetStickyTop(
+    isHeaderHidden ? 0 : headerHeightPx,
+    theme,
+  );
+  const bannerRef = useRef<HTMLDivElement>(null);
   const contentRow = hasAnnouncement ? 2 : 1;
   const [bannerHeightPx, setBannerHeightPx] = useState(0);
 
@@ -259,7 +264,7 @@ export const WidgetStage = ({
             minHeight: 0,
             zIndex: 10,
           },
-          getWidgetWidthSx(),
+          getWidgetWidthSx(hasSidePanel),
           stickyColumnSx,
         )}
       >
@@ -267,17 +272,19 @@ export const WidgetStage = ({
       </Box>
       {hasSidePanel && (
         <Box
-          sx={{
-            display: isWelcomeScreenOpen ? 'none' : undefined,
-            gridArea: { xs: 'sidePanel' },
-            gridColumn: { md: '2', lg: '3' },
-            gridRow: { md: contentRow },
-            minWidth: 0,
-            alignSelf: 'start',
-            width: '100%',
-            maxWidth: { sm: WIDGET_WIDTH, md: 'none' },
-            justifySelf: { xs: 'stretch', sm: 'center', md: 'stretch' },
-          }}
+          sx={mergeSx(
+            {
+              display: isWelcomeScreenOpen ? 'none' : undefined,
+              gridArea: { xs: 'sidePanel' },
+              gridColumn: { md: '2', lg: '3' },
+              gridRow: { md: contentRow },
+              minWidth: 0,
+              width: '100%',
+              maxWidth: { sm: WIDGET_WIDTH, md: 'none' },
+              justifySelf: { xs: 'stretch', sm: 'center', md: 'stretch' },
+            },
+            stickyColumnSx,
+          )}
         >
           {sidePanelContent}
         </Box>


### PR DESCRIPTION
## Linear
JUMADV-4: https://linear.app/lifi-linear/issue/JUMADV-4/advanced-swap-and-bridge-position-and-side-panel

## Summary
- Expand widget column to `auto` when no side panel is present so the LI.FI widget's internal chain/routes expansion panels render at their natural width without clipping
- Constrain widget box `maxWidth` only when our side panel is visible (limit tab), not on swap/bridge tabs where the internal expansion is expected
- Apply sticky positioning to the side panel column so it tracks with the widget column instead of scrolling independently
- Drop header height from sticky-top offset when the header has scrolled away, using `useScrollTrigger` to mirror `HideOnScroll` behaviour

## Test plan
- [ ] Open advanced page on limit tab — widget and orders table should stick together when scrolling
- [ ] Open advanced page on swap/bridge tab — widget internal chain selector should expand without clipping
- [ ] Verify announcement banner is not overlapped by the sticky widget on scroll
- [ ] Check simple mode widget is unaffected (still 416px, still sticky with header offset)