### PR TITLE
fix: remove header.swap override that renamed Swap tab to Limit

### DIFF
--- a/src/components/Widgets/variants/widgetConfig/useSharedConfigs.ts
+++ b/src/components/Widgets/variants/widgetConfig/useSharedConfigs.ts
@@ -182,10 +182,6 @@ export function useLanguageConfig(
             'widget.limitOrder.placeOrderButton',
           ),
         };
-        additionalLanguageResources.header = {
-          ...additionalLanguageResources.header,
-          swap: deps.translation.t('widget.limitOrder.inProgressTitle'),
-        };
       }
 
       if (context.usePrivateWidget) {

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -1344,7 +1344,6 @@ export default interface Resources {
         title: 'Exchange';
       };
       limitOrder: {
-        inProgressTitle: 'Limit';
         placeOrderButton: 'Place order';
         reviewTitle: 'Review order';
       };

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -1039,8 +1039,7 @@
     },
     "limitOrder": {
       "reviewTitle": "Review order",
-      "placeOrderButton": "Place order",
-      "inProgressTitle": "Limit"
+      "placeOrderButton": "Place order"
     }
   },
   "links": {


### PR DESCRIPTION
## Summary

- Removes the `header.swap` language override (set to `"Limit"`) that was introduced in #3057
- The `header.swap` key is used by the widget to render the **Swap navigation tab label** — overriding it caused the Swap tab to display as "Limit" whenever the Limit tab was active
- The `button` overrides from #3057 (`swapReview`, `startSwapping`) are kept — they were the legitimate fix for limit order review modal copy
- Removes the now-unused `widget.limitOrder.inProgressTitle` translation key

## Root cause

#3057 added `additionalLanguageResources.header.swap = t('widget.limitOrder.inProgressTitle')` inside the `useLimitOrdersWidget` branch of `useLanguageConfig`. In the tabbed navigation context, `useLimitOrdersWidget` is `true` whenever the Limit tab is active, so the Swap tab's label got renamed to `"Limit"`.

## Test plan

- [ ] Navigate to `/advanced?tab=limit` — tabs should read Swap, Bridge, Limit
- [ ] Switch to the Swap tab — tabs should still read Swap, Bridge, Limit
- [ ] Fresh page load on `/advanced?tab=swap-advanced` — Swap tab label is correct

Fixes JUM-1280