### PR TITLE
fix: only namespace keyPrefix for limit and private widget tabs

### DIFF
--- a/src/components/Widgets/variants/widgetConfig/useMainWidgetConfig.ts
+++ b/src/components/Widgets/variants/widgetConfig/useMainWidgetConfig.ts
@@ -8,7 +8,7 @@ import { useMemelist } from 'src/hooks/useMemelist';
 import { useUrlParams } from 'src/hooks/useUrlParams';
 import { themeAllowChains } from '../../Widget.types';
 import type { HookDependencies, MainWidgetContext } from './types';
-import { generateRouteLabel } from './utils';
+import { generateRouteLabel, resolveWidgetKeyPrefix } from './utils';
 import envConfig from '@/config/env-config';
 
 function toolsConfig(allow?: string[], deny?: string[]) {
@@ -68,7 +68,7 @@ export function useMainWidgetConfig(
     } = context.resolvedVariant ?? {};
 
     const config: Partial<WidgetConfig> = {
-      keyPrefix: `jumper-${activeTabKey ?? key}`,
+      keyPrefix: `jumper-${resolveWidgetKeyPrefix(key, activeTabKey)}`,
       variant: navigationTabs ? 'wide' : uiVariant,
       buildUrl: true,
       useRelayerRoutes: true,

--- a/src/components/Widgets/variants/widgetConfig/utils.spec.ts
+++ b/src/components/Widgets/variants/widgetConfig/utils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveActiveNavigationTab } from './utils';
+import { resolveActiveNavigationTab, resolveWidgetKeyPrefix } from './utils';
 
 describe('resolveActiveNavigationTab', () => {
   it('ignores the global tab for an instance that does not own navigation tabs', () => {
@@ -50,5 +50,29 @@ describe('resolveActiveNavigationTab', () => {
         globalActiveNavigationTab: 'private',
       }),
     ).toBe('swap-advanced');
+  });
+});
+
+describe('resolveWidgetKeyPrefix', () => {
+  it('uses the variant key when there is no active tab', () => {
+    expect(resolveWidgetKeyPrefix('advanced', undefined)).toBe('advanced');
+  });
+
+  it('keeps the variant key for non-namespaced tab switches', () => {
+    expect(resolveWidgetKeyPrefix('advanced', 'swap-advanced')).toBe(
+      'advanced',
+    );
+    expect(resolveWidgetKeyPrefix('advanced', 'bridge-advanced')).toBe(
+      'advanced',
+    );
+    expect(resolveWidgetKeyPrefix('default', 'refuel')).toBe('default');
+  });
+
+  it('uses its own namespace for the limit tab', () => {
+    expect(resolveWidgetKeyPrefix('advanced', 'limit')).toBe('limit');
+  });
+
+  it('uses its own namespace for the private tab', () => {
+    expect(resolveWidgetKeyPrefix('default', 'private')).toBe('private');
   });
 });

--- a/src/components/Widgets/variants/widgetConfig/utils.ts
+++ b/src/components/Widgets/variants/widgetConfig/utils.ts
@@ -105,6 +105,21 @@ export function resolveActiveNavigationTab({
     : navigationTabs![0];
 }
 
+/**
+ * Only the limit and private tabs need their own widget form-state namespace
+ * (they're functionally distinct flows). Every other in-widget tab
+ * (swap-advanced, bridge-advanced, refuel, ...) shares the variant's own key,
+ * so switching between them doesn't reset the widget's in-progress form.
+ */
+export function resolveWidgetKeyPrefix(
+  key: string,
+  activeTabKey?: NavigationTabKey,
+): string {
+  return activeTabKey === 'limit' || activeTabKey === 'private'
+    ? activeTabKey
+    : key;
+}
+
 export const generateRouteLabel = (
   text: string,
   theme: Theme,


### PR DESCRIPTION
## Summary
- Switching between in-widget tabs (swap-advanced ↔ bridge-advanced ↔ limit, etc.) changed `keyPrefix` on every switch, silently wiping in-progress widget form state (from/to token, amount).
- Only `limit` and `private` are functionally distinct flows that warrant their own form-state namespace; other tabs now keep sharing the variant's base key.
- Extracted the decision into a pure, testable `resolveWidgetKeyPrefix` helper in `utils.ts`.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:unit` for `utils.spec.ts` (added 4 new cases: no active tab, non-namespaced switch, limit, private)
- [ ] Manual QA: switch in-widget tabs and confirm from/to tokens + amounts persist, except when entering/leaving limit or private