### PR TITLE
chore: use gRPC baseUrl for Sui client - JUM-1189

### DIFF
--- a/src/providers/WalletProvider/SuiProvider.tsx
+++ b/src/providers/WalletProvider/SuiProvider.tsx
@@ -5,9 +5,8 @@ import {
   type DefaultExpectedDppKit,
 } from '@mysten/dapp-kit-react';
 import { SuiGrpcClient } from '@mysten/sui/grpc';
-import { getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc';
-import { useHydrated } from '@/hooks/useHydrated';
 import type { FC, PropsWithChildren } from 'react';
+import { useHydrated } from '@/hooks/useHydrated';
 
 const STORAGE_KEY = 'jumper-sui-wallet-connection';
 
@@ -39,7 +38,7 @@ const createSuiDappKit = (options: {
     createClient: (network) =>
       new SuiGrpcClient({
         network,
-        baseUrl: getJsonRpcFullnodeUrl('mainnet'),
+        baseUrl: 'https://fullnode.mainnet.sui.io:443',
       }),
     autoConnect: options.autoConnect,
     storageKey: STORAGE_KEY,


### PR DESCRIPTION
Closes JUM-1189

## What

`SuiProvider` already used `SuiGrpcClient`, but still imported `getJsonRpcFullnodeUrl` from the deprecated `@mysten/sui/jsonRpc` to derive its `baseUrl`. This drops that import and hardcodes the gRPC mainnet endpoint (`https://fullnode.mainnet.sui.io:443`), completing the JSON-RPC removal on the frontend.

## Sister PR

- Backend: jumperexchange/jumper-backend#1032 (real client migration in `sui.adapter.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Sui network connection to use the mainnet fullnode endpoint, improving consistency when connecting to the Sui mainnet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->