### PR TITLE
feat: instrument PostHog analytics for advanced mode widget events

### DIFF
--- a/src/components/LimitOrders/OrdersSection/OrderRowMenu.tsx
+++ b/src/components/LimitOrders/OrdersSection/OrderRowMenu.tsx
@@ -14,6 +14,12 @@ import { useRepeatOrderFlowStore } from '@/stores/limitOrderFlow/RepeatOrderFlow
 import { type Order } from '@/types/jumper-limit-order';
 import { isOrderExpired } from './utils';
 import { ORDERS_COMPLETED_STATUS, ORDERS_ONGOING_STATUS } from './constants';
+import { useUserTracking } from '@/hooks/userTracking';
+import {
+  TrackingAction,
+  TrackingCategory,
+  TrackingEventParameter,
+} from '@/const/trackingKeys';
 
 interface OrderRowMenuProps {
   order: Order;
@@ -21,6 +27,7 @@ interface OrderRowMenuProps {
 
 export const OrderRowMenu = ({ order }: OrderRowMenuProps) => {
   const { t } = useTranslation();
+  const { trackEvent } = useUserTracking();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const open = Boolean(anchorEl);
   const openCancelModal = useCancelOrderFlowStore((state) => state.openModal);
@@ -42,16 +49,34 @@ export const OrderRowMenu = ({ order }: OrderRowMenuProps) => {
   const handleModifyClick = () => {
     handleClose();
     openModifyModal(order);
+    trackEvent({
+      action: TrackingAction.OnModifyLimitOrderOpen,
+      category: TrackingCategory.Widget,
+      label: 'modify_limit_order_open',
+      data: { [TrackingEventParameter.OrderId]: order.orderId },
+    });
   };
 
   const handleCancelClick = () => {
     handleClose();
     openCancelModal(order);
+    trackEvent({
+      action: TrackingAction.OnCancelLimitOrderOpen,
+      category: TrackingCategory.Widget,
+      label: 'cancel_limit_order_open',
+      data: { [TrackingEventParameter.OrderId]: order.orderId },
+    });
   };
 
   const handleRepeatClick = () => {
     handleClose();
     openRepeatModal(order);
+    trackEvent({
+      action: TrackingAction.OnRepeatLimitOrderOpen,
+      category: TrackingCategory.Widget,
+      label: 'repeat_limit_order_open',
+      data: { [TrackingEventParameter.OrderId]: order.orderId },
+    });
   };
 
   return (

--- a/src/components/Widgets/Widgets.tsx
+++ b/src/components/Widgets/Widgets.tsx
@@ -7,6 +7,8 @@ import type { WidgetTrackingVariant } from '@/components/Widgets/tracking/widget
 import { ChainAlert } from '@/components/Alerts';
 import { TabsMap } from '@/const/tabsMap';
 import { useActiveTabStore } from '@/stores/activeTab';
+import { useRepeatOrderFlowStore } from '@/stores/limitOrderFlow/RepeatOrderFlowStore';
+import { useModifyOrderFlowStore } from '@/stores/limitOrderFlow/ModifyOrderFlowStore';
 import { PartnerThemeFooterImage } from '../PartnerThemeFooterImage';
 import { WidgetEvents } from './WidgetEvents';
 
@@ -14,6 +16,8 @@ export function Widgets() {
   const { setActiveTab } = useActiveTabStore();
   const pathname = usePathname();
   const activeNavigationTab = useActiveNavigationTab();
+  const isRepeatModalOpen = useRepeatOrderFlowStore((s) => s.isModalOpen);
+  const isModifyModalOpen = useModifyOrderFlowStore((s) => s.isModalOpen);
 
   useLayoutEffect(() => {
     const isAdvanced = TabsMap.Advanced.destination.some((dest) =>
@@ -25,15 +29,18 @@ export function Widgets() {
   const trackingVariant: WidgetTrackingVariant =
     activeNavigationTab === 'private'
       ? 'private'
-      : activeNavigationTab === 'limit'
-        ? 'limit'
+      : pathname.includes('advanced')
+        ? 'advanced'
         : 'main';
 
   return (
     <>
       <ChainAlert />
       <PartnerThemeFooterImage />
-      <WidgetTrackingProvider variant={trackingVariant}>
+      <WidgetTrackingProvider
+        variant={trackingVariant}
+        enabled={!isRepeatModalOpen && !isModifyModalOpen}
+      >
         <WidgetEvents />
       </WidgetTrackingProvider>
     </>

--- a/src/components/Widgets/tracking/WidgetTrackingSession.ts
+++ b/src/components/Widgets/tracking/WidgetTrackingSession.ts
@@ -1,4 +1,4 @@
-import type { ChainTokenSelected } from '@lifi/widget';
+import type { ChainTokenSelected, NavigationTabKey } from '@lifi/widget';
 import type { MutableRefObject } from 'react';
 import type { TrackTransactionDataProps } from '@/types/userTracking';
 
@@ -14,8 +14,10 @@ export interface WidgetTrackingUrlParams {
 export interface WidgetTrackingSession {
   readonly sourceChainToken: ChainTokenSelected | null;
   readonly destinationChainToken: ChainTokenSelected | null;
+  readonly activeTab: NavigationTabKey | null;
 
   onSourceTokenSelected(sourceToken: ChainTokenSelected): void;
+  onTabChanged(tab: NavigationTabKey): void;
   onDestinationTokenSelected(destinationToken: ChainTokenSelected): void;
   setDestinationTokenForTracking(destinationToken: ChainTokenSelected): void;
 
@@ -39,6 +41,7 @@ export const createWidgetTrackingSession = (
 ): WidgetTrackingSession => {
   let sourceChainToken: ChainTokenSelected | null = null;
   let destinationChainToken: ChainTokenSelected | null = null;
+  let activeTab: NavigationTabKey | null = null;
   let isRoutesForCurrentSourceTokenTracked = false;
   let isRoutesForCurrentDestinationTokenTracked = false;
   let isRoutesForCurrentFromAmountTracked = false;
@@ -55,6 +58,14 @@ export const createWidgetTrackingSession = (
     },
     get destinationChainToken() {
       return destinationChainToken;
+    },
+
+    get activeTab() {
+      return activeTab;
+    },
+
+    onTabChanged(tab: NavigationTabKey) {
+      activeTab = tab;
     },
 
     onSourceTokenSelected(sourceToken: ChainTokenSelected) {

--- a/src/components/Widgets/tracking/handlers/availableRoutes.ts
+++ b/src/components/Widgets/tracking/handlers/availableRoutes.ts
@@ -66,7 +66,12 @@ export const createAvailableRoutesHandler = (
       {},
     );
 
+    const tradeType = ctx.session.activeTab;
+
     trackWidgetEvent(ctx.tracking, config, 'routes_available', {
+      ...(tradeType !== null && {
+        [TrackingEventParameter.TradeType]: tradeType,
+      }),
       [TrackingEventParameter.FromToken]: fromToken || '',
       [TrackingEventParameter.FromChainId]: fromChainId || '',
       [TrackingEventParameter.ToToken]: toToken || '',

--- a/src/components/Widgets/tracking/handlers/routeHandlers.ts
+++ b/src/components/Widgets/tracking/handlers/routeHandlers.ts
@@ -1,6 +1,7 @@
 import type { Route, RouteExecutionUpdate } from '@lifi/widget';
 import { isEqual, omit } from 'lodash';
 import { TrackingEventParameter } from '@/const/trackingKeys';
+
 import type { WidgetEventsConfig } from '@/components/Widgets/WidgetEventsManager';
 import {
   trackWidgetEvent,
@@ -31,6 +32,7 @@ export const createRouteExecutionStartedHandler = (
     const routeData = handleRouteData(route, {
       [TrackingEventParameter.Action]: config.dataAction,
       [TrackingEventParameter.TransactionStatus]: 'STARTED',
+      [TrackingEventParameter.TradeType]: ctx.session.activeTab ?? undefined,
       ...config.extraData,
     });
 
@@ -47,6 +49,7 @@ export const createRouteExecutionUpdatedHandler = (
     const updatedRouteData = handleRouteData(update.route, {
       [TrackingEventParameter.Action]: config.dataAction,
       [TrackingEventParameter.TransactionStatus]: 'UPDATED',
+      [TrackingEventParameter.TradeType]: ctx.session.activeTab ?? undefined,
       ...config.extraData,
     });
     const routeData = ctx.session.getTrackedRoute(update.route.id);
@@ -86,6 +89,7 @@ export const createRouteExecutionCompletedHandler = (
       handleRouteData(route, {
         [TrackingEventParameter.Action]: config.dataAction,
         [TrackingEventParameter.TransactionStatus]: 'COMPLETED',
+        [TrackingEventParameter.TradeType]: ctx.session.activeTab ?? undefined,
         ...config.extraData,
       }),
       { isConversion: true },
@@ -109,6 +113,7 @@ export const createRouteExecutionFailedHandler = (
       handleRouteData(update.route, {
         [TrackingEventParameter.Action]: config.dataAction,
         [TrackingEventParameter.TransactionStatus]: 'FAILED',
+        [TrackingEventParameter.TradeType]: ctx.session.activeTab ?? undefined,
         [TrackingEventParameter.Message]:
           update.action.error?.message || update.action.message || '',
         [TrackingEventParameter.IsFinal]: true,

--- a/src/components/Widgets/tracking/widgetTrackingPresets.ts
+++ b/src/components/Widgets/tracking/widgetTrackingPresets.ts
@@ -3,6 +3,7 @@ import type { WidgetEventTrackerConfig } from '@/components/Widgets/tracking/typ
 
 export type WidgetTrackingVariant =
   | 'main'
+  | 'advanced'
   | 'private'
   | 'limit'
   | 'mission'
@@ -42,6 +43,24 @@ const SHARED_ROUTE_INTERACTION = {
 >;
 
 const VARIANT_ACTIONS: Record<WidgetTrackingVariant, VariantActions> = {
+  advanced: {
+    sourceChainAndTokenSelection:
+      TrackingAction.OnSourceChainAndTokenSelectionAdvanced,
+    availableRoutes: TrackingAction.OnAvailableRoutesAdvanced,
+    changeSettings: TrackingAction.OnChangeSettingsAdvanced,
+    routeHighValueLoss: TrackingAction.OnRouteHighValueLoss,
+    lowAddressActivityConfirmed: TrackingAction.OnLowAddressActivityConfirmed,
+    sendToWalletToggled: TrackingAction.OnSendToWalletToggled,
+    formFieldChanged: TrackingAction.OnFormFieldChanged,
+    execution: {
+      started: TrackingAction.OnRouteExecutionStartedAdvanced,
+      completed: TrackingAction.OnRouteExecutionCompletedAdvanced,
+      failed: TrackingAction.OnRouteExecutionFailedAdvanced,
+      dataStarted: TrackingEventDataAction.ExecutionStartAdvanced,
+      dataCompleted: TrackingEventDataAction.ExecutionCompletedAdvanced,
+      dataFailed: TrackingEventDataAction.ExecutionFailedAdvanced,
+    },
+  },
   main: {
     sourceChainAndTokenSelection: TrackingAction.OnSourceChainAndTokenSelection,
     destinationChainAndTokenSelection:
@@ -75,7 +94,10 @@ const VARIANT_ACTIONS: Record<WidgetTrackingVariant, VariantActions> = {
     },
   },
   limit: {
+    sourceChainAndTokenSelection:
+      TrackingAction.OnSourceChainAndTokenSelectionLimit,
     availableRoutes: TrackingAction.OnAvailableRoutesLimit,
+    changeSettings: TrackingAction.OnChangeSettingsLimit,
     execution: {
       started: TrackingAction.OnRouteExecutionStartedLimit,
       completed: TrackingAction.OnRouteExecutionCompletedLimit,

--- a/src/components/Widgets/variants/widgetConfig/useLimitOrdersWidgetConfig.ts
+++ b/src/components/Widgets/variants/widgetConfig/useLimitOrdersWidgetConfig.ts
@@ -31,7 +31,7 @@ export function useLimitOrdersWidgetConfig(
       ...mainConfig,
       variant: 'compact',
       mode: 'limit',
-      buildUrl: true,
+      buildUrl: false,
       useRelayerRoutes: true,
       hiddenUI: {
         ...mainConfig.hiddenUI,

--- a/src/components/composite/ModifyOrderFlow/ModifyOrderFlow.tsx
+++ b/src/components/composite/ModifyOrderFlow/ModifyOrderFlow.tsx
@@ -7,6 +7,7 @@ import { motion } from 'motion/react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Widget as BaseWidget } from '@/components/Widgets/variants/base/Widget';
+import { WidgetTrackingProvider } from '@/providers/WidgetTrackingProvider';
 import { SectionCard } from '@/components/Cards/SectionCard/SectionCard';
 import { StatusBottomSheet } from '@/components/composite/StatusBottomSheet/StatusBottomSheet';
 import { useCancelOrder } from '@/components/composite/CancelOrderFlow/hooks/useCancelOrder';
@@ -123,7 +124,19 @@ export const ModifyOrderFlowModal = () => {
   if (step === 'place' && context) {
     return (
       <ModalContainer isOpen={isModalOpen} onClose={handleClose}>
-        <BaseWidget type="limit" ctx={context} />
+        <WidgetTrackingProvider
+          variant="limit"
+          initialSourceToken={{
+            chainId: selectedOrder.fromToken.chainId,
+            tokenAddress: selectedOrder.fromToken.address,
+          }}
+          initialDestinationToken={{
+            chainId: selectedOrder.toToken.chainId,
+            tokenAddress: selectedOrder.toToken.address,
+          }}
+        >
+          <BaseWidget type="limit" ctx={context} />
+        </WidgetTrackingProvider>
       </ModalContainer>
     );
   }

--- a/src/components/composite/RepeatOrderFlow/RepeatOrderFlow.tsx
+++ b/src/components/composite/RepeatOrderFlow/RepeatOrderFlow.tsx
@@ -8,6 +8,7 @@ import { useRepeatOrderFlowStore } from '@/stores/limitOrderFlow/RepeatOrderFlow
 import type { LimitOrdersWidgetContext } from '@/components/Widgets/variants/widgetConfig/types';
 import { useTokenAmountInput } from '@/hooks/tokens/useTokenAmountInput';
 import { useTheme } from '@mui/material';
+import { WidgetTrackingProvider } from '@/providers/WidgetTrackingProvider';
 
 export const RepeatOrderFlowModal = () => {
   const { t } = useTranslation();
@@ -72,7 +73,19 @@ export const RepeatOrderFlowModal = () => {
 
   return (
     <ModalContainer isOpen={isModalOpen} onClose={closeModal}>
-      <BaseWidget type="limit" ctx={context} />
+      <WidgetTrackingProvider
+        variant="limit"
+        initialSourceToken={{
+          chainId: selectedOrder.fromToken.chainId,
+          tokenAddress: selectedOrder.fromToken.address,
+        }}
+        initialDestinationToken={{
+          chainId: selectedOrder.toToken.chainId,
+          tokenAddress: selectedOrder.toToken.address,
+        }}
+      >
+        <BaseWidget type="limit" ctx={context} />
+      </WidgetTrackingProvider>
     </ModalContainer>
   );
 };

--- a/src/const/trackingKeys.ts
+++ b/src/const/trackingKeys.ts
@@ -95,6 +95,9 @@ export enum TrackingAction {
   OnRouteExecutionStartedLimit = 'action_on_route_exec_started_limit',
   OnRouteExecutionCompletedLimit = 'action_on_route_exec_completed_limit',
   OnRouteExecutionFailedLimit = 'action_on_route_exec_failed_limit',
+  OnRepeatLimitOrderOpen = 'repeat_limit_order_open',
+  OnModifyLimitOrderOpen = 'modify_limit_order_open',
+  OnCancelLimitOrderOpen = 'cancel_limit_order_open',
 
   // Dust conversion
   OnRouteExecutionStartedDust = 'action_on_route_exec_started_dust',
@@ -423,4 +426,7 @@ export enum TrackingEventParameter {
   NotificationSourceRuleId = 'param_notification_source_rule_id',
   NotificationCategory = 'param_notification_category',
   NotificationCtaTarget = 'param_notification_cta_target',
+
+  // Limit orders
+  OrderId = 'param_order_id',
 }

--- a/src/const/trackingKeys.ts
+++ b/src/const/trackingKeys.ts
@@ -80,8 +80,18 @@ export enum TrackingAction {
   OnRouteExecutionCompletedPrivate = 'action_on_route_exec_completed_private',
   OnRouteExecutionFailedPrivate = 'action_on_route_exec_failed_private',
 
+  // Advanced Widget
+  OnSourceChainAndTokenSelectionAdvanced = 'action_on_source_selection_advanced',
+  OnAvailableRoutesAdvanced = 'action_available_routes_advanced',
+  OnRouteExecutionStartedAdvanced = 'action_on_route_exec_started_advanced',
+  OnRouteExecutionCompletedAdvanced = 'action_on_route_exec_completed_advanced',
+  OnRouteExecutionFailedAdvanced = 'action_on_route_exec_failed_advanced',
+  OnChangeSettingsAdvanced = 'action_change_settings_advanced',
+
   // Limit orders
+  OnSourceChainAndTokenSelectionLimit = 'action_on_source_selection_limit',
   OnAvailableRoutesLimit = 'action_available_routes_limit',
+  OnChangeSettingsLimit = 'action_change_settings_limit',
   OnRouteExecutionStartedLimit = 'action_on_route_exec_started_limit',
   OnRouteExecutionCompletedLimit = 'action_on_route_exec_completed_limit',
   OnRouteExecutionFailedLimit = 'action_on_route_exec_failed_limit',
@@ -194,6 +204,9 @@ export enum TrackingEventDataAction {
   ExecutionStartPrivate = 'execution_start_private',
   ExecutionCompletedPrivate = 'execution_completed_private',
   ExecutionFailedPrivate = 'execution_failed_private',
+  ExecutionStartAdvanced = 'execution_start_advanced',
+  ExecutionCompletedAdvanced = 'execution_completed_advanced',
+  ExecutionFailedAdvanced = 'execution_failed_advanced',
   ExecutionStartLimit = 'execution_start_limit',
   ExecutionCompletedLimit = 'execution_completed_limit',
   ExecutionFailedLimit = 'execution_failed_limit',
@@ -258,6 +271,7 @@ export enum TrackingEventParameter {
   Integrator = 'param_integrator',
 
   // Widget:
+  TradeType = 'param_trade_type',
   SourceChainSelection = 'param_source_chain',
   SourceTokenSelection = 'param_source_token',
   DestinationChainSelection = 'param_destination_chain',

--- a/src/hooks/useWidgetTracking.ts
+++ b/src/hooks/useWidgetTracking.ts
@@ -1,4 +1,5 @@
-import { useWidgetEvents } from '@lifi/widget';
+import { useWidgetEvents, WidgetEvent } from '@lifi/widget';
+import type { NavigationTabKey } from '@lifi/widget';
 import { useEffect, useMemo, useRef } from 'react';
 import { useUrlParams } from '@/hooks/useUrlParams';
 import { composeWidgetTrackingHandlers } from '@/components/Widgets/tracking/composeWidgetTrackingHandlers';
@@ -46,6 +47,16 @@ export const useWidgetTracking = (trackerConfig: WidgetEventTrackerConfig) => {
       teardownWidgetEvents(eventHandlers, widgetEvents);
     };
   }, [eventHandlers, widgetEvents]);
+
+  useEffect(() => {
+    const handler = ({ tab }: { tab: NavigationTabKey }) => {
+      session.onTabChanged(tab);
+    };
+    widgetEvents.on(WidgetEvent.NavigationTabChanged, handler);
+    return () => {
+      widgetEvents.off(WidgetEvent.NavigationTabChanged, handler);
+    };
+  }, [widgetEvents, session]);
 
   return session;
 };

--- a/src/providers/WidgetTrackingProvider.tsx
+++ b/src/providers/WidgetTrackingProvider.tsx
@@ -2,7 +2,7 @@
 
 import type { ChainTokenSelected } from '@lifi/widget';
 import type { FC, PropsWithChildren } from 'react';
-import { createContext, useContext, useMemo } from 'react';
+import { createContext, useContext, useEffect, useMemo } from 'react';
 import {
   createWidgetTrackerConfig,
   type CreateWidgetTrackerConfigOptions,
@@ -37,6 +37,9 @@ interface WidgetTrackingProviderProps extends PropsWithChildren {
   variant?: WidgetTrackingVariant;
   trackerConfig?: WidgetEventTrackerConfig;
   options?: CreateWidgetTrackerConfigOptions;
+  enabled?: boolean;
+  initialSourceToken?: ChainTokenSelected;
+  initialDestinationToken?: ChainTokenSelected;
 }
 
 export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
@@ -44,12 +47,26 @@ export const WidgetTrackingProvider: FC<WidgetTrackingProviderProps> = ({
   variant,
   trackerConfig,
   options,
+  enabled = true,
+  initialSourceToken,
+  initialDestinationToken,
 }) => {
-  const resolvedConfig =
-    trackerConfig ??
-    (variant ? createWidgetTrackerConfig(variant, options) : {});
+  const resolvedConfig = enabled
+    ? (trackerConfig ??
+      (variant ? createWidgetTrackerConfig(variant, options) : {}))
+    : {};
 
   const session = useWidgetTracking(resolvedConfig);
+
+  useEffect(() => {
+    if (initialSourceToken) {
+      session.onSourceTokenSelected(initialSourceToken);
+    }
+    if (initialDestinationToken) {
+      session.setDestinationTokenForTracking(initialDestinationToken);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const value = useMemo(
     () => ({

--- a/src/types/userTracking.ts
+++ b/src/types/userTracking.ts
@@ -67,6 +67,7 @@ export interface TrackTransactionDataProps {
   [TrackingEventParameter.TransactionHash]?: string;
   [TrackingEventParameter.TransactionLink]?: string;
   [TrackingEventParameter.TokenCount]?: number;
+  [TrackingEventParameter.TradeType]?: string;
   abTestVariants?: AbTestVariants;
 }
 


### PR DESCRIPTION
## Linear ticket
https://linear.app/lifi-linear/issue/JUMADV-9/posthog-analytics-instrument-advanced-mode-events

## Summary
- Add dedicated `advanced`-prefixed tracking action keys (`action_on_source_selection_advanced`, `action_available_routes_advanced`, `action_on_route_exec_*_advanced`, `action_change_settings_advanced`) so the advanced page widget fires its own PostHog events
- All tabs on the advanced page (swap-advanced, bridge-advanced, and limit) use the `'advanced'` tracking variant — limit tab no longer hijacks the `'limit'` keys
- Add `trade_type` parameter to route events, driven purely by the active widget navigation tab (`session.activeTab`)
- Add `OnSourceChainAndTokenSelectionLimit` and `OnChangeSettingsLimit` tracking actions for limit order modals

## Limit order modal fixes
- Wrap `RepeatOrderFlowModal` and `ModifyOrderFlowModal` widgets with `WidgetTrackingProvider variant="limit"` seeded with `initialSourceToken` / `initialDestinationToken` from `selectedOrder` — fixes missing token/chain data in `availableRoutes` tracking (session previously started empty and fell back to the main page's URL params)
- Add `enabled` prop to `WidgetTrackingProvider`; parent provider in `Widgets.tsx` is disabled while a limit order modal is open, preventing double-firing on the singleton `useWidgetEvents()` event bus

## Test plan
- [ ] Navigate to `/advanced`, select tokens on swap-advanced tab — confirm `action_on_source_selection_advanced` fires
- [ ] Trigger route calculation — confirm `action_available_routes_advanced` fires with correct `from_token`, `to_token`, and `trade_type`
- [ ] Switch to limit tab on advanced page — confirm events still fire as `action_*_advanced` (not `action_*_limit`)
- [ ] Open a RepeatOrder or ModifyOrder modal — confirm `action_available_routes_limit` fires with correct token/chain data from the selected order
- [ ] Confirm no double-firing while modal is open (parent provider disabled)
- [ ] Navigate to `/` — confirm main page events still fire as `action_on_source_selection` / `action_available_routes` (unchanged)
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)