### PR TITLE
fix: cancel stale limit-orders page fetch when wallet/protocol changes

### DIFF
--- a/src/hooks/useLimitOrders.ts
+++ b/src/hooks/useLimitOrders.ts
@@ -35,7 +35,7 @@ export const useLimitOrders = (
   >({
     queryKey,
     initialPageParam: undefined,
-    queryFn: async ({ pageParam }) => {
+    queryFn: async ({ pageParam, signal }) => {
       if (!address || !tool) {
         return { orders: [], nextCursor: null };
       }
@@ -45,6 +45,7 @@ export const useLimitOrders = (
         tool,
         address,
         { limit: pageSize, cursor: pageParam },
+        { signal },
       );
       return {
         orders: res.data.data ?? [],
@@ -69,9 +70,13 @@ export const useLimitOrders = (
     if (pageIndex < pageCount - 1) {
       setPageIndex((index) => index + 1);
     } else if (infiniteHasNextPage) {
-      const result = await fetchNextPage();
-      if (result.status === 'success') {
-        setPageIndex((index) => index + 1);
+      try {
+        const result = await fetchNextPage();
+        if (result.status === 'success') {
+          setPageIndex((index) => index + 1);
+        }
+      } catch {
+        // request was cancelled because address/tool changed mid-fetch
       }
     }
   };


### PR DESCRIPTION
## Summary
- `goToNextPage` in `useLimitOrders` awaited `fetchNextPage()` then bumped `pageIndex`; switching wallet address or protocol mid-fetch let the stale request resolve after pagination had already been reset, desyncing `pageIndex` from the new query's data.
- `queryFn` now forwards React Query's own `AbortSignal` into the request, so the stale fetch is genuinely cancelled when the query key (address/tool) changes.
- `goToNextPage` wraps the `fetchNextPage()` call in `try/catch` — a cancelled request rejects, so the `pageIndex` bump is naturally skipped.

## Test plan
- [x] `pnpm typecheck`
- [ ] Manual: open Orders section, paginate to page 2+, then switch wallet/protocol filter mid-fetch (throttle network to widen the window) — confirm it resets to page 1 of the new selection and the stale request shows cancelled in the Network tab