### PR TITLE
fix: evaluate gatekeeper access for any connected wallet address

### DIFF
--- a/src/app/ui/gatekeeper/useGatekeeperStatus.spec.ts
+++ b/src/app/ui/gatekeeper/useGatekeeperStatus.spec.ts
@@ -1,24 +1,25 @@
 // @vitest-environment jsdom
-import { useAccountAddress } from '@/hooks/earn/useAccountAddress';
-import { useIsWalletResolving } from '@/hooks/earn/useIsWalletResolving';
+import { useConnectedAccountAddress } from '@/hooks/accounts/useConnectedAccountAddress';
+import { useIsWalletResolving } from '@/hooks/accounts/useIsWalletResolving';
 import { useQuery } from '@tanstack/react-query';
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { GatekeeperStatus, useGatekeeperStatus } from './useGatekeeperStatus';
 
-vi.mock('@/hooks/earn/useAccountAddress', () => ({
-  useAccountAddress: vi.fn(),
+vi.mock('@/hooks/accounts/useConnectedAccountAddress', () => ({
+  useConnectedAccountAddress: vi.fn(),
 }));
-vi.mock('@/hooks/earn/useIsWalletResolving', () => ({
+vi.mock('@/hooks/accounts/useIsWalletResolving', () => ({
   useIsWalletResolving: vi.fn(),
 }));
 vi.mock('@tanstack/react-query', () => ({ useQuery: vi.fn() }));
 vi.mock('@/utils/isProduction', () => ({ isProduction: true }));
 
-const ADDRESS = '0x1111111111111111111111111111111111111111' as const;
+const EVM_ADDRESS = '0x1111111111111111111111111111111111111111';
+const SOLANA_ADDRESS = 'So11111111111111111111111111111111111111112';
 
-const mockAddress = (address: typeof ADDRESS | undefined) => {
-  vi.mocked(useAccountAddress).mockReturnValue(address);
+const mockAddress = (address: string | undefined) => {
+  vi.mocked(useConnectedAccountAddress).mockReturnValue(address);
 };
 
 const mockResolving = (resolving: boolean) => {
@@ -65,7 +66,7 @@ describe('useGatekeeperStatus', () => {
   });
 
   it('returns LOADING_ACCESS while wallet flags are fetching', () => {
-    mockAddress(ADDRESS);
+    mockAddress(EVM_ADDRESS);
     mockFlagsQuery({ isLoading: true });
 
     const { result } = renderHook(() => useGatekeeperStatus('hasAdvanced'));
@@ -73,8 +74,17 @@ describe('useGatekeeperStatus', () => {
     expect(result.current.status).toBe(GatekeeperStatus.LOADING_ACCESS);
   });
 
-  it('returns SUCCESS when the wallet has the requested flag', () => {
-    mockAddress(ADDRESS);
+  it('returns SUCCESS when an EVM wallet has the requested flag', () => {
+    mockAddress(EVM_ADDRESS);
+    mockFlagsQuery({ data: { hasAdvanced: true } });
+
+    const { result } = renderHook(() => useGatekeeperStatus('hasAdvanced'));
+
+    expect(result.current.status).toBe(GatekeeperStatus.SUCCESS);
+  });
+
+  it('returns SUCCESS when a non-EVM wallet has the requested flag', () => {
+    mockAddress(SOLANA_ADDRESS);
     mockFlagsQuery({ data: { hasAdvanced: true } });
 
     const { result } = renderHook(() => useGatekeeperStatus('hasAdvanced'));
@@ -83,7 +93,7 @@ describe('useGatekeeperStatus', () => {
   });
 
   it('returns NOT_ALLOWED when the wallet lacks the requested flag', () => {
-    mockAddress(ADDRESS);
+    mockAddress(EVM_ADDRESS);
     mockFlagsQuery({ data: { hasAdvanced: false } });
 
     const { result } = renderHook(() => useGatekeeperStatus('hasAdvanced'));
@@ -92,7 +102,7 @@ describe('useGatekeeperStatus', () => {
   });
 
   it('returns ERROR when the flags request fails', () => {
-    mockAddress(ADDRESS);
+    mockAddress(EVM_ADDRESS);
     mockFlagsQuery({ error: new Error('network') });
 
     const { result } = renderHook(() => useGatekeeperStatus('hasAdvanced'));

--- a/src/app/ui/gatekeeper/useGatekeeperStatus.ts
+++ b/src/app/ui/gatekeeper/useGatekeeperStatus.ts
@@ -1,5 +1,5 @@
-import { useAccountAddress } from '@/hooks/earn/useAccountAddress';
-import { useIsWalletResolving } from '@/hooks/earn/useIsWalletResolving';
+import { useConnectedAccountAddress } from '@/hooks/accounts/useConnectedAccountAddress';
+import { useIsWalletResolving } from '@/hooks/accounts/useIsWalletResolving';
 import { isProduction } from '@/utils/isProduction';
 import { useQuery } from '@tanstack/react-query';
 
@@ -26,14 +26,16 @@ const isEarnEnabledByDefault = (): boolean => {
 };
 
 export const useGatekeeperStatus = (flag: string): GatekeeperData => {
-  const accountAddress = useAccountAddress();
+  const accountAddress = useConnectedAccountAddress();
   const isWalletResolving = useIsWalletResolving();
   const earnEnabledByDefault = flag === 'hasEarn' && isEarnEnabledByDefault();
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['flags', accountAddress, flag],
     queryFn: async () => {
-      const response = await fetch(`/api/profile/${accountAddress}/flags`);
+      const response = await fetch(
+        `/api/profile/${encodeURIComponent(accountAddress!)}/flags`,
+      );
 
       if (!response.ok) {
         throw new Error('Failed to fetch wallet flags');

--- a/src/hooks/accounts/useConnectedAccountAddress.spec.ts
+++ b/src/hooks/accounts/useConnectedAccountAddress.spec.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { ChainType } from '@lifi/sdk';
+import { useAccount } from '@jumperexchange/wallet-management';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useConnectedAccountAddress } from './useConnectedAccountAddress';
+
+vi.mock('@jumperexchange/wallet-management', () => ({
+  useAccount: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.mocked(useAccount).mockReturnValue({
+    account: {
+      chainType: ChainType.EVM,
+      isConnected: false,
+      isConnecting: false,
+      isReconnecting: false,
+      isDisconnected: true,
+      status: 'disconnected',
+    },
+    accounts: [],
+  });
+});
+
+describe('useConnectedAccountAddress', () => {
+  it('returns the selected account address when present', () => {
+    vi.mocked(useAccount).mockReturnValue({
+      account: {
+        address: 'So11111111111111111111111111111111111111112',
+        chainType: ChainType.SVM,
+        isConnected: true,
+        isConnecting: false,
+        isReconnecting: false,
+        isDisconnected: false,
+        status: 'connected',
+      },
+      accounts: [],
+    });
+
+    const { result } = renderHook(() => useConnectedAccountAddress());
+
+    expect(result.current).toBe('So11111111111111111111111111111111111111112');
+  });
+
+  it('falls back to the first connected account address', () => {
+    vi.mocked(useAccount).mockReturnValue({
+      account: {
+        chainType: ChainType.EVM,
+        isConnected: false,
+        isConnecting: false,
+        isReconnecting: false,
+        isDisconnected: true,
+        status: 'disconnected',
+      },
+      accounts: [
+        {
+          address: 'TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf',
+          chainType: ChainType.MVM,
+          isConnected: true,
+          isConnecting: false,
+          isReconnecting: false,
+          isDisconnected: false,
+          status: 'connected',
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useConnectedAccountAddress());
+
+    expect(result.current).toBe('TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf');
+  });
+
+  it('returns undefined when no wallet is connected', () => {
+    const { result } = renderHook(() => useConnectedAccountAddress());
+
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/src/hooks/accounts/useConnectedAccountAddress.ts
+++ b/src/hooks/accounts/useConnectedAccountAddress.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useAccount } from '@jumperexchange/wallet-management';
+
+/**
+ * Address of the currently selected / first connected wallet, on any chain.
+ * Prefer this over `useAccountAddress` when access control is not EVM-specific.
+ */
+export const useConnectedAccountAddress = (): string | undefined => {
+  const { account, accounts } = useAccount();
+
+  if (account?.address) {
+    return account.address;
+  }
+
+  return accounts.find((connectedAccount) => connectedAccount.address)?.address;
+};

--- a/src/hooks/accounts/useIsWalletResolving.spec.ts
+++ b/src/hooks/accounts/useIsWalletResolving.spec.ts
@@ -1,4 +1,12 @@
 // @vitest-environment jsdom
+import { ChainType } from '@lifi/sdk';
+import type { Account } from '@jumperexchange/widget-provider';
+import {
+  useBitcoinContext,
+  useSolanaContext,
+  useSuiContext,
+  useTronContext,
+} from '@jumperexchange/widget-provider';
 import { useChains } from '@/hooks/useChains';
 import { useHydrated } from '@/hooks/useHydrated';
 import { act, renderHook } from '@testing-library/react';
@@ -13,6 +21,21 @@ import {
 vi.mock('@/hooks/useHydrated', () => ({ useHydrated: vi.fn() }));
 vi.mock('@/hooks/useChains', () => ({ useChains: vi.fn() }));
 vi.mock('wagmi', () => ({ useConnection: vi.fn() }));
+vi.mock('@jumperexchange/widget-provider', () => ({
+  useSolanaContext: vi.fn(),
+  useBitcoinContext: vi.fn(),
+  useSuiContext: vi.fn(),
+  useTronContext: vi.fn(),
+}));
+
+const disconnectedAccount = (chainType: ChainType): Account => ({
+  chainType,
+  isConnected: false,
+  isConnecting: false,
+  isReconnecting: false,
+  isDisconnected: true,
+  status: 'disconnected',
+});
 
 const mockHydrated = (hydrated: boolean) => {
   vi.mocked(useHydrated).mockReturnValue(hydrated);
@@ -40,11 +63,37 @@ const mockConnection = ({
   } as ReturnType<typeof useConnection>);
 };
 
+const mockNonEvmAccounts = ({
+  solana = disconnectedAccount(ChainType.SVM),
+  bitcoin = disconnectedAccount(ChainType.UTXO),
+  sui = disconnectedAccount(ChainType.MVM),
+  tron = disconnectedAccount(ChainType.TVM),
+}: {
+  solana?: Account;
+  bitcoin?: Account;
+  sui?: Account;
+  tron?: Account;
+} = {}) => {
+  vi.mocked(useSolanaContext).mockReturnValue({
+    account: solana,
+  } as ReturnType<typeof useSolanaContext>);
+  vi.mocked(useBitcoinContext).mockReturnValue({
+    account: bitcoin,
+  } as ReturnType<typeof useBitcoinContext>);
+  vi.mocked(useSuiContext).mockReturnValue({
+    account: sui,
+  } as ReturnType<typeof useSuiContext>);
+  vi.mocked(useTronContext).mockReturnValue({
+    account: tron,
+  } as ReturnType<typeof useTronContext>);
+};
+
 beforeEach(() => {
   window.localStorage.clear();
   mockHydrated(true);
   mockChains(true);
   mockConnection({ status: 'disconnected' });
+  mockNonEvmAccounts();
 });
 
 describe('hasRecentWagmiConnector', () => {
@@ -139,6 +188,40 @@ describe('useIsWalletResolving', () => {
     mockConnection({
       address: '0x1111111111111111111111111111111111111111',
       status: 'connected',
+    });
+
+    const { result } = renderHook(() => useIsWalletResolving());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('is resolving while a non-EVM wallet is connecting', () => {
+    mockNonEvmAccounts({
+      solana: {
+        ...disconnectedAccount(ChainType.SVM),
+        status: 'connecting',
+        isConnecting: true,
+        isDisconnected: false,
+      },
+    });
+
+    const { result } = renderHook(() => useIsWalletResolving());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('is not resolving when a non-EVM address is already available', () => {
+    mockChains(false);
+    mockNonEvmAccounts({
+      solana: {
+        address: 'So11111111111111111111111111111111111111112',
+        chainType: ChainType.SVM,
+        isConnected: true,
+        isConnecting: false,
+        isReconnecting: false,
+        isDisconnected: false,
+        status: 'connected',
+      },
     });
 
     const { result } = renderHook(() => useIsWalletResolving());

--- a/src/hooks/accounts/useIsWalletResolving.ts
+++ b/src/hooks/accounts/useIsWalletResolving.ts
@@ -1,6 +1,13 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import {
+  useBitcoinContext,
+  useSolanaContext,
+  useSuiContext,
+  useTronContext,
+  type Account,
+} from '@jumperexchange/widget-provider';
 import { useConnection } from 'wagmi';
 import { useChains } from '@/hooks/useChains';
 import { useHydrated } from '@/hooks/useHydrated';
@@ -22,19 +29,40 @@ export const hasRecentWagmiConnector = (): boolean => {
   }
 };
 
+const isAccountConnecting = (account?: Account): boolean =>
+  !!account &&
+  (account.status === 'connecting' ||
+    account.status === 'reconnecting' ||
+    account.isConnecting ||
+    account.isReconnecting);
+
 /**
- * True while the EVM wallet may still be restoring after a hard load.
+ * True while any wallet may still be restoring after a hard load.
  *
- * Reconnect is deferred until chains sync (`syncWagmiConfig` → `reconnect`),
+ * EVM reconnect is deferred until chains sync (`syncWagmiConfig` → `reconnect`),
  * so a missing address must not be treated as a settled disconnect yet.
+ * Non-EVM ecosystems restore via their own providers after hydrate.
  */
 export const useIsWalletResolving = (): boolean => {
   const hydrated = useHydrated();
   const { isSuccess: chainsReady } = useChains();
   const { address, status } = useConnection();
+  const { account: solanaAccount } = useSolanaContext();
+  const { account: bitcoinAccount } = useBitcoinContext();
+  const { account: suiAccount } = useSuiContext();
+  const { account: tronAccount } = useTronContext();
   const [reconnectGraceElapsed, setReconnectGraceElapsed] = useState(false);
 
   const isConnecting = status === 'connecting' || status === 'reconnecting';
+
+  const nonEvmAccounts = [
+    solanaAccount,
+    bitcoinAccount,
+    suiAccount,
+    tronAccount,
+  ];
+  const hasNonEvmAddress = nonEvmAccounts.some((account) => !!account?.address);
+  const isNonEvmConnecting = nonEvmAccounts.some(isAccountConnecting);
 
   // Chains just became ready: parent `useSyncWagmiConfig` will call reconnect()
   // in an effect. Stay resolving for one macrotask so that gap is not treated
@@ -62,7 +90,20 @@ export const useIsWalletResolving = (): boolean => {
     };
   }, [awaitingReconnectStart]);
 
-  if (!hydrated || !chainsReady) {
+  if (!hydrated) {
+    return true;
+  }
+
+  // Non-EVM wallets settle independently of the EVM chain-sync/reconnect path.
+  if (hasNonEvmAddress) {
+    return false;
+  }
+
+  if (isNonEvmConnecting) {
+    return true;
+  }
+
+  if (!chainsReady) {
     return true;
   }
 


### PR DESCRIPTION
Move wallet-resolving helpers under accounts and allow non-EVM wallets through hasAdvanced checks without breaking the existing EVM reconnect wait.

# Which Jira task belongs to this PR?

# Why did I implement it this way?

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] If this changed the API, I have updated the documentation
- [ ] I have provided QA instructions for the feature / fix implemented in this PR (if applicable)
- [ ] I have provided instructions for any environment / deployment changes that this PR needs when merged
