### PR TITLE
chore: bump @jumperexchange/widget to 4.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@intercom/messenger-js-sdk": "^0.0.19",
     "@jumperexchange/shared-ui": "^0.16.0",
     "@jumperexchange/wallet-management": "^4.1.3",
-    "@jumperexchange/widget": "^4.5.0",
+    "@jumperexchange/widget": "^4.6.0",
     "@jumperexchange/widget-provider": "^4.2.2",
     "@jumperexchange/widget-provider-bitcoin": "^4.2.2",
     "@jumperexchange/widget-provider-ethereum": "^4.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^4.1.3
         version: 4.1.3(@tanstack/react-query@5.101.1(react@19.2.7))(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))
       '@jumperexchange/widget':
-        specifier: ^4.5.0
-        version: 4.5.0(@emotion/is-prop-valid@1.4.0)(@tanstack/react-query@5.101.1(react@19.2.7))(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))
+        specifier: ^4.6.0
+        version: 4.6.0(@emotion/is-prop-valid@1.4.0)(@tanstack/react-query@5.101.1(react@19.2.7))(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))
       '@jumperexchange/widget-provider':
         specifier: ^4.2.2
         version: 4.2.2(react@19.2.7)
@@ -1495,8 +1495,8 @@ packages:
     peerDependencies:
       react: '>=19'
 
-  '@jumperexchange/widget@4.5.0':
-    resolution: {integrity: sha512-n+qO4MsCAsPJZ7l9VkZuk7UN8ptuI7RfkPqMrPYU8UeL5zUzZw4nUn+o0+jw96Hl0ZpY78r0kTSeul27YfIz0g==, tarball: https://npm.pkg.github.com/download/@jumperexchange/widget/4.5.0/ce52efa401889e7c6bc336ccfb624cc9a064e1e9}
+  '@jumperexchange/widget@4.6.0':
+    resolution: {integrity: sha512-ZUx+usPW1clgNKAYv6xtAyyV1TvwiYiosI0j/rNh8w9Im0jvnHGigxy0u+MY+rJ45xx91Ylxnt/39gFWceipkw==, tarball: https://npm.pkg.github.com/download/@jumperexchange/widget/4.6.0/196d9f36b7923c651292cf85f73aaf8fe069e1ae}
     peerDependencies:
       '@tanstack/react-query': '>=5.90.0'
       react: '>=19'
@@ -12246,7 +12246,7 @@ snapshots:
       '@lifi/sdk': 4.2.0
       react: 19.2.7
 
-  '@jumperexchange/widget@4.5.0(@emotion/is-prop-valid@1.4.0)(@tanstack/react-query@5.101.1(react@19.2.7))(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))':
+  '@jumperexchange/widget@4.6.0(@emotion/is-prop-valid@1.4.0)(@tanstack/react-query@5.101.1(react@19.2.7))(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)


### PR DESCRIPTION
## Summary

Bumps `@jumperexchange/widget` from `4.5.0` to `4.6.0`.

## Changes

- `package.json`: `@jumperexchange/widget` `^4.5.0` → `^4.6.0`
- `pnpm-lock.yaml`: lockfile updated (only the widget resolved from 4.5.0 → 4.6.0)

Widget 4.6.0 declares no peer requirements on the `widget-provider-*` or `@lifi/*` packages, so no companion bumps were needed. `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)