### PR TITLE
feat(tokens): mark Robinhood Chain meme tokens as verified

### DIFF
--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -1,10 +1,17 @@
-import { type BaseToken } from '@lifi/sdk';
-import type { AllowDeny } from '@lifi/widget';
+import type { WidgetTokens } from '@lifi/widget';
 import { ondoDenylist } from './generated/ondoDenylist';
 
 export const ARB_NATIVE_USDC = '0xaf88d065e77c8cc2239327c5edb3a432268e5831';
 
-export const tokens: AllowDeny<BaseToken> = {
+export const tokens: WidgetTokens = {
   allow: [],
   deny: ondoDenylist,
+  // Robinhood Chain (4663) meme tokens marked as verified to suppress the
+  // unverified-token warning in the widget token list.
+  verified: [
+    { chainId: 4663, address: '0xD7321801CAae694090694Ff55A9323139F043B88' }, // JUGGERNAUT
+    { chainId: 4663, address: '0x8e62F281f282686fCa6dCB39288069a93fC23F1c' }, // HOODRAT
+    { chainId: 4663, address: '0x3F298f2b7306Bf9a9e7177Ca461C58c4c2FDfa4c' }, // STONKS
+    { chainId: 4663, address: '0xf2915d1e3C1B0c769d0c756Ec43F1c1f6c99cD03' }, // ARROW
+  ],
 };


### PR DESCRIPTION
## What

Adds a `tokens.verified` allowlist to [`src/config/tokens.ts`](src/config/tokens.ts) for four Robinhood Chain (chainId `4663`) meme tokens:

| Symbol | Address |
|---|---|
| JUGGERNAUT | `0xD7321801CAae694090694Ff55A9323139F043B88` |
| HOODRAT | `0x8e62F281f282686fCa6dCB39288069a93fC23F1c` |
| STONKS | `0x3F298f2b7306Bf9a9e7177Ca461C58c4c2FDfa4c` |
| ARROW | `0xf2915d1e3C1B0c769d0c756Ec43F1c1f6c99cD03` |

## Why

These tokens aren't in LI.FI's priced token catalog, so they only surface via search and render with the yellow ⚠️ "unverified token" warning. Listing them under `tokens.verified` marks them as trusted and suppresses the warning without forcing them into the featured/popular categories.

## Notes / reviewer heads-up

- `tokens.verified` was introduced in `@lifi/widget` **4.1.0** ([widget#819](https://github.com/lifinance/widget/pull/819)). This repo currently pins `@lifi/widget@^4.0.0-beta.19` — **the allowlist only type-checks and takes effect once the widget dependency resolves to ≥4.1.0.** If CI type-checks against beta.19, a widget bump is needed first.
- The config `type` was changed from `AllowDeny<BaseToken>` to `WidgetTokens` (the widget's canonical `tokens` config type, which includes `verified` alongside `allow`/`deny`).
- **CASHCAT was omitted** — its `address`/`chainId` were cut off in the source data. Happy to add it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)