### PR TITLE
feat: gate advanced page and vertical tab behind widget-advanced + hasAdvanced allowlist

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -4,7 +4,7 @@ import i18nConfig from '../i18n-config';
 import { NO_PARTNER_THEME_UID } from './partnerThemeConstants.ts';
 import { withProviders } from './withProviders';
 
-sb.mock(import('@lifi/wallet-management'), { spy: true });
+sb.mock(import('@jumperexchange/wallet-management'), { spy: true });
 sb.mock(import('../src/hooks/useLoyaltyPass.ts'), { spy: true });
 sb.mock(import('../src/hooks/perks/usePerks.ts'), { spy: true });
 

--- a/.storybook/withProviders.tsx
+++ b/.storybook/withProviders.tsx
@@ -1,4 +1,3 @@
-import type { Decorator } from '@storybook/react';
 import type { i18n as I18nInstance } from 'i18next';
 import { type ReactNode, useEffect, useState } from 'react';
 import { I18nextProvider } from 'react-i18next';
@@ -19,6 +18,7 @@ import {
   isNoPartnerThemeUid,
   NO_PARTNER_THEME_UID,
 } from './partnerThemeConstants.ts';
+import { Decorator } from '@storybook/nextjs-vite';
 
 const ThemeBridge = ({
   children,

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "storybook-addon-pseudo-states": "^10.4.6",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.0",
-    "vite": "^8.1.0",
+    "vite": "8.1.4",
     "vite-plugin-node-polyfills": "^0.28.0",
     "vitest": "^4.1.9",
     "web-vitals": "^5.3.0"
@@ -214,5 +214,10 @@
       "pnpm prettier --write"
     ]
   },
-  "packageManager": "pnpm@11.5.1+sha512.93f7b57422ea7068257235b4c16eb60762eb68e1dc23723199cc739043ea9be2c4143274a399d8c6defa2b1176226d9ca1c4b63482d6200c1a8fbaa78c1d1485"
+  "packageManager": "pnpm@11.5.1+sha512.93f7b57422ea7068257235b4c16eb60762eb68e1dc23723199cc739043ea9be2c4143274a399d8c6defa2b1176226d9ca1c4b63482d6200c1a8fbaa78c1d1485",
+  "pnpm": {
+    "overrides": {
+      "vite": "8.1.4"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,7 +334,7 @@ importers:
         version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))
       '@storybook/addon-docs':
         specifier: ^10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))
       '@storybook/addon-onboarding':
         specifier: ^10.4.6
         version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))
@@ -343,7 +343,7 @@ importers:
         version: 10.4.6(@vitest/browser-playwright@4.1.9)(@vitest/browser@4.1.9)(@vitest/runner@4.1.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(vitest@4.1.9)
       '@storybook/nextjs-vite':
         specifier: ^10.4.6
-        version: 10.4.6(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(esbuild@0.27.7)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(typescript@6.0.3)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))
+        version: 10.4.6(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(esbuild@0.27.7)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -379,13 +379,13 @@ importers:
         version: 0.169.0
       '@vitejs/plugin-react':
         specifier: ^6.0.3
-        version: 6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
+        version: 6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
       '@vitest/browser':
         specifier: ^4.1.9
-        version: 4.1.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
+        version: 4.1.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/browser-playwright':
         specifier: ^4.1.9
-        version: 4.1.9(bufferutil@4.1.0)(playwright@1.61.1)(utf-8-validate@6.0.6)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
+        version: 4.1.9(bufferutil@4.1.0)(playwright@1.61.1)(utf-8-validate@6.0.6)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: ^4.1.9
         version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
@@ -462,14 +462,14 @@ importers:
         specifier: ^8.62.0
         version: 8.62.0(eslint@10.5.0)(typescript@6.0.3)
       vite:
-        specifier: ^8.1.0
-        version: 8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
+        specifier: 8.1.4
+        version: 8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
       vite-plugin-node-polyfills:
         specifier: ^0.28.0
-        version: 0.28.0(rollup@4.61.0)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
+        version: 0.28.0(rollup@4.61.0)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
       web-vitals:
         specifier: ^5.3.0
         version: 5.3.0
@@ -2563,8 +2563,8 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
-  '@oxc-project/types@0.137.0':
-    resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.20.0':
     resolution: {integrity: sha512-IjfWOXRgJFNdORDl+Uf1aibNgZY2guOD3zmOhx1BGVb/MIiqlFTdmjpQNplSN58lhWehnX4UNqC3QwpUo8pjJg==}
@@ -3303,97 +3303,97 @@ packages:
   '@reown/appkit@1.8.9':
     resolution: {integrity: sha512-e3N2DAzf3Xv3jnoD8IsUo0/Yfwuhk7npwJBe1+9rDJIRwgPsyYcCLD4gKPDFC5IUIfOLqK7YtGOh9oPEUnIWpw==}
 
-  '@rolldown/binding-android-arm64@1.1.3':
-    resolution: {integrity: sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==}
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.1.3':
-    resolution: {integrity: sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==}
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.1.3':
-    resolution: {integrity: sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==}
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.1.3':
-    resolution: {integrity: sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==}
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.3':
-    resolution: {integrity: sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.3':
-    resolution: {integrity: sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.1.3':
-    resolution: {integrity: sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==}
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.3':
-    resolution: {integrity: sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.3':
-    resolution: {integrity: sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.1.3':
-    resolution: {integrity: sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==}
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.1.3':
-    resolution: {integrity: sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==}
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.1.3':
-    resolution: {integrity: sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==}
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.1.3':
-    resolution: {integrity: sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==}
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.3':
-    resolution: {integrity: sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==}
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.1.3':
-    resolution: {integrity: sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==}
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -9396,8 +9396,8 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   preact@10.23.0:
@@ -9860,8 +9860,8 @@ packages:
     resolution: {integrity: sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==}
     engines: {node: '>= 0.8'}
 
-  rolldown@1.1.3:
-    resolution: {integrity: sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==}
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -10932,8 +10932,8 @@ packages:
       vite:
         optional: true
 
-  vite@8.1.0:
-    resolution: {integrity: sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==}
+  vite@8.1.4:
+    resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -12523,11 +12523,11 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
-      vite: 8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -14234,7 +14234,7 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
-  '@oxc-project/types@0.137.0': {}
+  '@oxc-project/types@0.139.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.20.0':
     optional: true
@@ -16198,53 +16198,53 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@rolldown/binding-android-arm64@1.1.3':
+  '@rolldown/binding-android-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.1.3':
+  '@rolldown/binding-darwin-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.3':
+  '@rolldown/binding-darwin-x64@1.1.5':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.1.3':
+  '@rolldown/binding-freebsd-x64@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.3':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.3':
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.3':
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.3':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.3':
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.1.3':
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.1.3':
+  '@rolldown/binding-linux-x64-musl@1.1.5':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.1.3':
+  '@rolldown/binding-openharmony-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.1.3':
+  '@rolldown/binding-wasm32-wasi@1.1.5':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.3':
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.1.3':
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -16254,10 +16254,10 @@ snapshots:
       '@rollup/pluginutils': 5.4.0(rollup@4.61.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      fdir: 6.5.0(picomatch@4.0.4)
+      fdir: 6.5.0(picomatch@4.0.5)
       is-reference: 1.2.1
       magic-string: 0.30.21
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.61.0
 
@@ -16273,7 +16273,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.61.0
 
@@ -18292,10 +18292,10 @@ snapshots:
       axe-core: 4.12.0
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6)
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))
       '@storybook/icons': 2.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))
       react: 19.2.7
@@ -18321,33 +18321,33 @@ snapshots:
       '@storybook/icons': 2.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6)
     optionalDependencies:
-      '@vitest/browser': 4.1.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
-      '@vitest/browser-playwright': 4.1.9(bufferutil@4.1.0)(playwright@1.61.1)(utf-8-validate@6.0.6)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser': 4.1.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser-playwright': 4.1.9(bufferutil@4.1.0)(playwright@1.61.1)(utf-8-validate@6.0.6)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/runner': 4.1.9
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.27.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.27.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6)
       ts-dedent: 2.2.0
-      vite: 8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.27.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.27.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))':
     dependencies:
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.7
       rollup: 4.61.0
-      vite: 8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
       webpack: 5.107.2(esbuild@0.27.7)
 
   '@storybook/global@5.0.0': {}
@@ -18357,18 +18357,18 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@storybook/nextjs-vite@10.4.6(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(esbuild@0.27.7)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(typescript@6.0.3)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))':
+  '@storybook/nextjs-vite@10.4.6(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(esbuild@0.27.7)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))':
     dependencies:
-      '@storybook/builder-vite': 10.4.6(esbuild@0.27.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.27.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))
       '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(typescript@6.0.3)
-      '@storybook/react-vite': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(typescript@6.0.3)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))
+      '@storybook/react-vite': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))
       next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(babel-plugin-macros@3.1.0)(react@19.2.7)
-      vite: 8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
-      vite-plugin-storybook-nextjs: 3.3.0(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(typescript@6.0.3)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
+      vite: 8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
+      vite-plugin-storybook-nextjs: 3.3.0(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -18390,11 +18390,11 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(typescript@6.0.3)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
       '@rollup/pluginutils': 5.4.0(rollup@4.61.0)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.27.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.27.7)(rollup@4.61.0)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.27.7))
       '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(typescript@6.0.3)
       empathic: 2.0.1
       magic-string: 0.30.21
@@ -18404,7 +18404,7 @@ snapshots:
       resolve: 1.22.12
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6)
       tsconfig-paths: 4.2.0
-      vite: 8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -19320,36 +19320,36 @@ snapshots:
     dependencies:
       '@vanilla-extract/css': 1.20.1(babel-plugin-macros@3.1.0)
 
-  '@vitejs/plugin-react@6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
 
-  '@vitest/browser-playwright@4.1.9(bufferutil@4.1.0)(playwright@1.61.1)(utf-8-validate@6.0.6)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)':
+  '@vitest/browser-playwright@4.1.9(bufferutil@4.1.0)(playwright@1.61.1)(utf-8-validate@6.0.6)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
-      '@vitest/browser': 4.1.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
-      '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
+      '@vitest/browser': 4.1.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/mocker': 4.1.9(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
       playwright: 1.61.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)':
+  '@vitest/browser@4.1.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.9(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
       '@vitest/utils': 4.1.9
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
@@ -19369,9 +19369,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser': 4.1.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -19390,13 +19390,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.9(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -23270,6 +23270,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
   fetch-retry@6.0.0: {}
 
   fflate@0.8.2: {}
@@ -25438,7 +25442,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.15:
+  postcss@8.5.19:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -26008,26 +26012,26 @@ snapshots:
       hash-base: 3.1.2
       inherits: 2.0.4
 
-  rolldown@1.1.3:
+  rolldown@1.1.5:
     dependencies:
-      '@oxc-project/types': 0.137.0
+      '@oxc-project/types': 0.139.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.1.3
-      '@rolldown/binding-darwin-arm64': 1.1.3
-      '@rolldown/binding-darwin-x64': 1.1.3
-      '@rolldown/binding-freebsd-x64': 1.1.3
-      '@rolldown/binding-linux-arm-gnueabihf': 1.1.3
-      '@rolldown/binding-linux-arm64-gnu': 1.1.3
-      '@rolldown/binding-linux-arm64-musl': 1.1.3
-      '@rolldown/binding-linux-ppc64-gnu': 1.1.3
-      '@rolldown/binding-linux-s390x-gnu': 1.1.3
-      '@rolldown/binding-linux-x64-gnu': 1.1.3
-      '@rolldown/binding-linux-x64-musl': 1.1.3
-      '@rolldown/binding-openharmony-arm64': 1.1.3
-      '@rolldown/binding-wasm32-wasi': 1.1.3
-      '@rolldown/binding-win32-arm64-msvc': 1.1.3
-      '@rolldown/binding-win32-x64-msvc': 1.1.3
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
 
   rollup@4.61.0:
     dependencies:
@@ -26845,7 +26849,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.16.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
 
   unstorage@1.17.5(idb-keyval@6.2.5):
@@ -27170,15 +27174,15 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite-plugin-node-polyfills@0.28.0(rollup@4.61.0)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)):
+  vite-plugin-node-polyfills@0.28.0(rollup@4.61.0)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.61.0)
       node-stdlib-browser: 1.3.1
-      vite: 8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - rollup
 
-  vite-plugin-storybook-nextjs@3.3.0(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(typescript@6.0.3)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)):
+  vite-plugin-storybook-nextjs@3.3.0(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6))(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
       '@next/env': 16.0.0
       image-size: 2.0.2
@@ -27187,29 +27191,29 @@ snapshots:
       next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6)
       ts-dedent: 2.2.0
-      vite: 8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
-      vite-tsconfig-paths: 5.1.4(typescript@6.0.3)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
+      vite: 8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
+      vite-tsconfig-paths: 5.1.4(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@5.1.4(typescript@6.0.3)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)):
+  vite-tsconfig-paths@5.1.4(typescript@6.0.3)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@6.0.3)
     optionalDependencies:
-      vite: 8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0):
+  vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.1.3
+      picomatch: 4.0.5
+      postcss: 8.5.19
+      rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.1
@@ -27218,10 +27222,10 @@ snapshots:
       terser: 5.48.0
       yaml: 2.9.0
 
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)):
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.9(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -27238,12 +27242,12 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.1
-      '@vitest/browser-playwright': 4.1.9(bufferutil@4.1.0)(playwright@1.61.1)(utf-8-validate@6.0.6)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser-playwright': 4.1.9(bufferutil@4.1.0)(playwright@1.61.1)(utf-8-validate@6.0.6)(vite@8.1.4(@types/node@25.9.1)(esbuild@0.27.7)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:

--- a/src/app/[lng]/(main)/advanced/page.tsx
+++ b/src/app/[lng]/(main)/advanced/page.tsx
@@ -1,30 +1,25 @@
 'use client';
 
-import { notFound } from 'next/navigation';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import Box from '@mui/material/Box';
 import { AdvancedPageContent } from '@/app/ui/widget/AdvancedPageContent';
-import { AB_TEST_NAME } from '@/const/abtests';
-import { useABTest } from '@/hooks/useABTest';
-import {
-  GatekeeperStatus,
-  useGatekeeperStatus,
-} from '@/app/ui/gatekeeper/useGatekeeperStatus';
+import { AppPaths } from '@/const/urls';
+import { useAdvancedAccess } from '@/hooks/useAdvancedAccess';
 
 export default function Page() {
-  const widgetAdvancedFlag = useABTest({
-    feature: AB_TEST_NAME.WIDGET_ADVANCED,
-  });
-  const { status } = useGatekeeperStatus('hasAdvanced');
+  const router = useRouter();
+  const { isLoading, isAllowed } = useAdvancedAccess();
+  const isDenied = !isLoading && !isAllowed;
 
-  if (!widgetAdvancedFlag.isLoading && !widgetAdvancedFlag.isEnabled) {
-    return notFound();
-  }
+  useEffect(() => {
+    if (isDenied) {
+      router.replace(AppPaths.Main);
+    }
+  }, [isDenied, router]);
 
-  const isLoading =
-    widgetAdvancedFlag.isLoading || status === GatekeeperStatus.LOADING_ACCESS;
-
-  if (!isLoading && status !== GatekeeperStatus.SUCCESS) {
-    return notFound();
+  if (isDenied) {
+    return null;
   }
 
   return (

--- a/src/app/[lng]/(main)/advanced/page.tsx
+++ b/src/app/[lng]/(main)/advanced/page.tsx
@@ -1,10 +1,35 @@
+'use client';
+
+import { notFound } from 'next/navigation';
 import Box from '@mui/material/Box';
 import { AdvancedPageContent } from '@/app/ui/widget/AdvancedPageContent';
+import { AB_TEST_NAME } from '@/const/abtests';
+import { useABTest } from '@/hooks/useABTest';
+import {
+  GatekeeperStatus,
+  useGatekeeperStatus,
+} from '@/app/ui/gatekeeper/useGatekeeperStatus';
 
-export default async function Page() {
+export default function Page() {
+  const widgetAdvancedFlag = useABTest({
+    feature: AB_TEST_NAME.WIDGET_ADVANCED,
+  });
+  const { status } = useGatekeeperStatus('hasAdvanced');
+
+  if (!widgetAdvancedFlag.isLoading && !widgetAdvancedFlag.isEnabled) {
+    return notFound();
+  }
+
+  const isLoading =
+    widgetAdvancedFlag.isLoading || status === GatekeeperStatus.LOADING_ACCESS;
+
+  if (!isLoading && status !== GatekeeperStatus.SUCCESS) {
+    return notFound();
+  }
+
   return (
     <Box sx={{ paddingBottom: { xs: 6, sm: 0 } }}>
-      <AdvancedPageContent />
+      <AdvancedPageContent isLoading={isLoading} />
     </Box>
   );
 }

--- a/src/app/api/profile/[walletAddress]/flags/route.tsx
+++ b/src/app/api/profile/[walletAddress]/flags/route.tsx
@@ -20,12 +20,18 @@ export async function GET(
     const data = await getWalletAccessControl(walletAddress);
 
     if (!data.data || data.data.length === 0) {
-      return NextResponse.json({ hasEarn: false, hasNotifications: false });
+      return NextResponse.json({
+        hasEarn: false,
+        hasNotifications: false,
+        hasAdvanced: false,
+      });
     }
 
     const flags = data.data[0];
 
-    return NextResponse.json(pick(flags, ['hasEarn', 'hasNotifications']));
+    return NextResponse.json(
+      pick(flags, ['hasEarn', 'hasNotifications', 'hasAdvanced']),
+    );
   } catch (error) {
     console.error('Error fetching wallet access control:', error);
     return NextResponse.json(

--- a/src/app/ui/widget/AdvancedPageContent.tsx
+++ b/src/app/ui/widget/AdvancedPageContent.tsx
@@ -13,7 +13,7 @@ import { MainWidgetPageContent } from './MainWidgetPageContent';
 import { WidgetSidePanel } from './WidgetSidePanel';
 import { useTranslation } from 'react-i18next';
 
-export const AdvancedPageContent = () => {
+export const AdvancedPageContent = ({ isLoading }: { isLoading?: boolean }) => {
   const { t } = useTranslation();
   const isLimitTabActive = useActiveNavigationTab() === 'limit';
   const isSidePanelExpanded = useWidgetSidePanelStore(
@@ -50,6 +50,7 @@ export const AdvancedPageContent = () => {
   return (
     <MainWidgetPageContent
       variant="advanced"
+      isLoading={isLoading}
       isSidePanelExpanded={isSidePanelExpanded}
       sidePanelContent={
         isLimitTabActive ? (

--- a/src/components/Badge/Badge.styles.ts
+++ b/src/components/Badge/Badge.styles.ts
@@ -15,6 +15,7 @@ export enum BadgeVariant {
   Primary = 'primary',
   Secondary = 'secondary',
   Tertiary = 'tertiary',
+  New = 'new',
 }
 
 export enum BadgeSize {
@@ -185,6 +186,14 @@ export const StyledBadge = styled(Box, {
         style: {
           backgroundColor: (theme.vars || theme).palette.surfaceAccent2Bg,
           color: (theme.vars || theme).palette.surfaceAccent2Fg,
+        },
+      },
+      {
+        props: ({ variant }) => variant === BadgeVariant.New,
+        style: {
+          pointerEvents: 'none',
+          backgroundColor: '#E5484D',
+          color: (theme.vars || theme).palette.white.main,
         },
       },
     ],

--- a/src/components/Menus/VerticalMenu/VerticalTabs.style.ts
+++ b/src/components/Menus/VerticalMenu/VerticalTabs.style.ts
@@ -48,6 +48,7 @@ export const VerticalTab = styled(MuiTab)(({ theme }) => ({
   transition: 'background 250ms',
   background: 'transparent',
   minHeight: 'unset',
+  overflow: 'visible',
   color: (theme.vars || theme).palette.text.primary,
   textDecoration: 'none',
   ':hover': {

--- a/src/components/Menus/VerticalMenu/VerticalTabs.tsx
+++ b/src/components/Menus/VerticalMenu/VerticalTabs.tsx
@@ -13,6 +13,10 @@ export const VerticalTabs = () => {
   };
   const verticalTabs = useVerticalTabs();
 
+  if (verticalTabs.length <= 1) {
+    return null;
+  }
+
   return (
     <VerticalTabsContainer
       value={!isDesktop ? false : activeTab}
@@ -29,6 +33,7 @@ export const VerticalTabs = () => {
               el.onClick(event, el.value);
             }}
             icon={el.icon}
+            disabled={el.disabled}
             data-testid={`tab-key-${el.value}`}
             aria-controls={`simple-tabpanel-${index}`}
           />

--- a/src/components/Menus/VerticalMenu/useVerticalTabs.tsx
+++ b/src/components/Menus/VerticalMenu/useVerticalTabs.tsx
@@ -1,7 +1,10 @@
 import { useAccount } from '@jumperexchange/wallet-management';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
+import Box from '@mui/material/Box';
 import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
+import { Badge } from '@/components/Badge/Badge';
+import { BadgeSize, BadgeVariant } from '@/components/Badge/Badge.styles';
 import { CandlestickChartIcon } from '@/components/illustrations/CandlestickChartIcon';
 import {
   TrackingAction,
@@ -9,12 +12,22 @@ import {
   TrackingEventParameter,
 } from '@/const/trackingKeys';
 import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
+import { useABTest } from '@/hooks/useABTest';
+import { AB_TEST_NAME } from '@/const/abtests';
+import {
+  GatekeeperStatus,
+  useGatekeeperStatus,
+} from '@/app/ui/gatekeeper/useGatekeeperStatus';
 
 export const useVerticalTabs = () => {
   const { trackEvent } = useUserTracking();
   const router = useRouter();
   const { t } = useTranslation();
-  const { account } = useAccount();
+  const widgetAdvancedFlag = useABTest({
+    feature: AB_TEST_NAME.WIDGET_ADVANCED,
+  });
+  const { status: advancedGatekeeperStatus } =
+    useGatekeeperStatus('hasAdvanced');
 
   const handleClickTab = (path: string, label: string) => () => {
     router.push(`/${path}`);
@@ -28,33 +41,64 @@ export const useVerticalTabs = () => {
     });
   };
 
+  const advancedDisabled =
+    !widgetAdvancedFlag.isEnabled ||
+    advancedGatekeeperStatus !== GatekeeperStatus.SUCCESS;
+
   const tabs = [
     {
       path: '',
       label: 'simple',
       displayLabel: t('navbar.links.simple'),
       icon: SwapHorizIcon,
+      showNewBadge: false,
+      disabled: false,
     },
     {
       path: 'advanced/',
       label: 'advanced',
       displayLabel: t('navbar.links.advanced'),
       icon: CandlestickChartIcon,
+      showNewBadge: widgetAdvancedFlag.isEnabled,
+      disabled: advancedDisabled,
     },
   ];
 
-  return tabs.map(({ path, label, displayLabel, icon: Icon }, index) => ({
-    onClick: handleClickTab(path, label),
-    value: index,
-    tooltip: displayLabel,
-    icon: (
-      <Icon
-        sx={(theme) => ({
-          marginRight: 0.75,
-          marginBottom: `${theme.spacing(0)} !important`,
-          color: (theme.vars || theme).palette.text.primary,
-        })}
-      />
-    ),
-  }));
+  return tabs.map(
+    (
+      { path, label, displayLabel, icon: Icon, showNewBadge, disabled },
+      index,
+    ) => ({
+      onClick: handleClickTab(path, label),
+      value: index,
+      tooltip: displayLabel,
+      disabled,
+      icon: (
+        <Box sx={{ position: 'relative', display: 'inline-flex' }}>
+          <Icon
+            sx={(theme) => ({
+              color: disabled
+                ? (theme.vars || theme).palette.iconDisabled
+                : (theme.vars || theme).palette.text.primary,
+            })}
+          />
+          {showNewBadge || disabled ? (
+            <Badge
+              label={disabled ? t('portfolio.views.soon') : t('promo.new')}
+              size={BadgeSize.XS}
+              variant={disabled ? BadgeVariant.Secondary : BadgeVariant.New}
+              sx={{
+                position: 'absolute',
+                top: -12,
+                right: -12,
+                transform: 'scale(0.75)',
+                transformOrigin: 'top right',
+                pointerEvents: 'none',
+              }}
+            />
+          ) : null}
+        </Box>
+      ),
+    }),
+  );
 };

--- a/src/components/Menus/VerticalMenu/useVerticalTabs.tsx
+++ b/src/components/Menus/VerticalMenu/useVerticalTabs.tsx
@@ -1,4 +1,3 @@
-import { useAccount } from '@jumperexchange/wallet-management';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import Box from '@mui/material/Box';
 import { useRouter } from 'next/navigation';
@@ -12,22 +11,14 @@ import {
   TrackingEventParameter,
 } from '@/const/trackingKeys';
 import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
-import { useABTest } from '@/hooks/useABTest';
-import { AB_TEST_NAME } from '@/const/abtests';
-import {
-  GatekeeperStatus,
-  useGatekeeperStatus,
-} from '@/app/ui/gatekeeper/useGatekeeperStatus';
+import { useAdvancedAccess } from '@/hooks/useAdvancedAccess';
 
 export const useVerticalTabs = () => {
   const { trackEvent } = useUserTracking();
   const router = useRouter();
   const { t } = useTranslation();
-  const widgetAdvancedFlag = useABTest({
-    feature: AB_TEST_NAME.WIDGET_ADVANCED,
-  });
-  const { status: advancedGatekeeperStatus } =
-    useGatekeeperStatus('hasAdvanced');
+  const { isEnabled: widgetAdvancedEnabled, isAllowed: advancedAllowed } =
+    useAdvancedAccess();
 
   const handleClickTab = (path: string, label: string) => () => {
     router.push(`/${path}`);
@@ -41,9 +32,7 @@ export const useVerticalTabs = () => {
     });
   };
 
-  const advancedDisabled =
-    !widgetAdvancedFlag.isEnabled ||
-    advancedGatekeeperStatus !== GatekeeperStatus.SUCCESS;
+  const advancedDisabled = !advancedAllowed;
 
   const tabs = [
     {
@@ -59,7 +48,7 @@ export const useVerticalTabs = () => {
       label: 'advanced',
       displayLabel: t('navbar.links.advanced'),
       icon: CandlestickChartIcon,
-      showNewBadge: widgetAdvancedFlag.isEnabled,
+      showNewBadge: widgetAdvancedEnabled,
       disabled: advancedDisabled,
     },
   ];

--- a/src/components/Widgets/Widget.tsx
+++ b/src/components/Widgets/Widget.tsx
@@ -81,16 +81,22 @@ export function Widget({
     address: account?.address ?? '',
   });
 
+  const widgetAdvancedFeatureFlag = useABTest({
+    feature: AB_TEST_NAME.WIDGET_ADVANCED,
+  });
+
   const resolvedVariant = useMemo(
     () =>
       resolveWidgetVariant(starterVariant, {
         limitOrders: limitOrdersFeatureFlag.isEnabled,
         privateSwaps: privateSwapsFeatureFlag.isEnabled,
+        widgetAdvanced: widgetAdvancedFeatureFlag.isEnabled,
       }),
     [
       starterVariant,
       limitOrdersFeatureFlag.isEnabled,
       privateSwapsFeatureFlag.isEnabled,
+      widgetAdvancedFeatureFlag.isEnabled,
     ],
   );
 

--- a/src/components/Widgets/variants/widgetConfig/types.ts
+++ b/src/components/Widgets/variants/widgetConfig/types.ts
@@ -31,6 +31,7 @@ export interface WidgetVariantDescriptor {
 export interface WidgetFeatureFlags {
   limitOrders: boolean;
   privateSwaps: boolean;
+  widgetAdvanced: boolean;
 }
 
 // Widget types

--- a/src/components/Widgets/variants/widgetConfig/useLimitOrdersWidgetConfig.ts
+++ b/src/components/Widgets/variants/widgetConfig/useLimitOrdersWidgetConfig.ts
@@ -18,6 +18,7 @@ export function useLimitOrdersWidgetConfig(
       resolvedVariant: resolveWidgetVariant('limit', {
         limitOrders: false,
         privateSwaps: false,
+        widgetAdvanced: false,
       }),
       partnerName: 'default',
       integrator: envConfig.NEXT_PUBLIC_WIDGET_INTEGRATOR_ADVANCED || undefined,

--- a/src/components/Widgets/variants/widgetConfig/utils.ts
+++ b/src/components/Widgets/variants/widgetConfig/utils.ts
@@ -42,6 +42,10 @@ export function resolveWidgetVariant(
     WIDGET_VARIANT_REGISTRY[starterVariant] ??
     WIDGET_VARIANT_REGISTRY['default']!;
 
+  if (starterVariant === 'advanced' && !flags.widgetAdvanced) {
+    return WIDGET_VARIANT_REGISTRY['default']!;
+  }
+
   if (starterVariant === 'advanced' && flags.limitOrders) {
     return {
       ...base,

--- a/src/const/abtests.ts
+++ b/src/const/abtests.ts
@@ -10,6 +10,7 @@ export enum AB_TEST_NAME {
   THEME_PARTNER_DEFAULT = 'theme-partner-default',
   PORTFOLIO_PNL_CHART = 'portfolio-pnl-chart',
   PORTFOLIO_TRANSACTIONS = 'portfolio-transactions',
+  WIDGET_ADVANCED = 'widget-advanced',
 }
 
 // Single source of truth for all A/B tests
@@ -56,6 +57,10 @@ export const AbTests = {
   },
   [AB_TEST_NAME.PORTFOLIO_TRANSACTIONS]: {
     name: 'portfolio-transactions',
+    enabled: true,
+  },
+  [AB_TEST_NAME.WIDGET_ADVANCED]: {
+    name: 'widget-advanced',
     enabled: true,
   },
 } as const;

--- a/src/hooks/useAdvancedAccess.spec.ts
+++ b/src/hooks/useAdvancedAccess.spec.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import {
+  GatekeeperStatus,
+  useGatekeeperStatus,
+} from '@/app/ui/gatekeeper/useGatekeeperStatus';
+import { useABTest } from '@/hooks/useABTest';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAdvancedAccess } from './useAdvancedAccess';
+
+vi.mock('@/hooks/useABTest', () => ({ useABTest: vi.fn() }));
+vi.mock('@/app/ui/gatekeeper/useGatekeeperStatus', () => ({
+  GatekeeperStatus: {
+    REQUIRES_CONNECT: 'requires_wallet',
+    LOADING_ACCESS: 'loading_access',
+    SUCCESS: 'success',
+    ERROR: 'error',
+    NOT_ALLOWED: 'not_allowed',
+  },
+  useGatekeeperStatus: vi.fn(),
+}));
+
+const mockFlag = (value: string | boolean | undefined, isLoading = false) => {
+  vi.mocked(useABTest).mockReturnValue({
+    isEnabled: !!value,
+    isLoading,
+    value,
+  });
+};
+
+const mockGatekeeper = (status: GatekeeperStatus) => {
+  vi.mocked(useGatekeeperStatus).mockReturnValue({ status });
+};
+
+beforeEach(() => {
+  mockGatekeeper(GatekeeperStatus.SUCCESS);
+});
+
+describe('useAdvancedAccess', () => {
+  it('denies access for the control variant', () => {
+    mockFlag('control');
+
+    const { result } = renderHook(() => useAdvancedAccess());
+
+    expect(result.current).toEqual({
+      isLoading: false,
+      isEnabled: false,
+      isAllowed: false,
+    });
+  });
+
+  it('allows access for the test variant regardless of gatekeeper status', () => {
+    mockFlag('test');
+    mockGatekeeper(GatekeeperStatus.NOT_ALLOWED);
+
+    const { result } = renderHook(() => useAdvancedAccess());
+
+    expect(result.current).toEqual({
+      isLoading: false,
+      isEnabled: true,
+      isAllowed: true,
+    });
+  });
+
+  it('allows access for wallet-access-control when the gatekeeper succeeds', () => {
+    mockFlag('wallet-access-control');
+    mockGatekeeper(GatekeeperStatus.SUCCESS);
+
+    const { result } = renderHook(() => useAdvancedAccess());
+
+    expect(result.current).toEqual({
+      isLoading: false,
+      isEnabled: true,
+      isAllowed: true,
+    });
+  });
+
+  it('denies access for wallet-access-control when the gatekeeper denies', () => {
+    mockFlag('wallet-access-control');
+    mockGatekeeper(GatekeeperStatus.NOT_ALLOWED);
+
+    const { result } = renderHook(() => useAdvancedAccess());
+
+    expect(result.current).toEqual({
+      isLoading: false,
+      isEnabled: true,
+      isAllowed: false,
+    });
+  });
+
+  it('is loading while the gatekeeper is still resolving wallet-access-control', () => {
+    mockFlag('wallet-access-control');
+    mockGatekeeper(GatekeeperStatus.LOADING_ACCESS);
+
+    const { result } = renderHook(() => useAdvancedAccess());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isAllowed).toBe(false);
+  });
+
+  it('fails closed while the flag is still loading', () => {
+    mockFlag(undefined, true);
+
+    const { result } = renderHook(() => useAdvancedAccess());
+
+    expect(result.current).toEqual({
+      isLoading: true,
+      isEnabled: false,
+      isAllowed: false,
+    });
+  });
+
+  it('allows access when the flag is a plain boolean toggle', () => {
+    mockFlag(true);
+    mockGatekeeper(GatekeeperStatus.NOT_ALLOWED);
+
+    const { result } = renderHook(() => useAdvancedAccess());
+
+    expect(result.current).toEqual({
+      isLoading: false,
+      isEnabled: true,
+      isAllowed: true,
+    });
+  });
+
+  it('fails closed for an unrecognized variant', () => {
+    mockFlag('some-future-variant');
+
+    const { result } = renderHook(() => useAdvancedAccess());
+
+    expect(result.current).toEqual({
+      isLoading: false,
+      isEnabled: false,
+      isAllowed: false,
+    });
+  });
+});

--- a/src/hooks/useAdvancedAccess.ts
+++ b/src/hooks/useAdvancedAccess.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { AB_TEST_NAME } from '@/const/abtests';
+import { useABTest } from '@/hooks/useABTest';
+import {
+  GatekeeperStatus,
+  useGatekeeperStatus,
+} from '@/app/ui/gatekeeper/useGatekeeperStatus';
+
+type AdvancedAccessRule = 'allow' | 'deny' | 'gatekeeper';
+
+// Single source of truth for how each widget-advanced AB test variant gates
+// access. Tune gating by editing this object only.
+const ADVANCED_ACCESS_RULES: Record<string, AdvancedAccessRule> = {
+  control: 'deny',
+  test: 'allow',
+  'wallet-access-control': 'gatekeeper',
+};
+
+// Applied when the flag hasn't resolved to a known variant yet (still
+// loading, or an unrecognized value) — fails closed.
+const DEFAULT_ADVANCED_ACCESS_RULE: AdvancedAccessRule = 'deny';
+
+export const useAdvancedAccess = () => {
+  const widgetAdvancedFlag = useABTest({
+    feature: AB_TEST_NAME.WIDGET_ADVANCED,
+  });
+  const { status } = useGatekeeperStatus('hasAdvanced');
+
+  const rule: AdvancedAccessRule =
+    widgetAdvancedFlag.value === true
+      ? 'allow'
+      : (typeof widgetAdvancedFlag.value === 'string' &&
+          ADVANCED_ACCESS_RULES[widgetAdvancedFlag.value]) ||
+        DEFAULT_ADVANCED_ACCESS_RULE;
+
+  const isLoading =
+    widgetAdvancedFlag.isLoading ||
+    (rule === 'gatekeeper' && status === GatekeeperStatus.LOADING_ACCESS);
+
+  const isAllowed =
+    rule === 'allow' ||
+    (rule === 'gatekeeper' && status === GatekeeperStatus.SUCCESS);
+
+  return {
+    isLoading,
+    isEnabled: rule !== 'deny',
+    isAllowed,
+  };
+};

--- a/src/hooks/useUrlParams.spec.tsx
+++ b/src/hooks/useUrlParams.spec.tsx
@@ -97,7 +97,7 @@ describe('useUrlParams', () => {
     expect(result.current.denyBridges).toEqual(['relay', 'across']);
   });
 
-  it('updates when the widget syncs the URL via history.replaceState', () => {
+  it('updates when the widget syncs the URL via history.replaceState', async () => {
     const { result } = renderHook(() => useUrlParams());
 
     expect(result.current.sourceChainToken).toEqual({
@@ -105,8 +105,9 @@ describe('useUrlParams', () => {
       token: undefined,
     });
 
-    act(() => {
+    await act(async () => {
       window.history.replaceState({}, '', '/?fromChain=1&fromToken=0xfrom');
+      await Promise.resolve();
     });
 
     expect(result.current.sourceChainToken).toEqual({
@@ -115,11 +116,12 @@ describe('useUrlParams', () => {
     });
   });
 
-  it('updates when the widget syncs the URL via history.pushState', () => {
+  it('updates when the widget syncs the URL via history.pushState', async () => {
     const { result } = renderHook(() => useUrlParams());
 
-    act(() => {
+    await act(async () => {
       window.history.pushState({}, '', '/?toChain=100&toToken=0xto');
+      await Promise.resolve();
     });
 
     expect(result.current.destinationChainToken).toEqual({
@@ -128,14 +130,15 @@ describe('useUrlParams', () => {
     });
   });
 
-  it('keeps the same object reference when replaceState does not change parsed params', () => {
+  it('keeps the same object reference when replaceState does not change parsed params', async () => {
     setSearch('?fromChain=1&fromToken=0xfrom');
 
     const { result } = renderHook(() => useUrlParams());
     const first = result.current;
 
-    act(() => {
+    await act(async () => {
       window.history.replaceState({}, '', '/?fromChain=1&fromToken=0xfrom');
+      await Promise.resolve();
     });
 
     expect(result.current).toBe(first);

--- a/src/hooks/useUrlParams.tsx
+++ b/src/hooks/useUrlParams.tsx
@@ -25,7 +25,7 @@ function patchHistoryForUrlChangeEvent() {
     const original = window.history[method];
     window.history[method] = function (...args) {
       const result = original.apply(this, args);
-      window.dispatchEvent(new Event(URL_CHANGE_EVENT));
+      queueMicrotask(() => window.dispatchEvent(new Event(URL_CHANGE_EVENT)));
       return result;
     };
   }


### PR DESCRIPTION
## Summary
- Added `useAdvancedAccess()` hook as the single source of truth for advanced-mode gating, replacing duplicated flag/allowlist checks in the page and the vertical tabs hook
- Gating is driven by the `widget-advanced` AB test's variant, via a rule table in `useAdvancedAccess.ts`:
  - `control` → denied
  - `test` → allowed for everyone in that bucket, no wallet check
  - `wallet-access-control` → allowed only if the wallet is on the `hasAdvanced` allowlist
  - a plain boolean `true` flag value (non-multivariate) also allows access, for backward compatibility
  - unresolved/unrecognized variants fail closed (denied)
- `/advanced` page now redirects to `AppPaths.Main` (client-side) instead of returning `notFound()` when access is denied
- Vertical tab always shown; displays **"New"** badge when the flag is enabled, **"Soon"** badge (disabled) otherwise
- Vertical tabs container hidden when only one tab is available
- `hasAdvanced` exposed from the `/api/profile/[walletAddress]/flags` route
- Added `BadgeVariant.New` to Badge styles
- `VerticalTab` overflow set to `visible` so the badge is not clipped
- Added unit tests for `useAdvancedAccess` covering every variant, the boolean-flag case, and loading/unknown-variant fallback

## Test plan
- [ ] `control` variant: advanced tab shows "Soon" badge and is disabled; navigating to `/advanced` redirects to the main page
- [ ] `test` variant: advanced tab shows "New" badge and is clickable regardless of wallet allowlist status; `/advanced` page loads
- [ ] `wallet-access-control` variant + wallet not on allowlist: "Soon" badge, disabled, `/advanced` redirects to main
- [ ] `wallet-access-control` variant + wallet on allowlist: "New" badge, clickable, `/advanced` page loads
- [ ] Flag returns a plain boolean `true` (no variant): treated as allowed
- [ ] When only the simple tab exists, vertical tabs component is not rendered
- [ ] `pnpm test:unit src/hooks/useAdvancedAccess.spec.ts` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Advanced widget experience with feature-gated navigation and side-panel controls.
  * Added limit-order views, including market pricing charts, order history, pagination, and actions to cancel, modify, or repeat orders.
  * Added localized labels, status messages, loading states, and empty states for limit orders.
  * Added improved responsive widget layouts and expanded/collapsed side-panel behavior.

* **Bug Fixes**
  * Widget content now updates correctly when navigation changes the URL.
  * Improved tab disabling, banner alignment, viewport behavior, and page redirects.

* **Tests**
  * Expanded coverage for widget navigation, URL updates, settings, and limit-order calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
