### PR TITLE
ci: trigger Zeus QA review via Agent Review Request label

### DIFF
--- a/.github/workflows/qa-review-trigger.yml
+++ b/.github/workflows/qa-review-trigger.yml
@@ -1,0 +1,66 @@
+name: Trigger Zeus QA Review
+
+on:
+  pull_request:
+    types: [labeled]
+
+concurrency:
+  group: qa-review-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  trigger:
+    if: github.event.label.name == 'Agent Review Request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.QA_APP_ID }}
+          private-key: ${{ secrets.QA_APP_PRIVATE_KEY }}
+          owner: lifinance
+          repositories: QA
+
+      - name: Swap labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api --method DELETE "repos/$REPO/issues/$PR_NUMBER/labels/Agent%20Review%20Request" || true
+          gh api --method DELETE "repos/$REPO/issues/$PR_NUMBER/labels/QA%20AI%20Approved" || true
+          if ! gh api --method POST "repos/$REPO/issues/$PR_NUMBER/labels" \
+            --field "labels[]=QA AI Reviewing"; then
+            echo "❌ Failed to apply QA AI Reviewing label — aborting"
+            exit 1
+          fi
+
+      - name: Dispatch to QA repo
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh api repos/lifinance/QA/actions/workflows/qa-run.yml/dispatches \
+            --method POST \
+            --field ref=main \
+            --field "inputs[scenario]=QAReviewJumper.md" \
+            --field "inputs[agent]=zeus" \
+            --field "inputs[ticket]=$PR_URL"
+
+      - name: Restore labels on dispatch failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api --method DELETE "repos/$REPO/issues/$PR_NUMBER/labels/QA%20AI%20Reviewing" || true
+          gh api --method POST "repos/$REPO/issues/$PR_NUMBER/labels" \
+            --field "labels[]=Agent Review Request" || true
+          echo "⚠️ Dispatch failed — restored Agent Review Request label"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/qa-review-trigger.yml`: on PR `labeled` with `Agent Review Request`, swaps GitHub labels and `workflow_dispatch`es `lifinance/QA`'s `qa-run.yml` with `scenario=QAReviewJumper.md`.
- Copied verbatim from the same trigger workflow already live in `lifinance/widget` and `lifinance/transak-wrapper` — no new mechanism, only the scenario input changed.
- The QA-side adapter (`qa-review-jumper`, Linear team JUM) already shipped in QA-153 and needs no further changes.

Refs [JUM-1253](https://linear.app/lifi-linear/issue/JUM-1253/wire-up-the-agent-review-request-label-trigger-for-zeus-qa-review)

## Test plan
- [x] Repo secrets `QA_APP_ID` / `QA_APP_PRIVATE_KEY` set on this repo
- [x] Linear team labels `QA AI Reviewing` / `QA AI Approved` created on the Jumper (JUM) team
- [x] GitHub repo labels `Agent Review Request` / `QA AI Reviewing` / `QA AI Approved` created on this repo
- [x] `lifi-qa-agent` GitHub App installed on the `jumperexchange` org with access to this repo
- [x] Apply `Agent Review Request` to this PR once labels exist and confirm the QA run dispatches and posts a review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated QA review workflow triggered by applying the “Agent Review Request” label.
  * Displays review progress with a “QA AI Reviewing” label.
  * Automatically restores the request label if the QA review cannot be started.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->