### PR TITLE
feat(widget): add hover tooltip to Verified route label - JUMADV-14

### DIFF
--- a/src/components/Widgets/variants/widgetConfig/useMainWidgetConfig.ts
+++ b/src/components/Widgets/variants/widgetConfig/useMainWidgetConfig.ts
@@ -123,8 +123,14 @@ export function useMainWidgetConfig(
           deps.theme.muiTheme,
           `${envConfig.NEXT_PUBLIC_SITE_URL}/widget/widget-label-verified.png`,
           '',
-          (route) => (route.tags ?? [])?.some((tag) => tag.includes('SIMULATED_BY_EVM') || tag.includes('SIMULATED_BY_COMPOSER')),
+          (route) =>
+            (route.tags ?? [])?.some(
+              (tag) =>
+                tag.includes('SIMULATED_BY_EVM') ||
+                tag.includes('SIMULATED_BY_COMPOSER'),
+            ),
           'neutral',
+          'Verified via onchain simulation',
         ),
       ],
     };

--- a/src/components/Widgets/variants/widgetConfig/utils.ts
+++ b/src/components/Widgets/variants/widgetConfig/utils.ts
@@ -52,7 +52,7 @@ export const generateRouteLabel = (
                 // Open downward: sibling route cards create their own stacking
                 // contexts, so a bubble opening upward is painted behind the
                 // card above. Below the badge it stays within this card.
-                top: 'calc(100% + 8px)',
+                top: 'calc(100% + 4px)',
                 // Anchor to the label's right edge (the badge is right-aligned)
                 // so the bubble extends leftward and stays inside the card.
                 right: 0,
@@ -60,24 +60,54 @@ export const generateRouteLabel = (
                 maxWidth: 240,
                 whiteSpace: 'normal',
                 textAlign: 'center',
-                padding: theme.spacing(0.5, 1),
-                borderRadius: theme.shape.borderRadius,
-                backgroundColor: '#6d44ad',
-                color: (theme.vars || theme).palette.white.main,
-                fontSize: 12,
-                lineHeight: 1.4,
-                fontWeight: 500,
+                padding: theme.spacing(1),
+                borderRadius: `${theme.shape.radius12}px`,
+                backgroundColor: (theme.vars || theme).palette.grey[900],
+                color: (theme.vars || theme).palette.textPrimaryInverted,
                 boxShadow: theme.shadows[3],
+                ...theme.typography.bodyXSmall,
                 opacity: 0,
                 visibility: 'hidden',
                 pointerEvents: 'none',
-                transition: 'opacity 150ms ease',
+                transition: 'opacity 150ms ease, visibility 150ms ease',
+                zIndex: theme.zIndex.tooltip,
+                ...theme.applyStyles('light', {
+                  backgroundColor: (theme.vars || theme).palette.grey[700],
+                  color: (theme.vars || theme).palette.textPrimaryInverted,
+                }),
+              },
+              // Arrow pointing up from the bubble toward the badge. The label's
+              // own ::before/::after are already used (icon + bubble), so the
+              // arrow is drawn on the text node's ::after, which shares the
+              // label's positioning context.
+              '&>p::after': {
+                content: '""',
+                position: 'absolute',
+                // Sits in the gap between the badge and the bubble: tip just
+                // below the badge, base meeting the bubble's top edge.
+                top: 'calc(100% - 1px)',
+                right: 'calc(50%)',
+                transform: 'translateX(50%)',
+                width: 0,
+                height: 0,
+                borderLeft: '5px solid transparent',
+                borderRight: '5px solid transparent',
+                borderBottom: `5px solid`,
+                borderBottomColor: (theme.vars || theme).palette.grey[900],
+                ...theme.applyStyles('light', {
+                  borderBottomColor: (theme.vars || theme).palette.grey[700],
+                }),
+                opacity: 0,
+                visibility: 'hidden',
+                pointerEvents: 'none',
+                transition: 'opacity 150ms ease, visibility 150ms ease',
                 zIndex: theme.zIndex.tooltip,
               },
-              '&:hover::after, &:focus-visible::after, &:focus-within::after': {
-                opacity: 1,
-                visibility: 'visible',
-              },
+              '&:hover::after, &:focus-visible::after, &:focus-within::after, &:hover>p::after, &:focus-visible>p::after, &:focus-within>p::after':
+                {
+                  opacity: 1,
+                  visibility: 'visible',
+                },
             }
           : {}),
         '&::before': {

--- a/src/components/Widgets/variants/widgetConfig/utils.ts
+++ b/src/components/Widgets/variants/widgetConfig/utils.ts
@@ -9,6 +9,7 @@ export const generateRouteLabel = (
   allowExchange?: string,
   match?: (route: Route) => boolean,
   variant: 'gradient' | 'neutral' = 'gradient',
+  tooltipText?: string,
 ): RouteLabelRule => {
   const isNeutral = variant === 'neutral';
   return {
@@ -19,7 +20,8 @@ export const generateRouteLabel = (
         display: 'flex',
         alignItems: 'center',
         position: 'relative',
-        overflow: 'hidden',
+        // Allow the CSS tooltip pseudo-element to escape the label bounds.
+        overflow: tooltipText ? 'visible' : 'hidden',
         marginLeft: 'auto',
         gap: theme.spacing(0.5),
         paddingLeft: theme.spacing(0.5),
@@ -37,6 +39,47 @@ export const generateRouteLabel = (
               // @Note we might adjust to use the theme config
               background: 'linear-gradient(90deg, #9B006F 0%, #37006B 100%)',
             })),
+        // The widget renders custom route labels without tooltip support
+        // (RouteLabel only exposes `text` + `sx`), so the explanation is
+        // surfaced through a CSS tooltip on hover/focus, mirroring the core
+        // Tooltip styling (dark surface, inverted text).
+        ...(tooltipText
+          ? {
+              cursor: 'help',
+              '&::after': {
+                content: JSON.stringify(tooltipText),
+                position: 'absolute',
+                // Open downward: sibling route cards create their own stacking
+                // contexts, so a bubble opening upward is painted behind the
+                // card above. Below the badge it stays within this card.
+                top: 'calc(100% + 8px)',
+                // Anchor to the label's right edge (the badge is right-aligned)
+                // so the bubble extends leftward and stays inside the card.
+                right: 0,
+                width: 'max-content',
+                maxWidth: 240,
+                whiteSpace: 'normal',
+                textAlign: 'center',
+                padding: theme.spacing(0.5, 1),
+                borderRadius: theme.shape.borderRadius,
+                backgroundColor: '#6d44ad',
+                color: (theme.vars || theme).palette.white.main,
+                fontSize: 12,
+                lineHeight: 1.4,
+                fontWeight: 500,
+                boxShadow: theme.shadows[3],
+                opacity: 0,
+                visibility: 'hidden',
+                pointerEvents: 'none',
+                transition: 'opacity 150ms ease',
+                zIndex: theme.zIndex.tooltip,
+              },
+              '&:hover::after, &:focus-visible::after, &:focus-within::after': {
+                opacity: 1,
+                visibility: 'visible',
+              },
+            }
+          : {}),
         '&::before': {
           content: '""',
           width: '16px',


### PR DESCRIPTION
Explain the "Verified" badge with a "Verified via onchain simulation" tooltip on hover/focus. The widget's RouteLabel only exposes text + sx, so the tooltip is rendered via a CSS pseudo-element on the label.

# Which Jira task belongs to this PR?

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional hover and focus tooltips to route labels.
  * Tooltips can now extend beyond the label bounds for better readability.

* **Style**
  * Reformatted the “Verified via onchain simulation” route-label condition for improved readability (no behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->