### PR TITLE
fix: forward locale segment in gas/private redirects

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -217,12 +217,12 @@ const nextConfig = {
       },
       {
         source: '/:lng?/gas',
-        destination: '/',
+        destination: '/:lng?',
         permanent: true,
       },
       {
         source: '/:lng?/private',
-        destination: '/',
+        destination: '/:lng?',
         permanent: true,
       },
     ];


### PR DESCRIPTION
## Summary
- `/:lng?/gas` and `/:lng?/private` redirected to `/` without carrying the matched `:lng` segment, dropping the locale from the URL
- A first-time visitor on e.g. `/fr/gas` would land on `/`, triggering a second locale-detection redirect that could resolve to a different locale than the original URL
- Destination now forwards `:lng?` so the locale segment is preserved

## Test plan
- [x] `node --check next.config.mjs`
- [ ] Manually verify `/fr/gas` → `/fr` and `/gas` → `/` in a running dev server