### PR TITLE
chore: restrict order modify/repeat widget to the order's exchange

### DIFF
--- a/src/components/Widgets/variants/widgetConfig/types.ts
+++ b/src/components/Widgets/variants/widgetConfig/types.ts
@@ -111,6 +111,7 @@ export interface ZapWidgetContext extends MissionWidgetContext {
 
 export interface LimitOrdersWidgetContext extends CommonWidgetContext {
   overrideHeader?: string;
+  allowExchange?: string | null;
 }
 
 // Union type for all contexts

--- a/src/components/Widgets/variants/widgetConfig/useLimitOrdersWidgetConfig.ts
+++ b/src/components/Widgets/variants/widgetConfig/useLimitOrdersWidgetConfig.ts
@@ -39,7 +39,10 @@ export function useLimitOrdersWidgetConfig(
         history: true,
         appearance: true,
       },
+      exchanges: context.allowExchange
+        ? { allow: [context.allowExchange] }
+        : mainConfig.exchanges,
     }),
-    [mainConfig],
+    [mainConfig, context.allowExchange],
   );
 }

--- a/src/components/composite/ModifyOrderFlow/ModifyOrderFlow.tsx
+++ b/src/components/composite/ModifyOrderFlow/ModifyOrderFlow.tsx
@@ -92,6 +92,7 @@ export const ModifyOrderFlowModal = () => {
     return {
       overrideHeader: t('limitOrders.modifyModal.title'),
       disabledUI: { fromToken: true, toToken: true },
+      allowExchange: selectedOrder.tool,
       theme: {
         container: getOrderFlowWidgetContainerStyle(theme),
       },

--- a/src/components/composite/RepeatOrderFlow/RepeatOrderFlow.tsx
+++ b/src/components/composite/RepeatOrderFlow/RepeatOrderFlow.tsx
@@ -31,6 +31,7 @@ export const RepeatOrderFlowModal = () => {
     }
     return {
       overrideHeader: t('limitOrders.repeatModal.title'),
+      allowExchange: selectedOrder.tool,
       theme: {
         container: getOrderFlowWidgetContainerStyle(theme),
       },


### PR DESCRIPTION
## Summary
- Add `allowExchange` to `LimitOrdersWidgetContext`, mirroring the existing pattern on `MissionWidgetContext`
- `useLimitOrdersWidgetConfig` now overrides `exchanges: { allow: [context.allowExchange] }` when set
- `RepeatOrderFlow.tsx` and `ModifyOrderFlow.tsx` pass `allowExchange: selectedOrder.tool` so the widget only routes through the exchange the original order used

## Test plan
- [x] `pnpm typecheck`
- [x] lint-staged (eslint + prettier) via pre-commit hook