### PR TITLE
ci(e2e): skip the Slack failure notification on fork PRs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -402,7 +402,9 @@ jobs:
 
   notify-slack-on-failure:
     needs: [test, merge-reports]
-    if: ${{ failure() && github.event_name == 'pull_request' }}
+    # Same-repo PRs only — forks don't receive the Slack webhook secret, so on a
+    # fork PR this job can only fail on top of the real failure.
+    if: ${{ failure() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: Build Slack payload


### PR DESCRIPTION
Fork PRs don't receive repo secrets, so on any failing fork-PR run `notify-slack-on-failure` gets an empty `SLACK_WEBHOOK_URL_UI_TESTS` and the Slack action dies with `Missing input! Either a method or webhook is required to take action.` — a second red job stacked on top of the real failure. Observed on #3023: https://github.com/jumperexchange/jumper-exchange/actions/runs/29081449237 (Build App correctly red on the PR's own type error, then this job red on the missing webhook).

Gates the job to same-repo PRs with the same head-repo comparison `publish-report` already uses; on fork PRs the job now shows as skipped.

Validation note: the guarded path only manifests on a failing fork PR, so it can't be exercised by a dispatch — the expression is identical to the proven `publish-report` gate, and actionlint is clean.

Linear: JUM-1250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted Slack failure notifications to pull requests originating from the same repository.
  * Prevented notifications from being triggered for pull requests from external repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->