### PR TITLE
feat: default placeholder tokens on new widget (JUMADV-30)

### DIFF
--- a/src/components/Menus/VerticalMenu/useVerticalTabs.tsx
+++ b/src/components/Menus/VerticalMenu/useVerticalTabs.tsx
@@ -4,14 +4,15 @@ import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import { Badge } from '@/components/Badge/Badge';
 import { BadgeSize, BadgeVariant } from '@/components/Badge/Badge.styles';
+import { prepareWidgetSurfaceNavigation } from '@/components/Widgets/variants/widgetConfig/utils';
 import { CandlestickChartIcon } from '@/components/illustrations/CandlestickChartIcon';
 import {
   TrackingAction,
   TrackingCategory,
   TrackingEventParameter,
 } from '@/const/trackingKeys';
-import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
 import { useAdvancedAccess } from '@/hooks/useAdvancedAccess';
+import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
 
 export const useVerticalTabs = () => {
   const { trackEvent } = useUserTracking();
@@ -21,6 +22,7 @@ export const useVerticalTabs = () => {
     useAdvancedAccess();
 
   const handleClickTab = (path: string, label: string) => () => {
+    prepareWidgetSurfaceNavigation();
     router.push(`/${path}`);
     trackEvent({
       category: TrackingCategory.Navigation,

--- a/src/components/Menus/VerticalMenu/useVerticalTabs.tsx
+++ b/src/components/Menus/VerticalMenu/useVerticalTabs.tsx
@@ -12,16 +12,29 @@ import {
   TrackingEventParameter,
 } from '@/const/trackingKeys';
 import { useAdvancedAccess } from '@/hooks/useAdvancedAccess';
+import { usePathnameWithoutLocale } from '@/hooks/routing/usePathnameWithoutLocale';
 import { useUserTracking } from '@/hooks/userTracking/useUserTracking';
+
+const normalizeVerticalTabPath = (path: string) => {
+  const withLeadingSlash = path.startsWith('/') ? path : `/${path}`;
+  return withLeadingSlash.replace(/\/+$/, '') || '/';
+};
 
 export const useVerticalTabs = () => {
   const { trackEvent } = useUserTracking();
   const router = useRouter();
+  const pathname = usePathnameWithoutLocale();
   const { t } = useTranslation();
   const { isEnabled: widgetAdvancedEnabled, isAllowed: advancedAllowed } =
     useAdvancedAccess();
 
   const handleClickTab = (path: string, label: string) => () => {
+    const targetPath = normalizeVerticalTabPath(path === '' ? '/' : path);
+    const currentPath = normalizeVerticalTabPath(pathname || '/');
+    if (currentPath === targetPath) {
+      return;
+    }
+
     prepareWidgetSurfaceNavigation();
     router.push(`/${path}`);
     trackEvent({

--- a/src/components/Widgets/Widget.tsx
+++ b/src/components/Widgets/Widget.tsx
@@ -4,16 +4,16 @@ import type { FormState } from '@jumperexchange/widget';
 import { PrefetchKind } from 'next/dist/client/components/router-reducer/router-reducer-types';
 import dynamic from 'next/dynamic';
 import { usePathname, useRouter } from 'next/navigation';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useBridgeConditions } from 'src/hooks/useBridgeConditions';
 import { useMultisig } from 'src/hooks/useMultisig';
 import { useWelcomeScreen } from 'src/hooks/useWelcomeScreen';
-import { useActiveTabStore } from 'src/stores/activeTab';
 import { useContributionStore } from 'src/stores/contribution/ContributionStore';
 import envConfig from '@/config/env-config';
 import { AB_TEST_NAME } from '@/const/abtests';
 import { AppPaths } from '@/const/urls';
 import { useABTest } from '@/hooks/useABTest';
+import { useActiveNavigationTab } from '@/hooks/useActiveNavigationTab';
 import { useThemeStore } from '@/stores/theme';
 import { useFormParameters } from './hooks';
 import { Widget as BaseWidget } from './variants/base/Widget';
@@ -21,7 +21,14 @@ import type {
   MainWidgetContext,
   WidgetVariantDescriptor,
 } from './variants/widgetConfig/types';
-import { resolveWidgetVariant } from './variants/widgetConfig/utils';
+import {
+  applyWidgetChainTokenFields,
+  clearWidgetChainTokenCache,
+  consumeWidgetSurfaceNavigation,
+  resolveActiveNavigationTab,
+  resolveWidgetPlaceholderTokens,
+  resolveWidgetVariant,
+} from './variants/widgetConfig/utils';
 import { WidgetWrapper } from './Widget.style';
 import type { WidgetProps } from './Widget.types';
 
@@ -30,6 +37,7 @@ const PrivateSwapModal = dynamic(() =>
     (mod) => mod.PrivateSwapModal,
   ),
 );
+
 export function Widget({
   starterVariant,
   fromChain,
@@ -45,6 +53,12 @@ export function Widget({
   isLoading,
   disableTabNavigation = false,
 }: WidgetProps) {
+  // Destination Simple↔Advanced: clear URL + cache before URL snapshot / form seed.
+  useState(() => {
+    consumeWidgetSurfaceNavigation();
+    return null;
+  });
+
   const [configTheme] = useThemeStore((state) => [state.configTheme]);
   const formRef = useRef<FormState>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -54,6 +68,10 @@ export function Widget({
     configThemeChains: configTheme?.chains,
   });
   const [isPrivateSwapModalOpen, setIsPrivateSwapModalOpen] = useState(false);
+  // After the user changes tabs, stop feeding chain/token via widget config so
+  // FormUpdater does not overwrite setFieldValue placeholders (or clears).
+  const [seedChainTokensFromConfig, setSeedChainTokensFromConfig] =
+    useState(true);
 
   useEffect(() => {
     setIsPrivateSwapModalOpen(bridgeConditions.isPrivateSwapSelected);
@@ -65,7 +83,6 @@ export function Widget({
   const isConnectedAGW = account?.connector?.name === 'Abstract';
   const { isSafe } = useMultisig();
 
-  const { activeTab } = useActiveTabStore();
   const partnerName = configTheme?.uid ?? 'default';
   const contributionDisplayed = useContributionStore(
     (state) => state.contributionDisplayed,
@@ -88,15 +105,23 @@ export function Widget({
   const resolvedVariant = useMemo(
     () =>
       resolveWidgetVariant(starterVariant, {
-        limitOrders: limitOrdersFeatureFlag.isEnabled,
-        privateSwaps: privateSwapsFeatureFlag.isEnabled,
-        widgetAdvanced: widgetAdvancedFeatureFlag.isEnabled,
+        limitOrders:
+          limitOrdersFeatureFlag.isLoading || limitOrdersFeatureFlag.isEnabled,
+        privateSwaps:
+          privateSwapsFeatureFlag.isLoading ||
+          privateSwapsFeatureFlag.isEnabled,
+        widgetAdvanced:
+          widgetAdvancedFeatureFlag.isLoading ||
+          widgetAdvancedFeatureFlag.isEnabled,
       }),
     [
       starterVariant,
       limitOrdersFeatureFlag.isEnabled,
+      limitOrdersFeatureFlag.isLoading,
       privateSwapsFeatureFlag.isEnabled,
+      privateSwapsFeatureFlag.isLoading,
       widgetAdvancedFeatureFlag.isEnabled,
+      widgetAdvancedFeatureFlag.isLoading,
     ],
   );
 
@@ -107,6 +132,33 @@ export function Widget({
         : resolvedVariant,
     [disableTabNavigation, resolvedVariant],
   );
+
+  const globalActiveNavigationTab = useActiveNavigationTab();
+  const activeTabKey = resolveActiveNavigationTab({
+    type: 'main',
+    resolvedVariant: effectiveVariant,
+    globalActiveNavigationTab,
+  });
+
+  // Keep the widget mounted. On tab change, write placeholders (or clear) into
+  // the existing FormStore so navigation state is preserved.
+  const previousActiveTabKeyRef = useRef(activeTabKey);
+  useLayoutEffect(() => {
+    const previous = previousActiveTabKeyRef.current;
+    previousActiveTabKeyRef.current = activeTabKey;
+    if (!previous || !activeTabKey || previous === activeTabKey) {
+      return;
+    }
+
+    clearWidgetChainTokenCache();
+    setSeedChainTokensFromConfig(false);
+
+    const placeholders = resolveWidgetPlaceholderTokens(
+      starterVariant,
+      activeTabKey,
+    );
+    applyWidgetChainTokenFields(formRef.current, placeholders ?? null);
+  }, [activeTabKey, starterVariant]);
 
   useEffect(() => {
     const routes = [AppPaths.Main, AppPaths.Advanced].filter(
@@ -157,7 +209,17 @@ export function Widget({
     toChain,
     toToken,
     fromAmount,
+    starterVariant,
+    activeTabKey,
   });
+
+  const formData = useMemo(() => {
+    if (seedChainTokensFromConfig) {
+      return formParametersCtx;
+    }
+
+    return fromAmount ? { fromAmount } : {};
+  }, [formParametersCtx, fromAmount, seedChainTokensFromConfig]);
 
   const context: MainWidgetContext = useMemo(
     () => ({
@@ -165,7 +227,7 @@ export function Widget({
       starterVariant,
       resolvedVariant: effectiveVariant,
       partnerName,
-      formData: formParametersCtx,
+      formData,
       allowFromChains: allowFromChains,
       allowToChains,
       bridgeConditions,
@@ -176,7 +238,7 @@ export function Widget({
       starterVariant,
       effectiveVariant,
       partnerName,
-      formParametersCtx,
+      formData,
       allowFromChains,
       allowToChains,
       bridgeConditions,

--- a/src/components/Widgets/Widget.tsx
+++ b/src/components/Widgets/Widget.tsx
@@ -25,9 +25,11 @@ import {
   applyWidgetChainTokenFields,
   clearWidgetChainTokenCache,
   consumeWidgetSurfaceNavigation,
+  getUrlChainTokenParams,
   resolveActiveNavigationTab,
   resolveWidgetPlaceholderTokens,
   resolveWidgetVariant,
+  writeUrlChainTokenParams,
 } from './variants/widgetConfig/utils';
 import { WidgetWrapper } from './Widget.style';
 import type { WidgetProps } from './Widget.types';
@@ -143,6 +145,9 @@ export function Widget({
   // Keep the widget mounted. On tab change, write placeholders (or clear) into
   // the existing FormStore so navigation state is preserved.
   const previousActiveTabKeyRef = useRef(activeTabKey);
+  const pendingTabApplyRef = useRef<typeof activeTabKey>(null);
+  const needsRemountReseedRef = useRef(false);
+
   useLayoutEffect(() => {
     const previous = previousActiveTabKeyRef.current;
     previousActiveTabKeyRef.current = activeTabKey;
@@ -151,14 +156,66 @@ export function Widget({
     }
 
     clearWidgetChainTokenCache();
-    setSeedChainTokensFromConfig(false);
 
-    const placeholders = resolveWidgetPlaceholderTokens(
-      starterVariant,
-      activeTabKey,
+    // Tab flipped while LiFiWidget is gated (null formRef): do not latch off —
+    // otherwise a later remount seeds an empty form. Apply when form is ready.
+    if (!formRef.current) {
+      pendingTabApplyRef.current = activeTabKey;
+      return;
+    }
+
+    setSeedChainTokensFromConfig(false);
+    needsRemountReseedRef.current = true;
+    applyWidgetChainTokenFields(
+      formRef.current,
+      resolveWidgetPlaceholderTokens(starterVariant, activeTabKey) ?? null,
     );
-    applyWidgetChainTokenFields(formRef.current, placeholders ?? null);
   }, [activeTabKey, starterVariant]);
+
+  const handleFormReady = () => {
+    const pendingTab = pendingTabApplyRef.current;
+    const shouldReseed = pendingTab != null || needsRemountReseedRef.current;
+
+    if (shouldReseed && formRef.current) {
+      pendingTabApplyRef.current = null;
+      needsRemountReseedRef.current = false;
+      setSeedChainTokensFromConfig(false);
+
+      const tabKey = pendingTab ?? activeTabKey;
+      const placeholders = resolveWidgetPlaceholderTokens(
+        starterVariant,
+        tabKey,
+      );
+      const liveUrl = getUrlChainTokenParams();
+      const tokens = placeholders
+        ? {
+            fromChain: liveUrl.fromChain ?? placeholders.fromChain,
+            fromToken: liveUrl.fromToken ?? placeholders.fromToken,
+            toChain: liveUrl.toChain ?? placeholders.toChain,
+            toToken: liveUrl.toToken ?? placeholders.toToken,
+          }
+        : null;
+
+      applyWidgetChainTokenFields(formRef.current, tokens);
+      return;
+    }
+
+    // Cold config seed does not write the query string; mirror placeholders so
+    // URL-driven panels (Market Price on Limit) match the form.
+    const liveUrl = getUrlChainTokenParams();
+    const hasUrlPair =
+      liveUrl.fromChain != null ||
+      liveUrl.fromToken != null ||
+      liveUrl.toChain != null ||
+      liveUrl.toToken != null;
+    if (hasUrlPair) {
+      return;
+    }
+
+    writeUrlChainTokenParams(
+      resolveWidgetPlaceholderTokens(starterVariant, activeTabKey) ?? null,
+    );
+  };
 
   useEffect(() => {
     const routes = [AppPaths.Main, AppPaths.Advanced].filter(
@@ -261,6 +318,7 @@ export function Widget({
         ctx={context}
         formRef={formRef}
         isLoading={isLoading}
+        onFormReady={handleFormReady}
       />
       {isPrivateSwapModalOpen && (
         <PrivateSwapModal

--- a/src/components/Widgets/WidgetEvents.tsx
+++ b/src/components/Widgets/WidgetEvents.tsx
@@ -194,11 +194,12 @@ export function WidgetEvents() {
         return;
       }
       if (formFieldData?.fieldName === 'fromToken') {
-        setFromToken(formFieldData.newValue);
+        // Empty string blocks placeholder fallback via `??` — store as unset.
+        setFromToken(formFieldData.newValue || undefined);
         return;
       }
       if (formFieldData?.fieldName === 'toToken') {
-        setToToken(formFieldData.newValue);
+        setToToken(formFieldData.newValue || undefined);
         return;
       }
     };

--- a/src/components/Widgets/hooks.spec.ts
+++ b/src/components/Widgets/hooks.spec.ts
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+
+import { ChainId } from '@lifi/sdk';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ETH_NATIVE, ETH_USDC, SOL_USDC } from '@/config/tokens';
+import { useWidgetCacheStore } from '@/stores/widgetCache';
+import { useFormParameters } from './hooks';
+
+vi.mock('@/stores/theme', () => ({
+  useThemeStore: (selector: (state: { configTheme: undefined }) => unknown) =>
+    selector({ configTheme: undefined }),
+}));
+
+const setSearch = (search: string) => {
+  window.history.replaceState({}, '', search ? `/${search}` : '/');
+};
+
+describe('useFormParameters', () => {
+  beforeEach(() => {
+    setSearch('');
+    useWidgetCacheStore.setState({
+      fromToken: undefined,
+      fromChainId: undefined,
+      toToken: undefined,
+      toChainId: undefined,
+    });
+  });
+
+  it('falls back to main-widget placeholders when nothing else is set', () => {
+    const { result } = renderHook(() =>
+      useFormParameters({
+        starterVariant: 'default',
+        activeTabKey: 'default',
+      }),
+    );
+
+    expect(result.current).toEqual({
+      sourceChain: { chainId: String(ChainId.ETH), chainKey: '' },
+      sourceToken: { tokenAddress: ETH_USDC, tokenSymbol: '' },
+      destinationChain: { chainId: String(ChainId.SOL), chainKey: '' },
+      destinationToken: { tokenAddress: SOL_USDC, tokenSymbol: '' },
+    });
+  });
+
+  it('uses advanced swap placeholders for the swap-advanced tab', () => {
+    const { result } = renderHook(() =>
+      useFormParameters({
+        starterVariant: 'advanced',
+        activeTabKey: 'swap-advanced',
+      }),
+    );
+
+    expect(result.current).toEqual({
+      sourceChain: { chainId: String(ChainId.ETH), chainKey: '' },
+      sourceToken: { tokenAddress: ETH_NATIVE, tokenSymbol: '' },
+      destinationChain: { chainId: String(ChainId.ETH), chainKey: '' },
+      destinationToken: { tokenAddress: ETH_USDC, tokenSymbol: '' },
+    });
+  });
+
+  it('leaves Private and Gas empty', () => {
+    const { result: privateResult } = renderHook(() =>
+      useFormParameters({
+        starterVariant: 'default',
+        activeTabKey: 'private',
+      }),
+    );
+    const { result: gasResult } = renderHook(() =>
+      useFormParameters({
+        starterVariant: 'default',
+        activeTabKey: 'refuel',
+      }),
+    );
+
+    expect(privateResult.current).toEqual({});
+    expect(gasResult.current).toEqual({});
+  });
+
+  it('ignores URL on Private and Gas so Exchange pairs do not seed those tabs', () => {
+    setSearch('?fromChain=42161&fromToken=0xarb&toChain=1&toToken=0xethusdc');
+
+    const { result: gasResult } = renderHook(() =>
+      useFormParameters({
+        starterVariant: 'default',
+        activeTabKey: 'refuel',
+      }),
+    );
+
+    expect(gasResult.current).toEqual({});
+    expect(window.location.search).toContain('fromChain=42161');
+  });
+
+  it('prefers URL params over placeholders on cold load', () => {
+    setSearch('?fromChain=42161&fromToken=0xarb&toChain=1&toToken=0xethusdc');
+
+    const { result } = renderHook(() =>
+      useFormParameters({
+        starterVariant: 'default',
+        activeTabKey: 'default',
+      }),
+    );
+
+    expect(result.current).toEqual({
+      sourceChain: { chainId: '42161', chainKey: '' },
+      sourceToken: { tokenAddress: '0xarb', tokenSymbol: '' },
+      destinationChain: { chainId: '1', chainKey: '' },
+      destinationToken: { tokenAddress: '0xethusdc', tokenSymbol: '' },
+    });
+  });
+
+  it('prefers widget cache over placeholders (wallet balance card)', () => {
+    act(() => {
+      useWidgetCacheStore.getState().setFrom('0xcache', ChainId.ARB);
+      useWidgetCacheStore.getState().setTo(ETH_USDC, ChainId.ETH);
+    });
+
+    const { result } = renderHook(() =>
+      useFormParameters({
+        starterVariant: 'default',
+        activeTabKey: 'default',
+      }),
+    );
+
+    expect(result.current).toEqual({
+      sourceChain: { chainId: String(ChainId.ARB), chainKey: '' },
+      sourceToken: { tokenAddress: '0xcache', tokenSymbol: '' },
+      destinationChain: { chainId: String(ChainId.ETH), chainKey: '' },
+      destinationToken: { tokenAddress: ETH_USDC, tokenSymbol: '' },
+    });
+  });
+
+  it('fills missing to-side from placeholders when wallet sets from-only cache', () => {
+    act(() => {
+      useWidgetCacheStore.getState().setFrom(ETH_USDC, ChainId.ETH);
+    });
+
+    const { result } = renderHook(() =>
+      useFormParameters({
+        starterVariant: 'advanced',
+        activeTabKey: 'swap-advanced',
+      }),
+    );
+
+    expect(result.current).toEqual({
+      sourceChain: { chainId: String(ChainId.ETH), chainKey: '' },
+      sourceToken: { tokenAddress: ETH_USDC, tokenSymbol: '' },
+      destinationChain: { chainId: String(ChainId.ETH), chainKey: '' },
+      destinationToken: { tokenAddress: ETH_USDC, tokenSymbol: '' },
+    });
+  });
+
+  it('ignores empty-string cache tokens so placeholders still fill', () => {
+    act(() => {
+      useWidgetCacheStore.setState({
+        fromToken: '',
+        toToken: '',
+        fromChainId: undefined,
+        toChainId: undefined,
+      });
+    });
+
+    const { result } = renderHook(() =>
+      useFormParameters({
+        starterVariant: 'default',
+        activeTabKey: 'default',
+      }),
+    );
+
+    expect(result.current.sourceToken?.tokenAddress).toBe(ETH_USDC);
+    expect(result.current.destinationToken?.tokenAddress).toBe(SOL_USDC);
+  });
+
+  it('does not pick up URL changes after the initial mount snapshot', () => {
+    setSearch('?fromChain=1&fromToken=0xfirst&toChain=1&toToken=0xfirstto');
+
+    const { result, rerender } = renderHook(() =>
+      useFormParameters({
+        starterVariant: 'default',
+        activeTabKey: 'default',
+      }),
+    );
+
+    expect(result.current.sourceToken?.tokenAddress).toBe('0xfirst');
+
+    setSearch('?fromChain=10&fromToken=0xsecond&toChain=10&toToken=0xsecondto');
+    rerender();
+
+    expect(result.current.sourceToken?.tokenAddress).toBe('0xfirst');
+  });
+
+  it('prefers explicit props over placeholders', () => {
+    const { result } = renderHook(() =>
+      useFormParameters({
+        starterVariant: 'default',
+        activeTabKey: 'default',
+        fromChain: ChainId.OPT,
+        fromToken: '0xprop',
+        toChain: ChainId.BAS,
+        toToken: '0xbas',
+      }),
+    );
+
+    expect(result.current).toEqual({
+      sourceChain: { chainId: String(ChainId.OPT), chainKey: '' },
+      sourceToken: { tokenAddress: '0xprop', tokenSymbol: '' },
+      destinationChain: { chainId: String(ChainId.BAS), chainKey: '' },
+      destinationToken: { tokenAddress: '0xbas', tokenSymbol: '' },
+    });
+  });
+});

--- a/src/components/Widgets/hooks.spec.ts
+++ b/src/components/Widgets/hooks.spec.ts
@@ -189,6 +189,24 @@ describe('useFormParameters', () => {
     expect(result.current.sourceToken?.tokenAddress).toBe('0xfirst');
   });
 
+  it('ignores junk URL chain params and falls back to placeholders', () => {
+    setSearch('?fromChain=abc&fromToken=xyz&toChain=1&toToken=0xok');
+
+    const { result } = renderHook(() =>
+      useFormParameters({
+        starterVariant: 'default',
+        activeTabKey: 'default',
+      }),
+    );
+
+    expect(result.current).toEqual({
+      sourceChain: { chainId: String(ChainId.ETH), chainKey: '' },
+      sourceToken: { tokenAddress: ETH_USDC, tokenSymbol: '' },
+      destinationChain: { chainId: '1', chainKey: '' },
+      destinationToken: { tokenAddress: '0xok', tokenSymbol: '' },
+    });
+  });
+
   it('prefers explicit props over placeholders', () => {
     const { result } = renderHook(() =>
       useFormParameters({

--- a/src/components/Widgets/hooks.ts
+++ b/src/components/Widgets/hooks.ts
@@ -1,6 +1,13 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
+import type { NavigationTabKey } from '@jumperexchange/widget';
 import { useThemeStore } from '@/stores/theme';
 import { useWidgetCacheStore } from '@/stores/widgetCache';
+import type { StarterVariantType } from '@/types/internal';
+import type { FormData } from './variants/widgetConfig/types';
+import {
+  getUrlChainTokenParams,
+  resolveWidgetPlaceholderTokens,
+} from './variants/widgetConfig/utils';
 
 interface UseFormParametersProps {
   fromChain?: number;
@@ -8,60 +15,124 @@ interface UseFormParametersProps {
   toChain?: number;
   toToken?: string;
   fromAmount?: string;
+  starterVariant?: StarterVariantType;
+  activeTabKey?: NavigationTabKey | null;
 }
 
+const isEmptyPlaceholderSurface = (
+  starterVariant?: StarterVariantType,
+  activeTabKey?: NavigationTabKey | null,
+) =>
+  activeTabKey === 'refuel' ||
+  activeTabKey === 'private' ||
+  starterVariant === 'refuel' ||
+  starterVariant === 'private';
+
+/** WidgetEvents sometimes mirrors cleared fields as "". Treat those as unset. */
+const nonemptyToken = (value?: string | null) =>
+  value != null && value !== '' ? value : undefined;
+
+type UrlChainTokenParams = ReturnType<typeof getUrlChainTokenParams>;
+
+/**
+ * Cold-load form seed only. Priority per field:
+ * partner theme → props → session cache → URL → placeholders.
+ * Private / Gas stay empty.
+ *
+ * URL is snapshotted once per mount so a sibling page's buildUrl cannot
+ * re-pollute this instance mid-lifecycle (Simple ↔ Advanced dual mount).
+ *
+ * Tab switches apply pairs via `applyWidgetChainTokenFields` and stop feeding
+ * chain/token through config (`seedChainTokensFromConfig` in Widget).
+ */
 export const useFormParameters = ({
   fromChain,
   fromToken,
   toChain,
   toToken,
   fromAmount,
-}: UseFormParametersProps) => {
+  starterVariant,
+  activeTabKey,
+}: UseFormParametersProps): FormData => {
   const configTheme = useThemeStore((state) => state.configTheme);
   const widgetCache = useWidgetCacheStore((state) => state);
+  const urlSnapshotRef = useRef<UrlChainTokenParams | null>(null);
+  if (urlSnapshotRef.current === null) {
+    urlSnapshotRef.current = getUrlChainTokenParams();
+  }
+  const url = urlSnapshotRef.current;
 
-  const formParametersCtx = useMemo(() => {
-    const params: Record<
-      string,
-      | number
-      | string
-      | { chainId: string | number | undefined }
-      | { tokenAddress: string | number | undefined }
-      | undefined
-    > = {};
+  return useMemo(() => {
+    if (isEmptyPlaceholderSurface(starterVariant, activeTabKey)) {
+      return {};
+    }
+
+    const placeholders =
+      starterVariant !== undefined
+        ? resolveWidgetPlaceholderTokens(starterVariant, activeTabKey)
+        : undefined;
 
     const sourceChainId =
-      configTheme?.fromChain ?? fromChain ?? widgetCache.fromChainId;
+      configTheme?.fromChain ??
+      fromChain ??
+      widgetCache.fromChainId ??
+      url.fromChain ??
+      placeholders?.fromChain;
 
     const sourceTokenAddress =
-      configTheme?.fromToken ?? fromToken ?? widgetCache.fromToken;
+      nonemptyToken(configTheme?.fromToken) ??
+      nonemptyToken(fromToken) ??
+      nonemptyToken(widgetCache.fromToken) ??
+      nonemptyToken(url.fromToken) ??
+      placeholders?.fromToken;
 
     const destinationChainId =
-      configTheme?.toChain ?? toChain ?? widgetCache.toChainId;
+      configTheme?.toChain ??
+      toChain ??
+      widgetCache.toChainId ??
+      url.toChain ??
+      placeholders?.toChain;
 
     const destinationTokenAddress =
-      configTheme?.toToken ?? toToken ?? widgetCache.toToken;
+      nonemptyToken(configTheme?.toToken) ??
+      nonemptyToken(toToken) ??
+      nonemptyToken(widgetCache.toToken) ??
+      nonemptyToken(url.toToken) ??
+      placeholders?.toToken;
 
-    const amount = fromAmount;
+    const formData: FormData = {};
 
-    if (sourceChainId) {
-      params.sourceChain = { chainId: sourceChainId };
+    if (sourceChainId != null) {
+      formData.sourceChain = {
+        chainId: String(sourceChainId),
+        chainKey: '',
+      };
     }
     if (sourceTokenAddress) {
-      params.sourceToken = { tokenAddress: sourceTokenAddress };
+      formData.sourceToken = {
+        tokenAddress: sourceTokenAddress,
+        tokenSymbol: '',
+      };
     }
-    if (destinationChainId) {
-      params.destinationChain = { chainId: destinationChainId };
+    if (destinationChainId != null) {
+      formData.destinationChain = {
+        chainId: String(destinationChainId),
+        chainKey: '',
+      };
     }
     if (destinationTokenAddress) {
-      params.destinationToken = { tokenAddress: destinationTokenAddress };
+      formData.destinationToken = {
+        tokenAddress: destinationTokenAddress,
+        tokenSymbol: '',
+      };
     }
-    if (amount) {
-      params.fromAmount = amount;
+    if (fromAmount) {
+      formData.fromAmount = fromAmount;
     }
 
-    return params;
+    return formData;
   }, [
+    activeTabKey,
     configTheme?.fromChain,
     configTheme?.fromToken,
     configTheme?.toChain,
@@ -69,13 +140,16 @@ export const useFormParameters = ({
     fromAmount,
     fromChain,
     fromToken,
+    starterVariant,
     toChain,
     toToken,
+    url.fromChain,
+    url.fromToken,
+    url.toChain,
+    url.toToken,
     widgetCache.fromChainId,
     widgetCache.fromToken,
     widgetCache.toChainId,
     widgetCache.toToken,
   ]);
-
-  return formParametersCtx;
 };

--- a/src/components/Widgets/variants/base/Widget.tsx
+++ b/src/components/Widgets/variants/base/Widget.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react';
+import { useEffect, useRef } from 'react';
 import {
   LiFiWidget,
   WidgetSkeleton as LifiWidgetSkeleton,
@@ -7,12 +8,28 @@ import type { WidgetProps } from './Widget.types';
 import { useWidgetConfig } from '../widgetConfig/useWidgetConfig';
 import { ClientOnly } from '@/components/ClientOnly';
 
-export const Widget: FC<WidgetProps> = ({ ctx, type, formRef, isLoading }) => {
+export const Widget: FC<WidgetProps> = ({
+  ctx,
+  type,
+  formRef,
+  isLoading,
+  onFormReady,
+}) => {
   const { config, isReady } = useWidgetConfig(type, ctx);
+  const showWidget = isReady && !isLoading;
+  const onFormReadyRef = useRef(onFormReady);
+  onFormReadyRef.current = onFormReady;
+
+  useEffect(() => {
+    if (!showWidget) {
+      return;
+    }
+    onFormReadyRef.current?.();
+  }, [showWidget]);
 
   return (
     <ClientOnly fallback={<LifiWidgetSkeleton config={config} />}>
-      {isReady && !isLoading ? (
+      {showWidget ? (
         <LiFiWidget
           config={config}
           integrator={config.integrator}

--- a/src/components/Widgets/variants/base/Widget.types.ts
+++ b/src/components/Widgets/variants/base/Widget.types.ts
@@ -12,4 +12,6 @@ export interface WidgetProps extends EntityWidgetProps {
   type: WidgetType;
   formRef?: FormRef;
   isLoading?: boolean;
+  /** Fires whenever LiFiWidget is mounted/shown (including after readiness remounts). */
+  onFormReady?: () => void;
 }

--- a/src/components/Widgets/variants/widgetConfig/utils.spec.ts
+++ b/src/components/Widgets/variants/widgetConfig/utils.spec.ts
@@ -189,6 +189,17 @@ describe('getUrlChainTokenParams', () => {
       toToken: 'EPjFWdd5',
     });
   });
+
+  it('ignores non-numeric chain params so placeholders are not blocked', () => {
+    setSearch('?fromChain=abc&fromToken=xyz&toChain=nope&toToken=zzz');
+
+    expect(getUrlChainTokenParams()).toEqual({
+      fromChain: undefined,
+      fromToken: undefined,
+      toChain: undefined,
+      toToken: undefined,
+    });
+  });
 });
 
 describe('clearWidgetChainTokenCache', () => {
@@ -224,7 +235,11 @@ describe('clearUrlChainTokenParams', () => {
 });
 
 describe('applyWidgetChainTokenFields', () => {
-  it('writes placeholder pairs onto the form', () => {
+  beforeEach(() => {
+    setSearch('');
+  });
+
+  it('writes placeholder pairs onto the form and URL', () => {
     const setFieldValue = vi.fn();
 
     applyWidgetChainTokenFields({ setFieldValue } as never, {
@@ -240,9 +255,16 @@ describe('applyWidgetChainTokenFields', () => {
       ['toChain', ChainId.SOL],
       ['toToken', SOL_USDC],
     ]);
+    expect(getUrlChainTokenParams()).toEqual({
+      fromChain: ChainId.ETH,
+      fromToken: ETH_USDC,
+      toChain: ChainId.SOL,
+      toToken: SOL_USDC,
+    });
   });
 
-  it('clears from/to when tokens are null', () => {
+  it('clears from/to on the form and URL when tokens are null', () => {
+    setSearch('?fromChain=1&fromToken=0x&toChain=1&toToken=0y&foo=1');
     const setFieldValue = vi.fn();
 
     applyWidgetChainTokenFields({ setFieldValue } as never, null);
@@ -253,5 +275,6 @@ describe('applyWidgetChainTokenFields', () => {
       ['toChain', undefined],
       ['toToken', undefined],
     ]);
+    expect(window.location.search).toBe('?foo=1');
   });
 });

--- a/src/components/Widgets/variants/widgetConfig/utils.spec.ts
+++ b/src/components/Widgets/variants/widgetConfig/utils.spec.ts
@@ -1,5 +1,23 @@
-import { describe, it, expect } from 'vitest';
-import { resolveActiveNavigationTab, resolveWidgetKeyPrefix } from './utils';
+// @vitest-environment jsdom
+
+import { ChainId } from '@lifi/sdk';
+import { act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ETH_NATIVE, ETH_USDC, SOL_USDC } from '@/config/tokens';
+import { useWidgetCacheStore } from '@/stores/widgetCache';
+import {
+  applyWidgetChainTokenFields,
+  clearUrlChainTokenParams,
+  clearWidgetChainTokenCache,
+  getUrlChainTokenParams,
+  resolveActiveNavigationTab,
+  resolveWidgetKeyPrefix,
+  resolveWidgetPlaceholderTokens,
+} from './utils';
+
+const setSearch = (search: string) => {
+  window.history.replaceState({}, '', search ? `/${search}` : '/');
+};
 
 describe('resolveActiveNavigationTab', () => {
   it('ignores the global tab for an instance that does not own navigation tabs', () => {
@@ -74,5 +92,166 @@ describe('resolveWidgetKeyPrefix', () => {
 
   it('uses its own namespace for the private tab', () => {
     expect(resolveWidgetKeyPrefix('default', 'private')).toBe('private');
+  });
+});
+
+describe('resolveWidgetPlaceholderTokens', () => {
+  it('returns Ethereum USDC → Solana USDC for the main widget', () => {
+    expect(resolveWidgetPlaceholderTokens('default')).toEqual({
+      fromChain: ChainId.ETH,
+      fromToken: ETH_USDC,
+      toChain: ChainId.SOL,
+      toToken: SOL_USDC,
+    });
+  });
+
+  it('returns Ethereum ETH → USDC for advanced swap', () => {
+    expect(resolveWidgetPlaceholderTokens('advanced', 'swap-advanced')).toEqual(
+      {
+        fromChain: ChainId.ETH,
+        fromToken: ETH_NATIVE,
+        toChain: ChainId.ETH,
+        toToken: ETH_USDC,
+      },
+    );
+  });
+
+  it('returns Ethereum USDC → Solana USDC for advanced bridge', () => {
+    expect(
+      resolveWidgetPlaceholderTokens('advanced', 'bridge-advanced'),
+    ).toEqual({
+      fromChain: ChainId.ETH,
+      fromToken: ETH_USDC,
+      toChain: ChainId.SOL,
+      toToken: SOL_USDC,
+    });
+  });
+
+  it('returns Ethereum USDC → ETH for advanced limit', () => {
+    expect(resolveWidgetPlaceholderTokens('advanced', 'limit')).toEqual({
+      fromChain: ChainId.ETH,
+      fromToken: ETH_USDC,
+      toChain: ChainId.ETH,
+      toToken: ETH_NATIVE,
+    });
+  });
+
+  it('defaults advanced without a resolved tab to the swap pair', () => {
+    expect(resolveWidgetPlaceholderTokens('advanced')).toEqual({
+      fromChain: ChainId.ETH,
+      fromToken: ETH_NATIVE,
+      toChain: ChainId.ETH,
+      toToken: ETH_USDC,
+    });
+  });
+
+  it('returns undefined for compact variants without placeholders', () => {
+    expect(resolveWidgetPlaceholderTokens('swap')).toBeUndefined();
+    expect(resolveWidgetPlaceholderTokens('bridge')).toBeUndefined();
+    expect(resolveWidgetPlaceholderTokens('blog')).toBeUndefined();
+    expect(resolveWidgetPlaceholderTokens('refuel')).toBeUndefined();
+  });
+
+  it('does not seed placeholders on the Gas/refuel tab', () => {
+    expect(resolveWidgetPlaceholderTokens('default', 'refuel')).toBeUndefined();
+  });
+
+  it('does not seed placeholders on the Private tab', () => {
+    expect(
+      resolveWidgetPlaceholderTokens('default', 'private'),
+    ).toBeUndefined();
+  });
+
+  it('seeds only the Exchange tab on the default variant', () => {
+    expect(resolveWidgetPlaceholderTokens('default', 'default')).toEqual({
+      fromChain: ChainId.ETH,
+      fromToken: ETH_USDC,
+      toChain: ChainId.SOL,
+      toToken: SOL_USDC,
+    });
+  });
+});
+
+describe('getUrlChainTokenParams', () => {
+  beforeEach(() => {
+    setSearch('');
+  });
+
+  it('parses from/to chain and token from the query string', () => {
+    setSearch(
+      '?fromChain=1&fromToken=0xfrom&toChain=1151111081099710&toToken=EPjFWdd5',
+    );
+
+    expect(getUrlChainTokenParams()).toEqual({
+      fromChain: 1,
+      fromToken: '0xfrom',
+      toChain: 1151111081099710,
+      toToken: 'EPjFWdd5',
+    });
+  });
+});
+
+describe('clearWidgetChainTokenCache', () => {
+  it('clears cached from/to chain and token', () => {
+    act(() => {
+      useWidgetCacheStore.getState().setFrom('0xcache', ChainId.ARB);
+      useWidgetCacheStore.getState().setTo(ETH_USDC, ChainId.ETH);
+    });
+
+    clearWidgetChainTokenCache();
+
+    expect(useWidgetCacheStore.getState()).toMatchObject({
+      fromToken: undefined,
+      fromChainId: undefined,
+      toToken: undefined,
+      toChainId: undefined,
+    });
+  });
+});
+
+describe('clearUrlChainTokenParams', () => {
+  beforeEach(() => {
+    setSearch('');
+  });
+
+  it('removes from/to params and leaves unrelated query intact', () => {
+    setSearch('?tab=gas&fromChain=1&fromToken=0x&toChain=1&toToken=0y&foo=1');
+
+    clearUrlChainTokenParams();
+
+    expect(window.location.search).toBe('?tab=gas&foo=1');
+  });
+});
+
+describe('applyWidgetChainTokenFields', () => {
+  it('writes placeholder pairs onto the form', () => {
+    const setFieldValue = vi.fn();
+
+    applyWidgetChainTokenFields({ setFieldValue } as never, {
+      fromChain: ChainId.ETH,
+      fromToken: ETH_USDC,
+      toChain: ChainId.SOL,
+      toToken: SOL_USDC,
+    });
+
+    expect(setFieldValue.mock.calls).toEqual([
+      ['fromChain', ChainId.ETH],
+      ['fromToken', ETH_USDC],
+      ['toChain', ChainId.SOL],
+      ['toToken', SOL_USDC],
+    ]);
+  });
+
+  it('clears from/to when tokens are null', () => {
+    const setFieldValue = vi.fn();
+
+    applyWidgetChainTokenFields({ setFieldValue } as never, null);
+
+    expect(setFieldValue.mock.calls).toEqual([
+      ['fromChain', undefined],
+      ['fromToken', undefined],
+      ['toChain', undefined],
+      ['toToken', undefined],
+    ]);
   });
 });

--- a/src/components/Widgets/variants/widgetConfig/utils.ts
+++ b/src/components/Widgets/variants/widgetConfig/utils.ts
@@ -196,6 +196,15 @@ export const resolveWidgetPlaceholderTokens = (
   return undefined;
 };
 
+/** Parses a chain id query value; rejects NaN / non-finite junk. */
+const parseUrlChainId = (raw: string | null): number | undefined => {
+  if (raw == null || raw === '') {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
 /** Synchronous URL read for cold-load deep links. */
 export const getUrlChainTokenParams = () => {
   if (typeof window === 'undefined') {
@@ -203,14 +212,25 @@ export const getUrlChainTokenParams = () => {
   }
 
   const query = new URLSearchParams(window.location.search);
-  const fromChain = query.get('fromChain');
-  const toChain = query.get('toChain');
+  const fromChainRaw = query.get('fromChain');
+  const toChainRaw = query.get('toChain');
+  const fromChain = parseUrlChainId(fromChainRaw);
+  const toChain = parseUrlChainId(toChainRaw);
+
+  // Junk chain params (e.g. fromChain=abc → NaN) must not block placeholders.
+  // Drop the matching token when the chain query was present but invalid.
+  const fromTokenRaw = query.get('fromToken') ?? undefined;
+  const toTokenRaw = query.get('toToken') ?? undefined;
 
   return {
-    fromChain: fromChain ? Number.parseInt(fromChain, 10) : undefined,
-    fromToken: query.get('fromToken') ?? undefined,
-    toChain: toChain ? Number.parseInt(toChain, 10) : undefined,
-    toToken: query.get('toToken') ?? undefined,
+    fromChain,
+    fromToken:
+      fromChainRaw != null && fromChain === undefined
+        ? undefined
+        : fromTokenRaw,
+    toChain,
+    toToken:
+      toChainRaw != null && toChain === undefined ? undefined : toTokenRaw,
   };
 };
 
@@ -246,6 +266,27 @@ export const clearUrlChainTokenParams = () => {
   if (changed) {
     window.history.replaceState(window.history.state, '', url);
   }
+};
+
+/** Writes from/to query params so URL-driven UI (e.g. Market Price) matches the form. */
+export const writeUrlChainTokenParams = (
+  tokens: WidgetPlaceholderTokens | null,
+) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (!tokens) {
+    clearUrlChainTokenParams();
+    return;
+  }
+
+  const url = new URL(window.location.href);
+  url.searchParams.set('fromChain', String(tokens.fromChain));
+  url.searchParams.set('fromToken', tokens.fromToken);
+  url.searchParams.set('toChain', String(tokens.toChain));
+  url.searchParams.set('toToken', tokens.toToken);
+  window.history.replaceState(window.history.state, '', url);
 };
 
 /**
@@ -287,13 +328,16 @@ export const applyWidgetChainTokenFields = (
     form.setFieldValue('fromToken', tokens.fromToken);
     form.setFieldValue('toChain', tokens.toChain);
     form.setFieldValue('toToken', tokens.toToken);
-    return;
+  } else {
+    form.setFieldValue('fromChain', undefined);
+    form.setFieldValue('fromToken', undefined);
+    form.setFieldValue('toChain', undefined);
+    form.setFieldValue('toToken', undefined);
   }
 
-  form.setFieldValue('fromChain', undefined);
-  form.setFieldValue('fromToken', undefined);
-  form.setFieldValue('toChain', undefined);
-  form.setFieldValue('toToken', undefined);
+  // Config/form seed does not always flow into the query string; URL-driven
+  // panels (Market Price) need an explicit sync.
+  writeUrlChainTokenParams(tokens);
 };
 
 export const generateRouteLabel = (

--- a/src/components/Widgets/variants/widgetConfig/utils.ts
+++ b/src/components/Widgets/variants/widgetConfig/utils.ts
@@ -1,12 +1,15 @@
 import type { Theme } from '@mui/material/styles';
 import type {
+  FormState,
   NavigationTabKey,
   Route,
   RouteLabelRule,
 } from '@jumperexchange/widget';
-import { ChainType } from '@jumperexchange/widget';
+import { ChainId, ChainType } from '@jumperexchange/widget';
+import { ETH_NATIVE, ETH_USDC, SOL_USDC } from '@/config/tokens';
 import type { StarterVariantType } from '@/types/internal';
 import type { LimitOrder } from '@/types/jumper-backend';
+import { useWidgetCacheStore } from '@/stores/widgetCache';
 import type {
   FormData,
   WidgetFeatureFlags,
@@ -119,6 +122,179 @@ export function resolveWidgetKeyPrefix(
     ? activeTabKey
     : key;
 }
+
+export interface WidgetPlaceholderTokens {
+  fromChain: number;
+  fromToken: string;
+  toChain: number;
+  toToken: string;
+}
+
+const ethUsdcToSolUsdc = (): WidgetPlaceholderTokens => ({
+  fromChain: ChainId.ETH,
+  fromToken: ETH_USDC,
+  toChain: ChainId.SOL,
+  toToken: SOL_USDC,
+});
+
+const ethNativeToEthUsdc = (): WidgetPlaceholderTokens => ({
+  fromChain: ChainId.ETH,
+  fromToken: ETH_NATIVE,
+  toChain: ChainId.ETH,
+  toToken: ETH_USDC,
+});
+
+/** Limit protocols (CoW / 1inch) do not support native ETH as the sell token. */
+const ethUsdcToEthNative = (): WidgetPlaceholderTokens => ({
+  fromChain: ChainId.ETH,
+  fromToken: ETH_USDC,
+  toChain: ChainId.ETH,
+  toToken: ETH_NATIVE,
+});
+
+/**
+ * Default from/to pair when the widget has no higher-priority source
+ * (partner theme, props, or URL). Private and Gas stay empty.
+ */
+export const resolveWidgetPlaceholderTokens = (
+  starterVariant: StarterVariantType,
+  activeTabKey?: NavigationTabKey | null,
+): WidgetPlaceholderTokens | undefined => {
+  if (
+    activeTabKey === 'refuel' ||
+    activeTabKey === 'private' ||
+    starterVariant === 'refuel' ||
+    starterVariant === 'private'
+  ) {
+    return undefined;
+  }
+
+  if (activeTabKey === 'swap-advanced') {
+    return ethNativeToEthUsdc();
+  }
+
+  if (activeTabKey === 'limit') {
+    return ethUsdcToEthNative();
+  }
+
+  if (activeTabKey === 'bridge-advanced') {
+    return ethUsdcToSolUsdc();
+  }
+
+  if (activeTabKey === 'default') {
+    return ethUsdcToSolUsdc();
+  }
+
+  if (starterVariant === 'default' && !activeTabKey) {
+    return ethUsdcToSolUsdc();
+  }
+
+  if (starterVariant === 'advanced' && !activeTabKey) {
+    return ethNativeToEthUsdc();
+  }
+
+  return undefined;
+};
+
+/** Synchronous URL read for cold-load deep links. */
+export const getUrlChainTokenParams = () => {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+
+  const query = new URLSearchParams(window.location.search);
+  const fromChain = query.get('fromChain');
+  const toChain = query.get('toChain');
+
+  return {
+    fromChain: fromChain ? Number.parseInt(fromChain, 10) : undefined,
+    fromToken: query.get('fromToken') ?? undefined,
+    toChain: toChain ? Number.parseInt(toChain, 10) : undefined,
+    toToken: query.get('toToken') ?? undefined,
+  };
+};
+
+export const clearWidgetChainTokenCache = () => {
+  useWidgetCacheStore.setState({
+    fromToken: undefined,
+    fromChainId: undefined,
+    toToken: undefined,
+    toChainId: undefined,
+  });
+};
+
+/** Clears from/to query params (e.g. after an intentional form reset). */
+export const clearUrlChainTokenParams = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const url = new URL(window.location.href);
+  let changed = false;
+  for (const key of [
+    'fromChain',
+    'fromToken',
+    'toChain',
+    'toToken',
+    'fromAmount',
+  ] as const) {
+    if (url.searchParams.has(key)) {
+      url.searchParams.delete(key);
+      changed = true;
+    }
+  }
+  if (changed) {
+    window.history.replaceState(window.history.state, '', url);
+  }
+};
+
+/**
+ * Simple ↔ Advanced: destination Widget clears URL + cache once on mount so
+ * the departing page's buildUrl leftovers do not seed the new surface.
+ * No form-seed suppress on the departing page.
+ */
+let surfaceHandoffGeneration = 0;
+let consumedSurfaceHandoffGeneration = 0;
+
+export const prepareWidgetSurfaceNavigation = () => {
+  surfaceHandoffGeneration += 1;
+  clearWidgetChainTokenCache();
+};
+
+export const consumeWidgetSurfaceNavigation = () => {
+  if (
+    surfaceHandoffGeneration === 0 ||
+    consumedSurfaceHandoffGeneration === surfaceHandoffGeneration
+  ) {
+    return;
+  }
+  consumedSurfaceHandoffGeneration = surfaceHandoffGeneration;
+  clearUrlChainTokenParams();
+  clearWidgetChainTokenCache();
+};
+
+/** Writes from/to into the live FormStore without remounting the widget. */
+export const applyWidgetChainTokenFields = (
+  form: FormState | null | undefined,
+  tokens: WidgetPlaceholderTokens | null,
+) => {
+  if (!form) {
+    return;
+  }
+
+  if (tokens) {
+    form.setFieldValue('fromChain', tokens.fromChain);
+    form.setFieldValue('fromToken', tokens.fromToken);
+    form.setFieldValue('toChain', tokens.toChain);
+    form.setFieldValue('toToken', tokens.toToken);
+    return;
+  }
+
+  form.setFieldValue('fromChain', undefined);
+  form.setFieldValue('fromToken', undefined);
+  form.setFieldValue('toChain', undefined);
+  form.setFieldValue('toToken', undefined);
+};
 
 export const generateRouteLabel = (
   text: string,

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -3,6 +3,15 @@ import { ondoDenylist } from './generated/ondoDenylist';
 
 export const ARB_NATIVE_USDC = '0xaf88d065e77c8cc2239327c5edb3a432268e5831';
 
+/** Native ETH sentinel used by LI.FI / @jumperexchange/widget */
+export const ETH_NATIVE = '0x0000000000000000000000000000000000000000';
+
+/** Circle USDC on Ethereum */
+export const ETH_USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+
+/** Circle USDC mint on Solana */
+export const SOL_USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
 export const tokens: WidgetTokens = {
   allow: [],
   deny: ondoDenylist,

--- a/src/stores/widgetCache/WidgetCacheStore.tsx
+++ b/src/stores/widgetCache/WidgetCacheStore.tsx
@@ -1,4 +1,3 @@
-import type { StateCreator } from 'zustand';
 import { shallow } from 'zustand/shallow';
 import { createWithEqualityFn } from 'zustand/traditional';
 import type { WidgetCacheState } from '@/types/widgetCache';
@@ -13,7 +12,7 @@ const defaultSettings = {
 /*--  Use Zustand  --*/
 
 export const useWidgetCacheStore = createWithEqualityFn<WidgetCacheState>(
-  (set, get) => ({
+  (set) => ({
     ...defaultSettings,
 
     setFromToken(token?: string) {


### PR DESCRIPTION
## Summary
- Seeds default from/to placeholder pairs per surface via `resolveWidgetPlaceholderTokens` (Private / Gas stay empty):
  - Main Exchange (`default`): ETH USDC → SOL USDC
  - Advanced Swap: ETH → ETH USDC
  - Advanced Bridge: ETH USDC → SOL USDC
  - Advanced Limit: ETH USDC → ETH native
  - Private / Gas: empty
- Cold-load form seed priority per field: partner theme → props → session cache → URL → placeholders
- Empty-string tokens (e.g. from WidgetEvents clears) are treated as unset so they do not block placeholder fallback via `??`
- URL chain/token params are snapshotted once at mount so a sibling page’s `buildUrl` cannot re-pollute mid-lifecycle (`buildUrl` stays `true` on the main widget)
- Simple ↔ Advanced vertical nav: `prepareWidgetSurfaceNavigation` on click; destination Widget `consumeWidgetSurfaceNavigation` clears URL + cache before URL snapshot / form seed
- In-widget tab switches keep the widget mounted: write placeholders (or clear) with `setFieldValue`, clear session cache, and stop seeding chain/token through widget config after the first tab write so FormUpdater does not overwrite

Linear: [JUMADV-30](https://linear.app/jumper-exchange/issue/JUMADV-30)

## Test plan
- [ ] Cold load Main Exchange → ETH USDC → SOL USDC
- [ ] Cold load Advanced → Swap: ETH → ETH USDC; Bridge: ETH USDC → SOL USDC; Limit: ETH USDC → ETH native
- [ ] Private and Gas tabs stay empty (no ETH/USDC leftovers)
- [ ] Simple ↔ Advanced via vertical nav: no wipe/flicker; destination gets correct placeholders (not the other surface’s tokens)
- [ ] In-widget tab switches apply the correct pair (or clear) without remount flicker; navigation/UI state preserved
- [ ] Deep link `?fromChain=&fromToken=&toChain=&toToken=` still wins over placeholders on cold load
- [ ] Wallet balance card from-side selection still works after placeholders seed
- [ ] Announcement / partner links that set chain+token still win over placeholders
- [ ] Unit tests: `pnpm exec vitest run src/components/Widgets/hooks.spec.ts src/components/Widgets/variants/widgetConfig/utils.spec.ts --project unit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Widget navigation now preserves selected chains and tokens when switching tabs.
  - Chain and token selections stay synchronized with the page URL for easier sharing and navigation.
  - Widget forms can update their values without unnecessary remounts or resets.
  - Empty states are handled consistently for specialized tabs.

- **Bug Fixes**
  - Prevented redundant navigation when selecting the already active tab.
  - Fixed empty token values being treated as valid selections.
  - Improved handling of invalid or incomplete URL parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->