### PR TITLE
fix: keep gatekeeper in loading state while wallet reconnect is pending

### DIFF
--- a/src/app/ui/gatekeeper/useGatekeeperStatus.spec.ts
+++ b/src/app/ui/gatekeeper/useGatekeeperStatus.spec.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { useAccountAddress } from '@/hooks/earn/useAccountAddress';
+import { useIsWalletResolving } from '@/hooks/earn/useIsWalletResolving';
+import { useQuery } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GatekeeperStatus, useGatekeeperStatus } from './useGatekeeperStatus';
+
+vi.mock('@/hooks/earn/useAccountAddress', () => ({
+  useAccountAddress: vi.fn(),
+}));
+vi.mock('@/hooks/earn/useIsWalletResolving', () => ({
+  useIsWalletResolving: vi.fn(),
+}));
+vi.mock('@tanstack/react-query', () => ({ useQuery: vi.fn() }));
+vi.mock('@/utils/isProduction', () => ({ isProduction: true }));
+
+const ADDRESS = '0x1111111111111111111111111111111111111111' as const;
+
+const mockAddress = (address: typeof ADDRESS | undefined) => {
+  vi.mocked(useAccountAddress).mockReturnValue(address);
+};
+
+const mockResolving = (resolving: boolean) => {
+  vi.mocked(useIsWalletResolving).mockReturnValue(resolving);
+};
+
+const mockFlagsQuery = ({
+  data,
+  isLoading = false,
+  error = null,
+}: {
+  data?: Record<string, boolean>;
+  isLoading?: boolean;
+  error?: unknown;
+}) => {
+  vi.mocked(useQuery).mockReturnValue({
+    data,
+    isLoading,
+    error,
+  } as ReturnType<typeof useQuery>);
+};
+
+beforeEach(() => {
+  mockAddress(undefined);
+  mockResolving(false);
+  mockFlagsQuery({});
+});
+
+describe('useGatekeeperStatus', () => {
+  it('returns LOADING_ACCESS while the wallet is still resolving with no address', () => {
+    mockResolving(true);
+
+    const { result } = renderHook(() => useGatekeeperStatus('hasAdvanced'));
+
+    expect(result.current.status).toBe(GatekeeperStatus.LOADING_ACCESS);
+  });
+
+  it('returns REQUIRES_CONNECT when settled disconnected', () => {
+    mockResolving(false);
+
+    const { result } = renderHook(() => useGatekeeperStatus('hasAdvanced'));
+
+    expect(result.current.status).toBe(GatekeeperStatus.REQUIRES_CONNECT);
+  });
+
+  it('returns LOADING_ACCESS while wallet flags are fetching', () => {
+    mockAddress(ADDRESS);
+    mockFlagsQuery({ isLoading: true });
+
+    const { result } = renderHook(() => useGatekeeperStatus('hasAdvanced'));
+
+    expect(result.current.status).toBe(GatekeeperStatus.LOADING_ACCESS);
+  });
+
+  it('returns SUCCESS when the wallet has the requested flag', () => {
+    mockAddress(ADDRESS);
+    mockFlagsQuery({ data: { hasAdvanced: true } });
+
+    const { result } = renderHook(() => useGatekeeperStatus('hasAdvanced'));
+
+    expect(result.current.status).toBe(GatekeeperStatus.SUCCESS);
+  });
+
+  it('returns NOT_ALLOWED when the wallet lacks the requested flag', () => {
+    mockAddress(ADDRESS);
+    mockFlagsQuery({ data: { hasAdvanced: false } });
+
+    const { result } = renderHook(() => useGatekeeperStatus('hasAdvanced'));
+
+    expect(result.current.status).toBe(GatekeeperStatus.NOT_ALLOWED);
+  });
+
+  it('returns ERROR when the flags request fails', () => {
+    mockAddress(ADDRESS);
+    mockFlagsQuery({ error: new Error('network') });
+
+    const { result } = renderHook(() => useGatekeeperStatus('hasAdvanced'));
+
+    expect(result.current).toEqual({
+      status: GatekeeperStatus.ERROR,
+      error: expect.any(Error),
+    });
+  });
+});

--- a/src/app/ui/gatekeeper/useGatekeeperStatus.ts
+++ b/src/app/ui/gatekeeper/useGatekeeperStatus.ts
@@ -1,4 +1,5 @@
 import { useAccountAddress } from '@/hooks/earn/useAccountAddress';
+import { useIsWalletResolving } from '@/hooks/earn/useIsWalletResolving';
 import { isProduction } from '@/utils/isProduction';
 import { useQuery } from '@tanstack/react-query';
 
@@ -26,6 +27,7 @@ const isEarnEnabledByDefault = (): boolean => {
 
 export const useGatekeeperStatus = (flag: string): GatekeeperData => {
   const accountAddress = useAccountAddress();
+  const isWalletResolving = useIsWalletResolving();
   const earnEnabledByDefault = flag === 'hasEarn' && isEarnEnabledByDefault();
 
   const { data, isLoading, error } = useQuery({
@@ -48,7 +50,11 @@ export const useGatekeeperStatus = (flag: string): GatekeeperData => {
   }
 
   if (!accountAddress) {
-    return { status: GatekeeperStatus.REQUIRES_CONNECT };
+    return {
+      status: isWalletResolving
+        ? GatekeeperStatus.LOADING_ACCESS
+        : GatekeeperStatus.REQUIRES_CONNECT,
+    };
   }
 
   if (isLoading) {

--- a/src/hooks/earn/useIsWalletResolving.spec.ts
+++ b/src/hooks/earn/useIsWalletResolving.spec.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { useChains } from '@/hooks/useChains';
+import { useHydrated } from '@/hooks/useHydrated';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useConnection } from 'wagmi';
+import {
+  WAGMI_RECENT_CONNECTOR_STORAGE_KEY,
+  hasRecentWagmiConnector,
+  useIsWalletResolving,
+} from './useIsWalletResolving';
+
+vi.mock('@/hooks/useHydrated', () => ({ useHydrated: vi.fn() }));
+vi.mock('@/hooks/useChains', () => ({ useChains: vi.fn() }));
+vi.mock('wagmi', () => ({ useConnection: vi.fn() }));
+
+const mockHydrated = (hydrated: boolean) => {
+  vi.mocked(useHydrated).mockReturnValue(hydrated);
+};
+
+const mockChains = (isSuccess: boolean) => {
+  vi.mocked(useChains).mockReturnValue({
+    chains: [],
+    isSuccess,
+    isLoading: !isSuccess,
+    getChainById: vi.fn(),
+  });
+};
+
+const mockConnection = ({
+  address,
+  status,
+}: {
+  address?: `0x${string}`;
+  status: 'connected' | 'reconnecting' | 'connecting' | 'disconnected';
+}) => {
+  vi.mocked(useConnection).mockReturnValue({
+    address,
+    status,
+  } as ReturnType<typeof useConnection>);
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  mockHydrated(true);
+  mockChains(true);
+  mockConnection({ status: 'disconnected' });
+});
+
+describe('hasRecentWagmiConnector', () => {
+  it('returns false when storage is empty', () => {
+    expect(hasRecentWagmiConnector()).toBe(false);
+  });
+
+  it('returns true when a recent connector id is stored', () => {
+    window.localStorage.setItem(
+      WAGMI_RECENT_CONNECTOR_STORAGE_KEY,
+      '"metaMask"',
+    );
+
+    expect(hasRecentWagmiConnector()).toBe(true);
+  });
+});
+
+describe('useIsWalletResolving', () => {
+  it('is resolving before hydration', () => {
+    mockHydrated(false);
+
+    const { result } = renderHook(() => useIsWalletResolving());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('is resolving while chains have not synced', () => {
+    mockChains(false);
+
+    const { result } = renderHook(() => useIsWalletResolving());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('is resolving while the wallet is reconnecting', () => {
+    mockConnection({ status: 'reconnecting' });
+
+    const { result } = renderHook(() => useIsWalletResolving());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('is resolving while the wallet is connecting', () => {
+    mockConnection({ status: 'connecting' });
+
+    const { result } = renderHook(() => useIsWalletResolving());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('is resolving briefly when chains are ready and a recent connector exists', () => {
+    window.localStorage.setItem(
+      WAGMI_RECENT_CONNECTOR_STORAGE_KEY,
+      '"metaMask"',
+    );
+
+    const { result } = renderHook(() => useIsWalletResolving());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('settles as not resolving after the reconnect grace period with a recent connector', async () => {
+    vi.useFakeTimers();
+    window.localStorage.setItem(
+      WAGMI_RECENT_CONNECTOR_STORAGE_KEY,
+      '"metaMask"',
+    );
+
+    const { result } = renderHook(() => useIsWalletResolving());
+
+    expect(result.current).toBe(true);
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(result.current).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it('is not resolving when settled disconnected without a recent connector', () => {
+    const { result } = renderHook(() => useIsWalletResolving());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('is not resolving when an address is already available', () => {
+    window.localStorage.setItem(
+      WAGMI_RECENT_CONNECTOR_STORAGE_KEY,
+      '"metaMask"',
+    );
+    mockConnection({
+      address: '0x1111111111111111111111111111111111111111',
+      status: 'connected',
+    });
+
+    const { result } = renderHook(() => useIsWalletResolving());
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/earn/useIsWalletResolving.ts
+++ b/src/hooks/earn/useIsWalletResolving.ts
@@ -1,0 +1,78 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useConnection } from 'wagmi';
+import { useChains } from '@/hooks/useChains';
+import { useHydrated } from '@/hooks/useHydrated';
+
+/** Matches wagmi's default storage prefix + recentConnectorId item key. */
+export const WAGMI_RECENT_CONNECTOR_STORAGE_KEY = 'wagmi.recentConnectorId';
+
+export const hasRecentWagmiConnector = (): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  try {
+    return Boolean(
+      window.localStorage.getItem(WAGMI_RECENT_CONNECTOR_STORAGE_KEY),
+    );
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * True while the EVM wallet may still be restoring after a hard load.
+ *
+ * Reconnect is deferred until chains sync (`syncWagmiConfig` → `reconnect`),
+ * so a missing address must not be treated as a settled disconnect yet.
+ */
+export const useIsWalletResolving = (): boolean => {
+  const hydrated = useHydrated();
+  const { isSuccess: chainsReady } = useChains();
+  const { address, status } = useConnection();
+  const [reconnectGraceElapsed, setReconnectGraceElapsed] = useState(false);
+
+  const isConnecting = status === 'connecting' || status === 'reconnecting';
+
+  // Chains just became ready: parent `useSyncWagmiConfig` will call reconnect()
+  // in an effect. Stay resolving for one macrotask so that gap is not treated
+  // as a settled disconnect when a recent connector is present.
+  const awaitingReconnectStart =
+    hydrated &&
+    chainsReady &&
+    !address &&
+    !isConnecting &&
+    hasRecentWagmiConnector();
+
+  useEffect(() => {
+    if (!awaitingReconnectStart) {
+      setReconnectGraceElapsed(false);
+      return;
+    }
+
+    setReconnectGraceElapsed(false);
+    const timeoutId = window.setTimeout(() => {
+      setReconnectGraceElapsed(true);
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [awaitingReconnectStart]);
+
+  if (!hydrated || !chainsReady) {
+    return true;
+  }
+
+  if (isConnecting) {
+    return true;
+  }
+
+  if (awaitingReconnectStart && !reconnectGraceElapsed) {
+    return true;
+  }
+
+  return false;
+};


### PR DESCRIPTION
## Summary
- Adds `useIsWalletResolving` to detect when an EVM wallet may still be restoring after a hard reload (waiting on chains sync / wagmi reconnect).
- `useGatekeeperStatus` now returns `LOADING_ACCESS` instead of `REQUIRES_CONNECT` while the wallet is resolving, avoiding a redirect/flash to the disconnected gate before reconnect completes.

Fixes [JUMADV-29](https://linear.app/lifi-linear/issue/JUMADV-29/fe-wallet-access-control-glitch-redirects-to-until-the-wallet-resolves).

## Test plan
- [x] `pnpm build`
- [x] Unit tests: `useGatekeeperStatus.spec.ts`, `useIsWalletResolving.spec.ts`