### PR TITLE
fix: serialize object params before sending to GA to prevent [object Object]

### DIFF
--- a/src/hooks/userTracking/useUserTracking.ts
+++ b/src/hooks/userTracking/useUserTracking.ts
@@ -1,4 +1,5 @@
 'use client';
+import { isObject, mapValues } from 'lodash';
 import { getSiteUrl } from '@/const/urls';
 import type { JumperEventData } from '@/utils/tracking/jumperTracking';
 import {
@@ -39,11 +40,16 @@ const googleEvent = ({
           | Record<number, TransformedRoute>;
       };
 }) => {
-  typeof window !== 'undefined' &&
-    window?.gtag('event', action, {
-      category: category,
-      ...data,
-    });
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const serialized = data
+    ? mapValues(data, (v) => (isObject(v) ? JSON.stringify(v) : v))
+    : undefined;
+  window?.gtag('event', action, {
+    category: category,
+    ...serialized,
+  });
 };
 
 const addressableEvent = ({


### PR DESCRIPTION
Fixes https://linear.app/lifi-linear/issue/JUM-1264/fe-action-available-routes-advanced-sends-param-routes-as-object

## What

`googleEvent` spreads tracking data directly into `gtag`, which cannot handle nested objects — it calls `.toString()` on them, producing `[object Object]` for `param_routes`.

## Fix

Serialize any object values to JSON strings via `mapValues` + `isObject` from lodash before passing to `gtag`. Scalar values (string, number, boolean) pass through unchanged.