### PR TITLE
feat: enable notifications behind a feature flag

### DIFF
--- a/src/app/api/profile/[walletAddress]/flags/route.tsx
+++ b/src/app/api/profile/[walletAddress]/flags/route.tsx
@@ -20,12 +20,12 @@ export async function GET(
     const data = await getWalletAccessControl(walletAddress);
 
     if (!data.data || data.data.length === 0) {
-      return NextResponse.json({ hasEarn: false, hasNotifications: false });
+      return NextResponse.json({ hasEarn: false });
     }
 
     const flags = data.data[0];
 
-    return NextResponse.json(pick(flags, ['hasEarn', 'hasNotifications']));
+    return NextResponse.json(pick(flags, ['hasEarn']));
   } catch (error) {
     console.error('Error fetching wallet access control:', error);
     return NextResponse.json(

--- a/src/components/Navbar/layout/DesktopLayout.tsx
+++ b/src/components/Navbar/layout/DesktopLayout.tsx
@@ -7,15 +7,13 @@ import { LabelButton } from '../components/Buttons/LabelButton';
 import { MainMenuToggle } from '../components/Buttons/MainMenuToggle';
 import type { LayoutVariantProps } from './Layout.types';
 import { NotificationBell } from '@/components/Notifications/NotificationBell';
-import {
-  GatekeeperStatus,
-  useGatekeeperStatus,
-} from '@/app/ui/gatekeeper/useGatekeeperStatus';
+import { AB_TEST_NAME } from '@/const/abtests';
+import { useABTest } from '@/hooks/useABTest';
 
 export const DesktopLayout: FC<LayoutVariantProps> = ({ secondaryButtons }) => {
   const { links, activeLink } = useMainLinks();
 
-  const { status } = useGatekeeperStatus('hasNotifications');
+  const notificationsFlag = useABTest({ feature: AB_TEST_NAME.NOTIFICATIONS });
 
   return (
     <>
@@ -37,7 +35,7 @@ export const DesktopLayout: FC<LayoutVariantProps> = ({ secondaryButtons }) => {
 
       <SecondaryLinksContainer>
         {secondaryButtons}
-        {status === GatekeeperStatus.SUCCESS && <NotificationBell />}
+        {notificationsFlag.isEnabled && <NotificationBell />}
         <MainMenuToggle />
       </SecondaryLinksContainer>
     </>

--- a/src/components/Navbar/layout/MobileLayout.tsx
+++ b/src/components/Navbar/layout/MobileLayout.tsx
@@ -3,21 +3,19 @@
 import type { FC } from 'react';
 
 import { NotificationBell } from '@/components/Notifications/NotificationBell';
-import {
-  GatekeeperStatus,
-  useGatekeeperStatus,
-} from '@/app/ui/gatekeeper/useGatekeeperStatus';
+import { AB_TEST_NAME } from '@/const/abtests';
+import { useABTest } from '@/hooks/useABTest';
 import { SecondaryLinksContainer } from './Layout.styles';
 import { MainMenuToggle } from '../components/Buttons/MainMenuToggle';
 import type { LayoutVariantProps } from './Layout.types';
 
 export const MobileLayout: FC<LayoutVariantProps> = ({ secondaryButtons }) => {
-  const { status } = useGatekeeperStatus('hasNotifications');
+  const notificationsFlag = useABTest({ feature: AB_TEST_NAME.NOTIFICATIONS });
 
   return (
     <SecondaryLinksContainer>
       {secondaryButtons}
-      {status === GatekeeperStatus.SUCCESS && <NotificationBell />}
+      {notificationsFlag.isEnabled && <NotificationBell />}
       <MainMenuToggle />
     </SecondaryLinksContainer>
   );

--- a/src/const/abtests.ts
+++ b/src/const/abtests.ts
@@ -9,6 +9,7 @@ export enum AB_TEST_NAME {
   THEME_PARTNER_DEFAULT = 'theme-partner-default',
   PORTFOLIO_PNL_CHART = 'portfolio-pnl-chart',
   PORTFOLIO_TRANSACTIONS = 'portfolio-transactions',
+  NOTIFICATIONS = 'notifications',
 }
 
 // Single source of truth for all A/B tests
@@ -51,6 +52,10 @@ export const AbTests = {
   },
   [AB_TEST_NAME.PORTFOLIO_TRANSACTIONS]: {
     name: 'portfolio-transactions',
+    enabled: true,
+  },
+  [AB_TEST_NAME.NOTIFICATIONS]: {
+    name: 'notifications',
     enabled: true,
   },
 } as const;


### PR DESCRIPTION
## Notifications behind a feature flag

Moves the notification bell off the per-wallet access control (`hasNotifications` WAC) and behind a regular Strapi-based feature flag, so it can be rolled out to all wallets without maintaining an allowlist.

### Changes

- Add `notifications` flag to `AB_TEST_NAME` / `AbTests` in `src/const/abtests.ts`
- Gate `NotificationBell` in `DesktopLayout` / `MobileLayout` via `useABTest({ feature: AB_TEST_NAME.NOTIFICATIONS })` instead of `useGatekeeperStatus('hasNotifications')`
- Remove `hasNotifications` from the `/api/profile/[walletAddress]/flags` route — it now only serves `hasEarn`, matching the `Gatekeeper` component typing and `WalletAccessControlData`

### Notes

- The connected-wallet requirement is unchanged: `NotificationBell` already returns `null` without a wallet
- Rollout is controlled entirely in Strapi — a `notifications` flag must exist there for the bell to appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added A/B testing to control notification bell visibility across desktop and mobile experiences.
  * The notifications variant is enabled by default.

* **Bug Fixes**
  * Updated wallet flag endpoint to return only the supported earnings status (`hasEarn`).
  * When no flag data is available, responses no longer include an unrelated notifications status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->