### PR TITLE
feat: feed widget verified tokens from backend endpoint - JUMEMB-10

### DIFF
--- a/src/components/Widgets/variants/widgetConfig/useMainWidgetConfig.ts
+++ b/src/components/Widgets/variants/widgetConfig/useMainWidgetConfig.ts
@@ -3,6 +3,7 @@ import { ChainId } from '@jumperexchange/widget';
 import { useMemo } from 'react';
 import { tokens } from 'src/config/tokens';
 import { ThemesMap } from 'src/const/themesMap';
+import { useVerifiedTokens } from 'src/hooks/tokens/useVerifiedTokens';
 import { useMemelist } from 'src/hooks/useMemelist';
 import { useUrlParams } from 'src/hooks/useUrlParams';
 import { themeAllowChains } from '../../Widget.types';
@@ -39,6 +40,8 @@ export function useMainWidgetConfig(
 
   const { denyBridges, denyExchanges } = useUrlParams();
 
+  const verifiedTokens = useVerifiedTokens();
+
   const allowedChainsByVariant = useMemo(
     () => (context.partnerName === ThemesMap.Memecoins ? themeAllowChains : []),
     [context.partnerName],
@@ -52,6 +55,9 @@ export function useMainWidgetConfig(
       const currentAllowList = _tokens?.allow ?? [];
       const newAllowList = currentAllowList.concat(memeListTokens);
       _tokens.allow = newAllowList;
+    }
+    if (verifiedTokens?.length) {
+      _tokens.verified = verifiedTokens;
     }
 
     const {
@@ -194,6 +200,7 @@ export function useMainWidgetConfig(
     context.bridgeConditions,
     deps.theme,
     memeListTokens,
+    verifiedTokens,
     allowedChainsByVariant,
     denyBridges,
     denyExchanges,

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -1,10 +1,9 @@
-import { type BaseToken } from '@lifi/sdk';
-import type { AllowDeny } from '@jumperexchange/widget';
+import type { WidgetTokens } from '@jumperexchange/widget';
 import { ondoDenylist } from './generated/ondoDenylist';
 
 export const ARB_NATIVE_USDC = '0xaf88d065e77c8cc2239327c5edb3a432268e5831';
 
-export const tokens: AllowDeny<BaseToken> = {
+export const tokens: WidgetTokens = {
   allow: [],
   deny: ondoDenylist,
 };

--- a/src/hooks/tokens/useVerifiedTokens.ts
+++ b/src/hooks/tokens/useVerifiedTokens.ts
@@ -1,13 +1,9 @@
+import { makeClient } from '@/app/lib/client';
+import { getQueryKey } from '@/utils/queries/getQueryKey';
 import type { BaseToken } from '@lifi/sdk';
 import { useQuery } from '@tanstack/react-query';
-import config from '@/config/env-config';
-import { getQueryKey } from '@/utils/queries/getQueryKey';
 
 const SIX_HOURS_MS = 6 * 60 * 60 * 1000;
-
-interface VerifiedTokensResponse {
-  tokens?: BaseToken[];
-}
 
 /**
  * Tokens curated as verified in the jumper-allowlist, served by
@@ -18,14 +14,9 @@ export const useVerifiedTokens = (): BaseToken[] | undefined => {
   const { data } = useQuery({
     queryKey: [getQueryKey('verified-tokens')],
     queryFn: async (): Promise<BaseToken[]> => {
-      const res = await fetch(
-        `${config.NEXT_PUBLIC_BACKEND_URL}/tokens/verified`,
-      );
-      if (!res.ok) {
-        throw new Error(`Failed to fetch verified tokens: ${res.status}`);
-      }
-      const { tokens }: VerifiedTokensResponse = await res.json();
-      return tokens ?? [];
+      const client = makeClient();
+      const res = await client.v1.verifiedTokensControllerGetVerifiedTokensV1();
+      return (res.data.tokens ?? []) as BaseToken[];
     },
     staleTime: SIX_HOURS_MS,
     gcTime: SIX_HOURS_MS,

--- a/src/hooks/tokens/useVerifiedTokens.ts
+++ b/src/hooks/tokens/useVerifiedTokens.ts
@@ -1,0 +1,36 @@
+import type { BaseToken } from '@lifi/sdk';
+import { useQuery } from '@tanstack/react-query';
+import config from '@/config/env-config';
+import { getQueryKey } from '@/utils/queries/getQueryKey';
+
+const SIX_HOURS_MS = 6 * 60 * 60 * 1000;
+
+interface VerifiedTokensResponse {
+  tokens?: BaseToken[];
+}
+
+/**
+ * Tokens curated as verified in the jumper-allowlist, served by
+ * jumper-backend. Fed into the widget's `tokens.verified` config to suppress
+ * the unverified-token warning.
+ */
+export const useVerifiedTokens = (): BaseToken[] | undefined => {
+  const { data } = useQuery({
+    queryKey: [getQueryKey('verified-tokens')],
+    queryFn: async (): Promise<BaseToken[]> => {
+      const res = await fetch(
+        `${config.NEXT_PUBLIC_BACKEND_URL}/tokens/verified`,
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to fetch verified tokens: ${res.status}`);
+      }
+      const { tokens }: VerifiedTokensResponse = await res.json();
+      return tokens ?? [];
+    },
+    staleTime: SIX_HOURS_MS,
+    gcTime: SIX_HOURS_MS,
+    refetchOnWindowFocus: false,
+  });
+
+  return data;
+};

--- a/src/types/jumper-backend.ts
+++ b/src/types/jumper-backend.ts
@@ -2343,6 +2343,24 @@ export interface MissionApyResponse {
   data: MissionApyDto;
 }
 
+export interface VerifiedTokenDto {
+  /**
+   * Chain id the token is verified on
+   * @example 4663
+   */
+  chainId: number;
+  /**
+   * Token address as listed in the allowlist
+   * @example "0xD7321801CAae694090694Ff55A9323139F043B88"
+   */
+  address: string;
+}
+
+export interface VerifiedTokensResponseDto {
+  /** Tokens curated as verified in the jumper-allowlist */
+  tokens: VerifiedTokenDto[];
+}
+
 export type QueryParamsType = Record<string | number, any>;
 export type ResponseFormat = keyof Omit<Body, 'body' | 'bodyUsed'>;
 
@@ -3666,6 +3684,22 @@ export class JumperBackend<
         path: `/v1/tokens/extended/price-change/all`,
         method: 'GET',
         query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Tokens marked as verified in the jumper-allowlist. The widget uses them to suppress the unverified-token warning.
+     *
+     * @tags Verified Tokens, Public
+     * @name VerifiedTokensControllerGetVerifiedTokensV1
+     * @summary Get the verified-token allowlist
+     * @request GET:/v1/tokens/verified
+     */
+    verifiedTokensControllerGetVerifiedTokensV1: (params: RequestParams = {}) =>
+      this.request<VerifiedTokensResponseDto, any>({
+        path: `/v1/tokens/verified`,
+        method: 'GET',
         format: 'json',
         ...params,
       }),


### PR DESCRIPTION
## Summary

Fetches the verified-token list from jumper-backend (`GET /v1/tokens/verified`, curated in the jumper-allowlist repo) and feeds it into the widget's `tokens.verified` config, suppressing the unverified-token warning without a jumper-exchange release. Replaces the hardcoded approach from #3023. Also carries the `@jumperexchange` widget-package migration commit this depends on.

## Changes

- `src/hooks/tokens/useVerifiedTokens.ts` — react-query hook (6h staleTime) against `NEXT_PUBLIC_BACKEND_URL`
- `src/components/Widgets/variants/widgetConfig/useMainWidgetConfig.ts` — wires the fetched list into `tokens.verified`
- `src/config/tokens.ts` — retyped to `WidgetTokens`
- `chore: use @jumperexchange widget packages` (pre-existing commit on this branch)

## Linked Linear ticket

JUMEMB-10

## Sister PRs

- https://github.com/jumperexchange/jumper-allowlist/pull/115
- https://github.com/jumperexchange/jumper-backend/pull/1030

🤖 Generated with [Claude Code](https://claude.com/claude-code)
