### PR TITLE
feat: protocol/wallet filters + cursor pagination for limit orders

### DIFF
--- a/src/components/LimitOrders/OrdersSection/OrdersEmptyState.tsx
+++ b/src/components/LimitOrders/OrdersSection/OrdersEmptyState.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import ReceiptLongOutlined from '@mui/icons-material/ReceiptLongOutlined';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { useTranslation } from 'react-i18next';
+
+export const OrdersEmptyState = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexDirection: 'column',
+        gap: 2,
+        minHeight: 220,
+      }}
+    >
+      <Box
+        sx={(theme) => ({
+          background: (theme.vars || theme).palette.alpha100.main,
+          borderRadius: `${theme.shape.radius16}px`,
+          p: theme.spacing(2.5),
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        })}
+      >
+        <ReceiptLongOutlined
+          sx={{ width: 24, height: 24, color: 'textSecondary' }}
+        />
+      </Box>
+      <Typography variant="bodySmall" color="textSecondary">
+        {t('limitOrders.ordersEmptyState')}
+      </Typography>
+    </Box>
+  );
+};

--- a/src/components/LimitOrders/OrdersSection/OrdersSection.tsx
+++ b/src/components/LimitOrders/OrdersSection/OrdersSection.tsx
@@ -1,20 +1,22 @@
 'use client';
 
-import { useAccount } from '@jumperexchange/wallet-management';
-import { useWidgetEvents, WidgetEvent } from '@jumperexchange/widget';
-import { useQueryClient } from '@tanstack/react-query';
 import { AnimatePresence, motion } from 'motion/react';
 import type { ReactNode } from 'react';
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import Stack from '@mui/material/Stack';
 import { ActionableSection } from '@/components/composite/ActionableSection/ActionableSection';
 import { CancelOrderFlowModal } from '@/components/composite/CancelOrderFlow/CancelOrderFlow';
 import { ModifyOrderFlowModal } from '@/components/composite/ModifyOrderFlow/ModifyOrderFlow';
 import { RepeatOrderFlowModal } from '@/components/composite/RepeatOrderFlow/RepeatOrderFlow';
-import { useLimitOrders } from '@/hooks/useLimitOrders';
-import { getQueryKey } from '@/utils/queries/getQueryKey';
-import { ORDERS_PAGE_SIZE } from './constants';
+import { OrdersEmptyState } from './OrdersEmptyState';
 import { OrdersTable } from './OrdersTable';
+import { useLimitOrders } from '@/hooks/useLimitOrders';
+import { useOrdersFilters } from './hooks';
+import { Select } from '@/components/core/form/Select/Select';
+import {
+  SelectSize,
+  SelectVariant,
+} from '@/components/core/form/Select/Select.types';
 
 interface OrdersSectionProps {
   isSidePanelExpanded: boolean;
@@ -26,35 +28,27 @@ export const OrdersSection = ({
   action,
 }: OrdersSectionProps) => {
   const { t } = useTranslation();
-  const { account } = useAccount();
-  const [page, setPage] = useState(0);
-  const { data, isLoading } = useLimitOrders(page);
-  const widgetEvents = useWidgetEvents();
-  const queryClient = useQueryClient();
 
-  // Refresh the order list shortly after a limit order is placed. The delay
-  // gives the backend time to index the newly created order before we refetch.
-  useEffect(() => {
-    const onRouteExecutionCompleted = () => {
-      setTimeout(() => {
-        queryClient.invalidateQueries({
-          queryKey: [getQueryKey('limit-orders')],
-        });
-      }, 1500);
-    };
-    widgetEvents.on(
-      WidgetEvent.RouteExecutionCompleted,
-      onRouteExecutionCompleted,
-    );
-    return () => {
-      widgetEvents.off(
-        WidgetEvent.RouteExecutionCompleted,
-        onRouteExecutionCompleted,
-      );
-    };
-  }, [widgetEvents, queryClient]);
+  const {
+    selectedAddress,
+    selectedProtocol,
+    addressOptions,
+    protocolOptions,
+    showWalletSelect,
+    setAddressFilter,
+    setProtocolFilter,
+  } = useOrdersFilters();
 
-  const shouldShow = !!account?.address && !isLoading && !!data?.total;
+  const {
+    orders,
+    hasNextPage,
+    hasPreviousPage,
+    goToNextPage,
+    goToPreviousPage,
+    isLoading,
+  } = useLimitOrders(selectedAddress, selectedProtocol);
+
+  const shouldShow = !!selectedAddress && !!selectedProtocol;
 
   return (
     <>
@@ -69,19 +63,63 @@ export const OrdersSection = ({
           >
             <ActionableSection
               title={t('limitOrders.orders')}
+              filters={
+                <Stack direction="row" sx={{ gap: 1.5, alignItems: 'center' }}>
+                  {showWalletSelect && (
+                    <Select
+                      options={addressOptions}
+                      value={selectedAddress ?? ''}
+                      onChange={setAddressFilter}
+                      label={t('limitOrders.walletLabel')}
+                      variant={SelectVariant.Single}
+                      size={SelectSize.Small}
+                    />
+                  )}
+                  <Select
+                    options={protocolOptions}
+                    value={selectedProtocol ?? ''}
+                    onChange={setProtocolFilter}
+                    label={t('limitOrders.protocolLabel')}
+                    variant={SelectVariant.Single}
+                    size={SelectSize.Small}
+                  />
+                </Stack>
+              }
               action={action}
               sx={{ flexShrink: 0 }}
             >
-              <OrdersTable
-                orders={data?.orders ?? []}
-                total={data?.total ?? 0}
-                pageSize={data?.pageSize ?? ORDERS_PAGE_SIZE}
-                pageCount={data?.pageCount ?? 0}
-                page={page}
-                setPage={setPage}
-                isExpanded={isSidePanelExpanded}
-                stickyHeader
-              />
+              <AnimatePresence mode="wait">
+                {isLoading || orders.length ? (
+                  <motion.div
+                    key="orders-table"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.3, ease: 'easeInOut' }}
+                  >
+                    <OrdersTable
+                      orders={orders}
+                      hasMore={hasNextPage}
+                      canGoPrev={hasPreviousPage}
+                      onNext={goToNextPage}
+                      onPrev={goToPreviousPage}
+                      isLoading={isLoading}
+                      isExpanded={isSidePanelExpanded}
+                      stickyHeader
+                    />
+                  </motion.div>
+                ) : (
+                  <motion.div
+                    key="orders-empty-state"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.3, ease: 'easeInOut' }}
+                  >
+                    <OrdersEmptyState />
+                  </motion.div>
+                )}
+              </AnimatePresence>
             </ActionableSection>
           </motion.div>
         )}

--- a/src/components/LimitOrders/OrdersSection/OrdersTable.stories.tsx
+++ b/src/components/LimitOrders/OrdersSection/OrdersTable.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { OrdersTable } from './OrdersTable';
 import { sampleOrders } from './fixtures';
-import { ORDERS_PAGE_SIZE } from './constants';
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
@@ -28,45 +27,41 @@ const activeOrders = sampleOrders.filter((o) => o.status === 'active');
 
 export const Default: Story = {
   args: {
-    orders: sampleOrders.slice(0, ORDERS_PAGE_SIZE),
-    total: sampleOrders.length,
-    pageSize: ORDERS_PAGE_SIZE,
-    pageCount: Math.ceil(sampleOrders.length / ORDERS_PAGE_SIZE),
-    page: 0,
-    setPage: () => {},
+    orders: sampleOrders,
+    hasMore: true,
+    canGoPrev: false,
+    onNext: () => {},
+    onPrev: () => {},
   },
 };
 
 export const ActiveOnly: Story = {
   args: {
-    orders: activeOrders.slice(0, ORDERS_PAGE_SIZE),
-    total: activeOrders.length,
-    pageSize: ORDERS_PAGE_SIZE,
-    pageCount: Math.ceil(activeOrders.length / ORDERS_PAGE_SIZE),
-    page: 0,
-    setPage: () => {},
+    orders: activeOrders,
+    hasMore: false,
+    canGoPrev: false,
+    onNext: () => {},
+    onPrev: () => {},
   },
 };
 
 export const Empty: Story = {
   args: {
     orders: [],
-    total: 0,
-    pageSize: ORDERS_PAGE_SIZE,
-    pageCount: 0,
-    page: 0,
-    setPage: () => {},
+    hasMore: false,
+    canGoPrev: false,
+    onNext: () => {},
+    onPrev: () => {},
   },
 };
 
 export const Loading: Story = {
   args: {
     orders: [],
-    total: 0,
-    pageSize: ORDERS_PAGE_SIZE,
-    pageCount: 0,
-    page: 0,
-    setPage: () => {},
+    hasMore: false,
+    canGoPrev: false,
+    onNext: () => {},
+    onPrev: () => {},
     isLoading: true,
   },
 };

--- a/src/components/LimitOrders/OrdersSection/OrdersTable.tsx
+++ b/src/components/LimitOrders/OrdersSection/OrdersTable.tsx
@@ -1,25 +1,20 @@
 'use client';
 
-import { useMediaQuery } from '@mui/material';
 import { DataTable } from '@/components/composite/DataTable/DataTable';
-import {
-  Pagination,
-  PaginationVariant,
-} from '@/components/core/Pagination/Pagination';
+import { CursorPagination } from '@/components/core/Pagination/CursorPagination';
 import { type LimitOrder as Order } from '@/types/jumper-backend';
 import { useOrderColumns } from './hooks';
+import { ORDERS_PAGE_SIZE } from './constants';
 
 interface OrdersTableProps {
-  /** Already the current page's rows — pagination is server-side (offset/limit). */
+  /** Already the current page's rows — pagination is server-side (cursor-based). */
   orders: Order[];
-  /** Total order count across all pages, from the backend's pagination meta. */
-  total: number;
-  /** The limit the backend actually applied to this page's request. */
-  pageSize: number;
-  /** Math.ceil(total / pageSize), computed once alongside the query result. */
-  pageCount: number;
-  page: number;
-  setPage: (page: number) => void;
+  /** Whether the backend has more results beyond this page. */
+  hasMore: boolean;
+  /** Whether a previous page is available to navigate back to. */
+  canGoPrev: boolean;
+  onNext: () => void;
+  onPrev: () => void;
   isLoading?: boolean;
   isExpanded?: boolean;
   stickyHeader?: boolean;
@@ -27,27 +22,15 @@ interface OrdersTableProps {
 
 export const OrdersTable = ({
   orders,
-  total,
-  pageSize,
-  pageCount,
-  page,
-  setPage,
+  hasMore,
+  canGoPrev,
+  onNext,
+  onPrev,
   isLoading = false,
   isExpanded = false,
   stickyHeader = false,
 }: OrdersTableProps) => {
   const columns = useOrderColumns(isExpanded);
-  const isMobile = useMediaQuery((theme) => theme.breakpoints.down('sm'));
-  const isTablet = useMediaQuery((theme) => theme.breakpoints.down('md'));
-  const isSmallScreen = useMediaQuery((theme) => theme.breakpoints.down('lg'));
-
-  const maxVisiblePages = isMobile
-    ? 1
-    : isTablet || (isSmallScreen && !isExpanded)
-      ? 2
-      : isSmallScreen
-        ? 3
-        : 5;
 
   return (
     <>
@@ -57,23 +40,19 @@ export const OrdersTable = ({
         columns={columns}
         getRowKey={(order) => order.orderId}
         hasMobileView={false}
+        skeletonCount={ORDERS_PAGE_SIZE}
         showHeader
         stickyHeader={stickyHeader}
         sx={{ marginInline: (theme) => theme.spacing(-1.5) }}
       />
-      {pageCount > 1 && (
-        <Pagination
-          variant={PaginationVariant.WindowedPages}
-          page={page}
-          setPage={setPage}
-          pagination={{
-            page,
-            pageSize,
-            pageCount,
-            total,
-          }}
-          maxVisiblePages={maxVisiblePages}
-          sx={{ mt: 1, gap: (theme) => theme.spacing(0.5) }}
+      {(canGoPrev || hasMore) && (
+        <CursorPagination
+          hasPrevious={canGoPrev}
+          hasNext={hasMore}
+          onPrevious={onPrev}
+          onNext={onNext}
+          disabled={isLoading}
+          sx={{ mt: 1 }}
         />
       )}
     </>

--- a/src/components/LimitOrders/OrdersSection/hooks.tsx
+++ b/src/components/LimitOrders/OrdersSection/hooks.tsx
@@ -1,20 +1,26 @@
 'use client';
 
 import type { ReactNode } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { differenceInCalendarDays } from 'date-fns';
+import { useAccount } from '@jumperexchange/wallet-management';
+import { AvatarItem } from '@jumperexchange/shared-ui/components';
 import type { ColumnDef } from '@/components/composite/DataTable/DataTable.types';
 import { Badge } from '@/components/Badge/Badge';
 import { BadgeVariant } from '@/components/Badge/Badge.styles';
 import { Tooltip } from '@/components/core/Tooltip/Tooltip';
+import { useAccountForChainType } from '@/hooks/accounts/useAccountForChainType';
 import { useTokenFormatters } from '@/hooks/tokens/useTokenFormatters';
+import { useLimitOrdersTools } from '@/hooks/useLimitOrdersTools';
 import { createExtendedToken, createTokenBalance } from '@/types/tokens';
 import { EntityAvatar } from '@/components/composite/EntityAvatar/EntityAvatar';
 import { AvatarSize } from '@/components/core/AvatarStack/AvatarStack.types';
+import { truncateAddress } from '@/utils/addresses/truncateAddress';
 import { OrderRowMenu } from './OrderRowMenu';
 import {
   ACTIONS_COL_WIDTH,
@@ -30,8 +36,61 @@ import {
   isOrderExpired,
 } from './utils';
 import type { LimitOrder as Order, TokenDto } from '@/types/jumper-backend';
-import type { CoinKey } from '@lifi/sdk';
+import { ChainType, type CoinKey } from '@lifi/sdk';
 import { BaseSurface1Skeleton } from '@/components/core/skeletons/BaseSurfaceSkeleton/BaseSurfaceSkeleton.style';
+
+export function useOrdersFilters() {
+  const { accounts } = useAccount();
+  const evmAccount = useAccountForChainType(ChainType.EVM);
+  const [protocolFilter, setProtocolFilter] = useState<string>();
+  const [addressFilter, setAddressFilter] = useState<string>();
+
+  const connectedAccounts = accounts.filter(
+    (connectedAccount) =>
+      connectedAccount.isConnected &&
+      connectedAccount.address &&
+      connectedAccount.chainType === ChainType.EVM,
+  );
+  const addressOptions = connectedAccounts.map((connectedAccount) => ({
+    value: connectedAccount.address as string,
+    label: truncateAddress(connectedAccount.address),
+    icon: connectedAccount.connector?.icon ? (
+      <AvatarItem
+        size={AvatarSize.XS}
+        avatar={{
+          id: connectedAccount.address as string,
+          src: connectedAccount.connector.icon,
+          alt: connectedAccount.connector.name,
+        }}
+      />
+    ) : undefined,
+  }));
+  const selectedAddress = addressFilter ?? evmAccount?.address;
+
+  const { tools } = useLimitOrdersTools();
+  const protocolOptions =
+    tools?.map(({ key, name, logoURI }) => ({
+      value: key,
+      label: name,
+      icon: (
+        <AvatarItem
+          size={AvatarSize.XS}
+          avatar={{ id: key, src: logoURI, alt: name }}
+        />
+      ),
+    })) ?? [];
+  const selectedProtocol = protocolFilter ?? tools?.[0]?.key;
+
+  return {
+    selectedAddress,
+    selectedProtocol,
+    addressOptions,
+    protocolOptions,
+    showWalletSelect: connectedAccounts.length > 1,
+    setAddressFilter,
+    setProtocolFilter,
+  };
+}
 
 export function useOrderColumns(isExpanded: boolean): ColumnDef<Order>[] {
   const { t } = useTranslation();

--- a/src/components/composite/ActionableSection/ActionableSection.tsx
+++ b/src/components/composite/ActionableSection/ActionableSection.tsx
@@ -8,11 +8,13 @@ import {
 
 interface ActionableSectionProps extends SectionCardProp {
   title: string;
+  filters?: ReactNode;
   action?: ReactNode;
 }
 
 export const ActionableSection: FC<ActionableSectionProps> = ({
   title,
+  filters,
   action,
   children,
   sx,
@@ -29,7 +31,10 @@ export const ActionableSection: FC<ActionableSectionProps> = ({
           flexShrink: 0,
         }}
       >
-        <Typography variant="titleSmall">{title}</Typography>
+        <Stack direction="row" sx={{ gap: 3, alignItems: 'center' }}>
+          <Typography variant="titleSmall">{title}</Typography>
+          {filters}
+        </Stack>
         {action}
       </Stack>
       {children}

--- a/src/hooks/useLimitOrders.ts
+++ b/src/hooks/useLimitOrders.ts
@@ -1,38 +1,89 @@
 'use client';
-import { useAccount } from '@jumperexchange/wallet-management';
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { makeClient } from '@/app/lib/client';
 import { getQueryKey } from '@/utils/queries/getQueryKey';
 import { ORDERS_PAGE_SIZE } from '@/components/LimitOrders/OrdersSection/constants';
+import type { LimitOrder } from '@/types/jumper-backend';
 
-export const useLimitOrders = (page: number, pageSize = ORDERS_PAGE_SIZE) => {
-  const { account } = useAccount();
-  const address = account?.address;
+interface LimitOrdersPage {
+  orders: LimitOrder[];
+  nextCursor: string | null;
+}
 
-  return useQuery({
-    queryKey: [getQueryKey('limit-orders'), address, page, pageSize],
-    queryFn: async () => {
-      if (!address) {
-        return { orders: [], total: 0, pageSize, pageCount: 0 };
+export const useLimitOrders = (
+  address: string | undefined,
+  tool: string | undefined,
+  pageSize = ORDERS_PAGE_SIZE,
+) => {
+  const [pageIndex, setPageIndex] = useState(0);
+
+  const {
+    data,
+    isLoading,
+    isFetchingNextPage,
+    hasNextPage: infiniteHasNextPage,
+    fetchNextPage,
+  } = useInfiniteQuery<
+    LimitOrdersPage,
+    Error,
+    { pages: LimitOrdersPage[] },
+    readonly unknown[],
+    string | undefined
+  >({
+    queryKey: [getQueryKey('limit-orders'), tool, address, pageSize],
+    initialPageParam: undefined,
+    queryFn: async ({ pageParam }) => {
+      if (!address || !tool) {
+        return { orders: [], nextCursor: null };
       }
 
       const client = makeClient();
       const res = await client.limitOrder.ordersControllerGetOrdersByUser(
+        tool,
         address,
-        { limit: pageSize, offset: page * pageSize },
+        { limit: pageSize, cursor: pageParam },
       );
-      const total = res.data.meta?.total ?? 0;
-      // Echo back the limit the backend actually applied, so callers never
-      // have to guess it from the request-time default.
-      const appliedPageSize = res.data.meta?.limit ?? pageSize;
       return {
         orders: res.data.data ?? [],
-        total,
-        pageSize: appliedPageSize,
-        pageCount: Math.ceil(total / appliedPageSize),
+        nextCursor: res.data.meta?.nextCursor ?? null,
       };
     },
-    placeholderData: keepPreviousData,
-    enabled: !!address,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    enabled: !!address && !!tool,
   });
+
+  useEffect(() => {
+    setPageIndex(0);
+  }, [address, tool]);
+
+  const pageCount = data?.pages.length ?? 0;
+  const currentPage = data?.pages[pageIndex];
+
+  const hasNextPage = pageIndex < pageCount - 1 || !!infiniteHasNextPage;
+  const hasPreviousPage = pageIndex > 0;
+
+  const goToNextPage = async () => {
+    if (pageIndex < pageCount - 1) {
+      setPageIndex((index) => index + 1);
+    } else if (infiniteHasNextPage) {
+      const result = await fetchNextPage();
+      if (result.status === 'success') {
+        setPageIndex((index) => index + 1);
+      }
+    }
+  };
+
+  const goToPreviousPage = () => {
+    setPageIndex((index) => Math.max(0, index - 1));
+  };
+
+  return {
+    orders: currentPage?.orders ?? [],
+    hasNextPage,
+    hasPreviousPage,
+    goToNextPage,
+    goToPreviousPage,
+    isLoading: isLoading || isFetchingNextPage,
+  };
 };

--- a/src/hooks/useLimitOrdersTools.ts
+++ b/src/hooks/useLimitOrdersTools.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import { pick } from 'lodash';
+import getApiUrl from '@/utils/getApiUrl';
+import { getQueryKey } from '@/utils/queries/getQueryKey';
+
+interface LimitOrderTool {
+  key: string;
+  name: string;
+  logoURI: string;
+}
+
+interface LimitOrderToolsResponse {
+  bridges: LimitOrderTool[];
+  exchanges: LimitOrderTool[];
+}
+
+export const useLimitOrdersTools = () => {
+  const {
+    data: tools,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: [getQueryKey('limit-order-tools')],
+    queryFn: async () => {
+      const apiUrl = getApiUrl({ isLimitVariant: true });
+      const response = await fetch(`${apiUrl}/tools`);
+      return (await response.json()) as LimitOrderToolsResponse;
+    },
+    select: (data) =>
+      [...data.bridges, ...data.exchanges].map((tool) =>
+        pick(tool, ['key', 'name', 'logoURI']),
+      ),
+  });
+
+  return { tools, isLoading, error };
+};

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -486,6 +486,8 @@ export default interface Resources {
         title: 'Modify limit order';
       };
       orders: 'Orders';
+      ordersEmptyState: 'No orders for this protocol yet';
+      protocolLabel: 'Protocol';
       repeatModal: {
         placeholderDescription: "Repeating an order isn't available yet. Placing a new order manually works the same way.";
         placeholderTitle: 'Coming soon';
@@ -521,6 +523,7 @@ export default interface Resources {
           temporarilyInvalid: 'Paused';
         };
       };
+      walletLabel: 'Wallet';
     };
     links: {
       discover: 'Discover {{name}}';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -1302,6 +1302,9 @@
     "orders": "Orders",
     "marketPrice": "Market Price",
     "marketPriceEmptyState": "Select a token to see its market price",
+    "ordersEmptyState": "No orders for this protocol yet",
+    "protocolLabel": "Protocol",
+    "walletLabel": "Wallet",
     "table": {
       "columns": {
         "chain": "Chain",

--- a/src/types/jumper-backend.ts
+++ b/src/types/jumper-backend.ts
@@ -1711,12 +1711,12 @@ export interface RelayResponseDto {
 }
 
 export interface LimitOrderPaginationMeta {
-  /** Total number of orders matching the filters */
-  total: number;
-  /** Max results per page */
+  /** Max results per page, per protocol */
   limit: number;
-  /** Offset for pagination */
-  offset: number;
+  /** Opaque cursor to pass as `cursor` to fetch the next page (cursor-paginated protocols only), or null if there are no more results. */
+  nextCursor?: string | null;
+  /** Whether more results are available beyond this page. */
+  hasMore?: boolean;
 }
 
 export interface LimitOrder {
@@ -3747,14 +3747,14 @@ export class JumperBackend<
      * @tags Orders, Public
      * @name OrdersControllerCancelOrderStepTransaction
      * @summary Get calldata/typed data to cancel a limit order
-     * @request POST:/limit-order/cancel/calldata
+     * @request POST:/limit-order/order/cancel/calldata
      */
     ordersControllerCancelOrderStepTransaction: (
       data: CancelStepTransactionRequestDto,
       params: RequestParams = {},
     ) =>
       this.request<CancelStepTransactionResponseDto, any>({
-        path: `/limit-order/cancel/calldata`,
+        path: `/limit-order/order/cancel/calldata`,
         method: 'POST',
         body: data,
         type: ContentType.Json,
@@ -3768,14 +3768,14 @@ export class JumperBackend<
      * @tags Orders, Public
      * @name OrdersControllerCancelOrderRelay
      * @summary Relay a signed limit order cancellation
-     * @request POST:/limit-order/cancel/relay
+     * @request POST:/limit-order/order/cancel/relay
      */
     ordersControllerCancelOrderRelay: (
       data: CancelRelayRequestDto,
       params: RequestParams = {},
     ) =>
       this.request<RelayResponseDto, any>({
-        path: `/limit-order/cancel/relay`,
+        path: `/limit-order/order/cancel/relay`,
         method: 'POST',
         body: data,
         type: ContentType.Json,
@@ -3784,18 +3784,17 @@ export class JumperBackend<
       }),
 
     /**
-     * No description
+     * @description Orders are fetched per protocol and merged by creation time. `limit`/`offset` apply per protocol, so up to limit × number-of-protocols items may be returned. Advance `offset` by `limit` to page.
      *
      * @tags Orders, Public
      * @name OrdersControllerGetOrdersByUser
      * @summary List limit orders for a user address
-     * @request GET:/limit-order/{address}
+     * @request GET:/limit-order/orders/{tool}/{address}
      */
     ordersControllerGetOrdersByUser: (
+      tool: string,
       address: string,
       query?: {
-        /** Filter by tool/protocol */
-        tools?: ('1inch' | 'cowswap')[];
         /**
          * Filter by chain IDs
          * @example [1,10,137]
@@ -3815,20 +3814,17 @@ export class JumperBackend<
         /** Filter by to token address */
         toTokenAddress?: string;
         /**
-         * Max results
+         * Max results per protocol (not the total). Applied independently to each queried protocol, so a response may contain up to limit × number-of-protocols items.
          * @default 10
          */
         limit?: number;
-        /**
-         * Offset for pagination
-         * @default 0
-         */
-        offset?: number;
+        /** Opaque order cursor for order pagination. Pass the `nextCursor` from the previous response to fetch the next page; omit for the first page. */
+        cursor?: string;
       },
       params: RequestParams = {},
     ) =>
       this.request<LimitOrdersListResponse, any>({
-        path: `/limit-order/${address}`,
+        path: `/limit-order/orders/${tool}/${address}`,
         method: 'GET',
         query: query,
         format: 'json',
@@ -3841,7 +3837,7 @@ export class JumperBackend<
      * @tags Orders, Public
      * @name OrdersControllerGetOrder
      * @summary Get a single limit order by protocol/chain/id
-     * @request GET:/limit-order/{tool}/{chainId}/{orderId}
+     * @request GET:/limit-order/order/{tool}/{chainId}/{orderId}
      */
     ordersControllerGetOrder: (
       tool: string,
@@ -3850,8 +3846,9 @@ export class JumperBackend<
       params: RequestParams = {},
     ) =>
       this.request<LimitOrder, any>({
-        path: `/limit-order/${tool}/${chainId}/${orderId}`,
+        path: `/limit-order/order/${tool}/${chainId}/${orderId}`,
         method: 'GET',
+        format: 'json',
         ...params,
       }),
   };


### PR DESCRIPTION
## Summary
- Wire the limit-orders protocol Select to the backend's `tool`-scoped orders endpoint, and add a wallet Select (EVM accounts only, via `useAccountForChainType`) shown when multiple accounts are connected.
- Add `useLimitOrdersTools` to fetch supported protocols from `/tools` and drive the protocol filter options dynamically.
- Add `OrdersEmptyState` for when the selected protocol/wallet has no orders, matching `MarketPriceEmptyState`'s pattern.
- Switch `useLimitOrders` from manual cursor-stack tracking to `useInfiniteQuery` + a `pageIndex` layered on top, matching the transactions table's established cursor-pagination pattern (`TransactionProvider.tsx`).
- Scope `jumper-backend.ts` changes to only the limit-order/orders API surface (cursor-based pagination, `tool`-scoped endpoint, path renames).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [ ] Manually verify protocol/wallet Select filtering and Prev/Next pagination in the browser