### PR TITLE
fix: auto-refresh orders panel and sync protocol filter after placing a limit order

### DIFF
--- a/src/components/LimitOrders/OrdersSection/hooks.tsx
+++ b/src/components/LimitOrders/OrdersSection/hooks.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLimitOrdersFilterStore } from '@/stores/limitOrderPrice/LimitOrdersFilterStore';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
@@ -42,7 +43,7 @@ import { BaseSurface1Skeleton } from '@/components/core/skeletons/BaseSurfaceSke
 export function useOrdersFilters() {
   const { accounts } = useAccount();
   const evmAccount = useAccountForChainType(ChainType.EVM);
-  const [protocolFilter, setProtocolFilter] = useState<string>();
+  const { protocolFilter, setProtocolFilter } = useLimitOrdersFilterStore();
   const [addressFilter, setAddressFilter] = useState<string>();
 
   const connectedAccounts = accounts.filter(

--- a/src/components/Widgets/WidgetEvents.tsx
+++ b/src/components/Widgets/WidgetEvents.tsx
@@ -10,6 +10,9 @@ import { useWidgetEvents } from '@jumperexchange/widget';
 import type { RouteExtended } from '@lifi/sdk';
 import dynamic from 'next/dynamic';
 import { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { getQueryKey } from '@/utils/queries/getQueryKey';
+import { useLimitOrdersFilterStore } from '@/stores/limitOrderPrice/LimitOrdersFilterStore';
 import { useContributionStore } from 'src/stores/contribution/ContributionStore';
 import { useRouteStore } from 'src/stores/route/RouteStore';
 import { useWidgetCacheStore } from 'src/stores/widgetCache/WidgetCacheStore';
@@ -47,6 +50,10 @@ export function WidgetEvents() {
   ]);
   const setCompletedRoute = useRouteStore((state) => state.setCompletedRoute);
   const setLimitPrice = useLimitOrderPriceStore((state) => state.setLimitPrice);
+  const setProtocolFilter = useLimitOrdersFilterStore(
+    (state) => state.setProtocolFilter,
+  );
+  const queryClient = useQueryClient();
 
   const { account } = useAccount();
 
@@ -85,6 +92,17 @@ export function WidgetEvents() {
 
       // Store the completed route
       setCompletedRoute(route);
+
+      const placedTool = route.steps?.[0]?.tool;
+      const limitOrderTools = ['cowswap', '1inch'];
+      if (placedTool && limitOrderTools.includes(placedTool)) {
+        setProtocolFilter(placedTool);
+        setTimeout(() => {
+          queryClient.invalidateQueries({
+            queryKey: [getQueryKey('limit-orders')],
+          });
+        }, 1500);
+      }
 
       const fromAddress = route.fromAddress;
       const toAddress = route.toAddress;

--- a/src/stores/limitOrderPrice/LimitOrdersFilterStore.ts
+++ b/src/stores/limitOrderPrice/LimitOrdersFilterStore.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { createWithEqualityFn } from 'zustand/traditional';
+
+interface LimitOrdersFilterState {
+  protocolFilter: string | undefined;
+  setProtocolFilter: (tool: string | undefined) => void;
+}
+
+export const useLimitOrdersFilterStore =
+  createWithEqualityFn<LimitOrdersFilterState>(
+    (set) => ({
+      protocolFilter: undefined,
+      setProtocolFilter: (tool) => set({ protocolFilter: tool }),
+    }),
+    Object.is,
+  );


### PR DESCRIPTION
## Linear

[JUM-1278](https://linear.app/lifi-linear/issue/JUM-1278/widget-placed-limit-order-is-hard-to-find-manual-refresh-and-protocol)

## Summary

- After a limit order is placed via the widget, the Orders panel now automatically refreshes (~1.5 s delay, matching the cancel flow pattern) without requiring a manual button click.
- The protocol dropdown now switches to the protocol used for the just-placed order (e.g. CowSwap), so the new order is visible immediately after the refresh.

## How it works

- New Zustand store (`LimitOrdersFilterStore`) lifts `protocolFilter` out of local component state so it can be written from `WidgetEvents`.
- `routeExecutionCompleted` in `WidgetEvents` detects when a limit-order tool (`cowswap` / `1inch`) completed, sets the protocol filter to that tool, and schedules `queryClient.invalidateQueries` on the `limit-orders` key.

## Test plan

- [ ] Place a CowSwap limit order — Orders panel refreshes automatically and shows the new order under CowSwap.
- [ ] Place a 1inch limit order — same behaviour for 1inch.
- [ ] Regular swaps (non-limit-order tools) are unaffected.
- [ ] `pnpm typecheck` passes.