### PR TITLE
fix: stop limit order success screen from showing swap copy

### DIFF
--- a/src/components/Widgets/variants/widgetConfig/useSharedConfigs.ts
+++ b/src/components/Widgets/variants/widgetConfig/useSharedConfigs.ts
@@ -182,6 +182,26 @@ export function useLanguageConfig(
             'widget.limitOrder.placeOrderButton',
           ),
         };
+        additionalLanguageResources.success = {
+          title: {
+            swapSuccessful: deps.translation.t(
+              'widget.limitOrder.orderPlacedTitle',
+            ),
+          },
+        };
+        additionalLanguageResources.main = {
+          process: {
+            swap: {
+              done: deps.translation.t(
+                'widget.limitOrder.orderPlacementCompleted',
+              ),
+            },
+          },
+        };
+        additionalLanguageResources.header = {
+          ...additionalLanguageResources.header,
+          received: deps.translation.t('widget.limitOrder.orderPlacedLabel'),
+        };
       }
 
       if (context.usePrivateWidget) {

--- a/src/i18n/resources.d.ts
+++ b/src/i18n/resources.d.ts
@@ -1344,6 +1344,9 @@ export default interface Resources {
         title: 'Exchange';
       };
       limitOrder: {
+        orderPlacedLabel: 'Order placed';
+        orderPlacedTitle: 'Order placed successfully';
+        orderPlacementCompleted: 'Order placement completed';
         placeOrderButton: 'Place order';
         reviewTitle: 'Review order';
       };

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -1039,7 +1039,10 @@
     },
     "limitOrder": {
       "reviewTitle": "Review order",
-      "placeOrderButton": "Place order"
+      "placeOrderButton": "Place order",
+      "orderPlacedTitle": "Order placed successfully",
+      "orderPlacementCompleted": "Order placement completed",
+      "orderPlacedLabel": "Order placed"
     }
   },
   "links": {


### PR DESCRIPTION
## Summary
- Limit orders that haven't filled yet were reusing the LI.FI/Jumper widget's default swap-completion copy ("Swap successful" / "Swap completed" / "Received X"), falsely implying the trade already executed while the order is still open.
- Overrides `success.title.swapSuccessful`, `main.process.swap.done`, and `header.received` for the limit-order widget instance only (each widget mount has its own isolated i18next instance, so the regular swap widget's success screen is unaffected).
- Adds the new source strings under `widget.limitOrder` in `translation.json` and regenerates `resources.d.ts`.

Fixes [JUMADV-17](https://linear.app/lifi-linear/issue/JUMADV-17/widget-limit-order-success-screen-reports-swap-successful-and-received).

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] Place a limit order priced away from market (e.g. via `validUntil` URL param for a short expiry) and confirm the terminal screen reads "Order placed successfully" / "Order placement completed" / "Order placed" while the order is still open
- [ ] Confirm a regular swap through the main widget still shows "Swap successful" / "Swap completed" / "Received"