### PR TITLE
ci(e2e): build the app once per run and share it across shards

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -74,13 +74,67 @@ jobs:
 
           echo "public_link=$public_link" >> "$GITHUB_OUTPUT"
           echo "Public link: $public_link"
+  # One build shared by all shards: the build prerenders against live Strapi/backend,
+  # so every extra build is another chance for a transient upstream blip to abort a
+  # shard ("Export encountered an error"). Building here also turns a build failure
+  # into a single red job instead of every shard failing with 0 tests.
+  build:
+    name: Build App
+    runs-on: ubuntu-latest
+    # Covers the retry path: install + two full build attempts + pack/upload.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: "pnpm"
+      - name: Install pnpm
+        run: npm install -g pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build production bundle
+        env:
+          E2E_PROD_BUILD: "1" # plain (non-standalone) build that `next start` serves
+        run: |
+          # Load tests/.env.test the way Playwright's webServer does (dotenv) — a
+          # bare `pnpm run build` lacks those vars, and the bundle must match what
+          # the shards serve. The retry absorbs a transient prerender-fetch failure.
+          build() {
+            node -e "require('dotenv').config({ path: './tests/.env.test' }); require('child_process').execSync('pnpm run build', { stdio: 'inherit' })"
+          }
+          for attempt in 1 2; do
+            if build; then exit 0; fi
+            echo "::warning::Build attempt ${attempt} failed"
+            rm -rf .next
+          done
+          exit 1
+      - name: Pack build for the shards
+        # A single zstd tar instead of thousands of small files — per-file upload
+        # overhead dwarfs the transfer otherwise, and .next is several GB raw (SSG
+        # pages × every locale). .next/cache is rebuild-only; `next start` never
+        # reads it, so it stays out.
+        run: |
+          tar -I 'zstd -T0' -cf next-build.tar.zst --exclude='.next/cache' .next
+          du -sh next-build.tar.zst
+      - name: Upload build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: next-build
+          path: next-build.tar.zst
+          # 4 days (matching the html report): "Re-run failed jobs" does not re-run the
+          # succeeded build job, so a late re-run must still find the artifact.
+          retention-days: 4
+          compression-level: 0 # already zstd-compressed
+
   test:
-    needs: [create-qase-run]
+    needs: [create-qase-run, build]
     name: Test (${{ matrix.shard }} / ${{ strategy.job-total}})
     continue-on-error: false # Instead we use fail-fast to forward the failure state to subsequent jobs
-    # 40 min: per-shard cold prod build (~5-8 min) on top of the existing headroom
-    # for `test.slow()` specs (swapActions/mainMenu) + a 90s Hyperliquid case.
-    timeout-minutes: 40
+    # 30 min: headroom for `test.slow()` specs (swapActions/mainMenu) + a 90s
+    # Hyperliquid case; the app arrives prebuilt from the build job.
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -104,15 +158,25 @@ jobs:
         # xclip owns the CLIPBOARD selection under xvfb; the wallet seed is pasted
         # (not typed) into MetaMask so it never lands in a Playwright trace.
         run: sudo apt-get update && sudo apt-get install -y xvfb xclip
+      - name: Download build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: next-build
+      - name: Unpack build artifact
+        run: |
+          tar -xf next-build.tar.zst
+          rm next-build.tar.zst
       - name: Run Playwright tests
         env:
           QASE_TESTOPS_RUN_ID: ${{ needs.create-qase-run.outputs.run_id || '' }}
           QASE_TESTOPS_API_TOKEN: ${{ secrets.QASE_TOKEN }}
           SHARD: ${{ matrix.shard }}/${{ strategy.job-total }}
-          E2E_PROD_BUILD: "1" # serve a plain prod build (not the dev server)
+          E2E_SKIP_BUILD: "1" # serve the prebuilt .next from the build job
+          # `next start` re-reads next.config.mjs, which keys output: standalone off
+          # this var — keep it so the config matches what the build job produced.
+          E2E_PROD_BUILD: "1"
           TEST_WALLET_SEED_PHRASE: ${{ secrets.TEST_WALLET_SEED_PHRASE }}
           TEST_WALLET_PASSWORD: ${{ secrets.TEST_WALLET_PASSWORD }}
-        if: ${{ !cancelled()}} # Always attempt to run the tests even if cache setup failed
         run: |
           if [ -n "$QASE_TESTOPS_API_TOKEN" ] && [ -n "$QASE_TESTOPS_RUN_ID" ]; then
             echo "Running tests with Qase reporting (Run ID: $QASE_TESTOPS_RUN_ID)"
@@ -130,9 +194,14 @@ jobs:
           name: blob-report-${{ matrix.shard }}
           path: blob-report
           retention-days: 1
+          # "Re-run failed jobs" keeps prior-attempt artifacts (merge-reports needs the
+          # passing shards' blobs), so a re-run shard must replace its own.
+          overwrite: true
 
   merge-reports:
-    if: ${{ !cancelled() }}
+    # Skipped shards (build failed) produce no blob reports — running would only
+    # stack a download failure on top of the real one.
+    if: ${{ !cancelled() && needs.test.result != 'skipped' }}
     needs: [test]
     timeout-minutes: 3
     outputs:
@@ -320,8 +389,10 @@ jobs:
     # !cancelled() lets this run even when publish-report is skipped (fork PR), so the
     # summary still posts. Qase reporting still runs (create-qase-run/complete-qase-run);
     # only its PR-comment link was dropped in favour of the Pages report link.
+    # The merge-reports guard keeps a run with no results (failed or skipped build/shards)
+    # from overwriting the previous summary with an empty sticky comment.
     needs: [merge-reports, publish-report]
-    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+    if: ${{ !cancelled() && needs.merge-reports.result == 'success' && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -90,8 +90,6 @@ jobs:
         with:
           node-version: 24
           cache: "pnpm"
-      - name: Install pnpm
-        run: npm install -g pnpm
       - name: Install dependencies
         run: pnpm install
       - name: Build production bundle
@@ -147,8 +145,6 @@ jobs:
         with:
           node-version: 24
           cache: "pnpm"
-      - name: Install pnpm
-        run: npm install -g pnpm
       - name: Install dependencies
         run: pnpm install
       - name: Install Playwright Browsers

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -76,13 +76,21 @@ export default defineConfig({
     : {
         // Serve a prod build under CI/E2E_PROD_BUILD — the Turbopack dev server
         // intermittently boot-hangs on CI runners (300s webServer timeout).
-        command:
-          process.env.E2E_PROD_BUILD || process.env.CI
+        // E2E_SKIP_BUILD serves a prebuilt .next handed over by the CI build job:
+        // the build prerenders against live Strapi/backend, so every extra build
+        // is another chance for a transient upstream blip to kill the run.
+        command: process.env.E2E_SKIP_BUILD
+          ? 'pnpm run start'
+          : process.env.E2E_PROD_BUILD || process.env.CI
             ? 'pnpm run build && pnpm run start'
             : 'pnpm run dev',
         url: 'http://localhost:3000',
         timeout:
-          (process.env.E2E_PROD_BUILD || process.env.CI ? 900 : 300) * 1000,
+          (process.env.E2E_SKIP_BUILD
+            ? 120
+            : process.env.E2E_PROD_BUILD || process.env.CI
+              ? 900
+              : 300) * 1000,
         reuseExistingServer: !process.env.CI,
       },
 


### PR DESCRIPTION
## Problem

Each of the 5 Playwright shards builds the app itself inside the webServer (`pnpm run build && pnpm run start`). The build prerenders against live Strapi/backend, so a single transient upstream blip aborts the whole build and the shard dies with 0 tests (`Export encountered an error... exiting`) — 4 such incidents on 2026-07-08 alone. Five builds per run means five chances to lose that lottery, and a build failure shows up as confusing shard noise instead of a clear cause.

## Change

- New `build` job: builds once (loading `tests/.env.test` the same way Playwright's webServer does, one retry for the transient prerender-fetch case), packs `.next` minus `.next/cache` as a zstd tar (**128 MB**), uploads it as an artifact.
- Test shards `needs: build`, download + unpack (**~9 s**), and boot `next start` directly via a new `E2E_SKIP_BUILD` mode in `playwright.config.ts`. `E2E_PROD_BUILD` stays set so `next.config.mjs` resolves the same non-standalone output the build was produced with. Local run modes unchanged.
- A failed build is now a single red job: `merge-reports` skips when the shards never ran, and `post-comment` requires merge-reports success so a no-result run can't overwrite the previous sticky summary with an empty one.

Also folded in, surfaced while walking the re-run paths:
- `overwrite: true` on the blob-report upload — "Re-run failed jobs" keeps prior-attempt artifacts (merge-reports needs the passing shards' blobs), so a re-run shard must replace its own blob; without it the re-upload 409s and the run can never converge to green.
- Build artifact retention 4 days (matching the html report) — "Re-run failed jobs" doesn't re-run the succeeded build job, so a late re-run must still find the artifact.
- Dropped the test step's stale `if: !cancelled()` — it predates the artifact handover (the step could self-heal by building); now it would only stack a doomed `next start` failure on top of a real download error.

## Validation

- workflow_dispatch on this branch: https://github.com/jumperexchange/jumper-exchange/actions/runs/29019894070 — all green first attempt. Build compile 76 s; artifact upload 2 s; per-shard download+unpack 9 s (replaces the per-shard build); Qase run + Pages report publish intact.
- `E2E_SKIP_BUILD` path also verified locally against a prebuilt `.next`.

Trade-off: a green run pays a small serial build hop (~+5 min); in exchange the run rolls one retried build lottery instead of five, re-runs reuse the artifact instead of rebuilding, and build failures get clean attribution.

Linear: JUM-1242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playwright end-to-end runs now reuse a shared, prebuilt application artifact across shards to speed up execution.

* **Bug Fixes**
  * Improved rerun behavior so shard report artifacts are reliably overwritten.
  * Tightened merge-report and sticky comment conditions to avoid stale/empty PR comments when shards are skipped due to build failures.

* **Improvements**
  * Added `E2E_SKIP_BUILD` support for the Playwright web server to reduce unnecessary rebuilds, including adjusted server startup timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->