### PR TITLE
[DO NOT MERGE][TEST] Decoy Playwright spec for QA agent validation

### DIFF
--- a/tests/e2e/decoyDoNotMerge.spec.ts
+++ b/tests/e2e/decoyDoNotMerge.spec.ts
@@ -1,20 +1,18 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+import { noWalletTest as test } from './fixtures/noWallet';
 
 /**
  * [DO NOT MERGE] Decoy PR — validates the QA review agent (QA-163).
- * This spec is INTENTIONALLY, obviously wrong. It is not a real test and must not be merged.
+ * This spec is INTENTIONALLY imperfect. It is not a real test and must not be merged.
  */
 
 test.describe('Jumper landing page', () => {
   test('landing page shows the swap widget', async ({ page }) => {
-    // Impossible assertion — placed first so CI fails fast without burning minutes.
-    expect(2 + 2).toBe(5);
+    // Critical fixes applied: relative navigation (respects baseURL) + correct title assertion.
+    await page.goto('/');
 
-    // Hardcoded production URL bypasses the configured baseURL in playwright.config.ts.
-    await page.goto('https://jumper.exchange');
-
-    // Wrong expectation — Jumper's page title is not the Uniswap interface.
-    await expect(page).toHaveTitle('Uniswap Interface');
+    await expect(page).toHaveTitle(/Jumper/);
 
     // Anti-pattern: arbitrary fixed sleep instead of awaiting an actual condition.
     await page.waitForTimeout(15000);
@@ -22,7 +20,7 @@ test.describe('Jumper landing page', () => {
     // Selector that cannot exist, and no Page Object Model (repo convention: tests/e2e/pages).
     await page.click('#totally-real-swap-button-99999');
 
-    // No assertion on the real result; no qase() id; not using the realWallet fixture.
+    // No assertion on the real result; no qase() id.
     console.log('done');
   });
 });

--- a/tests/e2e/decoyDoNotMerge.spec.ts
+++ b/tests/e2e/decoyDoNotMerge.spec.ts
@@ -1,32 +1,28 @@
-import { expect } from '@playwright/test';
+import { qase } from 'playwright-qase-reporter';
 
 import { noWalletTest as test } from './fixtures/noWallet';
+import { LandingPage } from './pages/LandingPage';
+import { seedWelcomeScreenClosed } from './utils/welcomeScreen';
 
 /**
  * [DO NOT MERGE] Decoy PR — validates the QA review agent (QA-163).
- * This spec is INTENTIONALLY imperfect. It is not a real test and must not be merged.
+ * Kept intentionally as a decoy; must not be merged to develop.
  */
 
-// Fresh LOW introduced this round: unused constant / dead code (cosmetic only).
-const UNUSED_RETRY_COUNT = 3;
-
 test.describe('Jumper landing page', () => {
-  // Fresh CRITICAL introduced this round: override the configured baseURL to force EVERY run
-  // (local, preview, staging, CI) against production, breaking environment isolation entirely.
-  test.use({ baseURL: 'https://jumper.exchange' });
-
-  test('landing page shows the swap widget', async ({ page }) => {
-    await page.goto('/');
-
-    await expect(page).toHaveTitle(/Jumper/);
-
-    // Anti-pattern: arbitrary fixed sleep instead of awaiting an actual condition.
-    await page.waitForTimeout(15000);
-
-    // Selector that cannot exist, and no Page Object Model (repo convention: tests/e2e/pages).
-    await page.click('#totally-real-swap-button-99999');
-
-    // No assertion on the real result; no qase() id.
-    console.log('done');
+  test.beforeEach(async ({ page }) => {
+    await seedWelcomeScreenClosed(page);
+    const landingPage = new LandingPage(page);
+    await landingPage.goto();
+    await page.waitForLoadState('load');
   });
+
+  test(
+    qase(3, 'Landing page loads and shows the welcome heading'),
+    async ({ page }) => {
+      const landingPage = new LandingPage(page);
+      await landingPage.clickJumperLogo();
+      await landingPage.expectWelcomeHeadingVisible();
+    },
+  );
 });

--- a/tests/e2e/decoyDoNotMerge.spec.ts
+++ b/tests/e2e/decoyDoNotMerge.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * [DO NOT MERGE] Decoy PR — validates the QA review agent (QA-163).
+ * This spec is INTENTIONALLY, obviously wrong. It is not a real test and must not be merged.
+ */
+
+test.describe('Jumper landing page', () => {
+  test('landing page shows the swap widget', async ({ page }) => {
+    // Impossible assertion — placed first so CI fails fast without burning minutes.
+    expect(2 + 2).toBe(5);
+
+    // Hardcoded production URL bypasses the configured baseURL in playwright.config.ts.
+    await page.goto('https://jumper.exchange');
+
+    // Wrong expectation — Jumper's page title is not the Uniswap interface.
+    await expect(page).toHaveTitle('Uniswap Interface');
+
+    // Anti-pattern: arbitrary fixed sleep instead of awaiting an actual condition.
+    await page.waitForTimeout(15000);
+
+    // Selector that cannot exist, and no Page Object Model (repo convention: tests/e2e/pages).
+    await page.click('#totally-real-swap-button-99999');
+
+    // No assertion on the real result; no qase() id; not using the realWallet fixture.
+    console.log('done');
+  });
+});

--- a/tests/e2e/decoyDoNotMerge.spec.ts
+++ b/tests/e2e/decoyDoNotMerge.spec.ts
@@ -7,9 +7,15 @@ import { noWalletTest as test } from './fixtures/noWallet';
  * This spec is INTENTIONALLY imperfect. It is not a real test and must not be merged.
  */
 
+// Fresh LOW introduced this round: unused constant / dead code (cosmetic only).
+const UNUSED_RETRY_COUNT = 3;
+
 test.describe('Jumper landing page', () => {
+  // Fresh CRITICAL introduced this round: override the configured baseURL to force EVERY run
+  // (local, preview, staging, CI) against production, breaking environment isolation entirely.
+  test.use({ baseURL: 'https://jumper.exchange' });
+
   test('landing page shows the swap widget', async ({ page }) => {
-    // Critical fixes applied: relative navigation (respects baseURL) + correct title assertion.
     await page.goto('/');
 
     await expect(page).toHaveTitle(/Jumper/);


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — this is a test

This PR is a **decoy** created to validate the automated QA review agent (Zeus, QA-163). It adds a Playwright spec that is **intentionally and obviously wrong** — impossible assertion (`2 + 2 === 5`), incorrect page-title expectation, a hardcoded production URL that bypasses the configured `baseURL`, an arbitrary fixed `waitForTimeout`, a non-existent selector, no Page Object Model, no `qase()` id, and no real assertion on the result.

It exists solely so we can confirm the QA agent flags these defects on a real PR. **Please do not review or merge it** — it will be closed once the agent has posted its review.

Not linked to any product ticket. The CI Playwright check is expected to fail by design.
