### PR TITLE
feat: add refresh button to limit orders section

### DIFF
--- a/src/components/LimitOrders/OrdersSection/OrdersSection.tsx
+++ b/src/components/LimitOrders/OrdersSection/OrdersSection.tsx
@@ -4,6 +4,8 @@ import { AnimatePresence, motion } from 'motion/react';
 import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
+import RefreshIcon from '@mui/icons-material/Refresh';
 import { ActionableSection } from '@/components/composite/ActionableSection/ActionableSection';
 import { CancelOrderFlowModal } from '@/components/composite/CancelOrderFlow/CancelOrderFlow';
 import { ModifyOrderFlowModal } from '@/components/composite/ModifyOrderFlow/ModifyOrderFlow';
@@ -17,6 +19,8 @@ import {
   SelectSize,
   SelectVariant,
 } from '@/components/core/form/Select/Select.types';
+import { IconButton } from '@/components/core/buttons/IconButton/IconButton';
+import { Size, Variant } from '@/components/core/buttons/types';
 
 interface OrdersSectionProps {
   isSidePanelExpanded: boolean;
@@ -46,6 +50,7 @@ export const OrdersSection = ({
     goToNextPage,
     goToPreviousPage,
     isLoading,
+    refresh,
   } = useLimitOrders(selectedAddress, selectedProtocol);
 
   const shouldShow = !!selectedAddress && !!selectedProtocol;
@@ -85,7 +90,26 @@ export const OrdersSection = ({
                   />
                 </Stack>
               }
-              action={action}
+              action={
+                <Stack direction="row" sx={{ gap: 1.5, alignItems: 'center' }}>
+                  <Tooltip title={t('limitOrders.table.actions.refresh')}>
+                    <span>
+                      <IconButton
+                        size={Size.SM}
+                        variant={Variant.AlphaDark}
+                        onClick={() => refresh()}
+                        disabled={isLoading}
+                        aria-label={t('limitOrders.table.actions.refresh')}
+                        data-testid="orders-section-refresh"
+                        sx={{ height: 32, width: 32 }}
+                      >
+                        <RefreshIcon fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                  {action}
+                </Stack>
+              }
               sx={{ flexShrink: 0 }}
             >
               <AnimatePresence mode="wait">

--- a/src/hooks/useLimitOrders.ts
+++ b/src/hooks/useLimitOrders.ts
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { makeClient } from '@/app/lib/client';
 import { getQueryKey } from '@/utils/queries/getQueryKey';
 import { ORDERS_PAGE_SIZE } from '@/components/LimitOrders/OrdersSection/constants';
@@ -17,6 +17,8 @@ export const useLimitOrders = (
   pageSize = ORDERS_PAGE_SIZE,
 ) => {
   const [pageIndex, setPageIndex] = useState(0);
+  const queryClient = useQueryClient();
+  const queryKey = [getQueryKey('limit-orders'), tool, address, pageSize];
 
   const {
     data,
@@ -31,7 +33,7 @@ export const useLimitOrders = (
     readonly unknown[],
     string | undefined
   >({
-    queryKey: [getQueryKey('limit-orders'), tool, address, pageSize],
+    queryKey,
     initialPageParam: undefined,
     queryFn: async ({ pageParam }) => {
       if (!address || !tool) {
@@ -78,6 +80,11 @@ export const useLimitOrders = (
     setPageIndex((index) => Math.max(0, index - 1));
   };
 
+  const refresh = async () => {
+    setPageIndex(0);
+    await queryClient.resetQueries({ queryKey });
+  };
+
   return {
     orders: currentPage?.orders ?? [],
     hasNextPage,
@@ -85,5 +92,6 @@ export const useLimitOrders = (
     goToNextPage,
     goToPreviousPage,
     isLoading: isLoading || isFetchingNextPage,
+    refresh,
   };
 };

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -499,6 +499,7 @@ export default interface Resources {
           collapsePanels: 'Collapse panels';
           expandPanels: 'Expand panels';
           modifyLimit: 'Modify limit';
+          refresh: 'Refresh orders';
           repeatOrder: 'Repeat order';
           rowActions: 'Row actions';
           viewOnExplorer: 'View on explorer';

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -1327,6 +1327,7 @@
       },
       "actions": {
         "rowActions": "Row actions",
+        "refresh": "Refresh orders",
         "expandPanels": "Expand panels",
         "collapsePanels": "Collapse panels",
         "viewOnExplorer": "View on explorer",


### PR DESCRIPTION
## Summary
- Add a refresh button to the limit orders section that refetches order data and resets pagination to the first page.

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] Manually verify: open limit orders, page forward, click refresh — data updates and view returns to page 1