### PR TITLE
fix(perf): convert /swap/[segments] to on-demand ISR to prevent build OOM

### DIFF
--- a/src/app/[lng]/swap/[segments]/page.tsx
+++ b/src/app/[lng]/swap/[segments]/page.tsx
@@ -51,11 +51,7 @@ export const dynamicParams = true; // or false, to 404 on unknown paths
 export const dynamic = 'force-static';
 
 export async function generateStaticParams() {
-  const { chains } = await getChainsQuery();
-
-  return chains.map((chain) => ({
-    segments: slugify(chain.name),
-  }));
+  return [];
 }
 
 export default async function Page({ params }: { params: Params }) {


### PR DESCRIPTION
## What

Converts `/swap/[segments]` from full static generation to on-demand ISR by returning an empty array from `generateStaticParams`.

## Why

`generateStaticParams` was calling `getChainsQuery()` and returning ~900+ paths (all chains × all locales). During Vercel builds, Next.js prerenders these concurrently. Measured peak process-tree RSS reached **~12.7 GB**, well above the Vercel build container ceiling — causing nondeterministic SIGKILL failures.

### Investigation

- **Vercel log forensics**: every failed build exits with `Command "pnpm run build" exited with SIGKILL`; Vercel explicitly reports an OOM event. No fetch errors or timeouts — the process goes silent mid-prerender for ~23 minutes then gets killed.
- **Local bisect**: peak RSS measured across 4 runs per condition (summing the full build process group). Results: `~12.7 GB` with and without the suspected commit `e5d7dae3`, `~11.5 GB` on `develop`. A ±4 GB swing between identical runs confirms nondeterministic concurrency behaviour. The Node heap cap (`--max-old-space-size=6144`) does not cover native Turbopack + prerender memory.
- **Commit correlation explained**: `e5d7dae3` appeared as the boundary between last-good and first-failing builds, but `feat/token-allowlist` built READY at 15:27 with the same code. The failing build sat **queued for 52 minutes** behind gh-pages deployment spam, running later on a busier container. The commit is not the cause.

## Fix

Return `[]` from `generateStaticParams`. Pages are still served correctly — `dynamicParams = true` and `dynamic = 'force-static'` remain set, so Next.js caches rendered HTML on the CDN edge after the first request. Same fix as `/bridge/[segments]` in #2964.

## Measured result

| Condition | Peak RSS | Exit |
|-----------|----------|------|
| Before fix | ~12.7 GB | varies (SIGKILL) |
| After fix | **6.9 GB** | 0 |
| `develop` baseline | 11.5 GB | 0 |

## SEO impact

None. Pages remain fully crawlable — first request triggers a render, subsequent requests are served from CDN cache.