### PR TITLE
fix: skip dust symbol placeholder in limit orders table

### DIFF
--- a/src/components/LimitOrders/OrdersSection/hooks.tsx
+++ b/src/components/LimitOrders/OrdersSection/hooks.tsx
@@ -89,7 +89,10 @@ export function useOrderColumns(isExpanded: boolean): ColumnDef<Order>[] {
       ),
       amount,
     );
-    const tokenAmount = toDisplayAmount(balance, '', { compact: !isExpanded });
+    const tokenAmount = toDisplayAmount(balance, '', {
+      compact: !isExpanded,
+      hideSymbol: true,
+    });
     const tokenAmountSymbol = toDisplayAmount(balance, balance.token.symbol);
     const tokenAmountUsd = token.priceUSD
       ? toDisplayAmountUSD(balance)

--- a/src/hooks/tokens/useTokenFormatters.spec.tsx
+++ b/src/hooks/tokens/useTokenFormatters.spec.tsx
@@ -71,6 +71,28 @@ describe('useTokenFormatters', () => {
       expect(result.current.toDisplayAmount(balance)).toBe(`<0.0001${NBSP}---`);
     });
 
+    it('omits the symbol on dust path when hideSymbol is set', () => {
+      const { result } = renderHook(() => useTokenFormatters());
+      const balance = buildBalance(1n);
+
+      expect(
+        result.current.toDisplayAmount(balance, balance.token.symbol, {
+          hideSymbol: true,
+        }),
+      ).toBe('<0.0001');
+    });
+
+    it('omits the symbol on normal path when hideSymbol is set', () => {
+      const { result } = renderHook(() => useTokenFormatters());
+      const balance = buildBalance(1000000000000000000n);
+
+      expect(
+        result.current.toDisplayAmount(balance, balance.token.symbol, {
+          hideSymbol: true,
+        }),
+      ).toBe('format.decimal');
+    });
+
     it('returns localized key without symbol when no symbol is provided on normal path', () => {
       const { result } = renderHook(() => useTokenFormatters());
       const balance = buildBalance(1000000000000000000n);

--- a/src/hooks/tokens/useTokenFormatters.ts
+++ b/src/hooks/tokens/useTokenFormatters.ts
@@ -21,6 +21,7 @@ export interface FormatAmountOptions {
   compact?: boolean;
   maximumFractionDigits?: number;
   minimumFractionDigits?: number;
+  hideSymbol?: boolean;
 }
 
 export const useTokenFormatters = () => {
@@ -72,7 +73,9 @@ export const useTokenFormatters = () => {
       const amount = toAmount(balance);
       const numeric = parseFloat(amount);
       if (numeric > 0 && numeric < DUST_AMOUNT_THRESHOLD) {
-        return formatTokenAmountWithDust(amount, symbol ?? '', t);
+        return formatTokenAmountWithDust(amount, symbol ?? '', t, {
+          hideSymbol: options?.hideSymbol,
+        });
       }
       const formatted = t(
         `format.${options?.compact ? 'decimalCompact' : 'decimal'}`,
@@ -82,7 +85,7 @@ export const useTokenFormatters = () => {
           maximumFractionDigits: options?.maximumFractionDigits ?? 3,
         },
       );
-      if (!symbol) {
+      if (options?.hideSymbol || !symbol) {
         return formatted;
       }
       return `${formatted}${NBSP}${symbol}`;

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -344,6 +344,7 @@ export default interface Resources {
       decimal2Digit: '{{value, decimalExt(maximumFractionDigits: 2)}}';
       decimalCompact: '{{value, decimalExt(maximumFractionDigits: 3; notation: compact; compactDisplay: short)}}';
       dustAmount: '<{{value, decimalExt(maximumFractionDigits: 4)}} {{symbol}}';
+      dustAmountValue: '<{{value, decimalExt(maximumFractionDigits: 4)}}';
       dustUsd: '<{{value, currencyExt(currency: USD)}}';
       percent: '{{value, percentExt()}}';
       shortDate: '{{value, dateExt(month: short)}}';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -460,6 +460,7 @@
     "date": "{{value, dateExt(month: long)}}",
     "shortDate": "{{value, dateExt(month: short)}}",
     "dustAmount": "<{{value, decimalExt(maximumFractionDigits: 4)}}\u00a0{{symbol}}",
+    "dustAmountValue": "<{{value, decimalExt(maximumFractionDigits: 4)}}",
     "dustUsd": "<{{value, currencyExt(currency: USD)}}"
   },
   "contribution": {

--- a/src/utils/formatNumbers.spec.ts
+++ b/src/utils/formatNumbers.spec.ts
@@ -19,6 +19,7 @@ async function buildFrT() {
         translation: {
           format: {
             dustAmount: `<{{value, decimalExt(maximumFractionDigits: 4)}}${NBSP}{{symbol}}`,
+            dustAmountValue: `<{{value, decimalExt(maximumFractionDigits: 4)}}`,
             dustUsd: '<{{value, currencyExt(currency: USD)}}',
           },
         },
@@ -64,6 +65,22 @@ describe('formatTokenAmountWithDust', () => {
       `<0.0001${NBSP}---`,
     );
   });
+
+  it('should omit the symbol on dust amount when hideSymbol is set', () => {
+    expect(
+      formatTokenAmountWithDust('0.000000000000000001', 'eETH', undefined, {
+        hideSymbol: true,
+      }),
+    ).toBe('<0.0001');
+  });
+
+  it('should return the bare amount on normal amounts when hideSymbol is set', () => {
+    expect(
+      formatTokenAmountWithDust('12.345', 'eETH', undefined, {
+        hideSymbol: true,
+      }),
+    ).toBe('12.345');
+  });
 });
 
 describe('formatUSDWithDust', () => {
@@ -107,6 +124,17 @@ describe('formatTokenAmountWithDust with fr locale', () => {
     expect(formatTokenAmountWithDust('0.000000000000000001', 'WAVAX')).toBe(
       `<0.0001${NBSP}WAVAX`,
     );
+  });
+
+  it('renders dust value with fr decimal separator when hideSymbol is set', async () => {
+    const t = await buildFrT();
+    const result = formatTokenAmountWithDust(
+      '0.000000000000000001',
+      'WAVAX',
+      t,
+      { hideSymbol: true },
+    );
+    expect(result).toBe('<0,0001');
   });
 });
 

--- a/src/utils/formatNumbers.ts
+++ b/src/utils/formatNumbers.ts
@@ -128,6 +128,15 @@ export const NBSP = '\u00a0'; // non-breaking space
 export const DUST_AMOUNT_THRESHOLD = 0.0001;
 export const DUST_AMOUNT_LABEL = `<${DUST_AMOUNT_THRESHOLD}`;
 
+export interface FormatTokenAmountWithDustOptions {
+  /**
+   * Omit the symbol entirely instead of falling back to the `---`
+   * placeholder. Use when the symbol is known but intentionally shown
+   * elsewhere in the UI, as opposed to a genuinely unknown symbol.
+   */
+  hideSymbol?: boolean;
+}
+
 /**
  * Combines a formatted decimal `amount` string with a token `symbol`,
  * collapsing non-zero values below the dust threshold to `<0.0001 SYMBOL`
@@ -139,10 +148,25 @@ export const formatTokenAmountWithDust = (
   amount: string,
   symbol: string,
   t?: TFunction,
+  options?: FormatTokenAmountWithDustOptions,
 ): string => {
   const numeric = parseFloat(amount);
+  const isDust = numeric > 0 && numeric < DUST_AMOUNT_THRESHOLD;
+
+  if (options?.hideSymbol) {
+    if (!isDust) {
+      return amount;
+    }
+    const translated = t?.('format.dustAmountValue', {
+      value: DUST_AMOUNT_THRESHOLD,
+    });
+    return !translated || translated.startsWith('format.dustAmountValue')
+      ? DUST_AMOUNT_LABEL
+      : translated;
+  }
+
   const label = symbol || '---';
-  if (numeric > 0 && numeric < DUST_AMOUNT_THRESHOLD) {
+  if (isDust) {
     const translated = t?.('format.dustAmount', {
       value: DUST_AMOUNT_THRESHOLD,
       symbol: label,


### PR DESCRIPTION
## Summary
- The order table's sell/buy cells intentionally hide the token symbol (it's already shown in the "Pair" column and the tooltip), but dust-sized amounts fell back to a `---` placeholder meant for genuinely unknown symbols — so dust positions rendered as `<0.0001 ---` instead of `<0.0001`.
- Added an explicit `hideSymbol` option on `formatTokenAmountWithDust`/`toDisplayAmount` so "no symbol wanted" is distinguishable from "symbol unknown," and wired it into the order table's cell renderer. Other callers (`Token.ts`, `usePortfolioFormatters.ts`) are unaffected.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:unit` (364/364 passing, including new cases in `formatNumbers.spec.ts` and `useTokenFormatters.spec.tsx`)
- [ ] Manually verify a dust-sized limit order in the table renders `<0.0001` (no `---`) with the correct symbol still shown in the tooltip